### PR TITLE
:hammer: Refactor SemanticColorGroup to use Tailwind CSS color palette

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -27,6 +27,7 @@ import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.SyncManager
+import com.crosspaste.ui.LocalThemeExtState
 import com.crosspaste.ui.base.InnerScaffold
 import com.crosspaste.ui.base.SectionHeader
 import com.crosspaste.ui.theme.AppUISize.large2X
@@ -73,8 +74,8 @@ fun DevicesContentView() {
                 onClick = {
                     showAddDeviceDialog = true
                 },
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                containerColor = LocalThemeExtState.current.success.surface,
+                contentColor = LocalThemeExtState.current.success.onContainer,
                 icon = { Icon(Icons.Default.Add, contentDescription = null) },
                 text = { Text(copywriter.getText("add_device_manually")) },
             )

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/theme/CrossPasteTheme.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/theme/CrossPasteTheme.kt
@@ -29,9 +29,7 @@ object CrossPasteTheme {
             themeDetector.setSystemInDark(isSystemInDark)
         }
 
-        val primary = themeState.colorScheme.primary
-
-        val themeExt = ThemeExt.buildThemeExt(primary, themeState.isCurrentThemeDark)
+        val themeExt = ThemeExt.buildThemeExt(themeState.isCurrentThemeDark)
 
         CompositionLocalProvider(LocalThemeExtState provides themeExt) {
             MaterialTheme(

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/theme/SemanticColorGroup.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/theme/SemanticColorGroup.kt
@@ -1,61 +1,93 @@
 package com.crosspaste.ui.theme
 
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
-import com.materialkolor.ktx.harmonize
-import com.materialkolor.ktx.toneColor
-import com.materialkolor.palettes.TonalPalette
-
-enum class SemanticColorPolicy {
-    Dynamic,
-    FixedHue,
-}
 
 data class SemanticColorGroup(
     val color: Color,
     val onColor: Color,
     val container: Color,
     val onContainer: Color,
+    val surface: Color,
 ) {
     companion object {
-        fun create(
-            sourceColor: Color,
-            primary: Color,
-            isDark: Boolean,
-            policy: SemanticColorPolicy,
-            isWarning: Boolean = false,
-        ): SemanticColorGroup {
-            val seed =
-                when (policy) {
-                    SemanticColorPolicy.Dynamic -> sourceColor.harmonize(primary)
-                    SemanticColorPolicy.FixedHue -> sourceColor
-                }
-            val palette = TonalPalette.fromInt(seed.toArgb())
+        // Light Theme Success - Green/Emerald palette (Tailwind green)
+        val LIGHT_SUCCESS =
+            SemanticColorGroup(
+                color = Color(0xFF22C55E), // green-500
+                onColor = Color(0xFFFFFFFF), // white
+                container = Color(0xFFDCFCE7), // green-100
+                onContainer = Color(0xFF14532D), // green-900
+                surface = Color(0xFFF0FDF4), // green-50
+            )
 
-            return if (isDark) {
-                SemanticColorGroup(
-                    color = palette.toneColor(80),
-                    onColor = palette.toneColor(20),
-                    container = palette.toneColor(30),
-                    onContainer = palette.toneColor(90),
-                )
-            } else {
-                if (isWarning) {
-                    SemanticColorGroup(
-                        color = palette.toneColor(80),
-                        onColor = palette.toneColor(10),
-                        container = palette.toneColor(90),
-                        onContainer = palette.toneColor(10),
-                    )
-                } else {
-                    SemanticColorGroup(
-                        color = palette.toneColor(40),
-                        onColor = palette.toneColor(100),
-                        container = palette.toneColor(90),
-                        onContainer = palette.toneColor(10),
-                    )
-                }
-            }
-        }
+        // Dark Theme Success
+        val DARK_SUCCESS =
+            SemanticColorGroup(
+                color = Color(0xFF4ADE80), // green-400
+                onColor = Color(0xFF14532D), // green-900
+                container = Color(0xFF14532D), // green-900
+                onContainer = Color(0xFFDCFCE7), // green-100
+                surface = Color(0xFF052E16), // green-950
+            )
+
+        // Light Theme Info - Blue palette (Tailwind blue)
+        val LIGHT_INFO =
+            SemanticColorGroup(
+                color = Color(0xFF3B82F6), // blue-500
+                onColor = Color(0xFFFFFFFF), // white
+                container = Color(0xFFDBEAFE), // blue-100
+                onContainer = Color(0xFF1E3A8A), // blue-900
+                surface = Color(0xFFEFF6FF), // blue-50
+            )
+
+        // Dark Theme Info
+        val DARK_INFO =
+            SemanticColorGroup(
+                color = Color(0xFF60A5FA), // blue-400
+                onColor = Color(0xFF1E3A5F), // blue-900 variant
+                container = Color(0xFF1E3A8A), // blue-900
+                onContainer = Color(0xFFDBEAFE), // blue-100
+                surface = Color(0xFF172554), // blue-950
+            )
+
+        // Light Theme Neutral - Gray palette (Tailwind gray)
+        val LIGHT_NEUTRAL =
+            SemanticColorGroup(
+                color = Color(0xFF6B7280), // gray-500
+                onColor = Color(0xFFFFFFFF), // white
+                container = Color(0xFFF3F4F6), // gray-100
+                onContainer = Color(0xFF1F2937), // gray-800
+                surface = Color(0xFFF9FAFB), // gray-50
+            )
+
+        // Dark Theme Neutral
+        val DARK_NEUTRAL =
+            SemanticColorGroup(
+                color = Color(0xFF9CA3AF), // gray-400
+                onColor = Color(0xFF1F2937), // gray-800
+                container = Color(0xFF374151), // gray-700
+                onContainer = Color(0xFFF3F4F6), // gray-100
+                surface = Color(0xFF111827), // gray-900
+            )
+
+        // Light Theme Warning - Amber palette (Tailwind amber)
+        val LIGHT_WARNING =
+            SemanticColorGroup(
+                color = Color(0xFFD97706), // amber-600
+                onColor = Color(0xFFFFFFFF), // white
+                container = Color(0xFFFEF3C7), // amber-100
+                onContainer = Color(0xFF78350F), // amber-900
+                surface = Color(0xFFFFFBEB), // amber-50
+            )
+
+        // Dark Theme Warning
+        val DARK_WARNING =
+            SemanticColorGroup(
+                color = Color(0xFFFBBF24), // amber-400
+                onColor = Color(0xFF78350F), // amber-900
+                container = Color(0xFF78350F), // amber-900
+                onContainer = Color(0xFFFEF3C7), // amber-100
+                surface = Color(0xFF451A03), // amber-950
+            )
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/theme/ThemeExt.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/theme/ThemeExt.kt
@@ -8,7 +8,6 @@ data class ThemeExt(
     val info: SemanticColorGroup,
     val neutral: SemanticColorGroup,
     val warning: SemanticColorGroup,
-    val special: SemanticColorGroup,
     val textPasteTypeExt: PasteTypeExt,
     val imagePasteTypeExt: PasteTypeExt,
     val filePasteTypeExt: PasteTypeExt,
@@ -19,28 +18,16 @@ data class ThemeExt(
     val mutedText: Color,
 ) {
     companion object {
-        private val COLOR_SUCCESS = Color(0xFF2E7D32)
-        private val COLOR_INFO = Color(0xFF0288D1)
-        private val COLOR_NEUTRAL = Color(0xFF747775)
-        private val COLOR_WARNING = Color(0xFFFBC02D)
-        private val COLOR_SPECIAL = Color(0xFF6750A4)
-
-        fun buildThemeExt(
-            primary: Color,
-            isDark: Boolean,
-        ): ThemeExt {
-            fun createGroup(
-                source: Color,
-                policy: SemanticColorPolicy,
-                isWarning: Boolean = false,
-            ) = SemanticColorGroup.create(source, primary, isDark, policy, isWarning)
-
-            return ThemeExt(
-                success = createGroup(COLOR_SUCCESS, SemanticColorPolicy.Dynamic),
-                info = createGroup(COLOR_INFO, SemanticColorPolicy.Dynamic),
-                neutral = createGroup(COLOR_NEUTRAL, SemanticColorPolicy.Dynamic),
-                warning = createGroup(COLOR_WARNING, SemanticColorPolicy.FixedHue, isWarning = true),
-                special = createGroup(COLOR_SPECIAL, SemanticColorPolicy.Dynamic),
+        fun buildThemeExt(isDark: Boolean): ThemeExt =
+            ThemeExt(
+                success =
+                    if (isDark) SemanticColorGroup.DARK_SUCCESS else SemanticColorGroup.LIGHT_SUCCESS,
+                info =
+                    if (isDark) SemanticColorGroup.DARK_INFO else SemanticColorGroup.LIGHT_INFO,
+                neutral =
+                    if (isDark) SemanticColorGroup.DARK_NEUTRAL else SemanticColorGroup.LIGHT_NEUTRAL,
+                warning =
+                    if (isDark) SemanticColorGroup.DARK_WARNING else SemanticColorGroup.LIGHT_WARNING,
                 textPasteTypeExt =
                     if (isDark) PasteTypeExt.DARK_TEXT_PASTE_TYPE_EXT else PasteTypeExt.LIGHT_TEXT_PASTE_TYPE_EXT,
                 imagePasteTypeExt =
@@ -58,6 +45,5 @@ data class ThemeExt(
                 mutedText =
                     if (isDark) Color(0xFF9CA3AF) else Color(0xFF6B7280),
             )
-        }
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/theme/DesktopThemeExt.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/theme/DesktopThemeExt.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
@@ -52,11 +51,8 @@ private fun SemanticColorRow(
 }
 
 @Composable
-private fun SemanticColorsPreviewContent(
-    primary: Color,
-    isDark: Boolean,
-) {
-    val ext = ThemeExt.buildThemeExt(primary = primary, isDark = isDark)
+private fun SemanticColorsPreviewContent(isDark: Boolean) {
+    val ext = ThemeExt.buildThemeExt(isDark = isDark)
     Column(
         modifier =
             Modifier
@@ -69,7 +65,6 @@ private fun SemanticColorsPreviewContent(
         SemanticColorRow("Info", ext.info)
         SemanticColorRow("Warning", ext.warning)
         SemanticColorRow("Neutral", ext.neutral)
-        SemanticColorRow("Special", ext.special)
     }
 }
 
@@ -78,7 +73,7 @@ private fun SemanticColorsPreviewContent(
 private fun SemanticColorsLightPreview() {
     val lightScheme = CrossPasteColor.lightColorScheme
     MaterialTheme(colorScheme = lightScheme) {
-        SemanticColorsPreviewContent(primary = lightScheme.primary, isDark = false)
+        SemanticColorsPreviewContent(isDark = false)
     }
 }
 
@@ -87,6 +82,6 @@ private fun SemanticColorsLightPreview() {
 private fun SemanticColorsDarkPreview() {
     val darkScheme = CrossPasteColor.darkColorScheme
     MaterialTheme(colorScheme = darkScheme) {
-        SemanticColorsPreviewContent(primary = darkScheme.primary, isDark = true)
+        SemanticColorsPreviewContent(isDark = true)
     }
 }


### PR DESCRIPTION
Closes #3733

## Summary
- Replace dynamic color generation (harmonize + TonalPalette) with static Tailwind CSS color constants
- Define 4 semantic color groups with light/dark variants: Success (green), Info (blue), Neutral (gray), Warning (amber)
- Add `surface` property to SemanticColorGroup
- Remove unused `SemanticColorPolicy` enum and `special` semantic group
- Simplify `buildThemeExt()` by removing `primary: Color` parameter

## Test plan
- [ ] Verify semantic colors display correctly in light theme
- [ ] Verify semantic colors display correctly in dark theme
- [ ] Check device state tags (synced, outgoing, incoming, paused, warning states)
- [ ] Check notification message colors

🤖 Generated with [Claude Code](https://claude.ai/code)