### PR TITLE
:construction_worker: Improve Gradle task for Swift compilation

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -189,21 +189,25 @@ compose.desktop {
                             else -> "darwin-x86-64"
                         }
 
-                    val libMacosApiFile =
+                    val inputFile =
+                        layout.projectDirectory.file("src/desktopMain/swift/MacosApi.swift").asFile
+
+                    val outputFile =
                         layout.buildDirectory.file("classes/kotlin/desktop/main/$archDir/libMacosApi.dylib")
                             .get().asFile
 
                     commandLine(
                         "swiftc",
                         "-emit-library",
-                        "src/desktopMain/swift/MacosApi.swift",
+                        inputFile.absolutePath,
                         "-target",
                         targetArch,
                         "-o",
-                        libMacosApiFile.absolutePath,
+                        outputFile.absolutePath,
                     )
 
-                    outputs.file(libMacosApiFile)
+                    inputs.file(inputFile)
+                    outputs.file(outputFile)
                 }
 
                 tasks.named("desktopJar") {


### PR DESCRIPTION
- Add explicit input file tracking for MacosApi.swift
- Ensure task recompiles when Swift source changes
- Use file objects for better path handling
- Add directory creation step to prevent build failures
- Update commandLine to use file object paths

This change ensures that the compileSwift task properly detects changes in the Swift source file and recompiles when necessary, improving the reliability of the build process.

close #1613