### PR TITLE
:bug: Add suspend modifiers and fix operation completion

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppControl.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppControl.kt
@@ -10,13 +10,13 @@ interface AppControl {
 
     fun isDeviceControlEnabled(): Boolean
 
-    fun isSendEnabled(): Boolean
+    suspend fun isSendEnabled(): Boolean
 
-    fun isReceiveEnabled(): Boolean
+    suspend fun isReceiveEnabled(): Boolean
 
-    fun completeSendOperation()
+    suspend fun completeSendOperation()
 
-    fun completeReceiveOperation()
+    suspend fun completeReceiveOperation()
 
     fun isFileSizeSyncEnabled(size: Long): Boolean
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -54,7 +54,7 @@ fun Routing.pasteRouting(
                     )
                 }
                 logger.debug { "sync handler ($appInstanceId) receive pasteData: $pasteData" }
-                appControl.isReceiveEnabled()
+                appControl.completeReceiveOperation()
                 successResponse(call)
             } catch (e: Exception) {
                 logger.error(e) { "sync handler ($appInstanceId) receive pasteData error" }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppControl.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppControl.kt
@@ -23,19 +23,19 @@ class DesktopAppControl(private val configManager: ConfigManager) : AppControl {
         return true
     }
 
-    override fun isSendEnabled(): Boolean {
+    override suspend fun isSendEnabled(): Boolean {
         return true
     }
 
-    override fun isReceiveEnabled(): Boolean {
+    override suspend fun isReceiveEnabled(): Boolean {
         return true
     }
 
-    override fun completeSendOperation() {
+    override suspend fun completeSendOperation() {
         // do nothing
     }
 
-    override fun completeReceiveOperation() {
+    override suspend fun completeReceiveOperation() {
         // do nothing
     }
 


### PR DESCRIPTION
This commit adds the suspend modifier to several methods in the AppControl interface, specifically:

isSendEnabled()
isReceiveEnabled()
completeSendOperation()
completeReceiveOperation()

Additionally, it fixes a critical bug where completeReceiveOperation() was not being properly called in the previous implementation, which could lead to incomplete operation handling and potential resource leaks.

close #2485