### PR TITLE
:bug: Fix FileExtFetcher wrong image path and OCR native resource leak

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/image/coil/FileExtFetcher.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/image/coil/FileExtFetcher.kt
@@ -30,11 +30,11 @@ class FileExtFetcher(
 
                 if (fileUtils.existFile(path)) {
                     if (!path.isDirectory) {
-                        fileExtLoader.load(path)?.let {
+                        fileExtLoader.load(path)?.let { iconPath ->
                             SourceFetchResult(
                                 source =
                                     ImageSource(
-                                        file = path,
+                                        file = iconPath,
                                         fileSystem = fileUtils.fileSystem,
                                     ),
                                 mimeType = null,

--- a/app/src/desktopMain/kotlin/com/crosspaste/module/ocr/DesktopOCRModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/module/ocr/DesktopOCRModule.kt
@@ -108,11 +108,17 @@ class DesktopOCRModule(
         val innerApi = TessBaseAPI()
         val dataPath = BytePointer(trainedDataPath.toString())
         val language = BytePointer(ocrLanguage)
-        return if (innerApi.Init(dataPath, language) != 0) {
-            null
-        } else {
-            innerApi.SetPageSegMode(6)
-            innerApi
+        return try {
+            if (innerApi.Init(dataPath, language) != 0) {
+                innerApi.deallocate()
+                null
+            } else {
+                innerApi.SetPageSegMode(6)
+                innerApi
+            }
+        } finally {
+            dataPath.deallocate()
+            language.deallocate()
         }
     }
 


### PR DESCRIPTION
Closes #3775

## Summary
- **FileExtFetcher**: Fixed `ImageSource` using original file path instead of the loaded icon path returned by `fileExtLoader.load()`. The `let` block now correctly passes the icon path (`iconPath`) to `ImageSource`.
- **DesktopOCRModule**: Fixed native resource leak in `createApi()` — `TessBaseAPI` is now `deallocate()`d when `Init()` fails, and `BytePointer` allocations for data path and language are explicitly freed in a `finally` block.

## Test plan
- [x] Verify compilation passes (`./gradlew compileKotlinDesktop`)
- [x] Verify OCR functionality still works after `createApi` cleanup changes
- [x] Verify file extension icons display correctly if `FileExtFetcher` is wired into UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)