### PR TITLE
:bug: Improve color format parsing and add conversion tests

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/settings/StoreSettingsContentView.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/settings/StoreSettingsContentView.kt
@@ -45,6 +45,7 @@ import com.crosspaste.realm.paste.PasteRealm
 import com.crosspaste.ui.base.CustomRectangleSwitch
 import com.crosspaste.ui.base.anglesUpDown
 import com.crosspaste.ui.base.clock
+import com.crosspaste.ui.base.color
 import com.crosspaste.ui.base.database
 import com.crosspaste.ui.base.file
 import com.crosspaste.ui.base.hashtag
@@ -142,7 +143,7 @@ fun StoreSettingsContentView() {
         arrayOf(
             Quadruple("pasteboard", hashtag(), pasteCount, pasteFormatSize),
             Quadruple("text", text(), textCount, textFormatSize),
-            Quadruple("color", hashtag(), colorCount, colorFormatSize),
+            Quadruple("color", color(), colorCount, colorFormatSize),
             Quadruple("link", link(), urlCount, urlFormatSize),
             Quadruple("html", htmlOrRtf(), htmlCount, htmlFormatSize),
             Quadruple("rtf", htmlOrRtf(), rtfCount, rtfFormatSize),

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/utils/ColorUtils.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/utils/ColorUtils.desktop.kt
@@ -1,5 +1,7 @@
 package com.crosspaste.utils
 
+import kotlin.math.roundToInt
+
 actual fun getColorUtils(): ColorUtils {
     return DesktopColorUtils
 }
@@ -9,19 +11,19 @@ object DesktopColorUtils : ColorUtils {
     private const val HEX_PATTERN = """[0-9A-Fa-f]"""
 
     // Regex patterns for different color formats
-    private val HEX_6_PATTERN = """#?(${HEX_PATTERN}{6})""".toRegex()
-    private val HEX_8_PATTERN = """#?(${HEX_PATTERN}{8})""".toRegex()
-    private val RGB_PATTERN = """rgb\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)""".toRegex()
-    private val RGBA_PATTERN = """rgba\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(0|1|0?\.\d+)\s*\)""".toRegex()
+    private val HEX_6_PATTERN = """^#?(${HEX_PATTERN}{6})$""".toRegex()
+    private val HEX_8_PATTERN = """^#?(${HEX_PATTERN}{8})$""".toRegex()
+    private val RGB_PATTERN = """^rgb\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$""".toRegex()
+    private val RGBA_PATTERN = """^rgba\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(1|0|0?\.\d+|1\.0)\s*\)$""".toRegex()
 
     override fun tryCovertToColor(text: String): Long? {
         // Quick check for common patterns to fail fast
         if (text.isEmpty()) return null
 
         return when {
-            text.startsWith("#") || text[0].isLetterOrDigit() -> tryConvertHex(text)
-            text.startsWith("rgb(") -> tryConvertRGB(text)
             text.startsWith("rgba(") -> tryConvertRGBA(text)
+            text.startsWith("rgb(") -> tryConvertRGB(text)
+            text.startsWith("#") || (text[0].isLetterOrDigit() && !text.startsWith("rgb")) -> tryConvertHex(text)
             else -> null
         }
     }
@@ -70,7 +72,7 @@ object DesktopColorUtils : ColorUtils {
             val red = r.toInt()
             val green = g.toInt()
             val blue = b.toInt()
-            val alpha = (a.toFloat() * 255).toInt()
+            val alpha = (a.toFloat() * 255).roundToInt()
 
             if (red !in 0..255 || green !in 0..255 || blue !in 0..255 || alpha !in 0..255) {
                 return null

--- a/composeApp/src/desktopTest/kotlin/com/crosspaste/utils/ColorUtilsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/crosspaste/utils/ColorUtilsTest.kt
@@ -1,0 +1,94 @@
+package com.crosspaste.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ColorUtilsTest {
+    private val colorUtils = getColorUtils()
+
+    @Test
+    fun testTryCovertToColor_Hex6() {
+        // Valid 6-digit hex
+        assertEquals(0xFFFF0000, colorUtils.tryCovertToColor("#FF0000"))
+        assertEquals(0xFF00FF00, colorUtils.tryCovertToColor("#00FF00"))
+        assertEquals(0xFF0000FF, colorUtils.tryCovertToColor("#0000FF"))
+
+        // Valid 6-digit hex without #
+        assertEquals(0xFFFF0000, colorUtils.tryCovertToColor("FF0000"))
+        assertEquals(0xFF00FF00, colorUtils.tryCovertToColor("00FF00"))
+
+        // Case insensitive
+        assertEquals(0xFFFF0000, colorUtils.tryCovertToColor("#ff0000"))
+        assertEquals(0xFF00FF00, colorUtils.tryCovertToColor("#00ff00"))
+    }
+
+    @Test
+    fun testTryCovertToColor_Hex8() {
+        // Valid 8-digit hex
+        assertEquals(0x80FF0000L, colorUtils.tryCovertToColor("#80FF0000"))
+        assertEquals(0x8000FF00L, colorUtils.tryCovertToColor("#8000FF00"))
+        assertEquals(0x800000FFL, colorUtils.tryCovertToColor("#800000FF"))
+
+        // Valid 8-digit hex without #
+        assertEquals(0x80FF0000L, colorUtils.tryCovertToColor("80FF0000"))
+
+        // Case insensitive
+        assertEquals(0x80FF0000L, colorUtils.tryCovertToColor("#80ff0000"))
+    }
+
+    @Test
+    fun testTryCovertToColor_RGB() {
+        // Valid RGB format
+        assertEquals(0xFFFF0000, colorUtils.tryCovertToColor("rgb(255, 0, 0)"))
+        assertEquals(0xFF00FF00, colorUtils.tryCovertToColor("rgb(0, 255, 0)"))
+        assertEquals(0xFF0000FF, colorUtils.tryCovertToColor("rgb(0, 0, 255)"))
+
+        // RGB with spaces
+        assertEquals(0xFFFF0000, colorUtils.tryCovertToColor("rgb( 255 , 0 , 0 )"))
+
+        // RGB with minimum values
+        assertEquals(0xFF000000, colorUtils.tryCovertToColor("rgb(0, 0, 0)"))
+    }
+
+    @Test
+    fun testTryCovertToColor_RGBA() {
+        // Valid RGBA format
+        assertEquals(0xFFFF0000, colorUtils.tryCovertToColor("rgba(255, 0, 0, 1)"))
+        assertEquals(0x80FF0000, colorUtils.tryCovertToColor("rgba(255, 0, 0, 0.5)"))
+        assertEquals(0x00FF0000, colorUtils.tryCovertToColor("rgba(255, 0, 0, 0)"))
+
+        // RGBA with spaces
+        assertEquals(0xFFFF0000, colorUtils.tryCovertToColor("rgba( 255 , 0 , 0 , 1.0 )"))
+
+        // RGBA with different alpha formats
+        assertEquals(0x80FF0000, colorUtils.tryCovertToColor("rgba(255, 0, 0, .5)"))
+    }
+
+    @Test
+    fun testTryCovertToColor_InvalidInput() {
+        // Empty input
+        assertNull(colorUtils.tryCovertToColor(""))
+
+        // Invalid hex
+        assertNull(colorUtils.tryCovertToColor("#ZZZZZZ"))
+        assertNull(colorUtils.tryCovertToColor("#12345")) // Too short
+        assertNull(colorUtils.tryCovertToColor("#1234567")) // Wrong length
+
+        // Invalid RGB
+        assertNull(colorUtils.tryCovertToColor("rgb(256, 0, 0)")) // Value > 255
+        assertNull(colorUtils.tryCovertToColor("rgb(-1, 0, 0)")) // Negative value
+        assertNull(colorUtils.tryCovertToColor("rgb(0, 0)")) // Missing value
+        assertNull(colorUtils.tryCovertToColor("rgb(0, 0, 0, 0)")) // Too many values
+        assertNull(colorUtils.tryCovertToColor("rgb(a, b, c)")) // Invalid numbers
+
+        // Invalid RGBA
+        assertNull(colorUtils.tryCovertToColor("rgba(255, 0, 0, 2)")) // Alpha > 1
+        assertNull(colorUtils.tryCovertToColor("rgba(255, 0, 0, -0.5)")) // Negative alpha
+        assertNull(colorUtils.tryCovertToColor("rgba(0, 0, 0)")) // Missing alpha
+        assertNull(colorUtils.tryCovertToColor("rgba(a, b, c, d)")) // Invalid numbers
+
+        // Completely invalid format
+        assertNull(colorUtils.tryCovertToColor("not a color"))
+    }
+}


### PR DESCRIPTION
- Fix hex color validation by adding strict length check (6 or 8 digits)
- Improve RGB/RGBA parsing with better whitespace handling
- Fix alpha value calculation using roundToInt instead of truncation
- Enhance RGBA alpha pattern to support all valid formats (0, 1, 0.x, 1.0)
- Add comprehensive unit tests for color format parsing and conversion

close #2152