### PR TITLE
Fix unchecked cast, short timeout, hardcoded User-Agent, and missing design comments

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/PasteClient.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/PasteClient.kt
@@ -30,7 +30,7 @@ class PasteClient(
                 header(HttpHeaders.AcceptEncoding, "identity")
             }
             install(HttpTimeout) {
-                requestTimeoutMillis = 1000
+                requestTimeoutMillis = 3000
             }
             install(Logging, configure = {
                 logger =
@@ -50,7 +50,7 @@ class PasteClient(
     suspend fun <T : Any> post(
         message: T,
         messageType: TypeInfo,
-        timeout: Long = 1000L,
+        timeout: Long = 3000L,
         headersBuilder: (HeadersBuilder.() -> Unit) = {},
         urlBuilder: URLBuilder.() -> Unit,
     ): HttpResponse =
@@ -68,7 +68,7 @@ class PasteClient(
         }
 
     suspend fun get(
-        timeout: Long = 1000L,
+        timeout: Long = 3000L,
         headersBuilder: (HeadersBuilder.() -> Unit) = {},
         urlBuilder: URLBuilder.() -> Unit,
     ): HttpResponse =

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/ClientApiResult.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/ClientApiResult.kt
@@ -12,11 +12,13 @@ import kotlinx.serialization.Serializable
 
 interface ClientApiResult
 
-@Suppress("UNCHECKED_CAST")
 class SuccessResult(
-    private val result: Any? = null,
+    @PublishedApi internal val value: Any? = null,
 ) : ClientApiResult {
-    fun <T> getResult(): T = result as T
+    inline fun <reified T> getResult(): T {
+        check(value is T) { "Expected ${T::class}, got ${value?.let { it::class }}" }
+        return value
+    }
 }
 
 class FailureResult(

--- a/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientDecryptPlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientDecryptPlugin.kt
@@ -45,6 +45,8 @@ class ClientDecryptPlugin(
                     val processor = secureStore.getMessageProcessor(appInstanceId)
 
                     if (contentType?.match(ContentType.Application.Json) == true) {
+                        // Note: reads entire JSON response into memory. Acceptable for LAN sync
+                        // where JSON payloads (metadata, device info) are bounded and small.
                         val bytes = byteReadChannel.readRemaining().readByteArray()
                         val decrypt = processor.decrypt(bytes)
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ServerEncryptPluginFactory.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ServerEncryptPluginFactory.kt
@@ -70,6 +70,8 @@ object EncryptResponse :
                 }
 
                 is OutgoingContent.ReadChannelContent -> {
+                    // Note: reads entire body into memory for encryption. Acceptable for small
+                    // responses (JSON metadata). Large payloads use WriteChannelContent with chunked streaming.
                     val bytes = body.readFrom().readRemaining().readByteArray()
                     context.subject =
                         ByteArrayContent(

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopResourcesClient.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopResourcesClient.kt
@@ -22,6 +22,9 @@ class DesktopResourcesClient(
 
     companion object {
 
+        private const val DEFAULT_USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
         fun createClient(
             clientLogger: KLogger,
             proxyConfig: Proxy? = null,
@@ -81,10 +84,7 @@ class DesktopResourcesClient(
     ): HttpResponse =
         client.request(url) {
             headers {
-                append(
-                    "User-Agent",
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                )
+                append("User-Agent", DEFAULT_USER_AGENT)
                 append("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
                 append("Accept-Language", "en-US,en;q=0.9")
                 append("DNT", "1")


### PR DESCRIPTION
Closes #3813

## Summary
- Increase `PasteClient` default timeout from 1000ms to 3000ms to avoid timeouts on slow networks
- Replace unchecked cast in `SuccessResult.getResult()` with `inline reified` type parameter and `check()` for runtime type safety
- Extract hardcoded User-Agent string to `DEFAULT_USER_AGENT` companion constant in `DesktopResourcesClient`
- Add design limitation comments in `ClientDecryptPlugin` and `ServerEncryptPluginFactory` documenting in-memory payload reads

## Test plan
- [x] Verify device sync works correctly with the increased timeout
- [x] Verify `SuccessResult.getResult()` still works for all existing callers
- [x] Verify resource fetching still works with extracted User-Agent constant
- [x] Build passes without errors or warnings

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)