### PR TITLE
:arrow_up: Bump compose-plugin from 1.7.1 to 1.7.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 coil = "3.0.4"
 compose = "1.7.6"
 compose-material3 = "1.3.1"
-compose-plugin = "1.7.1"
+compose-plugin = "1.7.3"
 compose-shimmer = "1.3.1"
 conveyor = "1.12"
 cryptography = "0.4.0"


### PR DESCRIPTION
close #2335