### PR TITLE
fix: Correct formatBytes logic to display decimals for KB/MB/GB

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/FileUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/FileUtilsTest.kt
@@ -112,6 +112,18 @@ class FileUtilsTest {
         assertEquals("Move me", destFile.toFile().readText())
     }
 
+    @Test
+    fun testFormatBytes() {
+        assertEquals("500 B", fileUtils.formatBytes(500))
+        assertEquals("1023 B", fileUtils.formatBytes(1023))
+        assertEquals("1 KB", fileUtils.formatBytes(1024))
+        assertEquals("1.5 KB", fileUtils.formatBytes(1536))
+        assertEquals("1 MB", fileUtils.formatBytes(1024 * 1024))
+        // Verify the bug reported by user: 1863330 should be 1.7 MB (1863330 / 1024 / 1024 = 1.777)
+        assertEquals("1.7 MB", fileUtils.formatBytes(1863330))
+        assertEquals("1 GB", fileUtils.formatBytes(1024L * 1024 * 1024))
+    }
+
     @AfterAll
     fun cleanup() {
         tempDir.toFile().deleteRecursively()

--- a/shared/src/commonMain/kotlin/com/crosspaste/utils/FileUtils.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/utils/FileUtils.kt
@@ -50,7 +50,7 @@ interface FileUtils {
     val fileBufferSize: Int
 
     fun formatBytes(bytesSize: Long): String {
-        if (bytesSize < 1024) return "$bytesSize B"
+        if (bytesSize < 1024) return "$bytesSize $B"
         var value = bytesSize.toDouble()
         var unitIndex = 0
         while (value >= 1024 && unitIndex < UNITS.size - 1) {
@@ -64,10 +64,11 @@ interface FileUtils {
 
     private fun formatDecimal(value: Double): String {
         val rounded = (value * 10).toLong() / 10.0
-        return if (rounded == rounded.toLong().toDouble()) {
-            rounded.toLong().toString()
+        val roundedLong = rounded.toLong()
+        return if (rounded == roundedLong.toDouble()) {
+            roundedLong.toString()
         } else {
-            "${rounded.toLong() / 10}.${(rounded.toLong() % 10)}"
+            rounded.toString()
         }
     }
 


### PR DESCRIPTION
Fixes #3698.

This PR corrects the `formatBytes` logic in `FileUtils` to correctly display decimal values for file sizes larger than 1024 bytes. It also adds a unit test to verify the fix.