### PR TITLE
Fix shortcut key system: wrong macOS rawCode, dead code, fragile reflection

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/listener/DesktopShortcutKeys.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/listener/DesktopShortcutKeys.kt
@@ -56,7 +56,7 @@ class DesktopShortcutKeys(
                 _shortcutKeysCore.value = it
             }
         }.onFailure {
-            defaultKeysCore()
+            _shortcutKeysCore.value = defaultKeysCore()
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/listener/KeyboardKeys.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/listener/KeyboardKeys.kt
@@ -207,7 +207,7 @@ interface KeyboardKeys {
     fun initAllMap(): Map<Int, KeyboardKeyDefine> =
         this::class
             .memberProperties
-            .filter { it.returnType.toString() == "com.crosspaste.listener.KeyboardKeyDefine" }
+            .filter { it.returnType.classifier == KeyboardKeyDefine::class }
             .map { it.getter.call(this) as KeyboardKeyDefine }
             .associateBy { it.code }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/listener/MacKeyboardKeys.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/listener/MacKeyboardKeys.kt
@@ -168,7 +168,7 @@ object MacKeyboardKeys : KeyboardKeys {
         KeyboardKeyDefine("9", NativeKeyEvent.VC_9, 0x19) { it.keyCode == NativeKeyEvent.VC_9 }
 
     override val _0: KeyboardKeyDefine =
-        KeyboardKeyDefine("0", NativeKeyEvent.VC_0, 0x1F) { it.keyCode == NativeKeyEvent.VC_0 }
+        KeyboardKeyDefine("0", NativeKeyEvent.VC_0, 0x1D) { it.keyCode == NativeKeyEvent.VC_0 }
 
     override val A: KeyboardKeyDefine =
         KeyboardKeyDefine("A", NativeKeyEvent.VC_A, 0x00) { it.keyCode == NativeKeyEvent.VC_A }


### PR DESCRIPTION
Closes #3783

## Summary
- **Fix `MacKeyboardKeys._0` rawCode**: Changed from `0x1F` to `0x1D`. The previous value collided with letter "O", causing wrong key simulation when digit "0" was used in a macOS shortcut.
- **Fix dead code in `DesktopShortcutKeys.init`**: The `onFailure` block called `defaultKeysCore()` but discarded the return value. Now properly assigns to `_shortcutKeysCore.value`.
- **Fix fragile reflection in `KeyboardKeys.initAllMap()`**: Replaced `returnType.toString()` string comparison with type-safe `returnType.classifier == KeyboardKeyDefine::class`.

## Test plan
- [x] Verify macOS shortcut with digit "0" simulates correct key
- [x] Verify shortcut key loading still works when user properties file is missing/corrupt
- [x] Verify all keyboard keys are correctly discovered by `initAllMap()` on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)