### PR TITLE
:hammer: Replace ScreenType enum with sealed interface pattern

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/HomeMenuView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/HomeMenuView.kt
@@ -85,7 +85,7 @@ fun HomeMenuView(
                 background = MaterialTheme.colorScheme.surfaceBright,
             ) {
                 openMainWindow()
-                appWindowManager.toScreen(ScreenType.SETTINGS)
+                appWindowManager.toScreen(Settings)
                 close()
             }
             MenuItem(
@@ -93,7 +93,7 @@ fun HomeMenuView(
                 background = MaterialTheme.colorScheme.surfaceBright,
             ) {
                 openMainWindow()
-                appWindowManager.toScreen(ScreenType.SHORTCUT_KEYS)
+                appWindowManager.toScreen(ShortcutKeys)
                 close()
             }
             MenuItem(
@@ -109,7 +109,7 @@ fun HomeMenuView(
                 background = MaterialTheme.colorScheme.surfaceBright,
             ) {
                 openMainWindow()
-                appWindowManager.toScreen(ScreenType.EXPORT)
+                appWindowManager.toScreen(Export)
                 close()
             }
             MenuItem(
@@ -117,7 +117,7 @@ fun HomeMenuView(
                 background = MaterialTheme.colorScheme.surfaceBright,
             ) {
                 openMainWindow()
-                appWindowManager.toScreen(ScreenType.IMPORT)
+                appWindowManager.toScreen(Import)
                 close()
             }
             MenuItem(
@@ -125,7 +125,7 @@ fun HomeMenuView(
                 background = MaterialTheme.colorScheme.surfaceBright,
             ) {
                 openMainWindow()
-                appWindowManager.toScreen(ScreenType.ABOUT)
+                appWindowManager.toScreen(About)
                 close()
             }
             MenuItem(

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/ScreenContext.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/ScreenContext.kt
@@ -7,7 +7,7 @@ class ScreenContext(val screenType: ScreenType, val nextScreenContext: ScreenCon
     constructor(screenType: ScreenType, nextScreenContext: ScreenContext) : this(screenType, nextScreenContext, Unit)
 
     fun returnNext(): ScreenContext {
-        return nextScreenContext ?: ScreenContext(ScreenType.PASTE_PREVIEW)
+        return nextScreenContext ?: ScreenContext(PastePreview)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -28,19 +28,4 @@ class ScreenContext(val screenType: ScreenType, val nextScreenContext: ScreenCon
         result = 31 * result + context.hashCode()
         return result
     }
-}
-
-enum class ScreenType {
-    ABOUT,
-    EXPORT,
-    DEBUG,
-    DEVICES,
-    DEVICE_DETAIL,
-    IMPORT,
-    PASTE_PREVIEW,
-    PASTE_TEXT_EDIT,
-    QR_CODE,
-    QR_SCANNER, // use in mobile
-    SETTINGS,
-    SHORTCUT_KEYS,
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/ScreenType.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/ScreenType.kt
@@ -1,0 +1,25 @@
+package com.crosspaste.ui
+
+interface ScreenType
+
+object About : ScreenType
+
+object Export : ScreenType
+
+object Debug : ScreenType
+
+object Devices : ScreenType
+
+object DeviceDetail : ScreenType
+
+object Import : ScreenType
+
+object PastePreview : ScreenType
+
+object PasteTextEdit : ScreenType
+
+object QrCode : ScreenType
+
+object Settings : ScreenType
+
+object ShortcutKeys : ScreenType

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
@@ -11,6 +11,7 @@ import com.crosspaste.listen.ActiveGraphicsDevice
 import com.crosspaste.listener.ShortcutKeys
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.platform.getPlatform
+import com.crosspaste.ui.PastePreview
 import com.crosspaste.ui.ScreenContext
 import com.crosspaste.ui.ScreenType
 import com.crosspaste.utils.Memoize
@@ -78,7 +79,7 @@ abstract class DesktopAppWindowManager(
 
     protected val ioScope = CoroutineScope(ioDispatcher + SupervisorJob())
 
-    private val _screenContext = MutableStateFlow(ScreenContext(ScreenType.PASTE_PREVIEW))
+    private val _screenContext = MutableStateFlow(ScreenContext(PastePreview))
     override val screenContext: StateFlow<ScreenContext> = _screenContext.asStateFlow()
 
     private val _firstLaunchCompleted = MutableStateFlow(false)

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/DesktopScreenProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/DesktopScreenProvider.kt
@@ -29,39 +29,39 @@ class DesktopScreenProvider(
         val screen by appWindowManager.screenContext.collectAsState()
 
         when (screen.screenType) {
-            ScreenType.PASTE_PREVIEW,
-            ScreenType.DEVICES,
-            ScreenType.QR_CODE,
-            ScreenType.DEBUG,
+            PastePreview,
+            Devices,
+            QrCode,
+            Debug,
             -> {
                 HomeScreen()
             }
 
-            ScreenType.SETTINGS -> {
+            Settings -> {
                 SettingsScreen()
             }
 
-            ScreenType.SHORTCUT_KEYS -> {
+            ShortcutKeys -> {
                 ShortcutKeysScreen()
             }
 
-            ScreenType.EXPORT -> {
+            Export -> {
                 ExportScreen()
             }
 
-            ScreenType.IMPORT -> {
+            Import -> {
                 ImportScreen()
             }
 
-            ScreenType.ABOUT -> {
+            About -> {
                 AboutScreen()
             }
 
-            ScreenType.DEVICE_DETAIL -> {
+            DeviceDetail -> {
                 DeviceDetailScreen()
             }
 
-            ScreenType.PASTE_TEXT_EDIT -> {
+            PasteTextEdit -> {
                 PasteTextEditScreen()
             }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/MacTrayView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/MacTrayView.kt
@@ -132,7 +132,7 @@ object MacTrayView {
             createMenuItem(copywriter.getText("settings")) {
                 mainCoroutineDispatcher.launch(CoroutineName("Open settings")) {
                     appWindowManager.activeMainWindow()
-                    appWindowManager.toScreen(ScreenType.SETTINGS)
+                    appWindowManager.toScreen(Settings)
                 }
             },
         )
@@ -141,7 +141,7 @@ object MacTrayView {
             createMenuItem(copywriter.getText("shortcut_keys")) {
                 mainCoroutineDispatcher.launch(CoroutineName("Open shortcut keys")) {
                     appWindowManager.activeMainWindow()
-                    appWindowManager.toScreen(ScreenType.SHORTCUT_KEYS)
+                    appWindowManager.toScreen(ShortcutKeys)
                 }
             },
         )
@@ -150,7 +150,7 @@ object MacTrayView {
             createMenuItem(copywriter.getText("export")) {
                 mainCoroutineDispatcher.launch(CoroutineName("Open export")) {
                     appWindowManager.activeMainWindow()
-                    appWindowManager.toScreen(ScreenType.EXPORT)
+                    appWindowManager.toScreen(Export)
                 }
             },
         )
@@ -159,7 +159,7 @@ object MacTrayView {
             createMenuItem(copywriter.getText("import")) {
                 mainCoroutineDispatcher.launch(CoroutineName("Open import")) {
                     appWindowManager.activeMainWindow()
-                    appWindowManager.toScreen(ScreenType.IMPORT)
+                    appWindowManager.toScreen(Import)
                 }
             },
         )
@@ -168,7 +168,7 @@ object MacTrayView {
             createMenuItem(copywriter.getText("about")) {
                 mainCoroutineDispatcher.launch(CoroutineName("Open about")) {
                     appWindowManager.activeMainWindow()
-                    appWindowManager.toScreen(ScreenType.ABOUT)
+                    appWindowManager.toScreen(About)
                 }
             },
         )

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/TabsView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/TabsView.kt
@@ -74,10 +74,10 @@ fun TabsView() {
     val tabs =
         remember {
             listOfNotNull(
-                Pair(listOf(ScreenType.PASTE_PREVIEW), "pasteboard"),
-                Pair(listOf(ScreenType.DEVICES), "devices"),
-                Pair(listOf(ScreenType.QR_CODE), "scan"),
-                if (getAppEnvUtils().isDevelopment()) Pair(listOf(ScreenType.DEBUG), "debug") else null,
+                Pair(listOf(PastePreview), "pasteboard"),
+                Pair(listOf(Devices), "devices"),
+                Pair(listOf(QrCode), "scan"),
+                if (getAppEnvUtils().isDevelopment()) Pair(listOf(Debug), "debug") else null,
             )
         }
 
@@ -103,7 +103,7 @@ fun TabsView() {
                         TabView(pair.first, copywriter.getText(pair.second))
                     }
                     Spacer(modifier = Modifier.weight(1f))
-                    if (screen.screenType == ScreenType.PASTE_PREVIEW) {
+                    if (screen.screenType == PastePreview) {
                         val notificationManager = koinInject<NotificationManager>()
                         val pasteDao = koinInject<PasteDao>()
                         val scope = rememberCoroutineScope()
@@ -178,10 +178,10 @@ fun TabsView() {
         }
 
         when (screen.screenType) {
-            ScreenType.PASTE_PREVIEW -> screenProvider.PasteboardScreen {}
-            ScreenType.DEVICES -> screenProvider.DevicesScreen()
-            ScreenType.QR_CODE -> screenProvider.QRScreen()
-            ScreenType.DEBUG -> DebugScreen()
+            PastePreview -> screenProvider.PasteboardScreen {}
+            Devices -> screenProvider.DevicesScreen()
+            QrCode -> screenProvider.QRScreen()
+            Debug -> DebugScreen()
             else -> screenProvider.PasteboardScreen {}
         }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
@@ -20,7 +20,7 @@ import com.crosspaste.paste.item.UrlPasteItem
 import com.crosspaste.paste.plugin.type.ColorTypePlugin
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.platform.getPlatform
-import com.crosspaste.ui.ScreenType
+import com.crosspaste.ui.PasteTextEdit
 import com.crosspaste.utils.extension
 import com.crosspaste.utils.getFileUtils
 import com.google.common.io.Files
@@ -197,7 +197,7 @@ class DesktopUISupport(
     }
 
     override fun openText(pasteData: PasteData) {
-        appWindowManager.toScreen(ScreenType.PASTE_TEXT_EDIT, pasteData)
+        appWindowManager.toScreen(PasteTextEdit, pasteData)
     }
 
     override fun openRtf(pasteData: PasteData) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/devices/DeviceConnectContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/devices/DeviceConnectContentView.kt
@@ -54,7 +54,7 @@ import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.notification.MessageType
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.sync.SyncManager
-import com.crosspaste.ui.ScreenType
+import com.crosspaste.ui.DeviceDetail
 import com.crosspaste.ui.base.MenuItem
 import com.crosspaste.ui.base.PasteIconButton
 import com.crosspaste.ui.base.getMenWidth
@@ -124,7 +124,7 @@ fun DeviceConnectContentView(
                 if (syncRuntimeInfo.connectState == SyncState.UNVERIFIED) {
                     syncManager.toVerify(syncRuntimeInfo.appInstanceId)
                 } else {
-                    appWindowManager.toScreen(ScreenType.DEVICE_DETAIL, syncRuntimeInfo)
+                    appWindowManager.toScreen(DeviceDetail, syncRuntimeInfo)
                 }
             }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/DesktopSettingsViewProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/DesktopSettingsViewProvider.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.crosspaste.app.AppInfo
 import com.crosspaste.app.AppWindowManager
-import com.crosspaste.ui.ScreenType
+import com.crosspaste.ui.About
 import com.crosspaste.ui.base.ExpandView
 import com.crosspaste.ui.base.clipboard
 import com.crosspaste.ui.base.database
@@ -35,7 +35,7 @@ class DesktopSettingsViewProvider(
                     Modifier
                         .clip(RoundedCornerShape(5.dp))
                         .clickable(onClick = {
-                            appWindowManager.toScreen(ScreenType.ABOUT)
+                            appWindowManager.toScreen(About)
                         })
                         .padding(horizontal = 5.dp, vertical = 5.dp),
             ) {


### PR DESCRIPTION
- Changed ScreenType from an enum class to a sealed interface
- Created object implementations for each screen type
- Improves extensibility by making it easier to add new screen types
- Note: QR_SCANNER type from the original enum is not included in the new implementation as it was for mobile use only

close #2498