### PR TITLE
Fix Windows native resource leaks: DC, COM, HICON, GlobalAlloc, and Process

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/JIconExtract.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/JIconExtract.kt
@@ -167,8 +167,9 @@ object JIconExtract {
         filePath: String,
     ): HBITMAP? {
         val h1 = Ole32.INSTANCE.CoInitialize(null)
+        if (!COMUtils.SUCCEEDED(h1)) return null
 
-        if (COMUtils.SUCCEEDED(h1)) {
+        try {
             val factory = PointerByReference()
 
             val h2: HRESULT? =
@@ -194,8 +195,10 @@ object JIconExtract {
                 imageFactory.Release()
                 return bitmap
             }
-        }
 
-        return null
+            return null
+        } finally {
+            Ole32.INSTANCE.CoUninitialize()
+        }
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowClipboard.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowClipboard.kt
@@ -73,8 +73,11 @@ object WindowClipboard {
             ptr.write(0, data, 0, data.size)
             kernel32.GlobalUnlock(hGlobal)
 
-            // Set to clipboard
+            // Set to clipboard — if successful, system takes ownership of hGlobal
             val result = user32.SetClipboardData(ClipboardFormats.CF_TEXT, hGlobal)
+            if (result == null) {
+                kernel32.GlobalFree(hGlobal)
+            }
             result != null
         }.getOrElse { e ->
             logger.error(e) { "Error adding CF_TEXT format" }
@@ -114,8 +117,12 @@ object WindowClipboard {
             ptr.setInt(0, lcidValue)
             kernel32.GlobalUnlock(hGlobal)
 
-            user32.SetClipboardData(ClipboardFormats.CF_LOCALE, hGlobal)
-            logger.info { "Added locale information: $lcidValue (0x${lcidValue.toString(16)})" }
+            val result = user32.SetClipboardData(ClipboardFormats.CF_LOCALE, hGlobal)
+            if (result == null) {
+                kernel32.GlobalFree(hGlobal)
+            } else {
+                logger.info { "Added locale information: $lcidValue (0x${lcidValue.toString(16)})" }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #3779

## Summary

- **User32.hiconToImage**: Store device context outside `runCatching`, release via `ReleaseDC` in cleanup block
- **JIconExtract.getHBITMAPForFile**: Wrap COM operations in `try/finally` with `CoUninitialize()` 
- **User32.extractAndSaveIcon**: Move HICON lifecycle to caller with `try/finally`; destroy both large and small icons via `DestroyIcon`
- **WindowClipboard**: Free `hGlobal` via `GlobalFree` when `SetClipboardData` fails (in both `addAnsiText` and `addLocale`)
- **WinProcessUtils.getChildProcessIds**: Use `redirectErrorStream(true)`, `.use {}` for streams, `destroyForcibly()` for process cleanup

## Test plan

- [x] Verify Windows clipboard CF_TEXT supplementation still works correctly
- [x] Verify icon extraction from EXE files produces correct PNG output
- [x] Verify child process enumeration returns expected results
- [x] Check no GDI/COM resource leaks under repeated icon extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)