### PR TITLE
:bug: Fix client API layer: error handling and logging improvements

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/AbstractResourcesClient.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/AbstractResourcesClient.kt
@@ -53,14 +53,22 @@ abstract class AbstractResourcesClient(
                         fileUtils.moveFile(tempFilePath, path)
                     }.onSuccess {
                         listener.onSuccess()
-                    }.onFailure {
-                        if (fileUtils.existFile(tempFilePath)) {
-                            fileUtils.deleteFile(tempFilePath)
+                    }.onFailure { error ->
+                        runCatching {
+                            if (fileUtils.existFile(tempFilePath)) {
+                                fileUtils.deleteFile(tempFilePath)
+                            }
+                        }.onFailure { e ->
+                            logger.warn(e) { "Failed to delete temp file: $tempFilePath" }
                         }
-                        if (fileUtils.existFile(path)) {
-                            fileUtils.deleteFile(path)
+                        runCatching {
+                            if (fileUtils.existFile(path)) {
+                                fileUtils.deleteFile(path)
+                            }
+                        }.onFailure { e ->
+                            logger.warn(e) { "Failed to delete target file: $path" }
                         }
-                        listener.onFailure(response.status, it)
+                        listener.onFailure(response.status, error)
                     }
                 } else {
                     listener.onFailure(response.status, null)

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/ClientApiResult.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/ClientApiResult.kt
@@ -59,7 +59,7 @@ suspend inline fun <T> request(
 ): ClientApiResult =
     try {
         val response = request()
-        logger.info { "response status: ${response.call.request.url} ${response.status}" }
+        logger.debug { "response status: ${response.call.request.url} ${response.status}" }
         if (response.status.value == 404) {
             createFailureResult(StandardErrorCode.NOT_FOUND_API, "Not found Api")
         } else if (response.status.value != 200) {

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
@@ -72,6 +72,9 @@ class SyncClientApi(
             val result = it.bodyAsText()
             result.toIntOrNull()?.let { connectedVersion ->
                 syncApi.compareVersion(connectedVersion)
+            } ?: run {
+                logger.warn { "heartbeat response is not a valid version int: '$result'" }
+                null
             }
         })
 


### PR DESCRIPTION
Closes #3757

## Summary

- **PullClientApi**: Wrap non-200 response body deserialization in `runCatching` with fallback error message — prevents crash on non-JSON error responses (e.g., from proxy/load balancer)
- **SyncClientApi**: Add `logger.warn` when heartbeat response body fails `toIntOrNull()` — makes unparseable version responses visible instead of silently returning null
- **AbstractResourcesClient**: Wrap each `deleteFile` call in download `onFailure` handler with independent `runCatching` — ensures both temp file and target file cleanup are attempted and `listener.onFailure` is always called
- **ClientApiResult**: Change `request()` response log from `info` to `debug` — reduces log noise from high-frequency operations like heartbeats
- **PullClientApi**: Remove unnecessary `@OptIn(InternalAPI::class)` annotation — no internal Ktor API is actually used

## Test plan

- [x] `./gradlew ktlintFormat` passes
- [x] `./gradlew compileKotlinDesktop` passes

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)