### PR TITLE
Fix runBlocking UI freeze and redundant koinInject in device sync UI

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -104,7 +104,6 @@ fun DevicesContentView() {
             }
 
             items(syncRuntimeInfos) { syncRuntimeInfo ->
-                val deviceScopeFactory = koinInject<DeviceScopeFactory>()
                 val scope =
                     remember(syncRuntimeInfo) {
                         deviceScopeFactory.createDeviceScope(syncRuntimeInfo)


### PR DESCRIPTION
Closes #3803

## Changes

### 1. Fix `runBlocking` UI freeze in AddDeviceDialog (HIGH)
- Replaced `runBlocking` with `rememberCoroutineScope().launch` so the network call (`syncClientApi.syncInfo`) no longer blocks the UI thread
- Added `isLoading` state to disable the confirm button during the async request, preventing double-clicks

### 2. Remove redundant `koinInject` in DevicesContentView (LOW)
- Removed duplicate `koinInject<DeviceScopeFactory>()` inside LazyColumn `items` lambda — the factory was already injected in the outer composable scope

## Verification
- `./gradlew ktlintFormat` — clean
- `./gradlew compileKotlinDesktop` — passes
- `./gradlew app:desktopTest` — 154/155 pass (1 pre-existing env-dependent failure)