### PR TITLE
:wrench: Add configuration `consistency-checks = warn` to avoid build failures

### DIFF
--- a/conveyor.conf
+++ b/conveyor.conf
@@ -8,9 +8,13 @@ app {
   license = "AGPL-3.0-or-later"
   display-name = "CrossPaste"
   rdns-name = "com.crosspaste"
-  site.base-url = "crosspaste.com/desktop/"
   url-schemes = [ crosspaste ]
   vcs-url = "https://github.com/CrossPaste/crosspaste-desktop"
+
+  site {
+    base-url = "crosspaste.com/desktop/"
+    consistency-checks = warn
+  }
 
   jvm {
     mac.amd64.inputs += "composeApp/jbr/jbrsdk-17.0.11-osx-x64-b1312.2.tar.gz"


### PR DESCRIPTION
close #1459