### PR TITLE
Add 12 sync integration tests for multi-instance device lifecycle

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
@@ -1,0 +1,384 @@
+package com.crosspaste.net
+
+import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.dto.sync.EndpointInfo
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.net.clientapi.FailureResult
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.sync.SyncHandler
+import com.crosspaste.utils.HostAndPort
+import com.crosspaste.utils.buildUrl
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class SyncIntegrationTest {
+
+    private val instances = mutableListOf<TestInstance>()
+
+    private fun createInstance(id: String): TestInstance = TestInstance(id).also { instances.add(it) }
+
+    @AfterTest
+    fun tearDown() {
+        runBlocking {
+            instances.forEach { it.stop() }
+        }
+    }
+
+    private fun urlFor(instance: TestInstance): (io.ktor.http.URLBuilder.() -> Unit) =
+        {
+            buildUrl(HostAndPort("localhost", instance.getPort()))
+        }
+
+    private suspend fun trustBToA(
+        a: TestInstance,
+        b: TestInstance,
+    ) {
+        val result =
+            b.syncClientApi.trust(
+                a.appInfo.appInstanceId,
+                "localhost",
+                a.getToken(),
+                urlFor(a),
+            )
+        assertTrue(result is SuccessResult, "Trust B->A should succeed")
+    }
+
+    // ---- Test 1: Full trust via token ----
+
+    @Test
+    fun testTwoDeviceTrust() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            trustBToA(a, b)
+
+            // A's secureIO should have B's public key
+            assertTrue(a.secureIO.existCryptPublicKey(b.appInfo.appInstanceId))
+            // B's secureIO should have A's public key
+            assertTrue(b.secureIO.existCryptPublicKey(a.appInfo.appInstanceId))
+
+            // Verify the stored keys match the original key pairs
+            assertContentEquals(
+                a.secureIO.serializedPublicKey(b.appInfo.appInstanceId),
+                TestInstance.secureKeyPairSerializer.encodeCryptPublicKey(
+                    b.secureKeyPair.cryptKeyPair.publicKey,
+                ),
+            )
+            assertContentEquals(
+                b.secureIO.serializedPublicKey(a.appInfo.appInstanceId),
+                TestInstance.secureKeyPairSerializer.encodeCryptPublicKey(
+                    a.secureKeyPair.cryptKeyPair.publicKey,
+                ),
+            )
+        }
+
+    // ---- Test 2: Encrypted heartbeat after trust ----
+
+    @Test
+    fun testHeartbeatAfterTrust() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            trustBToA(a, b)
+
+            val result =
+                b.syncClientApi.heartbeat(
+                    targetAppInstanceId = a.appInfo.appInstanceId,
+                    toUrl = urlFor(a),
+                )
+
+            assertTrue(result is SuccessResult)
+            assertEquals(VersionRelation.EQUAL_TO, result.getResult<VersionRelation>())
+        }
+
+    // ---- Test 3: Heartbeat with SyncInfo (encrypted body) ----
+
+    @Test
+    fun testHeartbeatWithSyncInfo() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            trustBToA(a, b)
+
+            val syncInfo =
+                SyncInfo(
+                    appInfo = b.appInfo,
+                    endpointInfo =
+                        EndpointInfo(
+                            deviceId = "test-device-id",
+                            deviceName = "test-device",
+                            platform = TestInstance.platform,
+                            hostInfoList =
+                                listOf(
+                                    HostInfo(
+                                        networkPrefixLength = 24,
+                                        hostAddress = "127.0.0.1",
+                                    ),
+                                ),
+                            port = b.getPort(),
+                        ),
+                )
+
+            val result =
+                b.syncClientApi.heartbeat(
+                    syncInfo = syncInfo,
+                    targetAppInstanceId = a.appInfo.appInstanceId,
+                    toUrl = urlFor(a),
+                )
+
+            assertTrue(result is SuccessResult)
+            assertEquals(VersionRelation.EQUAL_TO, result.getResult<VersionRelation>())
+
+            // A's syncRoutingApi should have received the syncInfo
+            assertNotNull(a.syncRoutingApi.syncInfo)
+            assertEquals(
+                b.appInfo.appInstanceId,
+                a.syncRoutingApi.syncInfo!!
+                    .appInfo.appInstanceId,
+            )
+        }
+
+    // ---- Test 4: Bidirectional trust ----
+
+    @Test
+    fun testBidirectionalTrust() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            // B trusts A
+            trustBToA(a, b)
+            // A trusts B
+            val result =
+                a.syncClientApi.trust(
+                    b.appInfo.appInstanceId,
+                    "localhost",
+                    b.getToken(),
+                    urlFor(b),
+                )
+            assertTrue(result is SuccessResult)
+
+            // All 4 key entries should exist
+            assertTrue(a.secureIO.existCryptPublicKey(b.appInfo.appInstanceId))
+            assertTrue(b.secureIO.existCryptPublicKey(a.appInfo.appInstanceId))
+            // From bidirectional trust, B's server also saved A's key
+            assertTrue(b.secureIO.existCryptPublicKey(a.appInfo.appInstanceId))
+            // And A's server also saved B's key
+            assertTrue(a.secureIO.existCryptPublicKey(b.appInfo.appInstanceId))
+        }
+
+    // ---- Test 5: Three device mesh ----
+
+    @Test
+    fun testThreeDeviceMesh() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            val c = createInstance("device-c")
+            a.start()
+            b.start()
+            c.start()
+
+            // B trusts A
+            trustBToA(a, b)
+            // C trusts A
+            trustBToA(a, c)
+            // C trusts B
+            trustBToA(b, c)
+
+            // A has B's and C's keys
+            assertTrue(a.secureIO.existCryptPublicKey(b.appInfo.appInstanceId))
+            assertTrue(a.secureIO.existCryptPublicKey(c.appInfo.appInstanceId))
+            // B has A's and C's keys
+            assertTrue(b.secureIO.existCryptPublicKey(a.appInfo.appInstanceId))
+            assertTrue(b.secureIO.existCryptPublicKey(c.appInfo.appInstanceId))
+            // C has A's and B's keys
+            assertTrue(c.secureIO.existCryptPublicKey(a.appInfo.appInstanceId))
+            assertTrue(c.secureIO.existCryptPublicKey(b.appInfo.appInstanceId))
+
+            // Heartbeat works between all 3 pairs
+            val resultBA =
+                b.syncClientApi.heartbeat(
+                    targetAppInstanceId = a.appInfo.appInstanceId,
+                    toUrl = urlFor(a),
+                )
+            assertTrue(resultBA is SuccessResult)
+
+            val resultCA =
+                c.syncClientApi.heartbeat(
+                    targetAppInstanceId = a.appInfo.appInstanceId,
+                    toUrl = urlFor(a),
+                )
+            assertTrue(resultCA is SuccessResult)
+
+            val resultCB =
+                c.syncClientApi.heartbeat(
+                    targetAppInstanceId = b.appInfo.appInstanceId,
+                    toUrl = urlFor(b),
+                )
+            assertTrue(resultCB is SuccessResult)
+        }
+
+    // ---- Test 6: Trust with wrong token ----
+
+    @Test
+    fun testTrustWithWrongToken() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            val result =
+                b.syncClientApi.trust(
+                    a.appInfo.appInstanceId,
+                    "localhost",
+                    999999,
+                    urlFor(a),
+                )
+
+            assertTrue(result is FailureResult)
+            assertFalse(a.secureIO.existCryptPublicKey(b.appInfo.appInstanceId))
+        }
+
+    // ---- Test 7: Heartbeat without trust ----
+
+    @Test
+    fun testHeartbeatWithoutTrust() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            val result =
+                b.syncClientApi.heartbeat(
+                    targetAppInstanceId = a.appInfo.appInstanceId,
+                    toUrl = urlFor(a),
+                )
+
+            // Should fail because A doesn't have B's public key
+            assertTrue(result is FailureResult)
+        }
+
+    // ---- Test 8: Telnet discovery ----
+
+    @Test
+    fun testTelnetDiscovery() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+
+            val versionRelation = b.telnetHelper.telnet("localhost", a.getPort())
+
+            assertNotNull(versionRelation)
+            assertEquals(VersionRelation.EQUAL_TO, versionRelation)
+        }
+
+    // ---- Test 9: SwitchHost first responder wins ----
+
+    @Test
+    fun testSwitchHostFirstResponderWins() =
+        runBlocking {
+            val a = createInstance("device-a")
+            a.start()
+
+            // One unreachable host and one reachable (localhost)
+            val hostInfoList =
+                listOf(
+                    HostInfo(networkPrefixLength = 24, hostAddress = "10.255.255.1"),
+                    HostInfo(networkPrefixLength = 8, hostAddress = "127.0.0.1"),
+                )
+
+            val b = createInstance("device-b")
+            val result = b.telnetHelper.switchHost(hostInfoList, a.getPort())
+
+            assertNotNull(result)
+            assertEquals("127.0.0.1", result.first.hostAddress)
+            assertEquals(VersionRelation.EQUAL_TO, result.second)
+        }
+
+    // ---- Test 10: Notify remove ----
+
+    @Test
+    fun testNotifyRemove() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            trustBToA(a, b)
+
+            // Add B's handler to A's routing so removal can be verified
+            a.syncRoutingApi.innerSyncHandlers[b.appInfo.appInstanceId] = mockk(relaxed = true)
+
+            b.syncClientApi.notifyRemove(urlFor(a))
+
+            // A's handlers should no longer contain B
+            assertFalse(a.syncRoutingApi.innerSyncHandlers.containsKey(b.appInfo.appInstanceId))
+        }
+
+    // ---- Test 11: Notify exit ----
+
+    @Test
+    fun testNotifyExit() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            trustBToA(a, b)
+
+            // Create a mock SyncHandler for B in A's routing
+            val mockHandler =
+                mockk<SyncHandler>(relaxed = true) {
+                    coEvery { markExit() } returns Unit
+                }
+            a.syncRoutingApi.innerSyncHandlers[b.appInfo.appInstanceId] = mockHandler
+
+            b.syncClientApi.notifyExit(urlFor(a))
+
+            // Give the coroutine scope time to execute markExit
+            kotlinx.coroutines.delay(200)
+
+            // markExit should have been called on B's handler in A
+            coVerify { mockHandler.markExit() }
+        }
+
+    // ---- Test 12: Show token ----
+
+    @Test
+    fun testShowToken() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+
+            val result = b.syncClientApi.showToken(urlFor(a))
+
+            assertTrue(result is SuccessResult)
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
@@ -1,0 +1,123 @@
+package com.crosspaste.net
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.app.EndpointInfoFactory
+import com.crosspaste.app.TestAppTokenService
+import com.crosspaste.config.TestReadWritePort
+import com.crosspaste.db.secure.MemorySecureIO
+import com.crosspaste.net.clientapi.SyncClientApi
+import com.crosspaste.net.exception.DesktopExceptionHandler
+import com.crosspaste.net.exception.ExceptionHandler
+import com.crosspaste.net.plugin.ClientDecryptPlugin
+import com.crosspaste.net.plugin.ClientEncryptPlugin
+import com.crosspaste.net.plugin.ServerDecryptionPluginFactory
+import com.crosspaste.net.plugin.ServerEncryptPluginFactory
+import com.crosspaste.net.routing.TestSyncRoutingApi
+import com.crosspaste.platform.DesktopPlatformProvider
+import com.crosspaste.platform.Platform
+import com.crosspaste.secure.GeneralSecureStore
+import com.crosspaste.secure.SecureKeyPair
+import com.crosspaste.secure.SecureKeyPairSerializer
+import com.crosspaste.secure.SecureStore
+import com.crosspaste.utils.CryptographyUtils.generateSecureKeyPair
+import com.crosspaste.utils.DesktopDeviceUtils
+import com.crosspaste.utils.DeviceUtils
+
+class TestInstance(
+    val appInstanceId: String,
+    userName: String = appInstanceId,
+) {
+    companion object {
+        val platform: Platform = DesktopPlatformProvider().getPlatform()
+        val deviceUtils: DeviceUtils = DesktopDeviceUtils(platform)
+        val secureKeyPairSerializer = SecureKeyPairSerializer()
+        val syncApi: SyncApi = SyncApi
+        val exceptionHandler: ExceptionHandler = DesktopExceptionHandler()
+        val networkInterfaceService: NetworkInterfaceService =
+            TestNetworkInterfaceService(
+                testNetworkInterfaces =
+                    listOf(
+                        NetworkInterfaceInfo("lo0", 8, "127.0.0.1"),
+                    ),
+                testPreferredInterface = NetworkInterfaceInfo("lo0", 8, "127.0.0.1"),
+            )
+    }
+
+    val appInfo =
+        AppInfo(
+            appInstanceId = appInstanceId,
+            appVersion = "0.0.1",
+            appRevision = "1",
+            userName = userName,
+        )
+
+    val secureKeyPair: SecureKeyPair = generateSecureKeyPair()
+    val secureIO: MemorySecureIO = MemorySecureIO()
+
+    val secureStore: SecureStore =
+        GeneralSecureStore(secureKeyPair, secureKeyPairSerializer, secureIO)
+
+    val appTokenApi = TestAppTokenService()
+
+    private val readWritePort = TestReadWritePort()
+
+    private val clientEncryptPlugin = ClientEncryptPlugin(secureStore)
+    private val clientDecryptPlugin = ClientDecryptPlugin(secureStore)
+
+    val pasteClient = PasteClient(appInfo, clientEncryptPlugin, clientDecryptPlugin)
+
+    val syncRoutingApi: TestSyncRoutingApi = TestSyncRoutingApi()
+
+    private val serverFactory =
+        DesktopServerFactory()
+
+    private val endpointInfoFactory =
+        EndpointInfoFactory(deviceUtils, lazy { pasteServer }, platform)
+
+    private val syncInfoFactory =
+        SyncInfoFactory(appInfo, endpointInfoFactory)
+
+    private val serverModule =
+        TestServerModule(
+            appInfo = appInfo,
+            appTokenApi = appTokenApi,
+            exceptionHandler = exceptionHandler,
+            networkInterfaceService = networkInterfaceService,
+            secureKeyPairSerializer = secureKeyPairSerializer,
+            secureStore = secureStore,
+            serverEncryptPluginFactory = ServerEncryptPluginFactory(secureStore),
+            serverDecryptionPluginFactory = ServerDecryptionPluginFactory(secureStore),
+            syncApi = syncApi,
+            syncInfoFactory = syncInfoFactory,
+            syncRoutingApi = syncRoutingApi,
+        )
+
+    val pasteServer: Server =
+        DesktopPasteServer(
+            readWritePort,
+            exceptionHandler,
+            serverFactory,
+            serverModule,
+        )
+
+    val syncClientApi =
+        SyncClientApi(pasteClient, exceptionHandler, secureKeyPairSerializer, secureStore, syncApi)
+
+    val telnetHelper = TelnetHelper(pasteClient, syncApi)
+
+    suspend fun start() {
+        pasteServer.start()
+    }
+
+    suspend fun stop() {
+        pasteServer.stop()
+        pasteClient.close()
+    }
+
+    fun getPort(): Int = pasteServer.port()
+
+    fun getToken(): Int =
+        appTokenApi.token.value
+            .concatToString()
+            .toInt()
+}


### PR DESCRIPTION
Closes #3817

## Summary
- Add `TestInstance` helper class that bundles all per-device components (server, client, crypto, secure store) without Koin, enabling multiple instances in one JVM
- Add `SyncIntegrationTest` with 12 end-to-end tests covering the full device connection lifecycle:
  - Token-based trust (correct, wrong, bidirectional, 3-device mesh)
  - Encrypted heartbeat (GET and POST with SyncInfo)
  - Telnet discovery and switchHost race condition
  - Device removal (`notifyRemove`) and graceful exit (`notifyExit`/`markExit`)
  - Show token request

## Test plan
- [x] All 12 integration tests pass: `./gradlew app:desktopTest --tests "com.crosspaste.net.SyncIntegrationTest"`
- [x] Full test suite passes with no regressions: `./gradlew app:desktopTest`
- [x] ktlintFormat passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)