### PR TITLE
Fix image resource leak, redundant hash computation, and silent plugin failures

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
@@ -134,6 +134,8 @@ class DesktopImageTypePlugin(
                     )
                 }
                 pasteCollector.updateCollectItem(itemIndex, this::class, update)
+            } else {
+                logger.warn { "Failed to write image for pasteId=$pasteId itemIndex=$itemIndex path=$imagePath" }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
@@ -100,8 +100,11 @@ data class ImagesPasteItem(
                     fileName = fileName,
                 )
             }
-        return createImagesPasteItem(
+        return ImagesPasteItem(
             identifiers = identifiers,
+            count = count,
+            hash = hash,
+            size = size,
             basePath = basePath,
             relativePathList = newRelativePathList,
             fileInfoTreeMap = fileInfoTreeMap,
@@ -117,6 +120,21 @@ data class ImagesPasteItem(
             fileInfoTreeMap = fileInfoTreeMap,
             extraInfo = extraInfo,
         )
+
+    override fun clear(
+        clearResource: Boolean,
+        pasteCoordinate: PasteCoordinate,
+        userDataPathProvider: UserDataPathProvider,
+    ) {
+        if (clearResource) {
+            // Non-reference types need to clean up copied files
+            if (basePath == null) {
+                for (path in getFilePaths(userDataPathProvider)) {
+                    fileUtils.deleteFile(path)
+                }
+            }
+        }
+    }
 
     override fun isValid(): Boolean =
         count > 0 &&


### PR DESCRIPTION
Closes #3747

## Changes

- **ImagesPasteItem: Add `clear()` override** — Mirrors `FilesPasteItem.clear()` logic to delete stored image files when paste data is removed, fixing a disk space leak
- **ImagesPasteItem: Optimize `bind()`** — Use direct constructor instead of `createImagesPasteItem()` to avoid redundant hash/count/size recalculation (hash computation can be expensive)
- **DesktopRtfTypePlugin: Close InputStream** — Use `.use { it.readBytes() }` to ensure the stream from Java AWT Transferable is properly closed
- **DesktopRtfTypePlugin: Log RTF conversion failure** — Add `logger.warn` when `rtfToHtml()` returns null
- **DesktopImageTypePlugin: Log image write failure** — Add `logger.warn` when `writeImage()` returns false