### PR TITLE
Fix import/export stream leaks and minor code quality issues

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -44,7 +44,7 @@ class PasteDao(
         private val fileUtils = getFileUtils()
     }
 
-    val logger = KotlinLogging.logger {}
+    private val logger = KotlinLogging.logger {}
 
     private val pasteDatabaseQueries = database.pasteDatabaseQueries
 

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/CacheManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/CacheManager.kt
@@ -26,11 +26,18 @@ interface CacheManager {
                 )
             val filesIndexBuilder = FilesIndexBuilder(PullFileTaskExecutor.CHUNK_SIZE)
             val fileItems = pasteData.getPasteAppearItems().filter { it is PasteFiles }
-            val id = pasteData.id
+            val pasteDataId = pasteData.id
             val appInstanceId = pasteData.appInstanceId
             for (pasteAppearItem in fileItems) {
                 val pasteFiles = pasteAppearItem as PasteFiles
-                userDataPathProvider.resolve(appInstanceId, dateString, id, pasteFiles, false, filesIndexBuilder)
+                userDataPathProvider.resolve(
+                    appInstanceId,
+                    dateString,
+                    pasteDataId,
+                    pasteFiles,
+                    false,
+                    filesIndexBuilder,
+                )
             }
             filesIndexBuilder.build()
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
@@ -85,10 +85,8 @@ class DesktopTaskBuilder(
                     SyncExtraInfo(appInstanceId),
                 ),
             )
-            return this
-        } else {
-            return this
         }
+        return this
     }
 
     override fun addPullIconTask(


### PR DESCRIPTION
Closes #3751

## Changes

- **PasteImportService: Fix stream leak** — Refactor `decompress()` to use `try-finally`, ensuring `bufferSource` is closed even when decompression fails
- **PasteExportService: Fix stream leak** — Refactor `compressExportFile()` to use `try-finally`, ensuring `bufferedSink` is closed even when compression fails
- **PasteExportService: Fix parameter shadowing** — Rename lambda param from `pasteData` to `pasteFiles` (it iterates `PasteFiles`, not `PasteData`)
- **PasteExportService: Fix typo** — Error message `"cant to write fail"` → `"can't write to export output"`
- **PasteDao: Make logger private** — Align with project convention (all other classes use `private val logger`)
- **DesktopTaskSubmitter: Remove redundant else** — `addRelaySyncTask` had if/else both returning `this`
- **CacheManager: Fix variable shadowing** — Rename `val id` to `val pasteDataId` to avoid shadowing method parameter