### PR TITLE
:zap: Optimize UI performance by eliminating unnecessary state and improving Compose stability

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/CrossPasteWindows.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/CrossPasteWindows.kt
@@ -1,8 +1,6 @@
 package com.crosspaste.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import com.crosspaste.app.generated.resources.Res
@@ -18,14 +16,14 @@ import org.koin.compose.koinInject
 @Composable
 fun CrossPasteWindows(exiting: Boolean) {
     val platform = koinInject<Platform>()
-    val isMacos by remember { mutableStateOf(platform.isMacos()) }
-    val isWindows by remember { mutableStateOf(platform.isWindows()) }
-    val isLinux by remember { mutableStateOf(platform.isLinux()) }
+    val isMacos = remember { platform.isMacos() }
+    val isWindows = remember { platform.isWindows() }
+    val isLinux = remember { platform.isLinux() }
 
     val windowIcon: Painter? =
-        if (platform.isMacos()) {
+        if (isMacos) {
             painterResource(Res.drawable.crosspaste_mac)
-        } else if (platform.isWindows() || platform.isLinux()) {
+        } else if (isWindows || isLinux) {
             painterResource(Res.drawable.crosspaste)
         } else {
             null

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/MainWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/MainWindow.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
@@ -105,7 +104,7 @@ fun MainWindow(windowIcon: Painter?) {
             }
         }
 
-        var isMac by remember { mutableStateOf(platform.isMacos()) }
+        val isMac = remember { platform.isMacos() }
 
         if (isMac) {
             MenuBar {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
@@ -7,9 +7,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
@@ -46,15 +44,12 @@ fun SearchWindow(windowIcon: Painter?) {
     val config by configManager.config.collectAsState()
     val searchWindowInfo by appWindowManager.searchWindowInfo.collectAsState()
 
-    val isMac by remember { mutableStateOf(platform.isMacos()) }
+    val isMac = remember { platform.isMacos() }
 
-    var currentStyle by remember { mutableStateOf(config.searchWindowStyle) }
-
-    val isCenterStyle by remember(currentStyle) {
-        mutableStateOf(
-            config.searchWindowStyle == DesktopSearchWindowStyle.CENTER_STYLE.style,
-        )
-    }
+    val isCenterStyle =
+        remember(config.searchWindowStyle) {
+            config.searchWindowStyle == DesktopSearchWindowStyle.CENTER_STYLE.style
+        }
 
     val animationProgress by animateFloatAsState(
         targetValue = if (searchWindowInfo.show && !isCenterStyle) 0f else 1f,
@@ -106,12 +101,6 @@ fun SearchWindow(windowIcon: Painter?) {
         transparent = false,
         resizable = false,
     ) {
-        LaunchedEffect(config.searchWindowStyle) {
-            if (currentStyle != config.searchWindowStyle) {
-                currentStyle = config.searchWindowStyle
-            }
-        }
-
         DisposableEffect(Unit) {
             if (isMac) {
                 runCatching {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/search/center/CenterSearchWindowContent.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/search/center/CenterSearchWindowContent.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -40,7 +38,7 @@ fun CenterSearchWindowContent() {
     val pasteSelectionViewModel = koinInject<PasteSelectionViewModel>()
     val platform = koinInject<Platform>()
 
-    val isLinux by remember { mutableStateOf(platform.isLinux()) }
+    val isLinux = remember { platform.isLinux() }
 
     val modifier =
         Modifier

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/DesktopSettingsViewProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/DesktopSettingsViewProvider.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -87,7 +85,7 @@ class DesktopSettingsViewProvider(
             },
         ) {
             PasteboardSettingsContentView {
-                val isWindows by remember { mutableStateOf(platform.isWindows()) }
+                val isWindows = remember { platform.isWindows() }
                 if (isWindows) {
                     WindowsPasteboardSettingsContentView()
                 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/NetSettingsContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/NetSettingsContentView.kt
@@ -55,17 +55,13 @@ fun NetSettingsContentView() {
     val syncScopeFactory = koinInject<SyncScopeFactory>()
     val jsonUtils = getJsonUtils()
 
-    var port: String? by remember { mutableStateOf(null) }
+    var port by remember { mutableStateOf<String?>(null) }
 
     val config by configManager.config.collectAsState()
 
     var networkInterfaces by remember { mutableStateOf(listOf<NetworkInterfaceInfo>()) }
 
-    var useNetworkInterfaces by remember { mutableStateOf(listOf<String>()) }
-
-    LaunchedEffect(config.useNetworkInterfaces) {
-        useNetworkInterfaces = jsonUtils.JSON.decodeFromString(config.useNetworkInterfaces)
-    }
+    val useNetworkInterfaces: List<String> = jsonUtils.JSON.decodeFromString(config.useNetworkInterfaces)
 
     LaunchedEffect(Unit) {
         networkInterfaces = networkInterfaceService.getAllNetworkInterfaceInfo()
@@ -99,12 +95,12 @@ fun NetSettingsContentView() {
                 onCheckedChange = { enableDiscovery ->
                     if (enableDiscovery) {
                         networkInterfaceService.getPreferredNetworkInterface()?.let {
-                            useNetworkInterfaces = listOf(it.name)
-                            val newUseNetworkInterfaces =
-                                jsonUtils.JSON.encodeToString(useNetworkInterfaces)
+                            val newUseNetworkInterfaces = listOf(it.name)
+                            val newUseNetworkInterfacesJson =
+                                jsonUtils.JSON.encodeToString(newUseNetworkInterfaces)
                             configManager.updateConfig(
                                 listOf("useNetworkInterfaces", "enableDiscovery"),
-                                listOf(newUseNetworkInterfaces, true),
+                                listOf(newUseNetworkInterfacesJson, true),
                             )
                         }
                     } else {
@@ -126,16 +122,16 @@ fun NetSettingsContentView() {
             },
             onChange = { index, isChecked ->
                 val currentInterface = networkInterfaces.map { it.name }[index]
-                useNetworkInterfaces =
+                val newUseNetworkInterfaces =
                     if (isChecked) {
                         useNetworkInterfaces + currentInterface
                     } else {
                         useNetworkInterfaces - currentInterface
                     }
-                val newUseNetworkInterfaces = jsonUtils.JSON.encodeToString(useNetworkInterfaces)
+                val newUseNetworkInterfacesJson = jsonUtils.JSON.encodeToString(newUseNetworkInterfaces)
                 configManager.updateConfig(
                     listOf("useNetworkInterfaces", "enableDiscovery"),
-                    listOf(newUseNetworkInterfaces, useNetworkInterfaces.isNotEmpty()),
+                    listOf(newUseNetworkInterfacesJson, useNetworkInterfaces.isNotEmpty()),
                 )
             },
         )

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/ShortcutKeysContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/ShortcutKeysContentView.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -155,6 +156,8 @@ fun ShortcutKeyRow(name: String) {
     val pasteDialogFactory = koinInject<PasteDialogFactory>()
     val shortcutKeys = koinInject<ShortcutKeys>()
 
+    val shortcutKeysCore by shortcutKeys.shortcutKeysCore.collectAsState()
+
     var hover by remember { mutableStateOf(false) }
 
     Row(
@@ -264,7 +267,7 @@ fun ShortcutKeyRow(name: String) {
 
         Spacer(modifier = Modifier.width(small3X))
 
-        shortcutKeys.shortcutKeysCore.value.keys[name]?.let { keys ->
+        shortcutKeysCore.keys[name]?.let { keys ->
             ShortcutKeyItemView(keys)
         } ?: run {
             Text(

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -16,6 +16,8 @@ group = "com.crosspaste"
 version = versionProperties.getProperty("version")
 
 plugins {
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.ktlint)
@@ -45,6 +47,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
+            implementation(compose.runtime)
             implementation(libs.cryptography.core)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteCollection.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteCollection.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.paste
 
+import androidx.compose.runtime.Stable
 import com.crosspaste.paste.item.PasteCoordinate
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.path.UserDataPathProvider
@@ -11,6 +12,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable
+@Stable
 data class PasteCollection(
     val pasteItems: List<PasteItem>,
 ) {

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.paste
 
+import androidx.compose.runtime.Stable
 import com.crosspaste.paste.item.PasteColor
 import com.crosspaste.paste.item.PasteCoordinate
 import com.crosspaste.paste.item.PasteFiles
@@ -26,6 +27,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.cast
 
 @Serializable(with = PasteDataSerializer::class)
+@Stable
 data class PasteData(
     val id: Long = -1L,
     val appInstanceId: String,

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteTag.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteTag.kt
@@ -1,8 +1,10 @@
 package com.crosspaste.paste
 
+import androidx.compose.runtime.Stable
 import kotlinx.serialization.Serializable
 
 @Serializable
+@Stable
 data class PasteTag(
     val id: Long,
     val name: String,

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItem.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItem.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.paste.item
 
+import androidx.compose.runtime.Stable
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.PasteItemProperties.MARKETING_PATH
 import com.crosspaste.path.UserDataPathProvider
@@ -15,6 +16,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import okio.Path
 
 @Serializable
+@Stable
 sealed interface PasteItem {
 
     companion object {


### PR DESCRIPTION
  - Replace mutableStateOf with remember for immutable platform checks
  - Add @Stable annotations to PasteData, PasteCollection, PasteTag, and PasteItem
  - Use collectAsState() instead of direct .value access for reactive state
  - Remove redundant state variables and unused imports
  - Add Compose compiler plugin and runtime dependency to shared module
  - Simplify conditional logic in UI components

close #3398