### PR TITLE
:bug: Fix notification loop, redundant rendering, resource leak, and Material 2 imports

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/PasteUrlIcon.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/PasteUrlIcon.kt
@@ -1,7 +1,6 @@
 package com.crosspaste.ui.base
 
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -32,7 +31,6 @@ fun PasteDataScope.PasteUrlIcon(size: Dp = large2X) {
     val urlPasteItem = getPasteItem(UrlPasteItem::class)
 
     val density = LocalDensity.current
-    val themeExt = LocalThemeExtState.current
 
     val sizePx = with(density) { size.roundToPx() }
 
@@ -63,13 +61,6 @@ fun PasteDataScope.PasteUrlIcon(size: Dp = large2X) {
                 is AsyncImagePainter.State.Loading,
                 is AsyncImagePainter.State.Error,
                 -> {
-                    Icon(
-                        imageVector = themeExt.urlTypeIconData.imageVector,
-                        contentDescription = "Paste Icon",
-                        modifier = Modifier.size(size),
-                        tint = themeExt.urlTypeIconData.color,
-                    )
-
                     LocalThemeExtState.current.urlTypeIconData.IconContent()
                 }
                 else -> {

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Icon
+import androidx.compose.material3.Icon
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.composables.icons.materialsymbols.MaterialSymbols

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/WindowDecoration.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/WindowDecoration.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.material.Icon
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/CrossPasteLogoView.desktop.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/CrossPasteLogoView.desktop.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopNotificationManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopNotificationManager.kt
@@ -27,7 +27,7 @@ class DesktopNotificationManager(
         if (appWindowManager.getCurrentMainWindowInfo().show) {
             pushNotification(message)
         } else if (platform.isLinux()) {
-            sendNotification(message)
+            pushNotification(message)
         } else {
             notifyTray(message)
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
@@ -1,6 +1,5 @@
 package com.crosspaste.ui.base
 
-import androidx.compose.ui.awt.ComposeWindow
 import com.crosspaste.app.AppFileType
 import com.crosspaste.app.AppUrls
 import com.crosspaste.i18n.DesktopGlobalCopywriter.Companion.ZH
@@ -141,10 +140,9 @@ class DesktopUISupport(
         pasteData.getPasteItem(ColorPasteItem::class)?.let { pasteItem ->
             val initialColor = Color(pasteItem.color)
             EventQueue.invokeLater {
-                JColorChooser(initialColor)
                 val result =
                     JColorChooser.showDialog(
-                        ComposeWindow(),
+                        null,
                         copywriter.getText("color_picker"),
                         initialColor,
                     )


### PR DESCRIPTION
Closes #3795

## Summary

Code review session 26 fixes for base UI components (`ui/base/`):

- **S26-01 (HIGH):** Fix Linux notification re-enqueue loop in `DesktopNotificationManager` — `sendNotification()` re-enters the channel/debounce pipeline from within `doSendNotification()`, silently dropping the notification. Changed to `pushNotification()` which directly updates the in-app toast list.
- **S26-03 (MEDIUM):** Remove redundant `Icon()` call in `PasteUrlIcon` loading/error state — `IconContent()` already renders the icon with proper background styling, making the plain `Icon()` a double-render.
- **S26-05 (LOW):** Fix `JColorChooser` orphaned `ComposeWindow` in `DesktopUISupport` — the window was never disposed, leaking a native resource. Pass `null` instead. Also removed a stray `JColorChooser(initialColor)` constructor creating an unused instance.
- **S26-06 (LOW):** Update Material 2 `Icon` imports to Material 3 in `CrossPasteLogoView.desktop.kt`, `WindowDecoration.kt`, and `DesktopPasteMenuService.kt`.

## Test plan

- [x] `./gradlew ktlintFormat` — passed, no changes
- [x] `./gradlew compileKotlinDesktop` — passed
- [x] `./gradlew app:desktopTest` — 154/155 passed, 1 skipped (pre-existing `HostInfoFilterTest` env-dependent failure unrelated to changes)

🤖 Generated with [Claude Code](https://claude.ai/code)