### PR TITLE
Fix StripedMutex overflow, hardcoded IV size, regex recompilation, and public logger

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/utils/StripedMutex.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/StripedMutex.kt
@@ -2,7 +2,6 @@ package com.crosspaste.utils
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.math.absoluteValue
 
 class StripedMutex(
     private val stripeCount: Int = 32,
@@ -10,7 +9,7 @@ class StripedMutex(
     private val mutexes = Array(stripeCount) { Mutex() }
 
     private fun getMutex(key: Any): Mutex {
-        val hash = key.hashCode().absoluteValue
+        val hash = key.hashCode() and Int.MAX_VALUE
         return mutexes[hash % stripeCount]
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/i18n/I18n.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/i18n/I18n.kt
@@ -141,7 +141,7 @@ class DesktopCopywriter(
     private val language: String,
 ) : Copywriter {
 
-    val logger = KotlinLogging.logger {}
+    private val logger = KotlinLogging.logger {}
 
     private val dateUtils = getDateUtils()
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/utils/EncryptUtils.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/utils/EncryptUtils.kt
@@ -46,8 +46,9 @@ object EncryptUtils {
         encryptedData: ByteArray,
     ): ByteArray {
         val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
-        val ivBytes = encryptedData.copyOfRange(0, 16)
-        val actualEncryptedData = encryptedData.copyOfRange(16, encryptedData.size)
+        val ivSize = cipher.blockSize
+        val ivBytes = encryptedData.copyOfRange(0, ivSize)
+        val actualEncryptedData = encryptedData.copyOfRange(ivSize, encryptedData.size)
 
         val ivSpec = IvParameterSpec(ivBytes)
         cipher.init(Cipher.DECRYPT_MODE, key, ivSpec)

--- a/app/src/desktopMain/kotlin/com/crosspaste/utils/HtmlColorUtils.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/utils/HtmlColorUtils.kt
@@ -64,11 +64,15 @@ object HtmlColorUtils {
             }
         } ?: elements.firstOrNull { it.tagName() == "div" }
 
+    private val WIDTH_100_PATTERN = "width:\\s*100%".toRegex()
+    private val MIN_HEIGHT_100VH_PATTERN = "min-height:\\s*100vh".toRegex()
+    private val HEIGHT_100VH_PATTERN = "height:\\s*100vh".toRegex()
+
     private fun hasFullWidthStyle(element: Element): Boolean {
         val style = element.attr("style")
-        return style.contains("width:\\s*100%".toRegex()) ||
-            style.contains("min-height:\\s*100vh".toRegex()) ||
-            style.contains("height:\\s*100vh".toRegex())
+        return style.contains(WIDTH_100_PATTERN) ||
+            style.contains(MIN_HEIGHT_100VH_PATTERN) ||
+            style.contains(HEIGHT_100VH_PATTERN)
     }
 
     private fun getColorFromElement(element: Element): Color? {


### PR DESCRIPTION
Closes #3811

## Summary
- **S33-01**: Use `and Int.MAX_VALUE` instead of `absoluteValue` in `StripedMutex.getMutex()` to avoid `ArrayIndexOutOfBoundsException` when `hashCode()` returns `Int.MIN_VALUE`
- **S33-02**: Replace hardcoded IV size `16` with `cipher.blockSize` in `EncryptUtils.decryptData()` for consistency with `encryptData()`
- **S33-03**: Precompile three regexes in `HtmlColorUtils.hasFullWidthStyle()` as class-level fields to avoid recompilation on every call
- **S33-04**: Add missing `private` modifier to `DesktopCopywriter.logger`

## Test plan
- [x] Verify StripedMutex handles keys with `Int.MIN_VALUE` hashCode without crashing
- [x] Verify AES encryption/decryption round-trip still works correctly
- [x] Verify HTML background color extraction works for elements with full-width styles
- [x] Verify i18n text loading still works after logger visibility change

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)