### PR TITLE
:hammer: Clean up core data models: unify error handling, remove redundant code, fix naming

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteTypeExt.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteTypeExt.kt
@@ -12,6 +12,7 @@ import com.composables.icons.materialsymbols.rounded.Palette
 import com.composables.icons.materialsymbols.rounded.Title
 import com.crosspaste.ui.LocalThemeExtState
 import com.crosspaste.ui.base.IconData
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 object PasteTypeExt {
     // Text
@@ -113,6 +114,8 @@ object PasteTypeExt {
         )
 }
 
+private val logger = KotlinLogging.logger {}
+
 @Composable
 fun PasteType.getIconData(): IconData {
     val themeExt = LocalThemeExtState.current
@@ -124,6 +127,9 @@ fun PasteType.getIconData(): IconData {
         PasteType.IMAGE_TYPE -> themeExt.imageTypeIconData
         PasteType.RTF_TYPE -> themeExt.rtfTypeIconData
         PasteType.COLOR_TYPE -> themeExt.colorTypeIconData
-        else -> themeExt.textTypeIconData
+        else -> {
+            logger.warn { "Unknown PasteType: $this, falling back to textTypeIconData" }
+            themeExt.textTypeIconData
+        }
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteDataFlavor.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteDataFlavor.kt
@@ -4,18 +4,6 @@ import java.awt.datatransfer.DataFlavor
 
 data class DesktopPasteDataFlavor(
     val dataFlavor: DataFlavor,
-) : PasteDataFlavor {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is DesktopPasteDataFlavor) return false
-
-        if (dataFlavor != other.dataFlavor) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int = dataFlavor.hashCode()
-}
+) : PasteDataFlavor
 
 fun DataFlavor.toPasteDataFlavor(): PasteDataFlavor = DesktopPasteDataFlavor(this)

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopWriteTransferable.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopWriteTransferable.kt
@@ -4,7 +4,6 @@ import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.paste.plugin.type.PasteTypePlugin
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
-import java.awt.datatransfer.UnsupportedFlavorException
 
 class DesktopWriteTransferableBuilder {
 
@@ -49,7 +48,7 @@ class DesktopWriteTransferable(
 
     override fun isDataFlavorSupported(flavor: DataFlavor?): Boolean = map.containsKey(flavor)
 
-    override fun getTransferData(flavor: DataFlavor?): Any = map[flavor] ?: throw UnsupportedFlavorException(flavor)
+    override fun getTransferData(flavor: DataFlavor?): Any = map[flavor] ?: NoneTransferData
 
     override fun getTransferData(pasteDataFlavor: PasteDataFlavor): Any {
         pasteDataFlavor as DesktopPasteDataFlavor

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
@@ -108,7 +108,7 @@ data class PasteData(
                 remote,
             )
 
-        fun createSearchContent(
+        fun buildRawSearchContent(
             source: String?,
             pasteItemSearchContent: String?,
         ): String? =

--- a/shared/src/commonMain/kotlin/com/crosspaste/serializer/PasteDataSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/serializer/PasteDataSerializer.kt
@@ -76,7 +76,7 @@ class PasteDataSerializer : KSerializer<PasteData> {
             hash = hash,
             createTime = DateUtils.nowEpochMilliseconds(),
             pasteSearchContent =
-                PasteData.createSearchContent(
+                PasteData.buildRawSearchContent(
                     source,
                     pasteAppearItem?.getSearchContent(),
                 ),


### PR DESCRIPTION
Closes #3743

## Summary

Apply fixes identified in code review session 1 (core data models & interfaces):

- **[M1]** Unify `getTransferData` error handling — both overloads now consistently return `NoneTransferData` (Null Object pattern) instead of one throwing `UnsupportedFlavorException`
- **[m1]** Remove redundant hand-written `equals()`/`hashCode()` from `DesktopPasteDataFlavor` — Kotlin data class auto-generates identical implementations
- **[m3]** Rename `PasteData.createSearchContent()` → `buildRawSearchContent()` to avoid naming ambiguity with `SearchContentService.createSearchContent()` (which does ICU tokenization)
- **[m4]** Add `logger.warn` for unknown `PasteType` in `getIconData()` else branch, making missing cases for new paste types discoverable while preserving the fallback behavior

### Findings verified as non-issues:
- **[M2]** `fromJson()` null handling — confirmed all callers handle null correctly
- **[M3]** `getPasteAppearItems()` duplicates — confirmed `pasteAppearItem` and `pasteCollection` are mutually exclusive by construction (`first()` / `drop(1)`)
- **[m2]** "Redundant" type cast — confirmed `as? PasteItem` is required (generic bound is `Any`, not `PasteItem`)

## Test plan
- [x] `./gradlew compileKotlinDesktop :shared:compileKotlinDesktop` passes
- [x] `./gradlew ktlintFormat` passes with no changes
- [x] Verify clipboard copy/paste still works correctly on desktop

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)