### PR TITLE
:bug: Fix network plugins: encryption error handling, scope leak, and stream safety

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientDecryptPlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientDecryptPlugin.kt
@@ -63,16 +63,12 @@ class ClientDecryptPlugin(
                     } else if (contentType?.match(ContentType.Application.OctetStream) == true) {
                         val result =
                             buildPacket {
-                                runCatching {
-                                    while (!byteReadChannel.isClosedForRead) {
-                                        val size = byteReadChannel.readInt()
-                                        val byteArray = ByteArray(size)
-                                        byteReadChannel.readFully(byteArray, 0, size)
-                                        val decryptByteArray = processor.decrypt(byteArray)
-                                        writeFully(decryptByteArray)
-                                    }
-                                }.onFailure { e ->
-                                    logger.error(e) { "Error decrypting content" }
+                                while (!byteReadChannel.isClosedForRead) {
+                                    val size = byteReadChannel.readInt()
+                                    val byteArray = ByteArray(size)
+                                    byteReadChannel.readFully(byteArray, 0, size)
+                                    val decryptByteArray = processor.decrypt(byteArray)
+                                    writeFully(decryptByteArray)
                                 }
                             }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientEncryptPlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientEncryptPlugin.kt
@@ -31,7 +31,6 @@ class ClientEncryptPlugin(
                 context.headers["secure"]?.let {
                     logger.debug { "client encrypt $targetAppInstanceId" }
                     when (context.body) {
-                        // Current all client requests use the Json protocol
                         is OutgoingContent.ByteArrayContent -> {
                             val processor = secureStore.getMessageProcessor(targetAppInstanceId)
                             val originalContent = context.body as OutgoingContent.ByteArrayContent
@@ -39,6 +38,9 @@ class ClientEncryptPlugin(
                             val ciphertextMessageBytes = processor.encrypt(bytes)
                             context.body =
                                 ByteArrayContent(ciphertextMessageBytes, contentType = ContentType.Application.Json)
+                        }
+                        else -> {
+                            logger.warn { "Unsupported content type for encryption: ${context.body::class}" }
                         }
                     }
                 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopFaviconLoader.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopFaviconLoader.kt
@@ -20,7 +20,9 @@ class DesktopFaviconLoader(
     ): Path? =
         resourcesClient.request(url).getOrNull()?.let { response ->
             FileOutputStream(path.toFile()).use { output ->
-                response.getBody().toInputStream().copyTo(output)
+                response.getBody().toInputStream().use { input ->
+                    input.copyTo(output)
+                }
             }
             path
         }


### PR DESCRIPTION
Closes #3759

## Summary

- **ServerEncryptPluginFactory**: Wrap `body.writeTo(originChannel)` in `runCatching` — on failure, close the channel with the error cause (`originChannel.close(e)`) so the reading coroutine terminates properly instead of hanging
- **ServerEncryptPluginFactory**: Replace orphaned `CoroutineScope(SupervisorJob() + ioDispatcher)` with structured `coroutineScope { async(ioDispatcher) }` — encryption coroutines now cancel automatically when the request is cancelled
- **ClientDecryptPlugin**: Remove `runCatching` around OctetStream chunk decryption loop — decryption errors now propagate as `PasteException(DECRYPT_FAIL)` to `ExceptionHandler` instead of being swallowed and producing corrupt response data
- **ClientEncryptPlugin**: Add `else` branch to `when` expression — logs a warning if an unsupported content type is encountered, preventing silent unencrypted transmission
- **DesktopFaviconLoader**: Wrap `response.getBody().toInputStream()` in `.use {}` to ensure the InputStream is closed even if `copyTo` fails partway through

## Test plan

- [x] `./gradlew ktlintFormat` passes
- [x] `./gradlew compileKotlinDesktop` passes
- [x] Manual verification: file transfer with encryption still works end-to-end
- [x] Manual verification: simulated encryption failure returns proper error instead of corrupt data

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)