### PR TITLE
:bug: Fix duplicate retry condition and check() crash in sync task executors

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
@@ -76,7 +76,19 @@ class PullFileTaskExecutor(
 
         return pasteDao.getNoDeletePasteData(pasteTask.pasteDataId)?.let { pasteData ->
             val fileItems = pasteData.getPasteAppearItems().filter { it is PasteFiles }
-            check(fileItems.isNotEmpty() && fileItems.size == 1)
+            if (fileItems.size != 1) {
+                return@let doFailure(
+                    pasteData,
+                    pullExtraInfo,
+                    listOf(
+                        createFailureResult(
+                            StandardErrorCode.PULL_FILE_TASK_FAIL,
+                            "Expected exactly 1 PasteFiles item, got ${fileItems.size}",
+                        ),
+                    ),
+                    pasteTask.modifyTime,
+                )
+            }
             val fileItem = fileItems.first()
             val appInstanceId = pasteData.appInstanceId
             val dateString =

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -224,7 +224,7 @@ class SyncPasteTaskExecutor(
             val noNeedRetry =
                 fails.values.any {
                     it.exception.match(StandardErrorCode.SYNC_NOT_ALLOW_RECEIVE_BY_APP) ||
-                        it.exception.match(StandardErrorCode.SYNC_NOT_ALLOW_RECEIVE_BY_APP) ||
+                        it.exception.match(StandardErrorCode.SYNC_NOT_ALLOW_SEND_BY_APP) ||
                         it.exception.match(StandardErrorCode.DECRYPT_FAIL)
                 }
 


### PR DESCRIPTION
Closes #3765

## Summary

Code review Session 13 fixes for sync task executors:

- **M1**: Fix duplicate `SYNC_NOT_ALLOW_RECEIVE_BY_APP` in `noNeedRetry` check — the second condition was a copy-paste bug and should be `SYNC_NOT_ALLOW_SEND_BY_APP`. Previously, sync tasks that failed due to send-permission errors would be incorrectly retried up to 3 times.
- **M3**: Replace `check(fileItems.isNotEmpty() && fileItems.size == 1)` in `PullFileTaskExecutor` with a proper `doFailure()` result. The `check()` threw an opaque `IllegalStateException` ("Check failed") that was caught by `TaskExecutor` as a non-retryable failure with no useful error message.

## Test plan

- [ ] Verify paste sync still works between devices
- [ ] Verify file pull tasks handle edge cases gracefully
- [ ] Pre-existing test failure (`HostInfoFilterTest.testInvalidSelfIPAddress`) is unrelated

🤖 Generated with [Claude Code](https://claude.ai/code)