### PR TITLE
Add Ctrl+N and Ctrl+P shortcuts to search window

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/search/PasteSearchView.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/search/PasteSearchView.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
@@ -150,6 +151,18 @@ fun CrossPasteSearchWindowContent() {
                             }
                             Key.DirectionDown -> {
                                 pasteSearchService.downSelectedIndex()
+                                true
+                            }
+                            Key.N -> {
+                                if (it.isCtrlPressed) {
+                                    pasteSearchService.downSelectedIndex()
+                                }
+                                true
+                            }
+                            Key.P -> {
+                                if (it.isCtrlPressed) {
+                                    pasteSearchService.upSelectedIndex()
+                                }
                                 true
                             }
                             else -> {


### PR DESCRIPTION
In scenarios where it's necessary to switch between items up and down, many software applications feature Ctrl+N and Ctrl+P keyboard shortcuts. This allows users to keep their hands on the main part of the keyboard (as opposed to moving their hands to use arrow keys), making it more user-friendly.