### PR TITLE
:hammer: Make launch function suspendable

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/app/AppLaunch.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/app/AppLaunch.kt
@@ -2,5 +2,5 @@ package com.crosspaste.app
 
 interface AppLaunch {
 
-    fun launch(): AppLaunchState
+    suspend fun launch(): AppLaunchState
 }

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -206,6 +206,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.painterResource
@@ -268,7 +269,7 @@ class CrossPaste {
                     single<CacheManager> { DesktopCacheManager(get(), get()) }
                     single<ConfigManager> { configManager }
                     single<CrossPasteLogger> { crossPasteLogger }
-                    single<DesktopAppLaunchState> { DesktopAppLaunch.launch() }
+                    single<DesktopAppLaunchState> { runBlocking { DesktopAppLaunch.launch() } }
                     single<DeviceUtils> { DesktopDeviceUtils }
                     single<EndpointInfoFactory> { EndpointInfoFactory(get(), lazy { get<Server>() }) }
                     single<FileExtImageLoader> { DesktopFileExtLoader(get(), get()) }
@@ -467,7 +468,7 @@ class CrossPaste {
         }
 
         @Throws(Exception::class)
-        private fun initInject() {
+        private fun startApplication() {
             try {
                 val koin = koinApplication.koin
                 val appLaunchState = koin.get<DesktopAppLaunchState>()
@@ -578,7 +579,7 @@ class CrossPaste {
             }
 
             logger.info { "Starting CrossPaste" }
-            initInject()
+            startApplication()
             logger.info { "CrossPaste started" }
 
             val appLaunchState = koinApplication.koin.get<DesktopAppLaunchState>()

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppLaunch.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppLaunch.kt
@@ -63,7 +63,7 @@ object DesktopAppLaunch : AppLaunch, AppLock {
         resetLock = true
     }
 
-    override fun launch(): DesktopAppLaunchState {
+    override suspend fun launch(): DesktopAppLaunchState {
         val pair = acquireLock()
         val platform = getPlatform()
         val pid = ProcessHandle.current().pid()


### PR DESCRIPTION
Convert AppLaunch.launch() to a suspend function to support asynchronous operations. This is particularly useful for mobile clients where app launching often involves async initialization steps.

close #2286