### PR TITLE
:bug: Add missing listener for backtick (`) key

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/listen/KeyboardKeys.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/listen/KeyboardKeys.kt
@@ -16,6 +16,8 @@ interface KeyboardKeys {
 
     val SPACE: KeyboardKeyDefine
 
+    val BACKTICK: KeyboardKeyDefine
+
     val UP: KeyboardKeyDefine
 
     val DOWN: KeyboardKeyDefine

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/listen/LinuxKeyboardKeys.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/listen/LinuxKeyboardKeys.kt
@@ -22,6 +22,9 @@ object LinuxKeyboardKeys : KeyboardKeys {
     override val SPACE: KeyboardKeyDefine =
         KeyboardKeyDefine("Space", NativeKeyEvent.VC_SPACE, 65) { it.keyCode == NativeKeyEvent.VC_SPACE }
 
+    override val BACKTICK: KeyboardKeyDefine =
+        KeyboardKeyDefine("`", NativeKeyEvent.VC_BACKQUOTE, 49) { it.keyCode == NativeKeyEvent.VC_BACKQUOTE }
+
     override val UP: KeyboardKeyDefine =
         KeyboardKeyDefine("↑", NativeKeyEvent.VC_UP, 98) { it.keyCode == NativeKeyEvent.VC_UP }
 

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/listen/MacKeyboardKeys.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/listen/MacKeyboardKeys.kt
@@ -23,6 +23,9 @@ object MacKeyboardKeys : KeyboardKeys {
     override val SPACE: KeyboardKeyDefine =
         KeyboardKeyDefine("Space", NativeKeyEvent.VC_SPACE, 0x31) { it.keyCode == NativeKeyEvent.VC_SPACE }
 
+    override val BACKTICK: KeyboardKeyDefine =
+        KeyboardKeyDefine("`", NativeKeyEvent.VC_BACKQUOTE, 0x32) { it.keyCode == NativeKeyEvent.VC_BACKQUOTE }
+
     override val UP: KeyboardKeyDefine =
         KeyboardKeyDefine("↑", NativeKeyEvent.VC_UP, 0x7E) { it.keyCode == NativeKeyEvent.VC_UP }
 

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/listen/WindowsKeyboardKeys.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/listen/WindowsKeyboardKeys.kt
@@ -22,6 +22,9 @@ object WindowsKeyboardKeys : KeyboardKeys {
     override val SPACE: KeyboardKeyDefine =
         KeyboardKeyDefine("Space", NativeKeyEvent.VC_SPACE, 0x20) { it.keyCode == NativeKeyEvent.VC_SPACE }
 
+    override val BACKTICK: KeyboardKeyDefine =
+        KeyboardKeyDefine("`", NativeKeyEvent.VC_BACKQUOTE, 0xC0) { it.keyCode == NativeKeyEvent.VC_BACKQUOTE }
+
     override val UP: KeyboardKeyDefine =
         KeyboardKeyDefine("↑", NativeKeyEvent.VC_UP, 0x26) { it.keyCode == NativeKeyEvent.VC_UP }
 


### PR DESCRIPTION
close #1694 