### PR TITLE
:sparkles: Add auto-scroll functionality to ExpandView component

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppSize.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppSize.kt
@@ -20,4 +20,6 @@ interface AppSize {
     val settingsItemHeight: Dp
 
     val toastViewWidth: Dp
+
+    val windowDecorationHeight: Dp
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
@@ -23,6 +23,8 @@ object DesktopAppSize : AppSize {
 
     override val toastViewWidth: Dp = 280.dp
 
+    override val windowDecorationHeight: Dp = 60.dp
+
     val appRoundedCornerShape = RoundedCornerShape(10.dp)
 
     val appBorderSize = 1.dp

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/WindowDecoration.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/WindowDecoration.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import com.crosspaste.app.AppSize
 import com.crosspaste.app.AppWindowManager
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.ui.base.arrowBack
@@ -41,6 +42,7 @@ import org.koin.compose.koinInject
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun WindowDecoration(title: String) {
+    val appSize = koinInject<AppSize>()
     val appWindowManager = koinInject<AppWindowManager>()
     val copywriter = koinInject<GlobalCopywriter>()
 
@@ -50,7 +52,7 @@ fun WindowDecoration(title: String) {
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(60.dp)
+                .height(appSize.windowDecorationHeight)
                 .background(MaterialTheme.colorScheme.primaryContainer),
     ) {
         Box {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/SettingsContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/SettingsContentView.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.ui.settings
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
@@ -18,7 +19,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,6 +37,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+
+val LocalSettingsScrollState = compositionLocalOf<ScrollState?> { null }
 
 @Composable
 fun SettingsContentView() {
@@ -56,47 +61,49 @@ fun SettingsContentView() {
         }
     }
 
-    Box(
-        modifier =
-            Modifier.fillMaxSize(),
-    ) {
-        Column(
+    CompositionLocalProvider(LocalSettingsScrollState provides scrollState) {
+        Box(
             modifier =
-                Modifier.verticalScroll(scrollState)
-                    .fillMaxSize()
-                    .padding(16.dp),
+                Modifier.fillMaxSize(),
         ) {
-            settingsViewProvider.SettingsCoreView()
-        }
+            Column(
+                modifier =
+                    Modifier.verticalScroll(scrollState)
+                        .fillMaxSize()
+                        .padding(16.dp),
+            ) {
+                settingsViewProvider.SettingsCoreView()
+            }
 
-        VerticalScrollbar(
-            modifier =
-                Modifier.background(color = Color.Transparent)
-                    .fillMaxHeight().align(Alignment.CenterEnd)
-                    .draggable(
-                        orientation = Orientation.Vertical,
-                        state =
-                            rememberDraggableState { delta ->
-                                coroutineScope.launch(CoroutineName("ScrollPaste")) {
-                                    scrollState.scrollBy(-delta)
-                                }
+            VerticalScrollbar(
+                modifier =
+                    Modifier.background(color = Color.Transparent)
+                        .fillMaxHeight().align(Alignment.CenterEnd)
+                        .draggable(
+                            orientation = Orientation.Vertical,
+                            state =
+                                rememberDraggableState { delta ->
+                                    coroutineScope.launch(CoroutineName("ScrollPaste")) {
+                                        scrollState.scrollBy(-delta)
+                                    }
+                                },
+                        ),
+                adapter = rememberScrollbarAdapter(scrollState),
+                style =
+                    ScrollbarStyle(
+                        minimalHeight = 16.dp,
+                        thickness = 8.dp,
+                        shape = RoundedCornerShape(4.dp),
+                        hoverDurationMillis = 300,
+                        unhoverColor =
+                            if (isScrolling) {
+                                MaterialTheme.colorScheme.onBackground.copy(alpha = 0.48f)
+                            } else {
+                                Color.Transparent
                             },
+                        hoverColor = MaterialTheme.colorScheme.onBackground,
                     ),
-            adapter = rememberScrollbarAdapter(scrollState),
-            style =
-                ScrollbarStyle(
-                    minimalHeight = 16.dp,
-                    thickness = 8.dp,
-                    shape = RoundedCornerShape(4.dp),
-                    hoverDurationMillis = 300,
-                    unhoverColor =
-                        if (isScrolling) {
-                            MaterialTheme.colorScheme.onBackground.copy(alpha = 0.48f)
-                        } else {
-                            Color.Transparent
-                        },
-                    hoverColor = MaterialTheme.colorScheme.onBackground,
-                ),
-        )
+            )
+        }
     }
 }


### PR DESCRIPTION
- Implement automatic scrolling when expanding cards in settings view
- Create LocalScrollState composition local to pass scroll state
- Add scroll animation that positions expanded card at top of viewport
- Use LaunchedEffect to trigger scroll on expand state change
- Store card bounds with onGloballyPositioned for accurate positioning

close #2794