### PR TITLE
Fix server routing: scope leak, path traversal, exit timeout, and logging gaps

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -7,23 +7,20 @@ import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
-import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.successResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 fun Routing.pasteRouting(
     appControl: AppControl,
     pasteboardService: PasteboardService,
+    pasteRoutingScope: CoroutineScope,
     syncRoutingApi: SyncRoutingApi,
 ) {
     val logger = KotlinLogging.logger {}
-
-    val scope = CoroutineScope(ioDispatcher + SupervisorJob())
 
     post("/sync/paste") {
         getAppInstanceId(call)?.let { appInstanceId ->
@@ -49,7 +46,7 @@ fun Routing.pasteRouting(
             runCatching {
                 val pasteData = call.receive<PasteData>()
 
-                scope.launch {
+                pasteRoutingScope.launch {
                     pasteboardService.tryWriteRemotePasteboard(
                         pasteData,
                     )

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
@@ -85,6 +85,12 @@ fun Routing.pullRouting(
                 return@get
             }
 
+        if (source.contains('/') || source.contains('\\') || source.contains("..")) {
+            logger.warn { "icon source contains invalid characters: $source" }
+            failResponse(call, StandardErrorCode.NOT_FOUND_SOURCE.toErrorCode())
+            return@get
+        }
+
         val iconPath = userDataPathProvider.resolve("$source.png", AppFileType.ICON)
         if (!fileUtils.existFile(iconPath)) {
             logger.error { "icon not found: $source" }


### PR DESCRIPTION
Closes #3755

## Summary
Code review session 8 fixes for server routing handlers (5 medium, 4 low severity):

- **PasteRouting scope leak**: Replace orphaned `CoroutineScope` with lifecycle-aware scope tied to Application's Job via `SupervisorJob(coroutineContext[Job])` — auto-cancels on server shutdown
- **Path traversal in `/pull/icon/{source}`**: Validate `source` parameter rejects `/`, `\`, and `..` before path resolution
- **Exit hang in `notifyExit()`**: Replace sequential `runBlocking` per handler with concurrent `async/awaitAll` wrapped in `withTimeout(5000)` 
- **Silent trust failure**: Add `logger.error(e)` to `/sync/trust` `onFailure` block
- **Silent device-not-found**: Add `logger.warn` in `trustSyncInfo()` when device not in nearby list
- **Heartbeat dedup**: Extract `validateHeartbeat()` helper to remove duplicated validation across GET/POST heartbeat endpoints
- **Log level fixes**: Signature verify fail upgraded from debug→warn; showToken logging upgraded from debug→info with caller host
- **Empty hostInfoList**: Add debug logging when `/sync/syncInfo` filter produces empty result

## Test plan
- [x] `ktlintFormat` passes
- [x] Project compiles successfully
- [ ] Manual verification of sync/trust flow between devices
- [ ] Verify server shutdown cleanly cancels in-flight paste writes