### PR TITLE
:sparkles: Support direct access to the web URL path of the crosspaste official website (with i18n support)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/crosspaste/ui/base/UISupport.kt
+++ b/composeApp/src/commonMain/kotlin/com/crosspaste/ui/base/UISupport.kt
@@ -9,7 +9,11 @@ interface UISupport {
 
     fun openUrlInBrowser(url: String)
 
-    fun openCrossPasteWebInBrowser(path: String = "")
+    fun getCrossPasteWebUrl(path: String = ""): String
+
+    fun openCrossPasteWebInBrowser(path: String = "") {
+        openUrlInBrowser(getCrossPasteWebUrl(path))
+    }
 
     fun openEmailClient(email: String)
 

--- a/composeApp/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
+++ b/composeApp/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
@@ -64,13 +64,13 @@ class DesktopUISupport(
         }
     }
 
-    override fun openCrossPasteWebInBrowser(path: String) {
+    override fun getCrossPasteWebUrl(path: String): String {
         val webPath =
             when (val language = copywriter.language()) {
                 ZH -> path
                 else -> "$language/$path"
             }
-        openUrlInBrowser("${appUrls.homeUrl}/$webPath")
+        return "${appUrls.homeUrl}/$webPath"
     }
 
     override fun openEmailClient(email: String) {


### PR DESCRIPTION
close #2382