### PR TITLE
Fix "launch_at_startup" switch bound to wrong config field

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/MainSettingsContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/MainSettingsContentView.kt
@@ -35,7 +35,7 @@ fun MainSettingsContentView() {
         SettingListSwitchItem(
             title = "launch_at_startup",
             icon = Icons.Default.RocketLaunch,
-            checked = config.enablePasteboardListening,
+            checked = config.enableAutoStartUp,
         ) {
             configManager.updateConfig("enableAutoStartUp", it)
         }


### PR DESCRIPTION
Closes #3721

## Summary
- Fix the "launch_at_startup" `SettingListSwitchItem` reading from `config.enablePasteboardListening` instead of `config.enableAutoStartUp`
- The switch now correctly reflects the auto-startup configuration state

## Test plan
- [ ] Open Settings → verify "launch at startup" toggle reflects the actual auto-startup setting
- [ ] Toggle the switch and confirm it updates `enableAutoStartUp` (not pasteboard listening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)