### PR TITLE
fix: Use FlowRow for adaptive layout of image info components

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
@@ -103,7 +103,7 @@ fun PasteDataScope.ImageSidePreviewView() {
         value = fileUtils.getFileSize(imagePath)
     }
 
-    val fileFormat = imagePath.extension
+    val fileFormat = remember(imagePath) { imagePath.extension }
 
     SidePasteLayoutView(
         pasteBottomContent = {},


### PR DESCRIPTION
Replaces `Row` with `FlowRow` in `ImageSidePreviewView` to allow image info components (format, resolution, size) to wrap to the next line if there is insufficient horizontal space.