### PR TITLE
Fix thread safety, race conditions, and resource leaks in UI infrastructure

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/clean/CleanScheduler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/clean/CleanScheduler.kt
@@ -56,6 +56,9 @@ class CleanScheduler(
     }
 
     private suspend fun cleanPaste() {
+        // Note: createTask + submitTask is not atomic across cancellation.
+        // If cancelled between them, an orphan task row remains in the database.
+        // This is acceptable because CleanTaskTaskExecutor cleans up stale tasks.
         val taskId =
             taskDao.createTask(
                 pasteDataId = null,

--- a/app/src/commonMain/kotlin/com/crosspaste/notification/NotificationManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/notification/NotificationManager.kt
@@ -8,24 +8,25 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @OptIn(FlowPreview::class)
 abstract class NotificationManager(
     private val copywriter: GlobalCopywriter,
 ) {
-    private val notificationChannel = Channel<Message>()
+    private val notificationChannel = Channel<Message>(Channel.BUFFERED)
 
     private val _notificationList: MutableStateFlow<List<Message>> = MutableStateFlow(listOf())
 
     val notificationList: StateFlow<List<Message>> = _notificationList
 
     fun pushNotification(toast: Message) {
-        this._notificationList.value = listOf(toast) + this._notificationList.value
+        _notificationList.update { listOf(toast) + it }
     }
 
     fun removeNotification(messageId: Int) {
-        this._notificationList.value = this._notificationList.value.filter { it.messageId != messageId }
+        _notificationList.update { list -> list.filter { it.messageId != messageId } }
     }
 
     init {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
@@ -47,6 +47,10 @@ class GeneralPasteSearchViewModel(
                         tag = params.tag,
                         limit = params.limit,
                     ).map { pasteDataList ->
+                        // Use pre-filter size for pagination: the SQL query already excludes
+                        // deleted items (pasteState != -1). isValid() only catches items that
+                        // became invalid after the query returned (e.g., concurrent deletion
+                        // or corrupted content), which is rare.
                         checkLoadAll(pasteDataList.size)
                         pasteDataList.filter { it.isValid() }
                     }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/PasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/PasteSearchViewModel.kt
@@ -8,6 +8,7 @@ import com.crosspaste.utils.getDateUtils
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
@@ -23,7 +24,7 @@ abstract class PasteSearchViewModel : ViewModel() {
 
     private val _inputSearch = MutableStateFlow("")
 
-    val inputSearch = _inputSearch
+    val inputSearch: StateFlow<String> = _inputSearch.asStateFlow()
 
     private val _searchBaseParams =
         MutableStateFlow(
@@ -36,12 +37,13 @@ abstract class PasteSearchViewModel : ViewModel() {
             ),
         )
 
-    val searchBaseParams = _searchBaseParams
+    val searchBaseParams: StateFlow<SearchBaseParams> = _searchBaseParams.asStateFlow()
 
     private val _loadAll = MutableStateFlow(false)
 
     abstract val convertTerm: (String) -> List<String>
 
+    @Volatile
     private var lastLoadTime = 0L
     private val loadMoreMutex = Mutex()
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/i18n/I18n.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/i18n/I18n.kt
@@ -68,6 +68,9 @@ class DesktopGlobalCopywriter(
             }
         }
 
+    // mutableStateOf is intentionally used here to trigger Compose recomposition when the
+    // language changes. Writes from non-Compose threads (e.g., switchLanguage()) are safe
+    // because Compose's global snapshot system handles cross-thread state mutations.
     private var copywriter: Copywriter by mutableStateOf(
         LANGUAGE_MAP
             .computeIfAbsent(language) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/model/PasteSelectionViewModel.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/model/PasteSelectionViewModel.kt
@@ -70,15 +70,17 @@ class PasteSelectionViewModel(
     }
 
     fun selectPrev() {
-        _selectedIndexes.value = listOf((_selectedIndexes.value.min() - 1).coerceAtLeast(0))
+        val indexes = _selectedIndexes.value
+        if (indexes.isEmpty()) return
+        _selectedIndexes.value = listOf((indexes.min() - 1).coerceAtLeast(0))
     }
 
     fun selectNext() {
-        _selectedIndexes.value =
-            listOf(
-                (_selectedIndexes.value.max() + 1)
-                    .coerceAtMost(searchViewModel.searchResults.value.size - 1),
-            )
+        val resultSize = searchViewModel.searchResults.value.size
+        if (resultSize == 0) return
+        val indexes = _selectedIndexes.value
+        if (indexes.isEmpty()) return
+        _selectedIndexes.value = listOf((indexes.max() + 1).coerceAtMost(resultSize - 1))
     }
 
     fun setFocusedElement(focusedElement: FocusedElement) {


### PR DESCRIPTION
Closes #3793

## Summary

Fixes from code review session 25 — addresses thread safety, race conditions, and resource leaks across 9 files in the ViewModel, Theme, Notification, and Sound infrastructure layers.

### Changes

- **NotificationManager**: Use `MutableStateFlow.update {}` for atomic read-modify-write in `pushNotification()`/`removeNotification()`; change rendezvous channel to `Channel.BUFFERED` to prevent silent notification loss during 300ms debounce
- **PasteSearchViewModel**: Add `@Volatile` to `lastLoadTime` for cross-thread visibility; expose `inputSearch`/`searchBaseParams` via `.asStateFlow()` to prevent external mutation bypassing pagination reset
- **PasteSelectionViewModel**: Guard `selectPrev()`/`selectNext()` against empty lists to prevent invalid index -1
- **DesktopSoundService**: Add `SupervisorJob()` so one failed sound doesn't cancel all future playback; replace polling loop with `LineListener` + `CompletableDeferred`
- **SearchWindow**: Use `AtomicBoolean` instead of `mutableStateOf` for focus flag read from AWT EDT; clear `searchComposeWindow` reference in `onDispose`
- **DesktopThemeDetector**: Combine `_isFollowSystem` and `_isUserInDark` into single `ThemeConfig` flow for atomic update, preventing intermediate theme flash

### Documentation comments added
- **GeneralPasteSearchViewModel**: Document intentional `checkLoadAll` ordering
- **I18n.kt**: Document thread-safe `mutableStateOf` usage
- **CleanScheduler**: Document non-atomic task creation/submission behavior

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)