### PR TITLE
:sparkles: Add method to PasteText for reading first 256 characters for preview, avoiding lag from loading large data

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/item/PasteText.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/item/PasteText.kt
@@ -1,6 +1,12 @@
 package com.crosspaste.paste.item
 
+import kotlin.math.min
+
 interface PasteText {
 
     val text: String
+
+    fun previewText(): String {
+        return text.substring(0, min(256, text.length))
+    }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/preview/TextPreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/preview/TextPreviewView.kt
@@ -47,7 +47,7 @@ fun TextPreviewView(pasteData: PasteData) {
                     ) {
                         Text(
                             modifier = Modifier.fillMaxSize(),
-                            text = pasteText.text,
+                            text = pasteText.previewText(),
                             fontFamily = FontFamily.SansSerif,
                             maxLines = 4,
                             softWrap = true,


### PR DESCRIPTION
close #2503