### PR TITLE
:lipstick: Menu item redesign by pencil

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/MainMenuView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/MainMenuView.kt
@@ -2,14 +2,30 @@ package com.crosspaste.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ExitToApp
+import androidx.compose.material.icons.outlined.Devices
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.Extension
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Keyboard
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material.icons.outlined.Upload
+import androidx.compose.material.icons.outlined.VpnKey
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
@@ -30,11 +47,16 @@ import com.crosspaste.app.ExitMode
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.ui.base.TutorialButton
-import com.crosspaste.ui.theme.AppUISize.large2X
+import com.crosspaste.ui.theme.AppUISize.large
 import com.crosspaste.ui.theme.AppUISize.medium
 import com.crosspaste.ui.theme.AppUISize.small2X
+import com.crosspaste.ui.theme.AppUISize.small3X
 import com.crosspaste.ui.theme.AppUISize.tiny
+import com.crosspaste.ui.theme.AppUISize.tiny3X
 import com.crosspaste.ui.theme.AppUISize.tiny4X
+import com.crosspaste.ui.theme.AppUISize.tiny5X
+import com.crosspaste.ui.theme.AppUISize.tinyRoundedCornerShape
+import com.crosspaste.ui.theme.AppUISize.xxxLarge
 import org.koin.compose.koinInject
 
 @Composable
@@ -44,24 +66,24 @@ fun MainMenuView() {
     val configManager = koinInject<DesktopConfigManager>()
     val navigateManage = koinInject<NavigationManager>()
 
-    val prevMenuList =
+    val primaryMenuList =
         remember {
             listOf(
-                MainMenuItem("devices", Devices),
-                MainMenuItem("pairing_code", PairingCode),
-                MainMenuItem("settings", Settings),
-                MainMenuItem("extension", Extension),
+                MainMenuItem("devices", Devices, Icons.Outlined.Devices),
+                MainMenuItem("pairing_code", PairingCode, Icons.Outlined.VpnKey),
+                MainMenuItem("settings", Settings, Icons.Outlined.Settings),
+                MainMenuItem("extension", Extension, Icons.Outlined.Extension),
             )
         }
 
-    val nextMenuList =
+    val secondaryMenuList =
         remember {
             listOf(
-                MainMenuItem("import", Import),
-                MainMenuItem("export", Export),
-                MainMenuItem("shortcut_keys", ShortcutKeys),
-                MainMenuItem("share", Share),
-                MainMenuItem("about", About),
+                MainMenuItem("import", Import, Icons.Outlined.Download),
+                MainMenuItem("export", Export, Icons.Outlined.Upload),
+                MainMenuItem("shortcut_keys", ShortcutKeys, Icons.Outlined.Keyboard),
+                MainMenuItem("share", Share, Icons.Outlined.Share),
+                MainMenuItem("about", About, Icons.Outlined.Info),
             )
         }
 
@@ -77,37 +99,72 @@ fun MainMenuView() {
             Modifier
                 .fillMaxSize()
                 .padding(bottom = medium),
+        verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        prevMenuList.forEach { item ->
-            MainMenuItemView(
-                title = item.title,
-                selected = rootRouteName == item.route.name,
-                onClick = { navigateManage.navigateAndClearStack(item.route) },
-            )
-        }
-
-        Spacer(Modifier.weight(1f))
-
-        if (firstLaunchCompleted && config.showTutorial) {
-            Box(modifier = Modifier.padding(horizontal = medium, vertical = tiny)) {
-                TutorialButton()
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = tiny),
+            verticalArrangement = Arrangement.spacedBy(tiny4X),
+        ) {
+            primaryMenuList.forEach { item ->
+                MainMenuItemView(
+                    title = item.title,
+                    icon = item.icon,
+                    selected = rootRouteName == item.route.name,
+                    onClick = { navigateManage.navigateAndClearStack(item.route) },
+                )
             }
         }
 
-        nextMenuList.forEach { item ->
-            MainMenuItemView(
-                title = item.title,
-                selected = rootRouteName == item.route.name,
-                onClick = { navigateManage.navigateAndClearStack(item.route) },
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = tiny, end = tiny),
+            verticalArrangement = Arrangement.spacedBy(tiny4X),
+        ) {
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = tiny3X),
+                thickness = tiny5X,
+                color = MaterialTheme.colorScheme.outlineVariant,
             )
-        }
 
-        MainMenuItemView("check_for_updates", false) {
-            appUpdateService.tryTriggerUpdate()
-        }
+            Spacer(modifier = Modifier.height(tiny3X))
 
-        MainMenuItemView("quit", false) {
-            exitApplication(ExitMode.EXIT)
+            if (firstLaunchCompleted && config.showTutorial) {
+                Box(modifier = Modifier.padding(horizontal = tiny, vertical = tiny3X)) {
+                    TutorialButton()
+                }
+            }
+
+            secondaryMenuList.forEach { item ->
+                MainMenuItemView(
+                    title = item.title,
+                    icon = item.icon,
+                    selected = rootRouteName == item.route.name,
+                    onClick = { navigateManage.navigateAndClearStack(item.route) },
+                    compact = true,
+                )
+            }
+
+            MainMenuItemView(
+                title = "check_for_updates",
+                icon = Icons.Outlined.Refresh,
+                selected = false,
+                onClick = { appUpdateService.tryTriggerUpdate() },
+                compact = true,
+            )
+
+            MainMenuItemView(
+                title = "quit",
+                icon = Icons.AutoMirrored.Outlined.ExitToApp,
+                selected = false,
+                onClick = { exitApplication(ExitMode.EXIT) },
+                compact = true,
+                tintColor = MaterialTheme.colorScheme.error,
+            )
         }
     }
 }
@@ -115,8 +172,11 @@ fun MainMenuView() {
 @Composable
 fun MainMenuItemView(
     title: String,
+    icon: ImageVector,
     selected: Boolean,
     onClick: () -> Unit,
+    compact: Boolean = false,
+    tintColor: Color? = null,
 ) {
     val copywriter = koinInject<GlobalCopywriter>()
 
@@ -128,24 +188,34 @@ fun MainMenuItemView(
         }
 
     val contentColor =
-        if (selected) {
-            MaterialTheme.colorScheme.onPrimaryContainer
-        } else {
-            MaterialTheme.colorScheme.onSurfaceVariant
-        }
+        tintColor
+            ?: if (selected) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            }
 
-    Box(
+    val itemHeight = if (compact) (xxxLarge - tiny4X) else xxxLarge
+    val iconSize = if (compact) medium else large
+
+    Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(large2X * 2)
-                .padding(horizontal = tiny, vertical = tiny4X)
-                .clip(RoundedCornerShape(tiny))
+                .height(itemHeight)
+                .clip(tinyRoundedCornerShape)
                 .background(containerColor)
                 .clickable(onClick = onClick)
                 .padding(horizontal = small2X),
-        contentAlignment = Alignment.CenterStart,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(small3X),
     ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(iconSize),
+            tint = contentColor,
+        )
         Text(
             text = copywriter.getText(title),
             maxLines = 1,
@@ -153,8 +223,8 @@ fun MainMenuItemView(
             color = contentColor,
             style =
                 MaterialTheme.typography.bodyMedium.copy(
-                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                    // Adjusting line height and letter spacing for desktop clarity
+                    fontSize = if (compact) 13.sp else 14.sp,
+                    fontWeight = if (selected) FontWeight.Medium else FontWeight.Normal,
                     letterSpacing = 0.2.sp,
                 ),
         )
@@ -164,4 +234,5 @@ fun MainMenuItemView(
 data class MainMenuItem(
     val title: String,
     val route: Route,
+    val icon: ImageVector,
 )


### PR DESCRIPTION
  - Changed from Box with Text only → Row with Icon + Text
  - Primary items: 36dp height, 18dp icons, 14sp font
  - Secondary items (compact = true): 34dp height, 16dp icons, 13sp font
  - Icon-text gap: 10dp, horizontal padding: 12dp, corner radius: 8dp
  - Selected state: primaryContainer background + onPrimaryContainer color + FontWeight.Medium
  - Quit item: tintColor = MaterialTheme.colorScheme.error (red) for both icon and text