### PR TITLE
:bug: Fix use-after-free in Swift async dispatches for window management

### DIFF
--- a/app/src/desktopMain/swift/MacosApi.swift
+++ b/app/src/desktopMain/swift/MacosApi.swift
@@ -179,8 +179,8 @@ public func saveAppIcon(bundleIdentifier: UnsafePointer<CChar>, path: UnsafePoin
 public func mainToBack(
     appName: UnsafePointer<CChar>
 ) {
+    let appNameString = String(cString: appName)
     DispatchQueue.main.async {
-        let appNameString = String(cString: appName)
         hideWindowAndActivateApp(hideTitle: "CrossPaste", appName: appNameString)
     }
 }
@@ -191,12 +191,16 @@ public func mainToBack(
     keyCodesPointer: UnsafePointer<Int32>,
     count: Int
 ) {
+    let appNameString = String(cString: appName)
+    let keyCodes = Array(UnsafeBufferPointer(start: keyCodesPointer, count: count))
     DispatchQueue.main.async {
-        let appNameString = String(cString: appName)
         hideWindowAndActivateApp(hideTitle: "CrossPaste", appName: appNameString)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            simulatePasteCommand(keyCodesPointer: keyCodesPointer, count: count)
+            keyCodes.withUnsafeBufferPointer { buffer in
+                guard let baseAddress = buffer.baseAddress else { return }
+                simulatePasteCommand(keyCodesPointer: baseAddress, count: buffer.count)
+            }
         }
     }
 }
@@ -205,8 +209,8 @@ public func mainToBack(
 public func searchToBack(
     appName: UnsafePointer<CChar>
 ) {
+    let appNameString = String(cString: appName)
     DispatchQueue.main.async {
-        let appNameString = String(cString: appName)
         hideWindowAndActivateApp(hideTitle: "CrossPaste Search", appName: appNameString)
     }
 }
@@ -217,12 +221,16 @@ public func searchToBackAndPaste(
     keyCodesPointer: UnsafePointer<Int32>,
     count: Int
 ) {
+    let appNameString = String(cString: appName)
+    let keyCodes = Array(UnsafeBufferPointer(start: keyCodesPointer, count: count))
     DispatchQueue.main.async {
-        let appNameString = String(cString: appName)
         hideWindowAndActivateApp(hideTitle: "CrossPaste Search", appName: appNameString)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            simulatePasteCommand(keyCodesPointer: keyCodesPointer, count: count)
+            keyCodes.withUnsafeBufferPointer { buffer in
+                guard let baseAddress = buffer.baseAddress else { return }
+                simulatePasteCommand(keyCodesPointer: baseAddress, count: buffer.count)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #3777

## Summary
- Copy `appName` string from JNA pointer **before** `DispatchQueue.main.async` in `mainToBack`, `mainToBackAndPaste`, `searchToBack`, `searchToBackAndPaste`
- Copy `keyCodesPointer` data to a Swift `Array<Int32>` **before** the nested `asyncAfter` closure, then pass back via `withUnsafeBufferPointer` for `simulatePasteCommand`
- Prevents use-after-free when JNA frees temporary native string memory after the function returns

## Test plan
- [x] Verify Swift dylib compiles (`./gradlew app:compileSwift`)
- [x] Verify paste-from-main-window works (select item → Cmd+V into previous app)
- [x] Verify paste-from-search-window works (search → select → paste into previous app)
- [x] Verify hide-main-window without paste works

🤖 Generated with [Claude Code](https://claude.com/claude-code)