### PR TITLE
:fire: Remove unused search methods from PasteDao

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -322,50 +322,9 @@ class PasteDao(
         }
     }
 
-    fun searchSingleFile(
-        source: String? = null,
-        fileName: String,
-    ): List<PasteData> {
-        val searchContent = if (source == null) {
-            fileName
-        } else {
-            "$source $fileName"
-        }
-        return searchByAllMatch(
-            pasteType = PasteType.FILE_TYPE.type.toLong(),
-            pasteSearchContent = searchContent,
-        )
-    }
-
-    fun searchSingleImage(
-        source: String? = null,
-        fileName: String,
-    ): List<PasteData> {
-        val searchContent = if (source == null) {
-            fileName
-        } else {
-            "$source $fileName"
-        }
-        return searchByAllMatch(
-            pasteType = PasteType.IMAGE_TYPE.type.toLong(),
-            pasteSearchContent = searchContent,
-        )
-    }
-
     fun searchBySource(source: String): List<PasteData> {
         return pasteDatabaseQueries.searchBySource(source, mapper = PasteData::mapper)
             .executeAsList()
-    }
-
-    fun searchByAllMatch(
-        pasteType: Long,
-        pasteSearchContent: String
-    ): List<PasteData> {
-        return pasteDatabaseQueries.searchByAllMatch(
-            pasteType = pasteType,
-            pasteSearchContent = pasteSearchContent.lowercase(),
-            mapper = PasteData::mapper
-        ).executeAsList()
     }
 
     suspend fun releaseRemotePasteData(


### PR DESCRIPTION
Remove redundant searchSingleFile, searchSingleImage, and searchByAllMatch methods that are no longer used in the codebase. This simplifies the data access layer and reduces code maintenance overhead.

🤖 Generated with [Claude Code](https://claude.ai/code)