### PR TITLE
Fix Linux native integration resource leaks and pointer bugs

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/FreedesktopUtils.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/FreedesktopUtils.kt
@@ -91,13 +91,18 @@ object FreedesktopUtils {
 
         findIconInTheme(themeName)?.let { return it }
 
+        val indexFile = File("/usr/share/icons/$themeName/index.theme")
         val inheritedThemes =
-            File("/usr/share/icons/$themeName/index.theme")
-                .readLines()
-                .find { it.startsWith("Inherits=") }
-                ?.substringAfter("=")
-                ?.split(",")
-                ?: emptyList()
+            if (indexFile.exists()) {
+                indexFile
+                    .readLines()
+                    .find { it.startsWith("Inherits=") }
+                    ?.substringAfter("=")
+                    ?.split(",")
+                    ?: emptyList()
+            } else {
+                emptyList()
+            }
 
         for (inheritedTheme in inheritedThemes) {
             findIconInTheme(inheritedTheme)?.let { return it }

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/LinuxPlatform.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/LinuxPlatform.kt
@@ -35,13 +35,16 @@ object LinuxPlatform {
         }.getOrElse { false }
 
     private fun getLsbReleaseInfo(): String {
-        val process = ProcessBuilder("lsb_release", "-ds").start()
-        val output =
-            process.inputStream
-                .bufferedReader()
-                .readText()
-                .trim()
-        return parseOsInfo(output)
+        val process = ProcessBuilder("lsb_release", "-ds").redirectErrorStream(true).start()
+        return try {
+            val output =
+                process.inputStream
+                    .bufferedReader()
+                    .use { it.readText().trim() }
+            parseOsInfo(output)
+        } finally {
+            process.destroyForcibly()
+        }
     }
 
     private fun getOsReleaseInfo(): String {


### PR DESCRIPTION
## Summary

Fixes 6 resource management issues found during code review Session 20 of Linux native integration code (X11, JNA, Freedesktop).

### Medium
- **M1**: `WMCtrl.findWindowByTitle` — `XQueryTree` children pointer never freed with `XFree`, causing native memory leak on every call. Wrapped iteration in `try/finally` with `free(children)`.
- **M2**: `WMCtrl.getProperty` — Error path called `free(retProp.pointer)` (JNA internal memory) instead of `free(retProp.value)` (X11-allocated data), risking native heap corruption.
- **M3**: `WMCtrl.getPropertyAsIcon` — X11 property data from `_NET_WM_ICON` never freed after extracting image. Added `try/finally` with `free(prop)`.

### Low
- **m1**: `WMCtrl.getWindowIconName` — Used `iconNameReturn.pointer` (JNA internal) instead of `iconNameReturn.value` (X11-allocated string) for both free and getString.
- **m2**: `LinuxPlatform.getLsbReleaseInfo` — Process never destroyed and streams not closed. Added `try/finally` with `.use {}` and `destroyForcibly()`.
- **m3**: `FreedesktopUtils.findLargeIcon` — `readLines()` called without existence check, would throw `FileNotFoundException` on missing `index.theme`.

Fixes #3781

## Test plan

- [x] Verify Linux clipboard monitoring still works (XFixes event loop)
- [x] Verify window activation and focus (bringToFront using EWMH)
- [x] Verify app icon extraction from X11 windows
- [x] Verify `findWindowByTitle` correctly finds windows by name
- [x] Verify icon theme resolution with inherited themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
