### PR TITLE
:hammer: Remove redundant encodeToString import, iOS side has fixed the mandatory import issue

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppInfo.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppInfo.kt
@@ -1,7 +1,6 @@
 package com.crosspaste.app
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 const val AppName: String = "CrossPaste"

--- a/app/src/commonMain/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDao.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDao.kt
@@ -7,7 +7,6 @@ import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.getJsonUtils
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.serialization.encodeToString
 import kotlin.reflect.KProperty1
 
 class SyncRuntimeInfoDao(private val database: Database) {

--- a/app/src/commonMain/kotlin/com/crosspaste/db/task/TaskDao.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/task/TaskDao.kt
@@ -3,7 +3,6 @@ package com.crosspaste.db.task
 import com.crosspaste.Database
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.getJsonUtils
-import kotlinx.serialization.encodeToString
 
 class TaskDao(private val database: Database) {
 

--- a/app/src/commonMain/kotlin/com/crosspaste/dto/sync/EndpointInfo.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/dto/sync/EndpointInfo.kt
@@ -3,7 +3,6 @@ package com.crosspaste.dto.sync
 import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.platform.Platform
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 @Serializable

--- a/app/src/commonMain/kotlin/com/crosspaste/dto/sync/SyncInfo.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/dto/sync/SyncInfo.kt
@@ -2,7 +2,6 @@ package com.crosspaste.dto.sync
 
 import com.crosspaste.app.AppInfo
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 @Serializable

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/QRCodeGenerator.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/QRCodeGenerator.kt
@@ -6,7 +6,6 @@ import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.image.PlatformImage
 import com.crosspaste.utils.getCodecsUtils
 import com.crosspaste.utils.getJsonUtils
-import kotlinx.serialization.encodeToString
 
 abstract class QRCodeGenerator(
     private val appInfo: AppInfo,

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/settings/NetSettingsContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/settings/NetSettingsContentView.kt
@@ -45,7 +45,6 @@ import com.crosspaste.ui.theme.AppUISize.xxxLarge
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.getNetUtils
 import kotlinx.coroutines.launch
-import kotlinx.serialization.encodeToString
 import org.koin.compose.koinInject
 
 @Composable

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/TaskUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/TaskUtils.kt
@@ -9,7 +9,6 @@ import com.crosspaste.task.FailurePasteTaskResult
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import io.github.oshai.kotlinlogging.KLogger
 import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/preview/TextPreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/preview/TextPreviewView.kt
@@ -28,7 +28,7 @@ fun TextPreviewView(pasteData: PasteData) {
                     text = AnnotatedString(pasteText.previewText()),
                     maxLines = 4,
                     softWrap = true,
-                    overflow = TextOverflow.Ellipsis,
+                    overflow = TextOverflow.Clip,
                     style = pasteTextStyle,
                     autoSize = previewAutoSize,
                 )

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/preview/TextPreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/preview/TextPreviewView.kt
@@ -28,7 +28,7 @@ fun TextPreviewView(pasteData: PasteData) {
                     text = AnnotatedString(pasteText.previewText()),
                     maxLines = 4,
                     softWrap = true,
-                    overflow = TextOverflow.Clip,
+                    overflow = TextOverflow.Ellipsis,
                     style = pasteTextStyle,
                     autoSize = previewAutoSize,
                 )

--- a/app/src/desktopTest/kotlin/com/crosspaste/serializer/SerializerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/serializer/SerializerTest.kt
@@ -9,7 +9,6 @@ import com.crosspaste.paste.plugin.type.DesktopTextTypePlugin
 import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.getCodecsUtils
 import com.crosspaste.utils.getJsonUtils
-import kotlinx.serialization.encodeToString
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals


### PR DESCRIPTION
close #2809