### PR TITLE
:hammer: Avoid using internal cursorColor method for Android compatibility in CustomTextField

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/CustomTextField.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/CustomTextField.kt
@@ -79,7 +79,14 @@ fun CustomTextField(
         enabled = enabled,
         readOnly = readOnly,
         textStyle = mergedTextStyle,
-        cursorBrush = SolidColor(colors.cursorColor(isError)),
+        cursorBrush =
+            SolidColor(
+                if (isError) {
+                    colors.errorCursorColor
+                } else {
+                    colors.cursorColor
+                },
+            ),
         visualTransformation = visualTransformation,
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,


### PR DESCRIPTION
close #3680