### PR TITLE
:bug: When setting up an image pasteboard, if you can't create a BufferedImage then forgo setting up DataFlavor.imageFlavor

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.Transient
 import org.mongodb.kbson.BsonObjectId
 import org.mongodb.kbson.ObjectId
 import java.awt.datatransfer.DataFlavor
+import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.charset.StandardCharsets
@@ -133,7 +134,8 @@ class ImagesPasteItem : RealmObject, PasteItem, PasteImages {
 
         if (fileList.size == 1) {
             try {
-                map[DataFlavor.imageFlavor] = ImageIO.read(fileList[0])
+                val image: BufferedImage? = ImageIO.read(fileList[0])
+                image?.let { map[DataFlavor.imageFlavor] = it }
             } catch (e: Exception) {
                 logger.error(e) { "read image fail" }
             }


### PR DESCRIPTION
close #1380