### PR TITLE
:bug: Fix NPE in writePasteboard when no PasteText item exists

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
@@ -282,7 +282,7 @@ class WindowsPasteboardService(
                 .getPasteAppearItems()
                 .firstOrNull {
                     it is PasteText
-                }.let { pasteItem ->
+                }?.let { pasteItem ->
                     (pasteItem as PasteText).let { textPasteItem ->
                         WindowClipboard.supplementCFText(textPasteItem.text)
                     }


### PR DESCRIPTION
close #3255