### PR TITLE
:bug: Fix SIGSEGV in XToolkit by deferring JNativeHook initialization

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -280,7 +280,7 @@ class CrossPaste {
                 val navController = rememberNavController()
 
                 LaunchedEffect(Unit) {
-                    if (globalListener.isRegistered()) {
+                    if (!globalListener.isRegistered()) {
                         globalListener.start()
                     }
                 }


### PR DESCRIPTION
close #3644