### PR TITLE
:bug: Fix macOS platform: getString memory leak and Keychain duplicate entry handling

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/macos/api/MacosApi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/macos/api/MacosApi.kt
@@ -120,11 +120,11 @@ interface MacosApi : Library {
 
         fun getString(ptr: Pointer?): String? {
             val pointer = ptr ?: return null
-            return runCatching {
-                return pointer.getString(0)
-            }.apply {
+            return try {
+                pointer.getString(0)
+            } finally {
                 Native.free(Pointer.nativeValue(pointer))
-            }.getOrNull()
+            }
         }
     }
 }

--- a/app/src/desktopMain/swift/MacosApi.swift
+++ b/app/src/desktopMain/swift/MacosApi.swift
@@ -73,7 +73,20 @@ public func setPassword(service: UnsafePointer<CChar>, account: UnsafePointer<CC
     // Try to add the item to the keychain
     let status = SecItemAdd(query as CFDictionary, nil)
 
-    // Check the result
+    if status == errSecDuplicateItem {
+        // Entry already exists, update it instead
+        let searchQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceString,
+            kSecAttrAccount as String: accountString
+        ]
+        let updateFields: [String: Any] = [
+            kSecValueData as String: passwordData
+        ]
+        let updateStatus = SecItemUpdate(searchQuery as CFDictionary, updateFields as CFDictionary)
+        return updateStatus == errSecSuccess
+    }
+
     return status == errSecSuccess
 }
 


### PR DESCRIPTION
Closes #3769

## Summary

- **Fix memory leak in `MacosApi.getString`**: The `return` inside `runCatching`'s lambda was a non-local return from `getString()`, causing `.apply { Native.free(...) }` to never execute on the success path. Replaced with `try`/`finally` to ensure `strdup`-allocated memory is always freed.
- **Fix `setPassword` duplicate entry handling**: `SecItemAdd` fails silently with `errSecDuplicateItem` when a Keychain entry already exists. Added fallback to `SecItemUpdate` on duplicate, preventing silent failures during concurrent startup scenarios.

## Test plan

- [x] `./gradlew ktlintFormat` passes
- [x] `./gradlew build` passes (only pre-existing `HostInfoFilterTest` failure)
- [x] Verify macOS Keychain operations work correctly (set/get/update/delete password)
- [x] Verify no memory leaks when repeatedly calling `getString` (e.g., `getComputerName`, `getHardwareUUID`)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)