### PR TITLE
 :bug: Fix PasteDataScopeImpl implementation

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/paste/PasteDataScope.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/paste/PasteDataScope.kt
@@ -18,15 +18,14 @@ fun createPasteDataScope(pasteData: PasteData): PasteDataScope? =
         null
     }
 
-internal class PasteDataScopeImpl(
+class PasteDataScopeImpl(
     override val pasteData: PasteData,
 ) : PasteDataScope {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
-
-        other as PasteDataScopeImpl
+        if (other !is PasteDataScopeImpl) return false
 
         return pasteData == other.pasteData
     }


### PR DESCRIPTION
 1. Remove javaClass to support multi-platform
 2. Remove internal modifier to enable reuse on mobile platforms

close #3131