### PR TITLE
:bug: Avoid circular reference between fileUtils and CodecsUtils, which will cause compilation failure in iOS environment

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/utils/CodecsUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/utils/CodecsUtils.kt
@@ -33,23 +33,7 @@ interface CodecsUtils {
     }
 
     fun hash(path: Path): String {
-        val streamingMurmurHash3 = StreamingMurmurHash3(CROSS_PASTE_SEED)
-        val bufferSize = fileUtils.fileBufferSize
-        val buffer = ByteArray(bufferSize)
-
-        fileUtils.fileSystem.source(path).buffer().use { bufferedSource ->
-            while (true) {
-                val bytesRead = bufferedSource.read(buffer, 0, bufferSize)
-                if (bytesRead == -1) break
-                streamingMurmurHash3.update(buffer, 0, bytesRead)
-            }
-        }
-
-        val (hash1, hash2) = streamingMurmurHash3.finish()
-        return buildString(32) {
-            appendHex(hash1)
-            appendHex(hash2)
-        }
+        return fileUtils.getFileHash(path)
     }
 
     fun hashByString(string: String): String {
@@ -73,13 +57,5 @@ interface CodecsUtils {
         }
         val hash = sha256Hasher.hashToByteArray()
         return hash.toHexString()
-    }
-
-    fun StringBuilder.appendHex(value: ULong) {
-        for (i in 0 until 8) {
-            val byte = (value shr i * 8).toByte()
-            append(HEX_DIGITS[(byte.toInt() shr 4) and 0xf])
-            append(HEX_DIGITS[byte.toInt() and 0xf])
-        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/crosspaste/utils/StringUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/utils/StringUtils.kt
@@ -1,0 +1,9 @@
+package com.crosspaste.utils
+
+fun StringBuilder.appendHex(value: ULong) {
+    for (i in 0 until 8) {
+        val byte = (value shr i * 8).toByte()
+        append(HEX_DIGITS[(byte.toInt() shr 4) and 0xf])
+        append(HEX_DIGITS[byte.toInt() and 0xf])
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/utils/FileUtils.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/utils/FileUtils.desktop.kt
@@ -17,8 +17,6 @@ actual fun getFileUtils(): FileUtils {
 
 object DesktopFileUtils : FileUtils {
 
-    private val codecsUtils = getCodecsUtils()
-
     private val dateUtils = getDateUtils()
 
     override val fileSystem: FileSystem = FileSystem.SYSTEM
@@ -73,10 +71,6 @@ object DesktopFileUtils : FileUtils {
 
     override fun getFileSize(path: Path): Long {
         return path.toFile().length()
-    }
-
-    override fun getFileHash(path: Path): String {
-        return codecsUtils.hash(path)
     }
 
     override fun createEmptyPasteFile(

--- a/composeApp/src/desktopTest/kotlin/com/crosspaste/utils/MurmurHash3Test.kt
+++ b/composeApp/src/desktopTest/kotlin/com/crosspaste/utils/MurmurHash3Test.kt
@@ -1,6 +1,5 @@
 package com.crosspaste.utils
 
-import com.crosspaste.utils.DesktopCodecsUtils.appendHex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 


### PR DESCRIPTION
close #2222