### PR TITLE
:bug: [Linux] Fix clipboard detection and memory leak in pasteboard service

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/os/linux/api/XFixes.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/os/linux/api/XFixes.kt
@@ -64,4 +64,8 @@ class XFixesSelectionNotifyEvent(p: Pointer) : Structure(p) {
     @JvmField var timestamp: NativeLong? = null
 
     @JvmField var selectionTimestamp: NativeLong? = null
+
+    init {
+        read()
+    }
 }


### PR DESCRIPTION
- Update clipboard event detection to use clipboardAtom.toLong() instead of hardcoded value (0x145L)
- Add selectionNotify.clear() to prevent memory leaks

This fix addresses a Linux-specific issue where clipboard changes were not being detected correctly due to system-dependent atom values. It also prevents potential memory leaks in the X11 event handling process.

close #1620