### PR TITLE
:bug: When doing heartbeat we should check the targetAppInstanceId

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
@@ -17,6 +17,7 @@ interface SyncClientApi {
     suspend fun heartbeat(
         syncInfo: SyncInfo,
         signalMessageProcessor: SignalMessageProcessor,
+        targetAppInstanceId: String,
         toUrl: URLBuilder.(URLBuilder) -> Unit,
     ): ClientApiResult
 

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/net/clientapi/DesktopSyncClientApi.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/net/clientapi/DesktopSyncClientApi.kt
@@ -56,6 +56,7 @@ class DesktopSyncClientApi(
     override suspend fun heartbeat(
         syncInfo: SyncInfo,
         signalMessageProcessor: SignalMessageProcessor,
+        targetAppInstanceId: String,
         toUrl: URLBuilder.(URLBuilder) -> Unit,
     ): ClientApiResult {
         return request(logger, request = {
@@ -65,6 +66,7 @@ class DesktopSyncClientApi(
             pasteClient.post(
                 dataContent,
                 typeInfo<DataContent>(),
+                targetAppInstanceId,
                 urlBuilder = {
                     toUrl(it)
                     buildUrl(it, "sync", "heartbeat")

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/routing/SyncRouting.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/routing/SyncRouting.kt
@@ -127,6 +127,12 @@ fun Routing.syncRouting() {
 
     post("/sync/heartbeat") {
         getAppInstanceId(call)?.let { appInstanceId ->
+            val targetAppInstanceId = call.request.headers["targetAppInstanceId"]
+            if (targetAppInstanceId != appInfo.appInstanceId) {
+                logger.debug { "targetAppInstanceId $targetAppInstanceId not match ${appInfo.appInstanceId}" }
+                failResponse(call, StandardErrorCode.SIGNAL_EXCHANGE_FAIL.toErrorCode())
+                return@let
+            }
             val dataContent = call.receive(DataContent::class)
             val bytes = dataContent.data
             val processor = signalProcessorCache.getSignalMessageProcessor(appInstanceId)

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/sync/DesktopSyncHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/sync/DesktopSyncHandler.kt
@@ -246,7 +246,7 @@ class DesktopSyncHandler(
     private suspend fun resolveConnecting() {
         syncRuntimeInfo.connectHostAddress?.let { host ->
             if (isExistSession()) {
-                if (heartbeat(host, syncRuntimeInfo.port)) {
+                if (heartbeat(host, syncRuntimeInfo.port, syncRuntimeInfo.appInstanceId)) {
                     return@resolveConnecting
                 }
                 if (syncRuntimeInfo.connectState == SyncState.UNMATCHED) {
@@ -271,11 +271,13 @@ class DesktopSyncHandler(
     private suspend fun heartbeat(
         host: String,
         port: Int,
+        targetAppInstanceId: String,
     ): Boolean {
         val result =
             syncClientApi.heartbeat(
                 getCurrentSyncInfo(),
                 signalProcessor,
+                targetAppInstanceId,
             ) { urlBuilder ->
                 buildUrl(urlBuilder, host, port)
             }


### PR DESCRIPTION
To avoid a bug where the device reboots and gets the ip of the previous device, causing the device to be messed up.

close #1423