### PR TITLE
:bug: Fix pasteboard sync bugs

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/dao/paste/PasteRealm.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/dao/paste/PasteRealm.kt
@@ -117,6 +117,10 @@ class PasteRealm(
         newPasteDataType: Int,
         newPasteDataHash: String,
     ): List<ObjectId> {
+        if (newPasteDataHash.isEmpty()) {
+            return emptyList()
+        }
+
         val tasks = mutableListOf<ObjectId>()
         query(
             PasteData::class,

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/routing/PasteRouting.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/routing/PasteRouting.kt
@@ -28,13 +28,19 @@ fun Routing.pasteRouting(
                     return@post
                 }
 
-                val pasteData = call.receive<PasteData>()
+                try {
+                    val pasteData = call.receive<PasteData>()
 
-                launch {
-                    pasteboardService.tryWriteRemotePasteboard(pasteData)
+                    launch {
+                        pasteboardService.tryWriteRemotePasteboard(pasteData)
+                    }
+                    logger.debug { "sync handler ($appInstanceId) receive pasteData: $pasteData" }
+                    successResponse(call)
+                } catch (e: Exception) {
+                    logger.error(e) { "sync handler ($appInstanceId) receive pasteData error" }
+                    failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
+                    return@post
                 }
-                logger.debug { "sync handler ($appInstanceId) receive pasteData: $pasteData" }
-                successResponse(call)
             } ?: run {
                 logger.error { "not found appInstance id: $appInstanceId" }
                 failResponse(call, StandardErrorCode.NOT_FOUND_APP_INSTANCE_ID.toErrorCode())

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
@@ -87,6 +87,13 @@ class PullFileTaskExecutor(
                 it.getConnectHostAddress()?.let { host ->
                     return pullFiles(pasteData, host, port, filesIndex, pullExtraInfo)
                 } ?: run {
+                    val needRetry = pullExtraInfo.executionHistories.size < 3
+
+                    if (!needRetry) {
+                        logger.error { "exist pull chunk fail" }
+                        pasteboardService.clearRemotePasteboard(pasteData)
+                    }
+
                     return createFailurePasteTaskResult(
                         logger = logger,
                         retryHandler = { pullExtraInfo.executionHistories.size < 3 },
@@ -102,6 +109,13 @@ class PullFileTaskExecutor(
                     )
                 }
             } ?: run {
+                val needRetry = pullExtraInfo.executionHistories.size < 3
+
+                if (!needRetry) {
+                    logger.error { "exist pull chunk fail" }
+                    pasteboardService.clearRemotePasteboard(pasteData)
+                }
+
                 return createFailurePasteTaskResult(
                     logger = logger,
                     retryHandler = { pullExtraInfo.executionHistories.size < 3 },


### PR DESCRIPTION
1. Remove loading status on sync failure
2. Catch clipboard serialization exceptions
3. Skip hash deduplication when hash is empty

close #1762