### PR TITLE
:bug: Fix security layer: race condition, null safety, and bounds checking

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/db/secure/SecureDao.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/secure/SecureDao.kt
@@ -10,13 +10,9 @@ class SecureDao(private val database: Database): SecureIO {
 
     override suspend fun saveCryptPublicKey(
         appInstanceId: String,
-        serialized: ByteArray
-    ): Boolean = withContext(ioDispatcher) {
-        database.transactionWithResult {
-            val result = secureDatabaseQueries.checkKeyExists(appInstanceId).executeAsOne()
-            secureDatabaseQueries.saveCryptPublicKey(appInstanceId, serialized)
-            result
-        }
+        serialized: ByteArray,
+    ): Unit = withContext(ioDispatcher) {
+        secureDatabaseQueries.saveCryptPublicKey(appInstanceId, serialized)
     }
 
     override suspend fun existCryptPublicKey(appInstanceId: String): Boolean = withContext(ioDispatcher) {

--- a/app/src/commonMain/kotlin/com/crosspaste/db/secure/SecureIO.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/secure/SecureIO.kt
@@ -4,7 +4,7 @@ interface SecureIO {
     suspend fun saveCryptPublicKey(
         appInstanceId: String,
         serialized: ByteArray,
-    ): Boolean
+    )
 
     suspend fun existCryptPublicKey(appInstanceId: String): Boolean
 

--- a/app/src/commonMain/kotlin/com/crosspaste/secure/GeneralSecureStore.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/secure/GeneralSecureStore.kt
@@ -18,8 +18,6 @@ class GeneralSecureStore(
             SecureSession()
         }
 
-    private fun removeSecureSession(appInstanceId: String): SecureSession? = sessions.remove(appInstanceId)
-
     override suspend fun saveCryptPublicKey(
         appInstanceId: String,
         cryptPublicKey: ByteArray,
@@ -39,10 +37,11 @@ class GeneralSecureStore(
     }
 
     override suspend fun deleteCryptPublicKey(appInstanceId: String) {
-        val session = removeSecureSession(appInstanceId)
-        session?.mutex?.withLock {
+        val session = getSecureSession(appInstanceId)
+        session.mutex.withLock {
             session.processor = null
             secureIO.deleteCryptPublicKey(appInstanceId)
+            sessions.remove(appInstanceId)
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/CryptographyUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/CryptographyUtils.kt
@@ -17,7 +17,6 @@ object CryptographyUtils {
     private val codecsUtils = getCodecsUtils()
 
     fun generateSecureKeyPair(): SecureKeyPair {
-        val provider = CryptographyProvider.Default
         val ecdsa = provider.get(ECDSA)
         val ecdh = provider.get(ECDH)
         val signKeyPairGenerator = ecdsa.keyPairGenerator(EC.Curve.P256)

--- a/app/src/desktopMain/kotlin/com/crosspaste/secure/WindowsSecureStoreFactory.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/secure/WindowsSecureStoreFactory.kt
@@ -49,8 +49,10 @@ class WindowsSecureStoreFactory(
         logger.info { "Generate secureKeyPair" }
         val secureKeyPair = CryptographyUtils.generateSecureKeyPair()
         val data = secureKeyPairSerializer.encodeSecureKeyPair(secureKeyPair)
-        val encryptData = WindowDapiHelper.encryptData(data)
-        filePersist.saveBytes(encryptData!!)
+        val encryptData =
+            WindowDapiHelper.encryptData(data)
+                ?: throw IllegalStateException("DPAPI encryption failed — cannot persist secure key pair")
+        filePersist.saveBytes(encryptData)
         return GeneralSecureStore(secureKeyPair, secureKeyPairSerializer, secureIO)
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/secure/MemorySecureIO.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/secure/MemorySecureIO.kt
@@ -9,8 +9,8 @@ class MemorySecureIO : SecureIO {
     override suspend fun saveCryptPublicKey(
         appInstanceId: String,
         serialized: ByteArray,
-    ): Boolean {
-        return cryptPublicKeyMap.put(appInstanceId, serialized) == null
+    ) {
+        cryptPublicKeyMap[appInstanceId] = serialized
     }
 
     override suspend fun existCryptPublicKey(appInstanceId: String): Boolean {


### PR DESCRIPTION
Closes #3767

## Summary

- **Fix race condition** in `GeneralSecureStore.deleteCryptPublicKey` — session was removed from `ConcurrentMap` before acquiring mutex, allowing concurrent threads to create a new session and use stale keys. Now acquires lock first, then removes.
- **Fix null safety** in `WindowsSecureStoreFactory` — DPAPI `encryptData()` result was force-unwrapped with `!!`. Replaced with proper null check and descriptive error message.
- **Add bounds checking** to `SecureKeyPairSerializer` deserialization — malformed/truncated byte arrays caused opaque `ArrayIndexOutOfBoundsException`. Added `readSegment` helper with `require()` validation for clear error messages.
- **Clean up `SecureIO` interface** — `saveCryptPublicKey` returned `Boolean` that was never used, with inverted semantics between `SecureDao` and `MemorySecureIO`. Changed to `Unit`.
- **Remove shadowed variable** — `CryptographyUtils.generateSecureKeyPair` had redundant local `provider` shadowing the class-level property.

## Test plan
- [x] All security tests pass (`SecureMessageProcessorTest`, `SecureKeyPairSerializerTest`)
- [x] Full build compiles successfully (155 tests, only pre-existing `HostInfoFilterTest` failure)
- [x] ktlintFormat passes with no issues