### PR TITLE
:bug: Use class instead of object for serialization to prevent iOS crashes

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/serializer/Base64ByteArraySerializer.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/serializer/Base64ByteArraySerializer.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-object Base64ByteArraySerializer : KSerializer<ByteArray> {
+class Base64ByteArraySerializer : KSerializer<ByteArray> {
 
     private val codecsUtils = getCodecsUtils()
 

--- a/composeApp/src/commonMain/kotlin/com/crosspaste/serializer/PasteDataSerializer.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/serializer/PasteDataSerializer.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import org.mongodb.kbson.BsonObjectId
 
-object PasteDataSerializer : KSerializer<PasteData> {
+class PasteDataSerializer : KSerializer<PasteData> {
     override val descriptor: SerialDescriptor =
         buildClassSerialDescriptor("pasteData") {
             element<String>("id")

--- a/composeApp/src/commonMain/kotlin/com/crosspaste/serializer/PasteLabelRealmSetSerializer.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/serializer/PasteLabelRealmSetSerializer.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-object PasteLabelRealmSetSerializer : KSerializer<RealmSet<PasteLabel>> {
+class PasteLabelRealmSetSerializer : KSerializer<RealmSet<PasteLabel>> {
     private val delegateSerializer = SetSerializer(PasteLabel.serializer())
 
     override val descriptor: SerialDescriptor = delegateSerializer.descriptor

--- a/composeApp/src/commonMain/kotlin/com/crosspaste/serializer/RealmListSerializer.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/serializer/RealmListSerializer.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import okio.Path
 
-object StringRealmListSerializer : KSerializer<RealmList<String>> {
+class StringRealmListSerializer : KSerializer<RealmList<String>> {
     private val delegateSerializer = ListSerializer(String.serializer())
 
     override val descriptor: SerialDescriptor = delegateSerializer.descriptor
@@ -30,7 +30,7 @@ object StringRealmListSerializer : KSerializer<RealmList<String>> {
     }
 }
 
-object PathStringRealmListSerializer : KSerializer<RealmList<String>> {
+class PathStringRealmListSerializer : KSerializer<RealmList<String>> {
     private val delegateSerializer = ListSerializer(ListSerializer(String.serializer()))
 
     private val separator = Path.DIRECTORY_SEPARATOR
@@ -51,7 +51,7 @@ object PathStringRealmListSerializer : KSerializer<RealmList<String>> {
     }
 }
 
-object RealmAnyRealmListSerializer : KSerializer<RealmList<RealmAny>> {
+class RealmAnyRealmListSerializer : KSerializer<RealmList<RealmAny>> {
     private val delegateSerializer = ListSerializer(RealmAnyKSerializer)
 
     override val descriptor: SerialDescriptor = delegateSerializer.descriptor

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/utils/JsonUtils.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/utils/JsonUtils.desktop.kt
@@ -39,7 +39,7 @@ object DesktopJsonUtils : JsonUtils {
             serializersModule =
                 SerializersModule {
                     // use in http request
-                    serializersModuleOf(ByteArray::class, Base64ByteArraySerializer)
+                    serializersModuleOf(ByteArray::class, Base64ByteArraySerializer())
 
                     // use in paste data
                     serializersModuleOf(MutableRealmIntKSerializer)


### PR DESCRIPTION
close #2237