### PR TITLE
:bug: Fix export filter UI, redundant variable shadow, and Material 2 import

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/paste/PasteExportContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/paste/PasteExportContentView.kt
@@ -318,19 +318,28 @@ fun PasteExportContentView() {
                         onCheckedChange = { favoritesSelected = it },
                     )
                     HorizontalDivider(modifier = Modifier.padding(start = xxxxLarge))
-                    SettingListItem(
-                        title = "export_favorites_only",
+                    SettingListSwitchItem(
+                        title = "max_back_up_file_size",
                         icon = IconData(MaterialSymbols.Rounded.Storage, themeExt.amberIconColor),
-                        trailingContent = {
-                            Counter(
-                                defaultValue = maxFileSize,
-                                unit = "MB",
-                                rule = { it >= 0 },
-                            ) {
-                                maxFileSize = it
-                            }
-                        },
+                        checked = sizeFilterSelected,
+                        onCheckedChange = { sizeFilterSelected = it },
                     )
+                    if (sizeFilterSelected) {
+                        HorizontalDivider(modifier = Modifier.padding(start = xxxxLarge))
+                        SettingListItem(
+                            title = "max_back_up_file_size",
+                            icon = IconData(MaterialSymbols.Rounded.Storage, themeExt.amberIconColor),
+                            trailingContent = {
+                                Counter(
+                                    defaultValue = maxFileSize,
+                                    unit = "MB",
+                                    rule = { it >= 0 },
+                                ) {
+                                    maxFileSize = it
+                                }
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/paste/PasteImportContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/paste/PasteImportContentView.kt
@@ -158,7 +158,6 @@ fun PasteImportContentView() {
 
                                 val strokeWidth = tiny4X.toPx()
                                 val dashEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
-                                val borderColor = borderColor
 
                                 val halfStroke = strokeWidth / 2
                                 drawRoundRect(

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/BottomGradient.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/BottomGradient.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
Closes #3797

## Summary

Code review session 27 fixes for paste history UI (`ui/paste/`):

- **S27-02 (MEDIUM):** Fix export view `PasteExportContentView.kt` — the max file size control used the wrong i18n key `"export_favorites_only"` (copy-paste error), and `sizeFilterSelected` was never connected to a UI toggle, making the file size filter permanently disabled. Added a `SettingListSwitchItem` for the size filter toggle with correct title `"max_back_up_file_size"`, and the Counter is now shown conditionally when the filter is enabled.
- **S27-03 (MEDIUM):** Update Material 2 `Text` import to Material 3 in `BottomGradient.kt`.
- **S27-05 (LOW):** Remove redundant `val borderColor = borderColor` variable shadow in `PasteImportContentView.kt` — the `drawWithContent` lambda already captures the outer variable.

## Test plan

- [x] `./gradlew ktlintFormat` — passed, no changes
- [x] `./gradlew compileKotlinDesktop` — passed
- [x] `./gradlew app:desktopTest` — 154/155 passed, 1 skipped (pre-existing `HostInfoFilterTest` env-dependent failure unrelated to changes)

🤖 Generated with [Claude Code](https://claude.ai/code)