### PR TITLE
:bug: Fix stale discovery toggle, IO thread state write, and dead code in settings

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/settings/LanguageSettingItemView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/settings/LanguageSettingItemView.kt
@@ -58,7 +58,7 @@ fun LanguageSettingItemView() {
                 offset = DpOffset(x = -medium, y = zero),
             ) {
                 val allLanguages = copywriter.getAllLanguages()
-                allLanguages.forEachIndexed { _, language ->
+                allLanguages.forEach { language ->
                     val isSelected = language.abridge == copywriter.language()
                     DropdownMenuItem(
                         modifier =

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/settings/NetworkSettingsContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/settings/NetworkSettingsContentView.kt
@@ -123,7 +123,7 @@ fun NetworkSettingsContentView(syncExtContent: @Composable () -> Unit = {}) {
                         val newUseNetworkInterfacesJson = jsonUtils.JSON.encodeToString(newUseNetworkInterfaces)
                         configManager.updateConfig(
                             listOf("useNetworkInterfaces", "enableDiscovery"),
-                            listOf(newUseNetworkInterfacesJson, useNetworkInterfaces.isNotEmpty()),
+                            listOf(newUseNetworkInterfacesJson, newUseNetworkInterfaces.isNotEmpty()),
                         )
                     },
                     trailingContent = { index ->

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/FontSettingItemView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/FontSettingItemView.kt
@@ -1,6 +1,5 @@
 package com.crosspaste.ui.settings
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -35,7 +34,6 @@ import com.crosspaste.ui.theme.AppUISize.xxLarge
 import com.crosspaste.ui.theme.AppUISize.zero
 import org.koin.compose.koinInject
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FontSettingItemView() {
     val fontManager = koinInject<FontManager>()
@@ -77,7 +75,7 @@ fun FontSettingItemView() {
                 offset = DpOffset(x = -medium, y = zero),
                 modifier = Modifier.heightIn(max = xxLarge * 8),
             ) {
-                allPossibleFonts.forEachIndexed { _, fontInfo ->
+                allPossibleFonts.forEach { fontInfo ->
                     val isSelected = fontInfo.name == currentFont.name
                     DropdownMenuItem(
                         modifier =

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/MigrationStorageDialog.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/MigrationStorageDialog.kt
@@ -156,7 +156,6 @@ fun MigrationStorageDialog(
                             delay(500)
                             isMigration = false
                         }
-                        isMigration = false
                     }.onFailure {
                         coroutineScope.launch {
                             isMigration = false


### PR DESCRIPTION
Closes #3799

## Summary
- **S28-01**: Fix `enableDiscovery` using stale `useNetworkInterfaces` list instead of `newUseNetworkInterfaces` when unchecking last network interface — discovery stayed enabled even when no interfaces were selected
- **S28-03**: Remove redundant `isMigration = false` write from IO dispatcher thread in `MigrationStorageDialog` (already handled by `coroutineScope.launch`)
- **S28-04**: Remove unnecessary `@OptIn(ExperimentalFoundationApi::class)` from `FontSettingItemView` (no experimental APIs used)
- **S28-05**: Replace `forEachIndexed { _, x ->` with `forEach { x ->` in `LanguageSettingItemView` and `FontSettingItemView`

## Test plan
- [x] `./gradlew ktlintFormat` — passes
- [x] `./gradlew compileKotlinDesktop` — passes
- [x] `./gradlew app:desktopTest` — 154/155 pass (1 pre-existing env-dependent failure)

🤖 Generated with [Claude Code](https://claude.ai/code)