### PR TITLE
:penguin: Support deb installation on Ubuntu 22.04 LTS (Jammy) or later

### DIFF
--- a/conveyor.conf
+++ b/conveyor.conf
@@ -46,6 +46,8 @@ app {
   }
 
   linux {
+    debian.distribution.name = jammy
+
     install-path = /usr/lib/crosspaste
 
     icons = "app/src/desktopMain/composeResources/drawable/crosspaste.png"


### PR DESCRIPTION
close #2788