### PR TITLE
:bug: Fix missing verification code on first device connection

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -456,7 +456,7 @@ class GeneralSyncHandler(
         return false
     }
 
-    override suspend fun showToken() {
+    override suspend fun showToken(syncRuntimeInfo: SyncRuntimeInfo) {
         if (syncRuntimeInfo.connectState == SyncState.UNVERIFIED) {
             syncRuntimeInfo.connectHostAddress?.let { host ->
                 val result =

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
@@ -26,7 +26,7 @@ class MarketingSyncHandler(
     override suspend fun trustByToken(token: Int) {
     }
 
-    override suspend fun showToken() {
+    override suspend fun showToken(syncRuntimeInfo: SyncRuntimeInfo) {
     }
 
     override suspend fun notifyExit() {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
@@ -20,7 +20,7 @@ interface SyncHandler {
     // use user input token to trust
     suspend fun trustByToken(token: Int)
 
-    suspend fun showToken()
+    suspend fun showToken(syncRuntimeInfo: SyncRuntimeInfo)
 
     suspend fun notifyExit()
 

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceVerifyView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceVerifyView.kt
@@ -67,7 +67,7 @@ fun DeviceVerifyView(syncRuntimeInfo: SyncRuntimeInfo) {
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
-        syncManager.getSyncHandlers()[syncRuntimeInfo.appInstanceId]?.showToken()
+        syncManager.getSyncHandlers()[syncRuntimeInfo.appInstanceId]?.showToken(syncRuntimeInfo)
         focusRequesters.firstOrNull()?.requestFocus()
     }
 


### PR DESCRIPTION
When attempting to connect a device for the first time from an attachment device, there was an issue where the verification code was not successfully displayed to the other party. This commit fixes this notification problem, ensuring that the verification code is properly shown during the initial connection process.

close #2461