### PR TITLE
:bug: Fix sync layer: silent error swallowing, duplicate fail counting, and missing callbacks

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -134,13 +134,15 @@ class GeneralSyncHandler(
             }
         }
 
-        when (current.connectState) {
-            SyncState.DISCONNECTED,
-            SyncState.INCOMPATIBLE,
-            SyncState.UNMATCHED,
-            SyncState.UNVERIFIED,
-            -> {
-                syncPollingManager.fail()
+        if (current.connectState == previous.connectState) {
+            when (current.connectState) {
+                SyncState.DISCONNECTED,
+                SyncState.INCOMPATIBLE,
+                SyncState.UNMATCHED,
+                SyncState.UNVERIFIED,
+                -> {
+                    syncPollingManager.fail()
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #3761

## Summary

Code review Session 11 fixes for the sync layer (SyncResolver, GeneralSyncHandler):

- **M1**: Add `.onFailure` error logging to `SyncResolver.emitEvent` — previously all event processing errors were silently swallowed by `runCatching`
- **M4**: Remove redundant variable shadowing `val versionRelation = versionRelation` in `tryUseTokenCache`
- **m2**: Guard trailing `syncPollingManager.fail()` with state-change check to prevent double-counting on disconnected state transitions (was causing exponential backoff to increase faster than intended)
- **m3**: Add missing `callback(false)` in `trustByToken` when `connectHostAddress` is null (UI would hang waiting for callback)
- **m5**: Correct misleading "exchangeSyncInfo" log messages to "heartbeat" in the heartbeat method

## Test plan

- [ ] Verify sync connection/disconnection cycle works correctly
- [ ] Verify trust-by-token flow handles null host address gracefully
- [ ] Verify exponential backoff timing is correct after disconnect events
- [ ] Pre-existing test failure (`HostInfoFilterTest.testInvalidSelfIPAddress`) is unrelated

🤖 Generated with [Claude Code](https://claude.ai/code)