### PR TITLE
:lipstick: Implement backspace functionality in DeviceVerifyView token input

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceVerifyView.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceVerifyView.kt
@@ -66,6 +66,7 @@ fun DeviceVerifyView(syncRuntimeInfo: SyncRuntimeInfo) {
 
     LaunchedEffect(Unit) {
         syncManager.getSyncHandlers()[syncRuntimeInfo.appInstanceId]?.showToken()
+        focusRequesters.firstOrNull()?.requestFocus()
     }
 
     val confirmAction = {
@@ -173,6 +174,15 @@ fun DeviceVerifyView(syncRuntimeInfo: SyncRuntimeInfo) {
                                                 Key.Escape -> {
                                                     cancelAction()
                                                     true
+                                                }
+                                                Key.Backspace -> {
+                                                    if (token.isEmpty() && index > 0) {
+                                                        focusRequesters[index - 1].requestFocus()
+                                                        tokens[index - 1] = ""
+                                                        true
+                                                    } else {
+                                                        false
+                                                    }
                                                 }
                                                 else -> {
                                                     false

--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceVerifyView.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceVerifyView.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.text.TextStyle
@@ -50,6 +51,7 @@ import com.crosspaste.sync.SyncManager
 import com.crosspaste.ui.base.CustomTextField
 import com.crosspaste.ui.base.DialogButtonsView
 import com.crosspaste.ui.base.DialogService
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
@@ -69,23 +71,10 @@ fun DeviceVerifyView(syncRuntimeInfo: SyncRuntimeInfo) {
         focusRequesters.firstOrNull()?.requestFocus()
     }
 
-    val confirmAction = {
-        tokens.joinToString("").let { token ->
-            if (token.length == tokenCount) {
-                coroutineScope.launch {
-                    syncManager.trustByToken(syncRuntimeInfo.appInstanceId, token.toInt())
-                }
-                dialogService.popDialog()
-            } else {
-                isError = true
-            }
-        }
-    }
+    val setError = { value: Boolean -> isError = value }
 
-    val cancelAction = {
-        syncManager.ignoreVerify(syncRuntimeInfo.appInstanceId)
-        dialogService.popDialog()
-    }
+    val confirmAction = { confirmToken(tokens, tokenCount, setError, syncManager, syncRuntimeInfo, dialogService, coroutineScope) }
+    val cancelAction = { cancelVerification(syncManager, syncRuntimeInfo, dialogService) }
 
     Box(
         Modifier.fillMaxWidth()
@@ -94,120 +83,7 @@ fun DeviceVerifyView(syncRuntimeInfo: SyncRuntimeInfo) {
         contentAlignment = Alignment.Center,
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            Column(
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .wrapContentHeight()
-                        .padding(10.dp),
-            ) {
-                DeviceBarView(
-                    modifier = Modifier,
-                    syncRuntimeInfo,
-                ) {
-                    Spacer(modifier = Modifier.weight(1f))
-                    Text(
-                        text = syncRuntimeInfo.connectHostAddress ?: "unknown",
-                        style =
-                            TextStyle(
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Light,
-                                fontFamily = FontFamily.SansSerif,
-                            ),
-                        color = MaterialTheme.colorScheme.onBackground,
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                }
-                Spacer(modifier = Modifier.size(8.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    tokens.forEachIndexed { index, token ->
-                        Box(
-                            contentAlignment = Alignment.Center,
-                            modifier =
-                                Modifier
-                                    .width(40.dp)
-                                    .height(50.dp)
-                                    .background(MaterialTheme.colorScheme.background, RoundedCornerShape(4.dp))
-                                    .border(
-                                        1.dp,
-                                        if (isError && token.length != 1) {
-                                            MaterialTheme.colorScheme.error
-                                        } else {
-                                            MaterialTheme.colorScheme.primary
-                                        },
-                                        RoundedCornerShape(4.dp),
-                                    ),
-                        ) {
-                            CustomTextField(
-                                value = token,
-                                onValueChange = { value ->
-                                    if (value.length <= 1 && value.all { it.isDigit() }) {
-                                        tokens[index] = value
-                                        if (value.isNotEmpty() && index < tokenCount - 1) {
-                                            focusRequesters[index + 1].requestFocus()
-                                        }
-                                    }
-                                },
-                                isError = isError && (token.length != 1),
-                                singleLine = true,
-                                textStyle =
-                                    LocalTextStyle.current.copy(
-                                        textAlign = TextAlign.Center,
-                                        color = MaterialTheme.colorScheme.primary,
-                                        fontSize = 24.sp,
-                                        fontWeight = FontWeight.Bold,
-                                        fontFamily = FontFamily.Monospace,
-                                    ),
-                                keyboardOptions =
-                                    KeyboardOptions.Default.copy(
-                                        keyboardType = KeyboardType.Number,
-                                        imeAction = if (index == tokenCount - 1) ImeAction.Done else ImeAction.Next,
-                                    ),
-                                modifier =
-                                    Modifier.fillMaxSize()
-                                        .focusRequester(focusRequesters[index])
-                                        .onKeyEvent {
-                                            when (it.key) {
-                                                Key.Enter -> {
-                                                    confirmAction()
-                                                    true
-                                                }
-                                                Key.Escape -> {
-                                                    cancelAction()
-                                                    true
-                                                }
-                                                Key.Backspace -> {
-                                                    if (token.isEmpty() && index > 0) {
-                                                        focusRequesters[index - 1].requestFocus()
-                                                        tokens[index - 1] = ""
-                                                        true
-                                                    } else {
-                                                        false
-                                                    }
-                                                }
-                                                else -> {
-                                                    false
-                                                }
-                                            }
-                                        },
-                                colors =
-                                    TextFieldDefaults.colors(
-                                        focusedTextColor = MaterialTheme.colorScheme.onBackground,
-                                        unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
-                                        disabledTextColor = Color.Transparent,
-                                        focusedContainerColor = Color.Transparent,
-                                        unfocusedContainerColor = Color.Transparent,
-                                        disabledContainerColor = Color.Transparent,
-                                        cursorColor = MaterialTheme.colorScheme.primary,
-                                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
-                                        unfocusedIndicatorColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.38f),
-                                        disabledIndicatorColor = Color.Transparent,
-                                    ),
-                                contentPadding = PaddingValues(4.dp, 10.dp, 4.dp, 10.dp),
-                            )
-                        }
-                    }
-                }
-            }
+            VerificationContent(syncRuntimeInfo, tokens, isError, focusRequesters, confirmAction, cancelAction)
             Spacer(modifier = Modifier.height(10.dp))
             DialogButtonsView(
                 height = 50.dp,
@@ -216,4 +92,202 @@ fun DeviceVerifyView(syncRuntimeInfo: SyncRuntimeInfo) {
             )
         }
     }
+}
+
+@Composable
+fun VerificationContent(
+    syncRuntimeInfo: SyncRuntimeInfo,
+    tokens: MutableList<String>,
+    isError: Boolean,
+    focusRequesters: List<FocusRequester>,
+    confirmAction: () -> Unit,
+    cancelAction: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .wrapContentHeight()
+                .padding(10.dp),
+    ) {
+        DeviceInfoHeader(syncRuntimeInfo)
+        Spacer(modifier = Modifier.size(8.dp))
+        TokenInputRow(tokens, isError, focusRequesters, confirmAction, cancelAction)
+    }
+}
+
+@Composable
+fun DeviceInfoHeader(syncRuntimeInfo: SyncRuntimeInfo) {
+    DeviceBarView(
+        modifier = Modifier,
+        syncRuntimeInfo,
+    ) {
+        Row(horizontalArrangement = Arrangement.End) {
+            Text(
+                text = syncRuntimeInfo.connectHostAddress ?: "unknown",
+                style =
+                    TextStyle(
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Light,
+                        fontFamily = FontFamily.SansSerif,
+                    ),
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+        }
+    }
+}
+
+@Composable
+fun TokenInputRow(
+    tokens: MutableList<String>,
+    isError: Boolean,
+    focusRequesters: List<FocusRequester>,
+    confirmAction: () -> Unit,
+    cancelAction: () -> Unit,
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        tokens.forEachIndexed { index, token ->
+            TokenInputBox(
+                token = token,
+                index = index,
+                isError = isError,
+                focusRequesters = focusRequesters,
+                onValueChange = { value ->
+                    if (value.length <= 1 && value.all { it.isDigit() }) {
+                        tokens[index] = value
+                        if (value.isNotEmpty() && index < tokens.size - 1) {
+                            focusRequesters[index + 1].requestFocus()
+                        }
+                    }
+                },
+                confirmAction = confirmAction,
+                cancelAction = cancelAction,
+            )
+        }
+    }
+}
+
+@Composable
+fun TokenInputBox(
+    token: String,
+    index: Int,
+    isError: Boolean,
+    focusRequesters: List<FocusRequester>,
+    onValueChange: (String) -> Unit,
+    confirmAction: () -> Unit,
+    cancelAction: () -> Unit,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier =
+            Modifier
+                .width(40.dp)
+                .height(50.dp)
+                .background(MaterialTheme.colorScheme.background, RoundedCornerShape(4.dp))
+                .border(
+                    1.dp,
+                    if (isError && token.length != 1) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                    RoundedCornerShape(4.dp),
+                ),
+    ) {
+        CustomTextField(
+            value = token,
+            onValueChange = onValueChange,
+            isError = isError && (token.length != 1),
+            singleLine = true,
+            textStyle =
+                LocalTextStyle.current.copy(
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Monospace,
+                ),
+            keyboardOptions =
+                KeyboardOptions.Default.copy(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = if (index == focusRequesters.size - 1) ImeAction.Done else ImeAction.Next,
+                ),
+            modifier =
+                Modifier.fillMaxSize()
+                    .focusRequester(focusRequesters[index])
+                    .onKeyEvent { handleKeyEvent(it, token, index, focusRequesters, confirmAction, cancelAction) },
+            colors = textFieldColors(),
+            contentPadding = PaddingValues(horizontal = 4.dp, vertical = 10.dp),
+        )
+    }
+}
+
+fun handleKeyEvent(
+    event: KeyEvent,
+    token: String,
+    index: Int,
+    focusRequesters: List<FocusRequester>,
+    confirmAction: () -> Unit,
+    cancelAction: () -> Unit,
+): Boolean {
+    return when (event.key) {
+        Key.Enter -> {
+            confirmAction()
+            true
+        }
+        Key.Escape -> {
+            cancelAction()
+            true
+        }
+        Key.Backspace -> {
+            if (token.isEmpty() && index > 0) {
+                focusRequesters[index - 1].requestFocus()
+                true
+            } else {
+                false
+            }
+        }
+        else -> false
+    }
+}
+
+@Composable
+fun textFieldColors() =
+    TextFieldDefaults.colors(
+        focusedTextColor = MaterialTheme.colorScheme.onBackground,
+        unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+        disabledTextColor = Color.Transparent,
+        focusedContainerColor = Color.Transparent,
+        unfocusedContainerColor = Color.Transparent,
+        disabledContainerColor = Color.Transparent,
+        cursorColor = MaterialTheme.colorScheme.primary,
+        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+        unfocusedIndicatorColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.38f),
+        disabledIndicatorColor = Color.Transparent,
+    )
+
+fun confirmToken(
+    tokens: MutableList<String>,
+    tokenCount: Int,
+    setError: (Boolean) -> Unit,
+    syncManager: SyncManager,
+    syncRuntimeInfo: SyncRuntimeInfo,
+    dialogService: DialogService,
+    coroutineScope: CoroutineScope,
+) {
+    tokens.joinToString("").let { token ->
+        if (token.length == tokenCount) {
+            coroutineScope.launch {
+                syncManager.trustByToken(syncRuntimeInfo.appInstanceId, token.toInt())
+            }
+            dialogService.popDialog()
+        } else {
+            setError(true)
+        }
+    }
+}
+
+fun cancelVerification(
+    syncManager: SyncManager,
+    syncRuntimeInfo: SyncRuntimeInfo,
+    dialogService: DialogService,
+) {
+    syncManager.ignoreVerify(syncRuntimeInfo.appInstanceId)
+    dialogService.popDialog()
 }


### PR DESCRIPTION
- Allow users to move focus to the previous input field when pressing backspace on an empty field
- Clear the content of the previous field when moving focus backwards
- Improve user experience by allowing easier correction of input errors

close #2091