### PR TITLE
Fix Zip Slip vulnerability, regex recompilation, and redundant hashCode

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/rendering/OpenGraphService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/rendering/OpenGraphService.kt
@@ -145,14 +145,17 @@ class OpenGraphService<Image>(
         for (script in jsonLdScripts) {
             runCatching {
                 val json = script.data()
-                val imagePattern = """"image"\s*:\s*"([^"]+)"""".toRegex()
-                val match = imagePattern.find(json)
+                val match = JSON_LD_IMAGE_PATTERN.find(json)
                 if (match != null) {
                     return match.groupValues[1]
                 }
             }
         }
         return null
+    }
+
+    companion object {
+        private val JSON_LD_IMAGE_PATTERN = """"image"\s*:\s*"([^"]+)"""".toRegex()
     }
 
     private fun findLargestImage(doc: Document): String? =

--- a/app/src/desktopMain/kotlin/com/crosspaste/utils/CompressUtils.desktop.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/utils/CompressUtils.desktop.kt
@@ -70,12 +70,17 @@ object DesktopCompressUtils : CompressUtils {
         targetDir: Path,
     ): Result<Unit> =
         runCatching {
+            val canonicalTarget = targetDir.toFile().canonicalPath
             ZipInputStream(
                 BufferedInputStream(bufferSource.inputStream()),
             ).use { zipIn ->
                 var entry = zipIn.nextEntry
                 while (entry != null) {
                     val filePath = targetDir.resolve(entry.name)
+                    val canonicalFile = filePath.toFile().canonicalPath
+                    require(canonicalFile.startsWith(canonicalTarget)) {
+                        "Zip entry outside target dir: ${entry!!.name}"
+                    }
 
                     filePath.parent?.toFile()?.mkdirs()
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteCoordinate.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteCoordinate.kt
@@ -49,9 +49,6 @@ open class PasteFileCoordinate(
         if (other !is PasteFileCoordinate) return false
         if (!super.equals(other)) return false
 
-        if (id != other.id) return false
-        if (appInstanceId != other.appInstanceId) return false
-        if (createTime != other.createTime) return false
         if (filePath != other.filePath) return false
 
         return true
@@ -59,9 +56,6 @@ open class PasteFileCoordinate(
 
     override fun hashCode(): Int {
         var result = super.hashCode()
-        result = 31 * result + id.hashCode()
-        result = 31 * result + appInstanceId.hashCode()
-        result = 31 * result + createTime.hashCode()
         result = 31 * result + filePath.hashCode()
         return result
     }
@@ -90,10 +84,6 @@ class PasteFileInfoTreeCoordinate(
         if (other !is PasteFileInfoTreeCoordinate) return false
         if (!super.equals(other)) return false
 
-        if (id != other.id) return false
-        if (appInstanceId != other.appInstanceId) return false
-        if (createTime != other.createTime) return false
-        if (filePath != other.filePath) return false
         if (fileInfoTree != other.fileInfoTree) return false
 
         return true
@@ -101,10 +91,6 @@ class PasteFileInfoTreeCoordinate(
 
     override fun hashCode(): Int {
         var result = super.hashCode()
-        result = 31 * result + id.hashCode()
-        result = 31 * result + appInstanceId.hashCode()
-        result = 31 * result + createTime.hashCode()
-        result = 31 * result + filePath.hashCode()
         result = 31 * result + fileInfoTree.hashCode()
         return result
     }


### PR DESCRIPTION
Closes #3809\n\n## Summary\n- **S32-01 (HIGH)**: Add path traversal validation in `CompressUtils.unzip()` to prevent Zip Slip attacks — resolved paths are checked against the canonical target directory before writing\n- **S32-02 (LOW)**: Move regex in `OpenGraphService.extractFromJsonLd()` to a companion object constant to avoid recompilation on every call\n- **S32-03 (LOW)**: Remove redundant inherited field hashing/comparison in `PasteFileCoordinate` and `PasteFileInfoTreeCoordinate` `hashCode()`/`equals()` — `super.hashCode()`/`super.equals()` already covers inherited fields\n\n## Test plan\n- [ ] Verify `unzip()` rejects zip entries with path traversal (e.g., `../../malicious.txt`)\n- [ ] Verify Open Graph image extraction still works for URLs with JSON-LD\n- [ ] Verify paste coordinate equality/hashing works correctly in file sync operations\n\n🤖 Generated with [Claude Code](https://claude.ai/code)\nvia [Happy](https://happy.engineering)