### PR TITLE
:bug: Fix TxtRecord sort bug, non-atomic StateFlow mutation, and unscoped async

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/utils/TxtRecordUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/TxtRecordUtils.kt
@@ -33,7 +33,7 @@ object TxtRecordUtils {
         // Combine the split data into a complete base64 encoded string
         val base64Encoded =
             txtRecordDict.entries
-                .sortedBy { it.key }
+                .sortedBy { it.key.toIntOrNull() ?: 0 }
                 .joinToString(separator = "") { (_, value) ->
                     value.decodeToString()
                 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
@@ -119,17 +119,19 @@ class DesktopPasteBonjourService(
             ensureMinExecutionTime(MIN_SEARCH_DURATION) {
                 logger.info { "Manual refresh started..." }
 
-                jmdnsMap
-                    .map { (hostAddress, jmdns) ->
-                        async {
-                            val services = jmdns.list(SERVICE_TYPE, ACTIVE_SCAN_TIMEOUT)
-                            logger.debug { "Interface $hostAddress found ${services.size} services" }
+                coroutineScope {
+                    jmdnsMap
+                        .map { (hostAddress, jmdns) ->
+                            async {
+                                val services = jmdns.list(SERVICE_TYPE, ACTIVE_SCAN_TIMEOUT)
+                                logger.debug { "Interface $hostAddress found ${services.size} services" }
 
-                            services.forEach { serviceInfo ->
-                                jmdns.requestServiceInfo(SERVICE_TYPE, serviceInfo.name)
+                                services.forEach { serviceInfo ->
+                                    jmdns.requestServiceInfo(SERVICE_TYPE, serviceInfo.name)
+                                }
                             }
-                        }
-                    }.awaitAll()
+                        }.awaitAll()
+                }
             }.onFailure { e ->
                 logger.error(e) { "Error during manual refreshAll" }
             }


### PR DESCRIPTION
Closes #3763

## Summary

Code review Session 12 fixes for device discovery layer:

- **m1**: Sort `TxtRecordUtils` chunk keys numerically (`.toIntOrNull()`) instead of lexicographically — prevents data corruption when TXT record payloads exceed 10 chunks (keys "10", "11" would sort before "2")
- **m2**: Use `MutableStateFlow.update {}` for atomic read-modify-write in `GeneralNearbyDeviceManager.addDevice`/`removeDevice` — JmDNS service listener callbacks can fire concurrently from different threads
- **m4**: Wrap `refreshAll` async calls in explicit `coroutineScope {}` for structured concurrency, matching the pattern already used in `setup()`

## Test plan

- [x] Verify mDNS device discovery still works (add/remove devices)
- [x] Verify manual refresh completes correctly
- [x] Pre-existing test failure (`HostInfoFilterTest.testInvalidSelfIPAddress`) is unrelated

🤖 Generated with [Claude Code](https://claude.ai/code)