### PR TITLE
:hammer: Refactor ExpandView API to use ExpandableState pattern

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/ExpandViewProvider.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/ExpandViewProvider.kt
@@ -1,15 +1,64 @@
 package com.crosspaste.ui.base
 
-import androidx.compose.foundation.layout.RowScope
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Dp
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.ui.theme.AppUIColors
+import com.crosspaste.ui.theme.AppUIFont
 import com.crosspaste.ui.theme.AppUISize.medium
+import com.crosspaste.ui.theme.AppUISize.tiny
+import com.crosspaste.ui.theme.AppUISize.xLarge
+
+data class ExpandableState(
+    val isExpanded: Boolean,
+    val isHovered: Boolean,
+    val onToggle: () -> Unit,
+    val enter: () -> Unit,
+    val exit: () -> Unit,
+) {
+    fun isExpandedOrHovered(): Boolean = isExpanded || isHovered
+}
+
+@Composable
+fun rememberExpandableState(defaultExpanded: Boolean = false): ExpandableState {
+    var expanded by remember { mutableStateOf(defaultExpanded) }
+    var hovered by remember { mutableStateOf(false) }
+    return remember(expanded, hovered) {
+        ExpandableState(
+            isExpanded = expanded,
+            isHovered = hovered,
+            onToggle = { expanded = !expanded },
+            enter = { hovered = true },
+            exit = { hovered = false },
+        )
+    }
+}
+
+interface ExpandViewScope {
+
+    val state: ExpandableState
+}
 
 interface ExpandViewProvider {
 
@@ -17,7 +66,7 @@ interface ExpandViewProvider {
 
     @Composable
     fun ExpandView(
-        defaultExpand: Boolean = false,
+        state: ExpandableState = rememberExpandableState(),
         horizontalPadding: Dp = medium,
         barBackground: Color = AppUIColors.expandBarBackground,
         onBarBackground: Color =
@@ -25,18 +74,52 @@ interface ExpandViewProvider {
                 AppUIColors.expandBarBackground,
             ),
         backgroundColor: Color = AppUIColors.generalBackground,
-        barContent: @Composable RowScope.(Float) -> Unit,
-        content: @Composable () -> Unit,
+        barContent: @Composable ExpandViewScope.() -> Unit,
+        content: @Composable ExpandViewScope.() -> Unit,
     )
 
     @Composable
     fun ExpandBarView(
+        state: ExpandableState,
         title: String,
-        iconScale: Float,
         onBarBackground: Color =
             MaterialTheme.colorScheme.contentColorFor(
                 AppUIColors.expandBarBackground,
             ),
         icon: @Composable () -> Painter? = { null },
-    )
+    ) {
+        val iconScale by animateFloatAsState(
+            targetValue = if (state.isExpandedOrHovered()) 1f else 0.8f,
+            animationSpec = tween(300),
+        )
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            icon()?.let {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(xLarge)
+                            .graphicsLayer(
+                                scaleX = iconScale,
+                                scaleY = iconScale,
+                                transformOrigin = TransformOrigin(0.5f, 0.5f),
+                            ),
+                ) {
+                    Icon(
+                        painter = it,
+                        contentDescription = null,
+                        modifier = Modifier.matchParentSize(),
+                        tint = onBarBackground,
+                    )
+                }
+                Spacer(modifier = Modifier.width(tiny))
+            }
+
+            Text(
+                text = copywriter.getText(title),
+                style = AppUIFont.expandTitleTextStyle,
+                color = onBarBackground,
+            )
+        }
+    }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.ui.base.ExpandViewProvider
+import com.crosspaste.ui.base.rememberExpandableState
 import com.crosspaste.ui.theme.AppUISize.small3X
 import com.crosspaste.ui.theme.AppUISize.tinyRoundedCornerShape
 import com.crosspaste.ui.theme.AppUISize.zero
@@ -40,12 +41,12 @@ fun DevicesContentView() {
 
             if (syncRuntimeInfos.isNotEmpty()) {
                 expandViewProvider.ExpandView(
+                    state = rememberExpandableState(true),
                     horizontalPadding = zero,
-                    defaultExpand = true,
-                    barContent = { iconScale ->
+                    barContent = {
                         expandViewProvider.ExpandBarView(
+                            state = this.state,
                             title = "my_devices",
-                            iconScale = iconScale,
                         )
                     },
                 ) {
@@ -56,11 +57,10 @@ fun DevicesContentView() {
 
             expandViewProvider.ExpandView(
                 horizontalPadding = zero,
-                defaultExpand = false,
-                barContent = { iconScale ->
+                barContent = {
                     expandViewProvider.ExpandBarView(
+                        state = this.state,
                         title = "add_device_manually",
-                        iconScale = iconScale,
                     )
                 },
             ) {
@@ -68,12 +68,12 @@ fun DevicesContentView() {
             }
             Spacer(modifier = Modifier.height(small3X))
             expandViewProvider.ExpandView(
+                state = rememberExpandableState(true),
                 horizontalPadding = zero,
-                defaultExpand = true,
-                barContent = { iconScale ->
+                barContent = {
                     expandViewProvider.ExpandBarView(
+                        state = this.state,
                         title = "nearby_devices",
-                        iconScale = iconScale,
                     )
                 },
             ) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/DesktopSettingsViewProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/DesktopSettingsViewProvider.kt
@@ -61,11 +61,11 @@ class DesktopSettingsViewProvider(
     @Composable
     override fun NetSettingsView() {
         expandViewProvider.ExpandView(
-            barContent = { iconScale ->
+            barContent = {
                 expandViewProvider.ExpandBarView(
+                    state = this.state,
                     title = "network",
                     icon = { network() },
-                    iconScale = iconScale,
                 )
             },
         ) {
@@ -76,11 +76,11 @@ class DesktopSettingsViewProvider(
     @Composable
     override fun PasteboardSettingsView() {
         expandViewProvider.ExpandView(
-            barContent = { iconScale ->
+            barContent = {
                 expandViewProvider.ExpandBarView(
+                    state = this.state,
                     title = "pasteboard",
                     icon = { clipboard() },
-                    iconScale = iconScale,
                 )
             },
         ) {
@@ -96,11 +96,11 @@ class DesktopSettingsViewProvider(
     @Composable
     override fun StoreSettingsView() {
         expandViewProvider.ExpandView(
-            barContent = { iconScale ->
+            barContent = {
                 expandViewProvider.ExpandBarView(
+                    state = this.state,
                     title = "store",
                     icon = { database() },
-                    iconScale = iconScale,
                 )
             },
         ) {


### PR DESCRIPTION
  Replace lambda-based expand state management with dedicated ExpandableState data class
  for better state control and composability in expand/collapse components.

close #3127