### PR TITLE
:lipstick: Adjust the UI spacing of the main interface

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/TabsView.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/TabsView.kt
@@ -76,17 +76,17 @@ fun TabsView(currentPageViewContext: MutableState<PageViewContext>) {
         Box {
             Column(
                 modifier =
-                    Modifier.padding(horizontal = 5.dp)
+                    Modifier.padding(horizontal = 8.dp)
                         .fillMaxWidth()
                         .height(40.dp)
-                        .clip(RoundedCornerShape(10.dp))
+                        .clip(RoundedCornerShape(8.dp))
                         .background(MaterialTheme.colors.surface.copy(0.64f)),
             ) {}
 
             Column(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
                 Row(
                     modifier =
-                        Modifier.padding(8.dp, 8.dp, 8.dp, 0.dp)
+                        Modifier.padding(12.dp, 8.dp, 12.dp, 0.dp)
                             .wrapContentWidth(),
                 ) {
                     tabs.forEach { pair ->
@@ -128,8 +128,8 @@ fun TabsView(currentPageViewContext: MutableState<PageViewContext>) {
                     }
                     sum
                 }
-                Row(modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp)) {
-                    Spacer(modifier = Modifier.width(4.dp + (10.dp * ((selectedIndex * 2) + 1)) + offset))
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Spacer(modifier = Modifier.width(8.dp + (10.dp * ((selectedIndex * 2) + 1)) + offset))
 
                     Box(
                         modifier =
@@ -142,8 +142,6 @@ fun TabsView(currentPageViewContext: MutableState<PageViewContext>) {
                 }
             }
         }
-
-        Spacer(modifier = Modifier.height(5.dp))
 
         when (currentPageViewContext.value.pageViewType) {
             PageViewType.PASTE_PREVIEW -> PastePreviewsView()

--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesView.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesView.kt
@@ -75,8 +75,8 @@ fun DevicesView(currentPageViewContext: MutableState<PageViewContext>) {
     Box(
         modifier =
             Modifier.fillMaxSize()
-                .padding(start = 5.dp, end = 5.dp, bottom = 5.dp)
-                .clip(RoundedCornerShape(10.dp))
+                .padding(8.dp)
+                .clip(RoundedCornerShape(5.dp))
                 .background(MaterialTheme.colors.surface.copy(0.64f)),
         contentAlignment = Alignment.TopCenter,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/devices/QrCodeView.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/devices/QrCodeView.kt
@@ -89,8 +89,8 @@ fun bindingQRCode() {
     Box(
         modifier =
             Modifier.fillMaxSize()
-                .padding(start = 5.dp, end = 5.dp, bottom = 5.dp)
-                .clip(RoundedCornerShape(10.dp))
+                .padding(8.dp)
+                .clip(RoundedCornerShape(5.dp))
                 .background(MaterialTheme.colors.surface.copy(0.64f)),
         contentAlignment = Alignment.Center,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/paste/preview/PastePreviewItemView.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/paste/preview/PastePreviewItemView.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
@@ -61,12 +60,11 @@ fun PastePreviewItemView(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(105.dp),
+                .height(100.dp),
     ) {
         Row(
             modifier =
                 Modifier.fillMaxSize()
-                    .padding(start = 5.dp, end = 5.dp, bottom = 5.dp)
                     .clip(RoundedCornerShape(5.dp)),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -122,7 +120,7 @@ fun PasteSpecificPreviewContentView(
     pasteRightInfo: @Composable ((Boolean) -> Unit) -> Unit,
 ) {
     var showMenu by remember { mutableStateOf(false) }
-    val width = animateDpAsState(targetValue = if (showMenu) 395.dp else 430.dp)
+    val width = animateDpAsState(targetValue = if (showMenu) (440 - 16 - 35).dp else (440 - 16).dp)
 
     Box(
         modifier =

--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/paste/preview/PastePreviewsView.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/paste/preview/PastePreviewsView.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -125,30 +126,44 @@ fun PastePreviewsView() {
 
     Box(
         modifier =
-            Modifier.fillMaxWidth(),
+            Modifier.fillMaxWidth()
+                .padding(start = 8.dp)
+                .padding(vertical = 8.dp),
     ) {
-        LazyColumn(
-            state = listState,
-            modifier = Modifier.wrapContentHeight(),
+        Box(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(end = 8.dp)
+                    .clip(RoundedCornerShape(5.dp)),
         ) {
-            itemsIndexed(
-                rememberPasteDataList,
-                key = { _, item -> item.id },
-            ) { _, pasteData ->
-                PastePreviewItemView(pasteData) {
-                    PasteSpecificPreviewView(this)
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.wrapContentHeight(),
+            ) {
+                itemsIndexed(
+                    rememberPasteDataList,
+                    key = { _, item -> item.id },
+                ) { index, pasteData ->
+                    PastePreviewItemView(pasteData) {
+                        PasteSpecificPreviewView(this)
+                    }
+                    if (index < rememberPasteDataList.size - 1) {
+                        Spacer(modifier = Modifier.height(5.dp))
+                    }
                 }
             }
-        }
 
-        if (rememberPasteDataList.isEmpty()) {
-            EmptyScreenView()
+            if (rememberPasteDataList.isEmpty()) {
+                EmptyScreenView()
+            }
         }
 
         VerticalScrollbar(
             modifier =
-                Modifier.background(color = Color.Transparent)
-                    .fillMaxHeight().align(Alignment.CenterEnd)
+                Modifier
+                    .background(color = Color.Transparent)
+                    .fillMaxHeight()
+                    .align(Alignment.CenterEnd)
                     .draggable(
                         orientation = Orientation.Vertical,
                         state =
@@ -162,7 +177,7 @@ fun PastePreviewsView() {
             style =
                 ScrollbarStyle(
                     minimalHeight = 16.dp,
-                    thickness = 8.dp,
+                    thickness = 6.dp,
                     shape = RoundedCornerShape(4.dp),
                     hoverDurationMillis = 300,
                     unhoverColor = if (isScrolling) MaterialTheme.colors.onBackground.copy(alpha = 0.48f) else Color.Transparent,
@@ -188,8 +203,6 @@ fun EmptyScreenView() {
         contentAlignment = Alignment.Center,
         modifier =
             Modifier.fillMaxSize()
-                .padding(start = 5.dp, end = 5.dp, bottom = 5.dp)
-                .clip(RoundedCornerShape(10.dp))
                 .background(MaterialTheme.colors.surface.copy(0.64f)),
     ) {
         Box(


### PR DESCRIPTION
1. Fix the problem that there is no spacing at the bottom of the pasteboard
2. Adjust the spacing size to avoid crowded feeling
3. Adjust the size of rounded corners of tabs
4. Adjust the spacing between tabs and main interface

close #1464 