### PR TITLE
:lipstick: Clarify refresh semantics and enhance search UX

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/PasteBonjourService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/PasteBonjourService.kt
@@ -4,7 +4,9 @@ import com.crosspaste.db.sync.HostInfo
 
 interface PasteBonjourService {
 
-    fun request(
+    fun refreshAll()
+
+    fun refreshTarget(
         appInstanceId: String,
         hostInfoList: List<HostInfo>,
     )

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
@@ -107,4 +107,12 @@ class GeneralNearbyDeviceManager(
             ratingPromptManager.trackSignificantAction()
         }
     }
+
+    override fun startSearching() {
+        _searching.value = true
+    }
+
+    override fun stopSearching() {
+        _searching.value = false
+    }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingNearbyDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingNearbyDeviceManager.kt
@@ -15,7 +15,7 @@ class MarketingNearbyDeviceManager : NearbyDeviceManager {
 
     override val nearbyDeviceScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob())
 
-    override val searching: StateFlow<Boolean> = MutableStateFlow(false)
+    override val searching: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override val nearbySyncInfos: StateFlow<List<SyncInfo>> =
         MutableStateFlow(
@@ -50,5 +50,13 @@ class MarketingNearbyDeviceManager : NearbyDeviceManager {
     }
 
     override fun removeDevice(syncInfo: SyncInfo) {
+    }
+
+    override fun startSearching() {
+        searching.value = true
+    }
+
+    override fun stopSearching() {
+        searching.value = false
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/NearbyDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/NearbyDeviceManager.kt
@@ -15,4 +15,8 @@ interface NearbyDeviceManager {
     fun addDevice(syncInfo: SyncInfo)
 
     fun removeDevice(syncInfo: SyncInfo)
+
+    fun startSearching()
+
+    fun stopSearching()
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -399,7 +399,7 @@ class SyncResolver(
         appInstanceId: String,
         hostInfoList: List<HostInfo>,
     ) {
-        lazyPasteBonjourService.value.request(appInstanceId, hostInfoList)
+        lazyPasteBonjourService.value.refreshTarget(appInstanceId, hostInfoList)
     }
 
     private suspend fun updateSyncInfo(syncInfo: SyncInfo) {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.crosspaste.i18n.GlobalCopywriter
+import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.ui.base.SectionHeader
@@ -41,6 +42,7 @@ import org.koin.compose.koinInject
 fun DevicesContentView() {
     val copywriter = koinInject<GlobalCopywriter>()
     val nearbyDeviceManager = koinInject<NearbyDeviceManager>()
+    val pasteBonjourService = koinInject<PasteBonjourService>()
     val syncManager = koinInject<SyncManager>()
     val syncScopeFactory = koinInject<SyncScopeFactory>()
 
@@ -110,7 +112,7 @@ fun DevicesContentView() {
                     trailingContent = {
                         IconButton(
                             onClick = {
-                                nearbyDeviceManager.searching
+                                pasteBonjourService.refreshAll()
                             },
                             modifier = Modifier.size(xxLarge),
                         ) {

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/ControlUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/ControlUtils.kt
@@ -12,12 +12,12 @@ interface ControlUtils {
     suspend fun <T> ensureMinExecutionTime(
         delayTime: Long = 20L,
         action: suspend () -> T,
-    ): T? {
+    ): Result<T> {
         val start = nowEpochMilliseconds()
         val result =
             runCatching {
                 action()
-            }.getOrNull()
+            }
         val end = nowEpochMilliseconds()
 
         val remainingDelay = delayTime + start - end

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/LinuxPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/LinuxPasteboardService.kt
@@ -129,9 +129,10 @@ class LinuxPasteboardService(
             if (firstChange) {
                 null
             } else {
-                controlUtils.ensureMinExecutionTime(delayTime = 20) {
-                    appWindowManager.getCurrentActiveAppName()
-                }
+                controlUtils
+                    .ensureMinExecutionTime(delayTime = 20) {
+                        appWindowManager.getCurrentActiveAppName()
+                    }.getOrNull()
             }
 
         val contents =

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
@@ -87,9 +87,10 @@ class MacosPasteboardService(
                                     logger.debug { "Ignoring crosspaste change" }
                                 } else {
                                     var source: String? =
-                                        controlUtils.ensureMinExecutionTime(delayTime = 20) {
-                                            appWindowManager.getCurrentActiveAppName()
-                                        }
+                                        controlUtils
+                                            .ensureMinExecutionTime(delayTime = 20) {
+                                                appWindowManager.getCurrentActiveAppName()
+                                            }.getOrNull()
 
                                     // https://github.com/CrossPaste/crosspaste-desktop/issues/1874
                                     // If it is the first time to read the pasteboard content and the source is CrossPaste


### PR DESCRIPTION
- Rename 'request' to 'refreshTarget' and implement 'refreshAll' for explicit active/passive discovery.
- Integrate 'NearbyDeviceManager' search state with 'refreshAll' lifecycle.
- Implement a minimum duration mechanism to prevent UI flickering when network scans complete too fast.
- Refactor the loading state logic into a reusable pattern using coroutine delay in a finally block.
- Ensure 'stopSearching' is reliably called after a predictable delay to maintain consistent UI feedback.

close #3522