### PR TITLE
Fix thread-unsafe RTFEditorKit, non-local return, and Memoize cache

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/utils/ToolUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/ToolUtils.kt
@@ -2,10 +2,11 @@ package com.crosspaste.utils
 
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import io.github.oshai.kotlinlogging.KLogger
+import io.ktor.util.collections.ConcurrentMap
 
 object Memoize {
-    fun <T, R> memoize(function: (T) -> R): (T) -> R {
-        val cache = mutableMapOf<T, R>()
+    fun <T : Any, R> memoize(function: (T) -> R): (T) -> R {
+        val cache = ConcurrentMap<T, R>()
         return {
             cache.getOrPut(it) { function(it) }
         }

--- a/shared/src/commonMain/kotlin/com/crosspaste/utils/HtmlUtils.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/utils/HtmlUtils.kt
@@ -24,7 +24,7 @@ object HtmlUtils {
             ksoupDoc.select("br").before("\\n")
             ksoupDoc.select("p").before("\\n")
             val str = ksoupDoc.html().replace("\\\\n".toRegex(), "\n")
-            return Ksoup.clean(str, Safelist.none(), "", outputSettings)
+            Ksoup.clean(str, Safelist.none(), "", outputSettings)
         }.getOrNull()
 
     fun ensureHtmlCharsetUtf8(html: String): String =

--- a/shared/src/desktopMain/kotlin/com/crosspaste/utils/RtfUtils.desktop.kt
+++ b/shared/src/desktopMain/kotlin/com/crosspaste/utils/RtfUtils.desktop.kt
@@ -14,28 +14,25 @@ object DesktopRtfUtils : RtfUtils {
 
     private val logger = KotlinLogging.logger {}
 
-    private val rtfParser = RTFEditorKit()
-
     override fun getText(rtf: String): String? =
         runCatching {
             val doc = DefaultStyledDocument()
-            rtfParser.read(ByteArrayInputStream(rtf.encodeToByteArray()), doc, 0)
+            RTFEditorKit().read(ByteArrayInputStream(rtf.encodeToByteArray()), doc, 0)
             doc.getText(0, doc.length)
         }.onFailure { e ->
             logger.error(e) { "Failed to parse RTF text" }
         }.getOrNull()
 
-    override fun rtfToHtml(rtf: String): String? {
-        return runCatching {
+    override fun rtfToHtml(rtf: String): String? =
+        runCatching {
             val doc = DefaultStyledDocument()
             StringReader(rtf).use { reader ->
                 RTFEditorKit().read(reader, doc, 0)
             }
             val out = StringWriter()
             MinimalHTMLWriter(out, doc).write()
-            return out.toString()
+            out.toString()
         }.onFailure { e ->
             logger.error(e) { "Failed to convert RTF to HTML" }
         }.getOrNull()
-    }
 }


### PR DESCRIPTION
Closes #3807

## Summary
- **S31-01**: Replace shared singleton `RTFEditorKit` with per-call instance in `getText()` to fix thread safety (consistent with `rtfToHtml()`)
- **S31-02**: Remove non-local `return` in `rtfToHtml` so `.onFailure{}.getOrNull()` chain is no longer dead code on success path
- **S31-03**: Remove non-local `return` in `HtmlUtils.getHtmlText` (same issue as S31-02)
- **S31-04**: Replace non-thread-safe `mutableMapOf()` with Ktor's multiplatform `ConcurrentMap` in `Memoize`

## Test plan
- [x] Verify RTF paste content is correctly parsed (text extraction and HTML conversion)
- [x] Verify HTML-to-text extraction works correctly for clipboard content
- [x] Build passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)