### PR TITLE
Fix FileToUrlPlugin resource leak and simplify MultiImagesPlugin

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/process/MultiImagesPlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/process/MultiImagesPlugin.kt
@@ -25,9 +25,7 @@ class MultiImagesPlugin(
 
             if (allMemoryImages) {
                 val maxSizeImagePasteItem =
-                    pasteItems.maxWith { a, b ->
-                        a.size.compareTo(b.size)
-                    } as ImagesPasteItem
+                    pasteItems.maxBy { it.size } as ImagesPasteItem
 
                 pasteItems
                     .filter { it != maxSizeImagePasteItem }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/process/FileToUrlPlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/process/FileToUrlPlugin.kt
@@ -32,6 +32,10 @@ class FileToUrlPlugin(
                 if (filePaths.size == 1 && filePaths[0].extension == "url") {
                     val url = extractUrlFromFile(filePaths[0])
                     if (url != null) {
+                        pasteAppearItem.clear(
+                            pasteCoordinate = pasteCoordinate,
+                            userDataPathProvider = userDataPathProvider,
+                        )
                         if (pasteItems.any { it is UrlPasteItem && it.url == url }) {
                             null
                         } else {


### PR DESCRIPTION
Closes #3749

## Changes

- **FileToUrlPlugin: Fix resource leak** — Add `clear()` call after successful URL extraction from `.url` files. Previously, when a `FilesPasteItem` was replaced by a `UrlPasteItem` (or removed as duplicate), the locally copied `.url` file was never cleaned up, causing disk space leak.
- **MultiImagesPlugin: Simplify comparator** — Replace verbose `maxWith { a, b -> a.size.compareTo(b.size) }` with idiomatic `maxBy { it.size }`.