### PR TITLE
:bug: Fix logic error in determining if the application was installed from the Microsoft Store

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/os/windows/api/User32.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/os/windows/api/User32.kt
@@ -3,6 +3,7 @@ package com.crosspaste.os.windows.api
 import com.crosspaste.app.AbstractAppWindowManager.Companion.MAIN_WINDOW_TITLE
 import com.crosspaste.app.AbstractAppWindowManager.Companion.SEARCH_WINDOW_TITLE
 import com.crosspaste.app.WinAppInfo
+import com.crosspaste.path.DesktopPathProvider
 import com.sun.jna.Memory
 import com.sun.jna.Native
 import com.sun.jna.Pointer
@@ -499,9 +500,8 @@ interface User32 : com.sun.jna.platform.win32.User32 {
         }
 
         fun isInstalledFromMicrosoftStore(): Boolean {
-            val appPath: Path = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
             val windowsAppsPath: Path = Paths.get("C:\\Program Files\\WindowsApps").toAbsolutePath()
-            return appPath.startsWith(windowsAppsPath)
+            return DesktopPathProvider.pasteAppPath.toNioPath().startsWith(windowsAppsPath)
         }
     }
 }

--- a/composeApp/src/desktopMain/resources/crosspaste-version.properties
+++ b/composeApp/src/desktopMain/resources/crosspaste-version.properties
@@ -1,1 +1,1 @@
-version=1.0.3
+version=1.0.5


### PR DESCRIPTION
This commit addresses a critical bug in the logic used to determine if an application was installed from the Microsoft Store. Due to the urgency of this bug, a new version is being released immediately. The current development version is now set to 1.0.5

close #1609