### PR TITLE
Fix queries returning deleted paste data and isValid() treating deleted state as valid

### DIFF
--- a/app/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
+++ b/app/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
@@ -54,7 +54,7 @@ SELECT last_insert_rowid();
 
 getBatchPasteData:
 SELECT * FROM PasteDataEntity
-WHERE id > :id
+WHERE id > :id AND pasteState != -1
 ORDER BY id ASC
 LIMIT :limit;
 
@@ -143,6 +143,7 @@ WHERE hash = :hash AND
 simpleSearch:
 SELECT * FROM PasteDataEntity
 WHERE
+    pasteState != -1 AND
     CASE WHEN :appInstanceId IS NOT NULL
         THEN CASE WHEN :local
             THEN appInstanceId = :appInstanceId

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
@@ -155,21 +155,27 @@ data class PasteData(
     }
 
     fun isValid(): Boolean =
-        if (pasteState == PasteState.LOADED) {
-            val pasteItem =
-                when (getType()) {
-                    PasteType.TEXT_TYPE -> getPasteItem(PasteText::class)
-                    PasteType.COLOR_TYPE -> getPasteItem(PasteColor::class)
-                    PasteType.URL_TYPE -> getPasteItem(PasteUrl::class)
-                    PasteType.HTML_TYPE -> getPasteItem(PasteHtml::class)
-                    PasteType.RTF_TYPE -> getPasteItem(PasteRtf::class)
-                    PasteType.IMAGE_TYPE -> getPasteItem(PasteImages::class)
-                    PasteType.FILE_TYPE -> getPasteItem(PasteFiles::class)
-                    else -> null
-                }
-            (pasteItem as? PasteItem)?.isValid() ?: false
-        } else {
-            true
+        when (pasteState) {
+            PasteState.LOADED -> {
+                val pasteItem =
+                    when (getType()) {
+                        PasteType.TEXT_TYPE -> getPasteItem(PasteText::class)
+                        PasteType.COLOR_TYPE -> getPasteItem(PasteColor::class)
+                        PasteType.URL_TYPE -> getPasteItem(PasteUrl::class)
+                        PasteType.HTML_TYPE -> getPasteItem(PasteHtml::class)
+                        PasteType.RTF_TYPE -> getPasteItem(PasteRtf::class)
+                        PasteType.IMAGE_TYPE -> getPasteItem(PasteImages::class)
+                        PasteType.FILE_TYPE -> getPasteItem(PasteFiles::class)
+                        else -> null
+                    }
+                (pasteItem as? PasteItem)?.isValid() ?: false
+            }
+            PasteState.LOADING -> {
+                true
+            }
+            else -> {
+                false
+            }
         }
 
     fun existFileCategory(): Boolean = getPasteAppearItems().any { it is PasteFiles }


### PR DESCRIPTION
Closes #3791

## Summary
- Add `pasteState != -1` filter to `getBatchPasteData` and `simpleSearch` SQL queries so soft-deleted paste records are excluded from results
- Rewrite `PasteData.isValid()` from `if/else` to `when` expression: `LOADED` validates the paste item, `LOADING` returns true, all other states (including `DELETED`) return false

## Test plan
- [x] Verify `getBatchPasteData` no longer returns deleted paste records
- [x] Verify `simpleSearch` no longer returns deleted paste records  
- [x] Verify `isValid()` returns false for paste data with DELETED state
- [x] Verify `isValid()` returns true for LOADING state paste data
- [x] Verify `isValid()` correctly validates LOADED state paste data

🤖 Generated with [Claude Code](https://claude.com/claude-code)