### PR TITLE
Add 209 unit tests for core data layer (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules/
 output*/
 /.claude/commands/
 /code-review/
+/ai/

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
@@ -1,0 +1,550 @@
+package com.crosspaste.db.paste
+
+import app.cash.turbine.test
+import com.crosspaste.app.AppInfo
+import com.crosspaste.db.TestDriverFactory
+import com.crosspaste.db.createDatabase
+import com.crosspaste.paste.CurrentPaste
+import com.crosspaste.paste.PasteCollection
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteState
+import com.crosspaste.paste.PasteType
+import com.crosspaste.paste.SearchContentService
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
+import com.crosspaste.paste.plugin.type.DesktopTextTypePlugin
+import com.crosspaste.task.TaskSubmitter
+import com.crosspaste.utils.DateUtils
+import com.crosspaste.utils.getJsonUtils
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PasteDaoTest {
+
+    // Eagerly initialize JsonUtils to avoid circular class initialization between
+    // PasteItem.Companion (which calls getJsonUtils()) and TextPasteItem
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    private val appInfo = AppInfo(
+        appInstanceId = "test-instance",
+        appVersion = "1.0.0",
+        appRevision = "abc",
+        userName = "testUser",
+    )
+
+    private val searchContentService = object : SearchContentService {
+        override fun createSearchContent(source: String?, searchContentList: List<String>): String {
+            return (listOfNotNull(source?.lowercase()) + searchContentList.map { it.lowercase() }).joinToString(" ")
+        }
+
+        override fun createSearchTerms(queryString: String): List<String> {
+            return queryString.trim().split("\\s+".toRegex()).filter { it.isNotBlank() }
+        }
+    }
+
+    private val currentPaste: CurrentPaste = mockk(relaxed = true)
+    private val taskSubmitter: TaskSubmitter = mockk(relaxed = true)
+    private val userDataPathProvider = mockk<com.crosspaste.path.UserDataPathProvider>(relaxed = true)
+
+    private val database = createDatabase(TestDriverFactory())
+
+    private val pasteDao = PasteDao(
+        appInfo = appInfo,
+        currentPaste = currentPaste,
+        database = database,
+        pasteProcessPlugins = listOf(),
+        searchContentService = searchContentService,
+        taskSubmitter = taskSubmitter,
+        userDataPathProvider = userDataPathProvider,
+    )
+
+    private fun createTestPasteData(
+        text: String = "hello world",
+        pasteType: PasteType = PasteType.TEXT_TYPE,
+        appInstanceId: String = "test-instance",
+        source: String? = null,
+        favorite: Boolean = false,
+    ): PasteData {
+        val textItem = createTextPasteItem(
+            identifiers = listOf(DesktopTextTypePlugin.TEXT),
+            text = text,
+        )
+        return PasteData(
+            appInstanceId = appInstanceId,
+            favorite = favorite,
+            pasteAppearItem = textItem,
+            pasteCollection = PasteCollection(listOf()),
+            pasteType = pasteType.type,
+            source = source,
+            size = textItem.size,
+            hash = textItem.hash,
+            pasteState = PasteState.LOADED,
+            createTime = DateUtils.nowEpochMilliseconds(),
+        )
+    }
+
+    // --- Create and retrieve ---
+
+    @Test
+    fun `createPasteData returns valid id`() = runTest {
+        val pasteData = createTestPasteData()
+        val id = pasteDao.createPasteData(pasteData)
+        assertTrue(id > 0)
+    }
+
+    @Test
+    fun `getNoDeletePasteData retrieves created paste`() = runTest {
+        val pasteData = createTestPasteData(text = "test retrieval")
+        val id = pasteDao.createPasteData(pasteData)
+
+        val retrieved = pasteDao.getNoDeletePasteData(id)
+        assertNotNull(retrieved)
+        assertEquals(id, retrieved.id)
+        assertEquals(pasteData.appInstanceId, retrieved.appInstanceId)
+        assertEquals(pasteData.pasteType, retrieved.pasteType)
+        assertEquals(pasteData.hash, retrieved.hash)
+    }
+
+    @Test
+    fun `getNoDeletePasteData returns null for non-existent id`() = runTest {
+        assertNull(pasteDao.getNoDeletePasteData(99999L))
+    }
+
+    @Test
+    fun `getLoadedPasteDataBlock retrieves LOADED paste`() = runTest {
+        val pasteData = createTestPasteData()
+        val id = pasteDao.createPasteData(pasteData)
+
+        val retrieved = pasteDao.getLoadedPasteDataBlock(id)
+        assertNotNull(retrieved)
+        assertEquals(PasteState.LOADED, retrieved.pasteState)
+    }
+
+    @Test
+    fun `getLoadingPasteData returns null for LOADED paste`() = runTest {
+        val pasteData = createTestPasteData()
+        val id = pasteDao.createPasteData(pasteData)
+
+        assertNull(pasteDao.getLoadingPasteData(id))
+    }
+
+    @Test
+    fun `getLoadingPasteData retrieves LOADING paste`() = runTest {
+        val pasteData = createTestPasteData()
+        val id = pasteDao.createPasteData(pasteData, pasteState = PasteState.LOADING)
+
+        val retrieved = pasteDao.getLoadingPasteData(id)
+        assertNotNull(retrieved)
+        assertEquals(PasteState.LOADING, retrieved.pasteState)
+    }
+
+    @Test
+    fun `multiple createPasteData calls return unique ids`() = runTest {
+        val id1 = pasteDao.createPasteData(createTestPasteData(text = "first"))
+        val id2 = pasteDao.createPasteData(createTestPasteData(text = "second"))
+        val id3 = pasteDao.createPasteData(createTestPasteData(text = "third"))
+
+        assertTrue(id1 != id2)
+        assertTrue(id2 != id3)
+    }
+
+    // --- Favorite ---
+
+    @Test
+    fun `setFavorite true marks paste as favorite`() = runTest {
+        val pasteData = createTestPasteData(favorite = false)
+        val id = pasteDao.createPasteData(pasteData)
+
+        pasteDao.setFavorite(id, true)
+        val retrieved = pasteDao.getNoDeletePasteData(id)
+        assertNotNull(retrieved)
+        assertTrue(retrieved.favorite)
+    }
+
+    @Test
+    fun `setFavorite false removes favorite`() = runTest {
+        val pasteData = createTestPasteData(favorite = true)
+        val id = pasteDao.createPasteData(pasteData)
+
+        pasteDao.setFavorite(id, false)
+        val retrieved = pasteDao.getNoDeletePasteData(id)
+        assertNotNull(retrieved)
+        assertFalse(retrieved.favorite)
+    }
+
+    // --- Update state ---
+
+    @Test
+    fun `updatePasteState changes paste state`() = runTest {
+        val pasteData = createTestPasteData()
+        val id = pasteDao.createPasteData(pasteData, pasteState = PasteState.LOADING)
+
+        pasteDao.updatePasteState(id, PasteState.LOADED)
+        val retrieved = pasteDao.getNoDeletePasteData(id)
+        assertNotNull(retrieved)
+        assertEquals(PasteState.LOADED, retrieved.pasteState)
+    }
+
+    @Test
+    fun `updateCreateTime changes the timestamp`() = runTest {
+        val pasteData = createTestPasteData()
+        val id = pasteDao.createPasteData(pasteData)
+        val before = pasteDao.getNoDeletePasteData(id)!!.createTime
+
+        Thread.sleep(10)
+        pasteDao.updateCreateTime(id)
+
+        val after = pasteDao.getNoDeletePasteData(id)!!.createTime
+        assertTrue(after >= before)
+    }
+
+    // --- Delete ---
+
+    @Test
+    fun `markDeletePasteData marks paste as deleted`() = runTest {
+        coEvery { taskSubmitter.submit(any()) } coAnswers {
+            val block = firstArg<suspend com.crosspaste.task.TaskBuilder.() -> Unit>()
+            val builder = mockk<com.crosspaste.task.TaskBuilder>(relaxed = true)
+            every { builder.addDeletePasteTasks(any()) } returns builder
+            block.invoke(builder)
+        }
+
+        val pasteData = createTestPasteData()
+        val id = pasteDao.createPasteData(pasteData)
+        assertNotNull(pasteDao.getNoDeletePasteData(id))
+
+        pasteDao.markDeletePasteData(id)
+
+        // getNoDeletePasteData should return null because it filters out DELETED
+        assertNull(pasteDao.getNoDeletePasteData(id))
+    }
+
+    @Test
+    fun `getDeletePasteData retrieves marked-deleted paste`() = runTest {
+        coEvery { taskSubmitter.submit(any()) } coAnswers {
+            val block = firstArg<suspend com.crosspaste.task.TaskBuilder.() -> Unit>()
+            val builder = mockk<com.crosspaste.task.TaskBuilder>(relaxed = true)
+            every { builder.addDeletePasteTasks(any()) } returns builder
+            block.invoke(builder)
+        }
+
+        val pasteData = createTestPasteData()
+        val id = pasteDao.createPasteData(pasteData)
+
+        pasteDao.markDeletePasteData(id)
+
+        val deleted = pasteDao.getDeletePasteData(id)
+        assertNotNull(deleted)
+        assertEquals(PasteState.DELETED, deleted.pasteState)
+    }
+
+    // --- Search ---
+
+    @Test
+    fun `searchPasteData returns all with empty search terms`() = runTest {
+        pasteDao.createPasteData(createTestPasteData(text = "apple"))
+        pasteDao.createPasteData(createTestPasteData(text = "banana"))
+        pasteDao.createPasteData(createTestPasteData(text = "cherry"))
+
+        val results = pasteDao.searchPasteData(
+            searchTerms = listOf(),
+            limit = 100,
+        )
+        assertEquals(3, results.size)
+    }
+
+    @Test
+    fun `searchPasteData with limit returns limited results`() = runTest {
+        pasteDao.createPasteData(createTestPasteData(text = "item1"))
+        pasteDao.createPasteData(createTestPasteData(text = "item2"))
+        pasteDao.createPasteData(createTestPasteData(text = "item3"))
+
+        val results = pasteDao.searchPasteData(
+            searchTerms = listOf(),
+            limit = 2,
+        )
+        assertEquals(2, results.size)
+    }
+
+    @Test
+    fun `searchPasteData with favorite filter`() = runTest {
+        val id1 = pasteDao.createPasteData(createTestPasteData(text = "fav item"))
+        pasteDao.createPasteData(createTestPasteData(text = "normal item"))
+        pasteDao.setFavorite(id1, true)
+
+        val results = pasteDao.searchPasteData(
+            searchTerms = listOf(),
+            favorite = true,
+            limit = 100,
+        )
+        assertEquals(1, results.size)
+        assertTrue(results[0].favorite)
+    }
+
+    @Test
+    fun `searchPasteData with type filter`() = runTest {
+        pasteDao.createPasteData(createTestPasteData(text = "text item"))
+
+        val urlItem = createUrlPasteItem(url = "https://example.com")
+        val urlPaste = PasteData(
+            appInstanceId = "test-instance",
+            pasteAppearItem = urlItem,
+            pasteCollection = PasteCollection(listOf()),
+            pasteType = PasteType.URL_TYPE.type,
+            size = urlItem.size,
+            hash = urlItem.hash,
+            pasteState = PasteState.LOADED,
+            createTime = DateUtils.nowEpochMilliseconds(),
+        )
+        pasteDao.createPasteData(urlPaste)
+
+        val textResults = pasteDao.searchPasteData(
+            searchTerms = listOf(),
+            pasteType = PasteType.TEXT_TYPE.type,
+            limit = 100,
+        )
+        assertEquals(1, textResults.size)
+        assertEquals(PasteType.TEXT_TYPE.type, textResults[0].pasteType)
+    }
+
+    // --- Size queries ---
+
+    @Test
+    fun `getSize returns total size of all pastes`() = runTest {
+        val paste1 = createTestPasteData(text = "hello")
+        val paste2 = createTestPasteData(text = "world")
+        pasteDao.createPasteData(paste1)
+        pasteDao.createPasteData(paste2)
+
+        val totalSize = pasteDao.getSize(allOrFavorite = true)
+        assertEquals(paste1.size + paste2.size, totalSize)
+    }
+
+    @Test
+    fun `getSize with allOrFavorite false returns only favorite size`() = runTest {
+        val paste1 = createTestPasteData(text = "hello")
+        val paste2 = createTestPasteData(text = "world")
+        val id1 = pasteDao.createPasteData(paste1)
+        pasteDao.createPasteData(paste2)
+        pasteDao.setFavorite(id1, true)
+
+        val favoriteSize = pasteDao.getSize(allOrFavorite = false)
+        assertEquals(paste1.size, favoriteSize)
+    }
+
+    @Test
+    fun `getSize returns 0 for empty database`() = runTest {
+        assertEquals(0L, pasteDao.getSize(allOrFavorite = true))
+    }
+
+    @Test
+    fun `getMinPasteDataCreateTime returns earliest time`() = runTest {
+        val earlyPaste = createTestPasteData(text = "early").copy(createTime = 1000L)
+        val latePaste = createTestPasteData(text = "late").copy(createTime = 2000L)
+        pasteDao.createPasteData(earlyPaste)
+        pasteDao.createPasteData(latePaste)
+
+        val minTime = pasteDao.getMinPasteDataCreateTime()
+        assertEquals(1000L, minTime)
+    }
+
+    @Test
+    fun `getMinPasteDataCreateTime returns null for empty database`() = runTest {
+        assertNull(pasteDao.getMinPasteDataCreateTime())
+    }
+
+    @Test
+    fun `getSizeByTimeLessThan returns cumulative size before given time`() = runTest {
+        val paste1 = createTestPasteData(text = "old").copy(createTime = 1000L)
+        val paste2 = createTestPasteData(text = "new").copy(createTime = 5000L)
+        pasteDao.createPasteData(paste1)
+        pasteDao.createPasteData(paste2)
+
+        val sizeBefore3000 = pasteDao.getSizeByTimeLessThan(3000L)
+        assertEquals(paste1.size, sizeBefore3000)
+    }
+
+    // --- Tags ---
+
+    @Test
+    fun `createPasteTag returns valid id`() = runTest {
+        val tagId = pasteDao.createPasteTag("important", 0xFF0000L)
+        assertTrue(tagId > 0)
+    }
+
+    @Test
+    fun `updatePasteTagName changes tag name`() = runTest {
+        val tagId = pasteDao.createPasteTag("old_name", 0xFF0000L)
+        pasteDao.updatePasteTagName(tagId, "new_name")
+        // Verify through flow
+        pasteDao.getAllTagsFlow().test {
+            val tags = awaitItem()
+            val tag = tags.find { it.id == tagId }
+            assertNotNull(tag)
+            assertEquals("new_name", tag.name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `updatePasteTagColor changes tag color`() = runTest {
+        val tagId = pasteDao.createPasteTag("tag", 0xFF0000L)
+        pasteDao.updatePasteTagColor(tagId, 0x00FF00L)
+        pasteDao.getAllTagsFlow().test {
+            val tags = awaitItem()
+            val tag = tags.find { it.id == tagId }
+            assertNotNull(tag)
+            assertEquals(0x00FF00L, tag.color)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `switchPinPasteTagBlock toggles pin state`() = runTest {
+        val pasteData = createTestPasteData()
+        val pasteId = pasteDao.createPasteData(pasteData)
+        val tagId = pasteDao.createPasteTag("tag1", 0xFF0000L)
+
+        // Initially not pinned
+        var pinned = pasteDao.getPasteTagsBlock(pasteId)
+        assertFalse(pinned.contains(tagId))
+
+        // Pin
+        pasteDao.switchPinPasteTagBlock(pasteId, tagId)
+        pinned = pasteDao.getPasteTagsBlock(pasteId)
+        assertTrue(pinned.contains(tagId))
+
+        // Unpin
+        pasteDao.switchPinPasteTagBlock(pasteId, tagId)
+        pinned = pasteDao.getPasteTagsBlock(pasteId)
+        assertFalse(pinned.contains(tagId))
+    }
+
+    @Test
+    fun `deletePasteTagBlock removes tag`() = runTest {
+        val tagId = pasteDao.createPasteTag("to_delete", 0xFF0000L)
+        pasteDao.deletePasteTagBlock(tagId)
+
+        pasteDao.getAllTagsFlow().test {
+            val tags = awaitItem()
+            assertNull(tags.find { it.id == tagId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `getMaxSortOrder returns max sort order`() = runTest {
+        val initialMax = pasteDao.getMaxSortOrder()
+        pasteDao.createPasteTag("tag1", 0xFF0000L)
+        val afterFirst = pasteDao.getMaxSortOrder()
+        pasteDao.createPasteTag("tag2", 0x00FF00L)
+        val afterSecond = pasteDao.getMaxSortOrder()
+
+        assertTrue(afterFirst > initialMax)
+        assertTrue(afterSecond > afterFirst)
+    }
+
+    // --- Flow ---
+
+    @Test
+    fun `getAllTagsFlow emits on tag creation`() = runTest {
+        pasteDao.getAllTagsFlow().test {
+            val initial = awaitItem()
+            assertTrue(initial.isEmpty())
+
+            pasteDao.createPasteTag("new_tag", 0xFF0000L)
+
+            val updated = awaitItem()
+            assertEquals(1, updated.size)
+            assertEquals("new_tag", updated[0].name)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- Batch read ---
+
+    @Test
+    fun `batchReadPasteData processes all pastes`() = runTest {
+        pasteDao.createPasteData(createTestPasteData(text = "a"))
+        pasteDao.createPasteData(createTestPasteData(text = "b"))
+        pasteDao.createPasteData(createTestPasteData(text = "c"))
+
+        val processed = mutableListOf<PasteData>()
+        val count = pasteDao.batchReadPasteData(
+            batchNum = 2,
+            readPasteDataList = { id, limit ->
+                database.pasteDatabaseQueries.getBatchPasteData(id, limit, PasteData::mapper)
+                    .executeAsList()
+            },
+            dealPasteData = { processed.add(it) },
+        )
+
+        assertEquals(3L, count)
+        assertEquals(3, processed.size)
+    }
+
+    @Test
+    fun `batchReadPasteData returns 0 for empty database`() = runTest {
+        val count = pasteDao.batchReadPasteData(
+            readPasteDataList = { id, limit ->
+                database.pasteDatabaseQueries.getBatchPasteData(id, limit, PasteData::mapper)
+                    .executeAsList()
+            },
+            dealPasteData = {},
+        )
+
+        assertEquals(0L, count)
+    }
+
+    // --- Search by source ---
+
+    @Test
+    fun `searchBySource returns matching pastes`() = runTest {
+        pasteDao.createPasteData(createTestPasteData(text = "from chrome", source = "Chrome"))
+        pasteDao.createPasteData(createTestPasteData(text = "from vscode", source = "VSCode"))
+        pasteDao.createPasteData(createTestPasteData(text = "also chrome", source = "Chrome"))
+
+        val results = pasteDao.searchBySource("Chrome")
+        assertEquals(2, results.size)
+    }
+
+    @Test
+    fun `searchBySource returns empty for no match`() = runTest {
+        pasteDao.createPasteData(createTestPasteData(text = "test", source = "Chrome"))
+        val results = pasteDao.searchBySource("Firefox")
+        assertTrue(results.isEmpty())
+    }
+
+    // --- Update paste appear item ---
+
+    @Test
+    fun `updatePasteAppearItem changes the item and hash`() = runTest {
+        val pasteData = createTestPasteData(text = "original")
+        val id = pasteDao.createPasteData(pasteData)
+
+        val newItem = createTextPasteItem(
+            identifiers = listOf(DesktopTextTypePlugin.TEXT),
+            text = "updated",
+        )
+        val result = pasteDao.updatePasteAppearItem(
+            id = id,
+            pasteItem = newItem,
+            pasteSearchContent = "updated",
+        )
+        assertTrue(result.isSuccess)
+
+        val retrieved = pasteDao.getNoDeletePasteData(id)
+        assertNotNull(retrieved)
+        assertEquals(newItem.hash, retrieved.hash)
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/secure/SecureDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/secure/SecureDaoTest.kt
@@ -1,0 +1,140 @@
+package com.crosspaste.db.secure
+
+import com.crosspaste.db.TestDriverFactory
+import com.crosspaste.db.createDatabase
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SecureDaoTest {
+
+    private val database = createDatabase(TestDriverFactory())
+    private val secureDao = SecureDao(database)
+
+    // --- Save and retrieve ---
+
+    @Test
+    fun `saveCryptPublicKey and retrieve with serializedPublicKey`() = runTest {
+        val appInstanceId = "test-app-1"
+        val keyData = byteArrayOf(1, 2, 3, 4, 5)
+
+        secureDao.saveCryptPublicKey(appInstanceId, keyData)
+        val retrieved = secureDao.serializedPublicKey(appInstanceId)
+
+        assertNotNull(retrieved)
+        assertContentEquals(keyData, retrieved)
+    }
+
+    @Test
+    fun `saveCryptPublicKey with empty byte array`() = runTest {
+        val appInstanceId = "test-empty"
+        val keyData = byteArrayOf()
+
+        secureDao.saveCryptPublicKey(appInstanceId, keyData)
+        val retrieved = secureDao.serializedPublicKey(appInstanceId)
+
+        assertNotNull(retrieved)
+        assertContentEquals(keyData, retrieved)
+    }
+
+    @Test
+    fun `saveCryptPublicKey with large byte array`() = runTest {
+        val appInstanceId = "test-large"
+        val keyData = ByteArray(4096) { it.toByte() }
+
+        secureDao.saveCryptPublicKey(appInstanceId, keyData)
+        val retrieved = secureDao.serializedPublicKey(appInstanceId)
+
+        assertNotNull(retrieved)
+        assertContentEquals(keyData, retrieved)
+    }
+
+    @Test
+    fun `saveCryptPublicKey overwrites existing key`() = runTest {
+        val appInstanceId = "test-overwrite"
+        val originalKey = byteArrayOf(1, 2, 3)
+        val updatedKey = byteArrayOf(4, 5, 6, 7)
+
+        secureDao.saveCryptPublicKey(appInstanceId, originalKey)
+        secureDao.saveCryptPublicKey(appInstanceId, updatedKey)
+        val retrieved = secureDao.serializedPublicKey(appInstanceId)
+
+        assertNotNull(retrieved)
+        assertContentEquals(updatedKey, retrieved)
+    }
+
+    // --- Existence check ---
+
+    @Test
+    fun `existCryptPublicKey returns true for existing key`() = runTest {
+        val appInstanceId = "test-exists"
+        secureDao.saveCryptPublicKey(appInstanceId, byteArrayOf(1, 2, 3))
+
+        assertTrue(secureDao.existCryptPublicKey(appInstanceId))
+    }
+
+    @Test
+    fun `existCryptPublicKey returns false for non-existent key`() = runTest {
+        assertFalse(secureDao.existCryptPublicKey("non-existent-id"))
+    }
+
+    // --- Delete ---
+
+    @Test
+    fun `deleteCryptPublicKey removes stored key`() = runTest {
+        val appInstanceId = "test-delete"
+        secureDao.saveCryptPublicKey(appInstanceId, byteArrayOf(1, 2, 3))
+        assertTrue(secureDao.existCryptPublicKey(appInstanceId))
+
+        secureDao.deleteCryptPublicKey(appInstanceId)
+
+        assertFalse(secureDao.existCryptPublicKey(appInstanceId))
+        assertNull(secureDao.serializedPublicKey(appInstanceId))
+    }
+
+    @Test
+    fun `deleteCryptPublicKey on non-existent key does not throw`() = runTest {
+        secureDao.deleteCryptPublicKey("non-existent-id")
+        // Should not throw
+    }
+
+    // --- Retrieval ---
+
+    @Test
+    fun `serializedPublicKey returns null for non-existent key`() = runTest {
+        assertNull(secureDao.serializedPublicKey("non-existent-id"))
+    }
+
+    // --- Multiple keys ---
+
+    @Test
+    fun `store and retrieve multiple keys independently`() = runTest {
+        val key1 = byteArrayOf(1, 1, 1)
+        val key2 = byteArrayOf(2, 2, 2)
+        val key3 = byteArrayOf(3, 3, 3)
+
+        secureDao.saveCryptPublicKey("app-1", key1)
+        secureDao.saveCryptPublicKey("app-2", key2)
+        secureDao.saveCryptPublicKey("app-3", key3)
+
+        assertContentEquals(key1, secureDao.serializedPublicKey("app-1"))
+        assertContentEquals(key2, secureDao.serializedPublicKey("app-2"))
+        assertContentEquals(key3, secureDao.serializedPublicKey("app-3"))
+    }
+
+    @Test
+    fun `delete one key does not affect other keys`() = runTest {
+        secureDao.saveCryptPublicKey("app-a", byteArrayOf(10))
+        secureDao.saveCryptPublicKey("app-b", byteArrayOf(20))
+
+        secureDao.deleteCryptPublicKey("app-a")
+
+        assertFalse(secureDao.existCryptPublicKey("app-a"))
+        assertTrue(secureDao.existCryptPublicKey("app-b"))
+        assertContentEquals(byteArrayOf(20), secureDao.serializedPublicKey("app-b"))
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/task/PasteTaskExtraInfoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/task/PasteTaskExtraInfoTest.kt
@@ -1,0 +1,176 @@
+package com.crosspaste.db.task
+
+import com.crosspaste.utils.getJsonUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PasteTaskExtraInfoTest {
+
+    private val json = getJsonUtils().JSON
+
+    // --- BaseExtraInfo ---
+
+    @Test
+    fun `BaseExtraInfo serialization roundtrip`() {
+        val original: PasteTaskExtraInfo = BaseExtraInfo()
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded)
+        assertTrue(decoded is BaseExtraInfo)
+        assertTrue(decoded.executionHistories.isEmpty())
+    }
+
+    @Test
+    fun `BaseExtraInfo with execution histories roundtrip`() {
+        val original = BaseExtraInfo()
+        original.executionHistories.add(
+            ExecutionHistory(
+                startTime = 1000L,
+                endTime = 2000L,
+                status = TaskStatus.SUCCESS,
+                message = "completed",
+            )
+        )
+        val encoded = json.encodeToString(original as PasteTaskExtraInfo)
+        val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded)
+
+        assertTrue(decoded is BaseExtraInfo)
+        assertEquals(1, decoded.executionHistories.size)
+        assertEquals(1000L, decoded.executionHistories[0].startTime)
+        assertEquals(2000L, decoded.executionHistories[0].endTime)
+        assertEquals(TaskStatus.SUCCESS, decoded.executionHistories[0].status)
+        assertEquals("completed", decoded.executionHistories[0].message)
+    }
+
+    // --- SyncExtraInfo ---
+
+    @Test
+    fun `SyncExtraInfo serialization roundtrip`() {
+        val original: PasteTaskExtraInfo = SyncExtraInfo(appInstanceId = "test-app-1")
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded)
+
+        assertTrue(decoded is SyncExtraInfo)
+        assertEquals("test-app-1", (decoded as SyncExtraInfo).appInstanceId)
+        assertTrue(decoded.syncFails.isEmpty())
+    }
+
+    @Test
+    fun `SyncExtraInfo with syncFails roundtrip`() {
+        val original = SyncExtraInfo(appInstanceId = "app-1")
+        original.syncFails.add("remote-1")
+        original.syncFails.add("remote-2")
+        original.executionHistories.add(
+            ExecutionHistory(1000, 2000, TaskStatus.FAILURE, "network error")
+        )
+
+        val encoded = json.encodeToString(original as PasteTaskExtraInfo)
+        val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded) as SyncExtraInfo
+
+        assertEquals("app-1", decoded.appInstanceId)
+        assertEquals(2, decoded.syncFails.size)
+        assertTrue(decoded.syncFails.contains("remote-1"))
+        assertTrue(decoded.syncFails.contains("remote-2"))
+        assertEquals(1, decoded.executionHistories.size)
+    }
+
+    // --- PullExtraInfo ---
+
+    @Test
+    fun `PullExtraInfo serialization roundtrip`() {
+        val original: PasteTaskExtraInfo = PullExtraInfo(id = 42L)
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded)
+
+        assertTrue(decoded is PullExtraInfo)
+        assertEquals(42L, (decoded as PullExtraInfo).id)
+    }
+
+    @Test
+    fun `PullExtraInfo with pullChunks roundtrip`() {
+        val original = PullExtraInfo(id = 10L)
+        original.pullChunks = intArrayOf(0, 1, 2, 3)
+
+        val encoded = json.encodeToString(original as PasteTaskExtraInfo)
+        val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded) as PullExtraInfo
+
+        assertEquals(10L, decoded.id)
+        assertEquals(4, decoded.pullChunks.size)
+        assertEquals(0, decoded.pullChunks[0])
+        assertEquals(3, decoded.pullChunks[3])
+    }
+
+    @Test
+    fun `PullExtraInfo empty pullChunks roundtrip`() {
+        val original = PullExtraInfo(id = 1L)
+        // pullChunks defaults to empty
+
+        val encoded = json.encodeToString(original as PasteTaskExtraInfo)
+        val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded) as PullExtraInfo
+
+        assertTrue(decoded.pullChunks.isEmpty())
+    }
+
+    // --- SwitchLanguageInfo ---
+
+    @Test
+    fun `SwitchLanguageInfo serialization roundtrip`() {
+        val original: PasteTaskExtraInfo = SwitchLanguageInfo(language = "zh-CN")
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded)
+
+        assertTrue(decoded is SwitchLanguageInfo)
+        assertEquals("zh-CN", (decoded as SwitchLanguageInfo).language)
+    }
+
+    // --- ExecutionHistory ---
+
+    @Test
+    fun `ExecutionHistory serialization roundtrip`() {
+        val original = ExecutionHistory(
+            startTime = 100L,
+            endTime = 200L,
+            status = TaskStatus.EXECUTING,
+            message = null,
+        )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<ExecutionHistory>(encoded)
+
+        assertEquals(100L, decoded.startTime)
+        assertEquals(200L, decoded.endTime)
+        assertEquals(TaskStatus.EXECUTING, decoded.status)
+        assertEquals(null, decoded.message)
+    }
+
+    @Test
+    fun `ExecutionHistory with message roundtrip`() {
+        val original = ExecutionHistory(
+            startTime = 100L,
+            endTime = 200L,
+            status = TaskStatus.FAILURE,
+            message = "Connection timeout",
+        )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<ExecutionHistory>(encoded)
+
+        assertEquals("Connection timeout", decoded.message)
+    }
+
+    // --- Polymorphic deserialization ---
+
+    @Test
+    fun `different PasteTaskExtraInfo types can be deserialized polymorphically`() {
+        val infos: List<PasteTaskExtraInfo> = listOf(
+            BaseExtraInfo(),
+            SyncExtraInfo(appInstanceId = "app-1"),
+            PullExtraInfo(id = 1L),
+            SwitchLanguageInfo(language = "en"),
+        )
+
+        for (info in infos) {
+            val encoded = json.encodeToString(info)
+            val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded)
+            assertEquals(info::class, decoded::class)
+        }
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/task/TaskDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/task/TaskDaoTest.kt
@@ -1,0 +1,265 @@
+package com.crosspaste.db.task
+
+import com.crosspaste.db.TestDriverFactory
+import com.crosspaste.db.createDatabase
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class TaskDaoTest {
+
+    private val database = createDatabase(TestDriverFactory())
+    private val taskDao = TaskDao(database)
+
+    // --- Task creation ---
+
+    @Test
+    fun `createTask returns valid task id`() = runTest {
+        val taskId = taskDao.createTask(
+            pasteDataId = 100L,
+            taskType = TaskType.SYNC_PASTE_TASK,
+        )
+        assert(taskId > 0)
+    }
+
+    @Test
+    fun `createTask with null pasteDataId succeeds`() = runTest {
+        val taskId = taskDao.createTask(
+            pasteDataId = null,
+            taskType = TaskType.CLEAN_TASK_TASK,
+        )
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertNull(task.pasteDataId)
+    }
+
+    @Test
+    fun `createTask stores correct task type`() = runTest {
+        val taskId = taskDao.createTask(
+            pasteDataId = 1L,
+            taskType = TaskType.DELETE_PASTE_TASK,
+        )
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertEquals(TaskType.DELETE_PASTE_TASK, task.taskType)
+    }
+
+    @Test
+    fun `createTask sets initial status to PREPARING`() = runTest {
+        val taskId = taskDao.createTask(
+            pasteDataId = 1L,
+            taskType = TaskType.SYNC_PASTE_TASK,
+        )
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertEquals(TaskStatus.PREPARING, task.status)
+    }
+
+    @Test
+    fun `createTask with custom extraInfo stores JSON`() = runTest {
+        val extraInfo = SyncExtraInfo(appInstanceId = "test-app-1")
+        val taskId = taskDao.createTask(
+            pasteDataId = 1L,
+            taskType = TaskType.SYNC_PASTE_TASK,
+            extraInfo = extraInfo,
+        )
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assert(task.extraInfo.contains("test-app-1"))
+    }
+
+    @Test
+    fun `createTaskBlock returns valid id synchronously`() {
+        val taskId = taskDao.createTaskBlock(
+            pasteDataId = 1L,
+            taskType = TaskType.PULL_FILE_TASK,
+        )
+        assert(taskId > 0)
+    }
+
+    @Test
+    fun `multiple createTask calls return unique ids`() = runTest {
+        val id1 = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        val id2 = taskDao.createTask(pasteDataId = 2L, taskType = TaskType.SYNC_PASTE_TASK)
+        val id3 = taskDao.createTask(pasteDataId = 3L, taskType = TaskType.DELETE_PASTE_TASK)
+        assert(id1 != id2)
+        assert(id2 != id3)
+    }
+
+    // --- Task state transitions ---
+
+    @Test
+    fun `executingTask changes status to EXECUTING`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertEquals(TaskStatus.EXECUTING, task.status)
+    }
+
+    @Test
+    fun `successTask changes status to SUCCESS`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        taskDao.successTask(taskId, newExtraInfo = null)
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertEquals(TaskStatus.SUCCESS, task.status)
+    }
+
+    @Test
+    fun `successTask with newExtraInfo updates extraInfo`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        val newExtraInfo = """{"type":"base","executionHistories":[]}"""
+        taskDao.successTask(taskId, newExtraInfo = newExtraInfo)
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertEquals(TaskStatus.SUCCESS, task.status)
+        assertEquals(newExtraInfo, task.extraInfo)
+    }
+
+    @Test
+    fun `failureTask with needRetry resets status to PREPARING`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        taskDao.failureTask(taskId, needRetry = true, newExtraInfo = null)
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertEquals(TaskStatus.PREPARING, task.status)
+    }
+
+    @Test
+    fun `failureTask without needRetry sets status to FAILURE`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        taskDao.failureTask(taskId, needRetry = false, newExtraInfo = null)
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertEquals(TaskStatus.FAILURE, task.status)
+    }
+
+    @Test
+    fun `failureTask with newExtraInfo updates extraInfo`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        val newExtraInfo = """{"type":"sync","appInstanceId":"x","executionHistories":[],"syncFails":["a"]}"""
+        taskDao.failureTask(taskId, needRetry = false, newExtraInfo = newExtraInfo)
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertEquals(newExtraInfo, task.extraInfo)
+    }
+
+    @Test
+    fun `executingTask updates modifyTime`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        val taskBefore = taskDao.getTask(taskId)!!
+        Thread.sleep(10)
+        taskDao.executingTask(taskId)
+        val taskAfter = taskDao.getTask(taskId)!!
+        assert(taskAfter.modifyTime >= taskBefore.modifyTime)
+    }
+
+    // --- Task retrieval ---
+
+    @Test
+    fun `getTask returns null for non-existent id`() = runTest {
+        val task = taskDao.getTask(99999L)
+        assertNull(task)
+    }
+
+    @Test
+    fun `getTask returns complete task data`() = runTest {
+        val taskId = taskDao.createTask(
+            pasteDataId = 42L,
+            taskType = TaskType.PULL_ICON_TASK,
+        )
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+        assertEquals(taskId, task.taskId)
+        assertEquals(42L, task.pasteDataId)
+        assertEquals(TaskType.PULL_ICON_TASK, task.taskType)
+        assertEquals(TaskStatus.PREPARING, task.status)
+        assert(task.createTime > 0)
+        assert(task.modifyTime > 0)
+        assert(task.extraInfo.isNotEmpty())
+    }
+
+    // --- Task cleanup ---
+
+    @Test
+    fun `cleanSuccessTask removes old success tasks`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        taskDao.successTask(taskId, newExtraInfo = null)
+
+        // Clean with a future time to remove all success tasks
+        taskDao.cleanSuccessTask(System.currentTimeMillis() + 10000)
+        val task = taskDao.getTask(taskId)
+        assertNull(task)
+    }
+
+    @Test
+    fun `cleanSuccessTask does not remove tasks newer than threshold`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        taskDao.successTask(taskId, newExtraInfo = null)
+
+        // Clean with a past time - should not remove
+        taskDao.cleanSuccessTask(1L)
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+    }
+
+    @Test
+    fun `cleanFailureTask removes old failure tasks`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        taskDao.failureTask(taskId, needRetry = false, newExtraInfo = null)
+
+        taskDao.cleanFailureTask(System.currentTimeMillis() + 10000)
+        val task = taskDao.getTask(taskId)
+        assertNull(task)
+    }
+
+    @Test
+    fun `cleanFailureTask does not remove non-failure tasks`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        taskDao.executingTask(taskId)
+        taskDao.successTask(taskId, newExtraInfo = null)
+
+        // Cleaning failures should not affect success tasks
+        taskDao.cleanFailureTask(System.currentTimeMillis() + 10000)
+        val task = taskDao.getTask(taskId)
+        assertNotNull(task)
+    }
+
+    // --- Full lifecycle ---
+
+    @Test
+    fun `complete task lifecycle PREPARING to EXECUTING to SUCCESS`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+        assertEquals(TaskStatus.PREPARING, taskDao.getTask(taskId)!!.status)
+
+        taskDao.executingTask(taskId)
+        assertEquals(TaskStatus.EXECUTING, taskDao.getTask(taskId)!!.status)
+
+        taskDao.successTask(taskId, newExtraInfo = null)
+        assertEquals(TaskStatus.SUCCESS, taskDao.getTask(taskId)!!.status)
+    }
+
+    @Test
+    fun `task lifecycle with retry PREPARING to EXECUTING to PREPARING to EXECUTING to FAILURE`() = runTest {
+        val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+
+        taskDao.executingTask(taskId)
+        taskDao.failureTask(taskId, needRetry = true, newExtraInfo = null)
+        assertEquals(TaskStatus.PREPARING, taskDao.getTask(taskId)!!.status)
+
+        taskDao.executingTask(taskId)
+        taskDao.failureTask(taskId, needRetry = false, newExtraInfo = null)
+        assertEquals(TaskStatus.FAILURE, taskDao.getTask(taskId)!!.status)
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
@@ -1,0 +1,382 @@
+package com.crosspaste.dto
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.dto.paste.SyncPasteCollection
+import com.crosspaste.dto.paste.SyncPasteData
+import com.crosspaste.dto.paste.SyncPasteLabel
+import com.crosspaste.dto.pull.PullFileRequest
+import com.crosspaste.dto.secure.PairingRequest
+import com.crosspaste.dto.secure.PairingResponse
+import com.crosspaste.dto.secure.TrustRequest
+import com.crosspaste.dto.secure.TrustResponse
+import com.crosspaste.dto.sync.EndpointInfo
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.platform.Platform
+import com.crosspaste.utils.getJsonUtils
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DtoSerializationTest {
+
+    private val json = getJsonUtils().JSON
+
+    private val testPlatform =
+        Platform(
+            name = "TestOS",
+            arch = "x86_64",
+            bitMode = 64,
+            version = "1.0.0",
+        )
+
+    // --- PullFileRequest ---
+
+    @Test
+    fun `PullFileRequest serialization roundtrip`() {
+        val original = PullFileRequest(id = 42L, chunkIndex = 7)
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<PullFileRequest>(encoded)
+        assertEquals(42L, decoded.id)
+        assertEquals(7, decoded.chunkIndex)
+    }
+
+    @Test
+    fun `PullFileRequest toString contains fields`() {
+        val req = PullFileRequest(id = 1, chunkIndex = 0)
+        val str = req.toString()
+        assertTrue(str.contains("id=1"))
+        assertTrue(str.contains("chunkIndex=0"))
+    }
+
+    // --- EndpointInfo ---
+
+    @Test
+    fun `EndpointInfo serialization roundtrip`() {
+        val original =
+            EndpointInfo(
+                deviceId = "device-1",
+                deviceName = "TestDevice",
+                platform = testPlatform,
+                hostInfoList = listOf(HostInfo(24, "192.168.1.100")),
+                port = 8080,
+            )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<EndpointInfo>(encoded)
+
+        assertEquals("device-1", decoded.deviceId)
+        assertEquals("TestDevice", decoded.deviceName)
+        assertEquals(testPlatform, decoded.platform)
+        assertEquals(1, decoded.hostInfoList.size)
+        assertEquals("192.168.1.100", decoded.hostInfoList[0].hostAddress)
+        assertEquals(8080, decoded.port)
+    }
+
+    @Test
+    fun `EndpointInfo with multiple hosts`() {
+        val original =
+            EndpointInfo(
+                deviceId = "device-1",
+                deviceName = "Multi",
+                platform = testPlatform,
+                hostInfoList =
+                    listOf(
+                        HostInfo(24, "192.168.1.1"),
+                        HostInfo(16, "10.0.0.1"),
+                    ),
+                port = 9090,
+            )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<EndpointInfo>(encoded)
+        assertEquals(2, decoded.hostInfoList.size)
+    }
+
+    // --- SyncInfo ---
+
+    @Test
+    fun `SyncInfo serialization roundtrip`() {
+        val original =
+            SyncInfo(
+                appInfo = AppInfo("app-1", "1.0.0", "rev", "user"),
+                endpointInfo =
+                    EndpointInfo(
+                        deviceId = "dev-1",
+                        deviceName = "Test",
+                        platform = testPlatform,
+                        hostInfoList = listOf(HostInfo(24, "192.168.1.1")),
+                        port = 8080,
+                    ),
+            )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<SyncInfo>(encoded)
+
+        assertEquals("app-1", decoded.appInfo.appInstanceId)
+        assertEquals("dev-1", decoded.endpointInfo.deviceId)
+    }
+
+    @Test
+    fun `SyncInfo merge combines host lists and takes other info`() {
+        val info1 =
+            SyncInfo(
+                appInfo = AppInfo("app-1", "1.0.0", "rev", "user"),
+                endpointInfo =
+                    EndpointInfo(
+                        deviceId = "dev-1",
+                        deviceName = "OldName",
+                        platform = testPlatform,
+                        hostInfoList = listOf(HostInfo(24, "192.168.1.1")),
+                        port = 8080,
+                    ),
+            )
+        val info2 =
+            SyncInfo(
+                appInfo = AppInfo("app-1", "2.0.0", "rev2", "user2"),
+                endpointInfo =
+                    EndpointInfo(
+                        deviceId = "dev-1",
+                        deviceName = "NewName",
+                        platform = testPlatform,
+                        hostInfoList = listOf(HostInfo(24, "192.168.1.2")),
+                        port = 9090,
+                    ),
+            )
+
+        val merged = info1.merge(info2)
+
+        assertEquals("app-1", merged.appInfo.appInstanceId)
+        assertEquals("2.0.0", merged.appInfo.appVersion)
+        assertEquals("NewName", merged.endpointInfo.deviceName)
+        assertEquals(9090, merged.endpointInfo.port)
+        assertEquals(2, merged.endpointInfo.hostInfoList.size)
+    }
+
+    @Test
+    fun `SyncInfo merge deduplicates hosts by address`() {
+        val info1 =
+            SyncInfo(
+                appInfo = AppInfo("app-1", "1.0.0", "rev", "user"),
+                endpointInfo =
+                    EndpointInfo(
+                        deviceId = "dev-1",
+                        deviceName = "Test",
+                        platform = testPlatform,
+                        hostInfoList = listOf(HostInfo(24, "192.168.1.1")),
+                        port = 8080,
+                    ),
+            )
+        val info2 =
+            SyncInfo(
+                appInfo = AppInfo("app-1", "1.0.0", "rev", "user"),
+                endpointInfo =
+                    EndpointInfo(
+                        deviceId = "dev-1",
+                        deviceName = "Test",
+                        platform = testPlatform,
+                        hostInfoList = listOf(HostInfo(24, "192.168.1.1")), // same host
+                        port = 8080,
+                    ),
+            )
+
+        val merged = info1.merge(info2)
+        assertEquals(1, merged.endpointInfo.hostInfoList.size)
+    }
+
+    // --- PairingRequest ---
+
+    @Test
+    fun `PairingRequest serialization roundtrip`() {
+        val original =
+            PairingRequest(
+                signPublicKey = byteArrayOf(1, 2, 3),
+                cryptPublicKey = byteArrayOf(4, 5, 6),
+                token = 12345,
+                timestamp = 1000L,
+            )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<PairingRequest>(encoded)
+
+        assertContentEquals(byteArrayOf(1, 2, 3), decoded.signPublicKey)
+        assertContentEquals(byteArrayOf(4, 5, 6), decoded.cryptPublicKey)
+        assertEquals(12345, decoded.token)
+        assertEquals(1000L, decoded.timestamp)
+    }
+
+    @Test
+    fun `PairingRequest equals works correctly with byte arrays`() {
+        val a = PairingRequest(byteArrayOf(1, 2), byteArrayOf(3, 4), 1, 100)
+        val b = PairingRequest(byteArrayOf(1, 2), byteArrayOf(3, 4), 1, 100)
+        val c = PairingRequest(byteArrayOf(1, 2), byteArrayOf(3, 5), 1, 100)
+
+        assertEquals(a, b)
+        assertTrue(a != c)
+    }
+
+    @Test
+    fun `PairingRequest hashCode consistent with equals`() {
+        val a = PairingRequest(byteArrayOf(1, 2), byteArrayOf(3, 4), 1, 100)
+        val b = PairingRequest(byteArrayOf(1, 2), byteArrayOf(3, 4), 1, 100)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    // --- PairingResponse ---
+
+    @Test
+    fun `PairingResponse serialization roundtrip`() {
+        val original =
+            PairingResponse(
+                signPublicKey = byteArrayOf(10, 20),
+                cryptPublicKey = byteArrayOf(30, 40),
+                timestamp = 2000L,
+            )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<PairingResponse>(encoded)
+
+        assertContentEquals(byteArrayOf(10, 20), decoded.signPublicKey)
+        assertContentEquals(byteArrayOf(30, 40), decoded.cryptPublicKey)
+        assertEquals(2000L, decoded.timestamp)
+    }
+
+    @Test
+    fun `PairingResponse equals and hashCode`() {
+        val a = PairingResponse(byteArrayOf(1), byteArrayOf(2), 100)
+        val b = PairingResponse(byteArrayOf(1), byteArrayOf(2), 100)
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    // --- TrustRequest ---
+
+    @Test
+    fun `TrustRequest serialization roundtrip`() {
+        val pairingRequest = PairingRequest(byteArrayOf(1), byteArrayOf(2), 42, 1000)
+        val original =
+            TrustRequest(
+                pairingRequest = pairingRequest,
+                signature = byteArrayOf(7, 8, 9),
+            )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<TrustRequest>(encoded)
+
+        assertEquals(pairingRequest, decoded.pairingRequest)
+        assertContentEquals(byteArrayOf(7, 8, 9), decoded.signature)
+    }
+
+    @Test
+    fun `TrustRequest equals and hashCode`() {
+        val pr = PairingRequest(byteArrayOf(1), byteArrayOf(2), 1, 1)
+        val a = TrustRequest(pr, byteArrayOf(3))
+        val b = TrustRequest(pr, byteArrayOf(3))
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    // --- TrustResponse ---
+
+    @Test
+    fun `TrustResponse serialization roundtrip`() {
+        val pairingResponse = PairingResponse(byteArrayOf(10), byteArrayOf(20), 2000)
+        val original =
+            TrustResponse(
+                pairingResponse = pairingResponse,
+                signature = byteArrayOf(50, 60),
+            )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<TrustResponse>(encoded)
+
+        assertEquals(pairingResponse, decoded.pairingResponse)
+        assertContentEquals(byteArrayOf(50, 60), decoded.signature)
+    }
+
+    // --- SyncPasteLabel ---
+
+    @Test
+    fun `SyncPasteLabel serialization roundtrip`() {
+        val original = SyncPasteLabel(id = "label-1", color = 0xFF0000, text = "Important")
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<SyncPasteLabel>(encoded)
+
+        assertEquals("label-1", decoded.id)
+        assertEquals(0xFF0000, decoded.color)
+        assertEquals("Important", decoded.text)
+    }
+
+    // --- SyncPasteCollection ---
+
+    @Test
+    fun `SyncPasteCollection serialization roundtrip`() {
+        val textItem = createTextPasteItem(text = "test item")
+        val original = SyncPasteCollection(pasteItems = listOf(textItem))
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<SyncPasteCollection>(encoded)
+
+        assertEquals(1, decoded.pasteItems.size)
+    }
+
+    @Test
+    fun `SyncPasteCollection empty items roundtrip`() {
+        val original = SyncPasteCollection(pasteItems = listOf())
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<SyncPasteCollection>(encoded)
+
+        assertTrue(decoded.pasteItems.isEmpty())
+    }
+
+    // --- SyncPasteData ---
+
+    @Test
+    fun `SyncPasteData serialization roundtrip`() {
+        val textItem = createTextPasteItem(text = "sync content")
+        val original =
+            SyncPasteData(
+                id = "sync-1",
+                appInstanceId = "app-1",
+                pasteId = 100L,
+                pasteType = 0,
+                source = "Chrome",
+                size = textItem.size,
+                hash = textItem.hash,
+                favorite = true,
+                pasteAppearItem = textItem,
+                pasteCollection = SyncPasteCollection(listOf()),
+                labels = setOf(SyncPasteLabel("l1", 0xFF, "tag")),
+            )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<SyncPasteData>(encoded)
+
+        assertEquals("sync-1", decoded.id)
+        assertEquals("app-1", decoded.appInstanceId)
+        assertEquals(100L, decoded.pasteId)
+        assertEquals("Chrome", decoded.source)
+        assertTrue(decoded.favorite)
+        assertNotNull(decoded.pasteAppearItem)
+        assertEquals(1, decoded.labels.size)
+    }
+
+    @Test
+    fun `SyncPasteData with null optional fields`() {
+        val original =
+            SyncPasteData(
+                id = "sync-2",
+                appInstanceId = "app-1",
+                pasteId = 1L,
+                pasteType = 0,
+                source = null,
+                size = 0L,
+                hash = "",
+                favorite = false,
+                pasteAppearItem = null,
+                pasteCollection = null,
+                labels = emptySet(),
+            )
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<SyncPasteData>(encoded)
+
+        assertEquals(null, decoded.source)
+        assertEquals(null, decoded.pasteAppearItem)
+        assertEquals(null, decoded.pasteCollection)
+        assertTrue(decoded.labels.isEmpty())
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectionTest.kt
@@ -1,0 +1,100 @@
+package com.crosspaste.paste
+
+import com.crosspaste.paste.item.CreatePasteItemHelper.createColorPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createHtmlPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
+import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.paste.item.TextPasteItem
+import com.crosspaste.utils.getJsonUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PasteCollectionTest {
+
+    // Eagerly initialize JsonUtils to avoid circular class initialization between
+    // PasteItem.Companion (which calls getJsonUtils()) and TextPasteItem
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    // --- Construction ---
+
+    @Test
+    fun `empty PasteCollection has no items`() {
+        val collection = PasteCollection(listOf())
+        assertTrue(collection.pasteItems.isEmpty())
+    }
+
+    @Test
+    fun `PasteCollection preserves item order`() {
+        val item1 = createTextPasteItem(text = "first")
+        val item2 = createTextPasteItem(text = "second")
+        val item3 = createTextPasteItem(text = "third")
+        val collection = PasteCollection(listOf(item1, item2, item3))
+
+        assertEquals(3, collection.pasteItems.size)
+        assertEquals("first", (collection.pasteItems[0] as TextPasteItem).text)
+        assertEquals("second", (collection.pasteItems[1] as TextPasteItem).text)
+        assertEquals("third", (collection.pasteItems[2] as TextPasteItem).text)
+    }
+
+    // --- toJson / fromJson ---
+
+    @Test
+    fun `empty collection roundtrip`() {
+        val original = PasteCollection(listOf())
+        val json = original.toJson()
+        val restored = PasteCollection.fromJson(json)
+        assertTrue(restored.pasteItems.isEmpty())
+    }
+
+    @Test
+    fun `single text item collection roundtrip`() {
+        val textItem = createTextPasteItem(text = "hello")
+        val original = PasteCollection(listOf(textItem))
+
+        val json = original.toJson()
+        val restored = PasteCollection.fromJson(json)
+
+        assertEquals(1, restored.pasteItems.size)
+        val restoredItem = restored.pasteItems[0] as TextPasteItem
+        assertEquals("hello", restoredItem.text)
+        assertEquals(textItem.hash, restoredItem.hash)
+    }
+
+    @Test
+    fun `multiple mixed items collection roundtrip`() {
+        val items: List<PasteItem> =
+            listOf(
+                createTextPasteItem(text = "text content"),
+                createUrlPasteItem(url = "https://example.com"),
+                createColorPasteItem(color = 0xFF0000.toInt()),
+            )
+        val original = PasteCollection(items)
+
+        val json = original.toJson()
+        val restored = PasteCollection.fromJson(json)
+
+        assertEquals(3, restored.pasteItems.size)
+    }
+
+    @Test
+    fun `html item collection roundtrip preserves html`() {
+        val htmlItem = createHtmlPasteItem(html = "<div>Hello <b>World</b></div>")
+        val original = PasteCollection(listOf(htmlItem))
+
+        val json = original.toJson()
+        val restored = PasteCollection.fromJson(json)
+
+        assertEquals(1, restored.pasteItems.size)
+    }
+
+    @Test
+    fun `toJson produces valid JSON array`() {
+        val collection = PasteCollection(listOf(createTextPasteItem(text = "test")))
+        val json = collection.toJson()
+        assertTrue(json.startsWith("["))
+        assertTrue(json.endsWith("]"))
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteDataTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteDataTest.kt
@@ -1,0 +1,275 @@
+package com.crosspaste.paste
+
+import com.crosspaste.paste.item.ColorPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createHtmlPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.PasteText
+import com.crosspaste.utils.DateUtils
+import com.crosspaste.utils.getJsonUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PasteDataTest {
+
+    private val jsonUtils = getJsonUtils()
+
+    private fun createTestPasteData(
+        text: String = "test",
+        pasteType: PasteType = PasteType.TEXT_TYPE,
+        pasteState: Int = PasteState.LOADED,
+        collection: List<com.crosspaste.paste.item.PasteItem> = listOf(),
+    ): PasteData {
+        val textItem = createTextPasteItem(text = text)
+        return PasteData(
+            appInstanceId = "test-app",
+            pasteAppearItem = textItem,
+            pasteCollection = PasteCollection(collection),
+            pasteType = pasteType.type,
+            size = textItem.size,
+            hash = textItem.hash,
+            pasteState = pasteState,
+            createTime = DateUtils.nowEpochMilliseconds(),
+        )
+    }
+
+    // --- getType ---
+
+    @Test
+    fun `getType returns correct PasteType for TEXT`() {
+        val pd = createTestPasteData(pasteType = PasteType.TEXT_TYPE)
+        assertEquals(PasteType.TEXT_TYPE, pd.getType())
+    }
+
+    @Test
+    fun `getType returns INVALID_TYPE for unknown type`() {
+        val pd = createTestPasteData().copy(pasteType = 999)
+        assertEquals(PasteType.INVALID_TYPE, pd.getType())
+    }
+
+    // --- getPasteItem ---
+
+    @Test
+    fun `getPasteItem returns item when type matches`() {
+        val pd = createTestPasteData()
+        val item = pd.getPasteItem(PasteText::class)
+        assertNotNull(item)
+    }
+
+    @Test
+    fun `getPasteItem returns null when type does not match`() {
+        val pd = createTestPasteData()
+        val item = pd.getPasteItem(ColorPasteItem::class)
+        assertNull(item)
+    }
+
+    @Test
+    fun `getPasteItem returns null when pasteAppearItem is null`() {
+        val pd = createTestPasteData().copy(pasteAppearItem = null)
+        val item = pd.getPasteItem(PasteText::class)
+        assertNull(item)
+    }
+
+    // --- getPasteAppearItems ---
+
+    @Test
+    fun `getPasteAppearItems returns appear item plus collection items`() {
+        val textItem = createTextPasteItem(text = "main")
+        val extraItem = createTextPasteItem(text = "extra")
+        val pd =
+            PasteData(
+                appInstanceId = "test",
+                pasteAppearItem = textItem,
+                pasteCollection = PasteCollection(listOf(extraItem)),
+                pasteType = PasteType.TEXT_TYPE.type,
+                size = textItem.size + extraItem.size,
+                hash = textItem.hash,
+                pasteState = PasteState.LOADED,
+                createTime = DateUtils.nowEpochMilliseconds(),
+            )
+        val items = pd.getPasteAppearItems()
+        assertEquals(2, items.size)
+    }
+
+    @Test
+    fun `getPasteAppearItems with null appear item returns only collection`() {
+        val extraItem = createTextPasteItem(text = "only")
+        val pd =
+            PasteData(
+                appInstanceId = "test",
+                pasteAppearItem = null,
+                pasteCollection = PasteCollection(listOf(extraItem)),
+                pasteType = PasteType.TEXT_TYPE.type,
+                size = extraItem.size,
+                hash = "",
+                pasteState = PasteState.LOADED,
+                createTime = DateUtils.nowEpochMilliseconds(),
+            )
+        val items = pd.getPasteAppearItems()
+        assertEquals(1, items.size)
+    }
+
+    @Test
+    fun `getPasteAppearItems with empty collection returns only appear item`() {
+        val pd = createTestPasteData()
+        val items = pd.getPasteAppearItems()
+        assertEquals(1, items.size)
+    }
+
+    // --- isValid ---
+
+    @Test
+    fun `isValid returns true for LOADED paste with valid text item`() {
+        val pd = createTestPasteData(pasteState = PasteState.LOADED)
+        assertTrue(pd.isValid())
+    }
+
+    @Test
+    fun `isValid returns true for LOADING paste`() {
+        val pd = createTestPasteData(pasteState = PasteState.LOADING)
+        assertTrue(pd.isValid())
+    }
+
+    @Test
+    fun `isValid returns false for DELETED paste`() {
+        val pd = createTestPasteData(pasteState = PasteState.DELETED)
+        assertFalse(pd.isValid())
+    }
+
+    @Test
+    fun `isValid returns false when appear item type does not match paste type`() {
+        val textItem = createTextPasteItem(text = "text")
+        val pd =
+            PasteData(
+                appInstanceId = "test",
+                pasteAppearItem = textItem,
+                pasteCollection = PasteCollection(listOf()),
+                pasteType = PasteType.COLOR_TYPE.type, // mismatch
+                size = textItem.size,
+                hash = textItem.hash,
+                pasteState = PasteState.LOADED,
+                createTime = DateUtils.nowEpochMilliseconds(),
+            )
+        assertFalse(pd.isValid())
+    }
+
+    // --- existFileCategory ---
+
+    @Test
+    fun `existFileCategory returns false for text only paste`() {
+        val pd = createTestPasteData()
+        assertFalse(pd.existFileCategory())
+    }
+
+    // --- getTypeName ---
+
+    @Test
+    fun `getTypeName returns correct name for each type`() {
+        assertEquals("text", createTestPasteData(pasteType = PasteType.TEXT_TYPE).getTypeName())
+    }
+
+    // --- getPasteCoordinate ---
+
+    @Test
+    fun `getPasteCoordinate returns correct coordinate`() {
+        val pd = createTestPasteData().copy(id = 42)
+        val coord = pd.getPasteCoordinate()
+        assertEquals(42, coord.id)
+        assertEquals("test-app", coord.appInstanceId)
+    }
+
+    @Test
+    fun `getPasteCoordinate with override id`() {
+        val pd = createTestPasteData().copy(id = 42)
+        val coord = pd.getPasteCoordinate(id = 100)
+        assertEquals(100, coord.id)
+    }
+
+    // --- getSummary ---
+
+    @Test
+    fun `getSummary returns loading string when LOADING`() {
+        val pd = createTestPasteData(pasteState = PasteState.LOADING)
+        assertEquals("Loading...", pd.getSummary("Loading...", "Unknown"))
+    }
+
+    @Test
+    fun `getSummary returns text content for TEXT type`() {
+        val pd = createTestPasteData(text = "hello world")
+        val summary = pd.getSummary("Loading...", "Unknown")
+        assertEquals("hello world", summary)
+    }
+
+    @Test
+    fun `getSummary for HTML type prefers text item from collection`() {
+        val htmlItem = createHtmlPasteItem(html = "<p>Hello</p>")
+        val textItem = createTextPasteItem(text = "Hello plain")
+        val pd =
+            PasteData(
+                appInstanceId = "test",
+                pasteAppearItem = htmlItem,
+                pasteCollection = PasteCollection(listOf(textItem)),
+                pasteType = PasteType.HTML_TYPE.type,
+                size = htmlItem.size,
+                hash = htmlItem.hash,
+                pasteState = PasteState.LOADED,
+                createTime = DateUtils.nowEpochMilliseconds(),
+            )
+        val summary = pd.getSummary("Loading...", "Unknown")
+        assertEquals("Hello plain", summary)
+    }
+
+    // --- toJson / fromJson roundtrip ---
+
+    @Test
+    fun `toJson and fromJson roundtrip preserves key fields`() {
+        val pd = createTestPasteData(text = "roundtrip test")
+        val json = pd.toJson()
+        val restored = PasteData.fromJson(json)
+
+        assertNotNull(restored)
+        assertEquals(pd.appInstanceId, restored.appInstanceId)
+        assertEquals(pd.pasteType, restored.pasteType)
+        assertEquals(pd.hash, restored.hash)
+        assertEquals(pd.size, restored.size)
+    }
+
+    @Test
+    fun `fromJson returns null for invalid json`() {
+        assertNull(PasteData.fromJson("not valid json"))
+    }
+
+    @Test
+    fun `fromJson returns null for empty json`() {
+        assertNull(PasteData.fromJson("{}"))
+    }
+
+    // --- buildRawSearchContent ---
+
+    @Test
+    fun `buildRawSearchContent with both source and content`() {
+        val result = PasteData.buildRawSearchContent("Chrome", "hello")
+        assertEquals("chrome hello", result)
+    }
+
+    @Test
+    fun `buildRawSearchContent with source only`() {
+        val result = PasteData.buildRawSearchContent("Chrome", null)
+        assertEquals("chrome", result)
+    }
+
+    @Test
+    fun `buildRawSearchContent with content only`() {
+        val result = PasteData.buildRawSearchContent(null, "hello")
+        assertEquals("hello", result)
+    }
+
+    @Test
+    fun `buildRawSearchContent with both null`() {
+        val result = PasteData.buildRawSearchContent(null, null)
+        assertNull(result)
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteTypeTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteTypeTest.kt
@@ -1,0 +1,150 @@
+package com.crosspaste.paste
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PasteTypeTest {
+
+    // --- fromType ---
+
+    @Test
+    fun `fromType returns TEXT_TYPE for type 0`() {
+        assertEquals(PasteType.TEXT_TYPE, PasteType.fromType(0))
+    }
+
+    @Test
+    fun `fromType returns URL_TYPE for type 1`() {
+        assertEquals(PasteType.URL_TYPE, PasteType.fromType(1))
+    }
+
+    @Test
+    fun `fromType returns HTML_TYPE for type 2`() {
+        assertEquals(PasteType.HTML_TYPE, PasteType.fromType(2))
+    }
+
+    @Test
+    fun `fromType returns FILE_TYPE for type 3`() {
+        assertEquals(PasteType.FILE_TYPE, PasteType.fromType(3))
+    }
+
+    @Test
+    fun `fromType returns IMAGE_TYPE for type 4`() {
+        assertEquals(PasteType.IMAGE_TYPE, PasteType.fromType(4))
+    }
+
+    @Test
+    fun `fromType returns RTF_TYPE for type 5`() {
+        assertEquals(PasteType.RTF_TYPE, PasteType.fromType(5))
+    }
+
+    @Test
+    fun `fromType returns COLOR_TYPE for type 6`() {
+        assertEquals(PasteType.COLOR_TYPE, PasteType.fromType(6))
+    }
+
+    @Test
+    fun `fromType returns INVALID_TYPE for unknown type`() {
+        assertEquals(PasteType.INVALID_TYPE, PasteType.fromType(999))
+        assertEquals(PasteType.INVALID_TYPE, PasteType.fromType(-2))
+    }
+
+    // --- Type check methods ---
+
+    @Test
+    fun `isText returns true only for TEXT_TYPE`() {
+        assertTrue(PasteType.TEXT_TYPE.isText())
+        assertFalse(PasteType.URL_TYPE.isText())
+        assertFalse(PasteType.FILE_TYPE.isText())
+    }
+
+    @Test
+    fun `isUrl returns true only for URL_TYPE`() {
+        assertTrue(PasteType.URL_TYPE.isUrl())
+        assertFalse(PasteType.TEXT_TYPE.isUrl())
+    }
+
+    @Test
+    fun `isHtml returns true only for HTML_TYPE`() {
+        assertTrue(PasteType.HTML_TYPE.isHtml())
+        assertFalse(PasteType.TEXT_TYPE.isHtml())
+    }
+
+    @Test
+    fun `isFile returns true only for FILE_TYPE`() {
+        assertTrue(PasteType.FILE_TYPE.isFile())
+        assertFalse(PasteType.IMAGE_TYPE.isFile())
+    }
+
+    @Test
+    fun `isImage returns true only for IMAGE_TYPE`() {
+        assertTrue(PasteType.IMAGE_TYPE.isImage())
+        assertFalse(PasteType.FILE_TYPE.isImage())
+    }
+
+    @Test
+    fun `isRtf returns true only for RTF_TYPE`() {
+        assertTrue(PasteType.RTF_TYPE.isRtf())
+        assertFalse(PasteType.HTML_TYPE.isRtf())
+    }
+
+    @Test
+    fun `isColor returns true only for COLOR_TYPE`() {
+        assertTrue(PasteType.COLOR_TYPE.isColor())
+        assertFalse(PasteType.TEXT_TYPE.isColor())
+    }
+
+    @Test
+    fun `isInValid returns true only for INVALID_TYPE`() {
+        assertTrue(PasteType.INVALID_TYPE.isInValid())
+        assertFalse(PasteType.TEXT_TYPE.isInValid())
+        assertFalse(PasteType.FILE_TYPE.isInValid())
+    }
+
+    // --- TYPES list ---
+
+    @Test
+    fun `TYPES contains all valid types`() {
+        assertEquals(7, PasteType.TYPES.size)
+        assertTrue(PasteType.TYPES.contains(PasteType.TEXT_TYPE))
+        assertTrue(PasteType.TYPES.contains(PasteType.URL_TYPE))
+        assertTrue(PasteType.TYPES.contains(PasteType.HTML_TYPE))
+        assertTrue(PasteType.TYPES.contains(PasteType.FILE_TYPE))
+        assertTrue(PasteType.TYPES.contains(PasteType.IMAGE_TYPE))
+        assertTrue(PasteType.TYPES.contains(PasteType.RTF_TYPE))
+        assertTrue(PasteType.TYPES.contains(PasteType.COLOR_TYPE))
+    }
+
+    @Test
+    fun `TYPES does not contain INVALID_TYPE`() {
+        assertFalse(PasteType.TYPES.contains(PasteType.INVALID_TYPE))
+    }
+
+    // --- MAP_TYPES ---
+
+    @Test
+    fun `MAP_TYPES maps all valid type ids`() {
+        assertEquals(7, PasteType.MAP_TYPES.size)
+        for (type in PasteType.TYPES) {
+            assertEquals(type, PasteType.MAP_TYPES[type.type])
+        }
+    }
+
+    // --- Priority ---
+
+    @Test
+    fun `each type has unique priority`() {
+        val priorities = PasteType.TYPES.map { it.priority }
+        assertEquals(priorities.size, priorities.distinct().size)
+    }
+
+    // --- Name ---
+
+    @Test
+    fun `type names are non-empty`() {
+        for (type in PasteType.TYPES) {
+            assertTrue(type.name.isNotEmpty())
+        }
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/item/CreatePasteItemHelperTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/item/CreatePasteItemHelperTest.kt
@@ -1,0 +1,264 @@
+package com.crosspaste.paste.item
+
+import com.crosspaste.paste.item.CreatePasteItemHelper.copy
+import com.crosspaste.paste.item.CreatePasteItemHelper.createColorPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createHtmlPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createRtfPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
+import com.crosspaste.presist.SingleFileInfoTree
+import com.crosspaste.utils.getJsonUtils
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class CreatePasteItemHelperTest {
+
+    // Eagerly initialize JsonUtils to avoid circular class initialization between
+    // PasteItem.Companion (which calls getJsonUtils()) and TextPasteItem
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    // --- TextPasteItem ---
+
+    @Test
+    fun `createTextPasteItem creates item with correct text`() {
+        val item = createTextPasteItem(text = "Hello World")
+        assertEquals("Hello World", item.text)
+    }
+
+    @Test
+    fun `createTextPasteItem computes hash from text bytes`() {
+        val item = createTextPasteItem(text = "test")
+        assertTrue(item.hash.isNotEmpty())
+    }
+
+    @Test
+    fun `createTextPasteItem computes size from text bytes`() {
+        val text = "Hello"
+        val item = createTextPasteItem(text = text)
+        assertEquals(text.encodeToByteArray().size.toLong(), item.size)
+    }
+
+    @Test
+    fun `createTextPasteItem same text produces same hash`() {
+        val item1 = createTextPasteItem(text = "identical")
+        val item2 = createTextPasteItem(text = "identical")
+        assertEquals(item1.hash, item2.hash)
+    }
+
+    @Test
+    fun `createTextPasteItem different text produces different hash`() {
+        val item1 = createTextPasteItem(text = "alpha")
+        val item2 = createTextPasteItem(text = "beta")
+        assertNotEquals(item1.hash, item2.hash)
+    }
+
+    @Test
+    fun `createTextPasteItem stores identifiers`() {
+        val ids = listOf("text/plain", "text/html")
+        val item = createTextPasteItem(identifiers = ids, text = "test")
+        assertEquals(ids, item.identifiers)
+    }
+
+    @Test
+    fun `createTextPasteItem handles empty text`() {
+        val item = createTextPasteItem(text = "")
+        assertEquals("", item.text)
+        assertEquals(0L, item.size)
+    }
+
+    @Test
+    fun `createTextPasteItem handles unicode text`() {
+        val text = "你好世界 🌍"
+        val item = createTextPasteItem(text = text)
+        assertEquals(text, item.text)
+        assertEquals(text.encodeToByteArray().size.toLong(), item.size)
+    }
+
+    @Test
+    fun `TextPasteItem copy creates new item with different text`() {
+        val original = createTextPasteItem(identifiers = listOf("id"), text = "original")
+        val copy = original.copy(text = "modified")
+        assertEquals("modified", copy.text)
+        assertEquals(original.identifiers, copy.identifiers)
+        assertNotEquals(original.hash, copy.hash)
+    }
+
+    // --- HtmlPasteItem ---
+
+    @Test
+    fun `createHtmlPasteItem creates item with correct html`() {
+        val html = "<p>Hello</p>"
+        val item = createHtmlPasteItem(html = html)
+        assertEquals(html, item.html)
+    }
+
+    @Test
+    fun `createHtmlPasteItem computes hash from html bytes`() {
+        val item = createHtmlPasteItem(html = "<b>test</b>")
+        assertTrue(item.hash.isNotEmpty())
+    }
+
+    @Test
+    fun `createHtmlPasteItem computes size from html bytes`() {
+        val html = "<b>Hello</b>"
+        val item = createHtmlPasteItem(html = html)
+        assertEquals(html.encodeToByteArray().size.toLong(), item.size)
+    }
+
+    @Test
+    fun `HtmlPasteItem copy preserves identifiers and changes html`() {
+        val original = createHtmlPasteItem(identifiers = listOf("text/html"), html = "<p>old</p>")
+        val copy = original.copy(html = "<p>new</p>")
+        assertEquals("<p>new</p>", copy.html)
+        assertEquals(original.identifiers, copy.identifiers)
+    }
+
+    // --- RtfPasteItem ---
+
+    @Test
+    fun `createRtfPasteItem creates item with correct rtf`() {
+        val rtf = "{\\rtf1 Hello}"
+        val item = createRtfPasteItem(rtf = rtf)
+        assertEquals(rtf, item.rtf)
+    }
+
+    @Test
+    fun `createRtfPasteItem computes hash and size`() {
+        val rtf = "{\\rtf1 test}"
+        val item = createRtfPasteItem(rtf = rtf)
+        assertTrue(item.hash.isNotEmpty())
+        assertEquals(rtf.encodeToByteArray().size.toLong(), item.size)
+    }
+
+    @Test
+    fun `RtfPasteItem copy changes rtf content`() {
+        val original = createRtfPasteItem(rtf = "{\\rtf1 old}")
+        val copy = original.copy(rtf = "{\\rtf1 new}")
+        assertEquals("{\\rtf1 new}", copy.rtf)
+    }
+
+    // --- UrlPasteItem ---
+
+    @Test
+    fun `createUrlPasteItem creates item with correct url`() {
+        val url = "https://example.com"
+        val item = createUrlPasteItem(url = url)
+        assertEquals(url, item.url)
+    }
+
+    @Test
+    fun `createUrlPasteItem computes hash from url bytes`() {
+        val item = createUrlPasteItem(url = "https://example.com")
+        assertTrue(item.hash.isNotEmpty())
+    }
+
+    @Test
+    fun `createUrlPasteItem size includes title when provided`() {
+        val url = "https://example.com"
+        val title = "Example"
+        val extraInfo = JsonObject(mapOf(PasteItemProperties.TITLE to JsonPrimitive(title)))
+        val item = createUrlPasteItem(url = url, extraInfo = extraInfo)
+        assertEquals(url.encodeToByteArray().size.toLong() + title.length.toLong(), item.size)
+    }
+
+    @Test
+    fun `createUrlPasteItem size without title is just url size`() {
+        val url = "https://example.com"
+        val item = createUrlPasteItem(url = url)
+        assertEquals(url.encodeToByteArray().size.toLong(), item.size)
+    }
+
+    @Test
+    fun `UrlPasteItem copy creates new item with different url`() {
+        val original = createUrlPasteItem(identifiers = listOf("url"), url = "https://old.com")
+        val copy = original.copy(url = "https://new.com")
+        assertTrue(copy is UrlPasteItem)
+        assertEquals("https://new.com", (copy as UrlPasteItem).url)
+    }
+
+    // --- ColorPasteItem ---
+
+    @Test
+    fun `createColorPasteItem creates item with correct color`() {
+        val item = createColorPasteItem(color = 0xFF0000)
+        assertEquals(0xFF0000, item.color)
+    }
+
+    @Test
+    fun `createColorPasteItem hash is string of color`() {
+        val item = createColorPasteItem(color = 255)
+        assertEquals("255", item.hash)
+    }
+
+    @Test
+    fun `createColorPasteItem size is always 8`() {
+        val item = createColorPasteItem(color = 0)
+        assertEquals(8L, item.size)
+    }
+
+    @Test
+    fun `ColorPasteItem copy changes color value`() {
+        val original = createColorPasteItem(color = 0xFF0000)
+        val copy = original.copy(color = 0x00FF00)
+        assertEquals(0x00FF00, copy.color)
+        assertEquals(original.identifiers, copy.identifiers)
+    }
+
+    // --- FilesPasteItem ---
+
+    @Test
+    fun `createFilesPasteItem computes hash from sorted file names`() {
+        val fileInfoTreeMap =
+            mapOf(
+                "b.txt" to SingleFileInfoTree(size = 100, hash = "hash_b"),
+                "a.txt" to SingleFileInfoTree(size = 200, hash = "hash_a"),
+            )
+        val item =
+            CreatePasteItemHelper.createFilesPasteItem(
+                relativePathList = listOf("a.txt", "b.txt"),
+                fileInfoTreeMap = fileInfoTreeMap,
+            )
+        assertTrue(item.hash.isNotEmpty())
+        assertEquals(300L, item.size)
+        assertEquals(2L, item.count)
+    }
+
+    @Test
+    fun `createFilesPasteItem with single file`() {
+        val fileInfoTreeMap =
+            mapOf(
+                "test.txt" to SingleFileInfoTree(size = 50, hash = "hash_test"),
+            )
+        val item =
+            CreatePasteItemHelper.createFilesPasteItem(
+                relativePathList = listOf("test.txt"),
+                fileInfoTreeMap = fileInfoTreeMap,
+            )
+        assertEquals(50L, item.size)
+        assertEquals(1L, item.count)
+    }
+
+    // --- ImagesPasteItem ---
+
+    @Test
+    fun `createImagesPasteItem computes correct size and count`() {
+        val fileInfoTreeMap =
+            mapOf(
+                "img1.png" to SingleFileInfoTree(size = 1024, hash = "hash_img1"),
+                "img2.jpg" to SingleFileInfoTree(size = 2048, hash = "hash_img2"),
+            )
+        val item =
+            CreatePasteItemHelper.createImagesPasteItem(
+                relativePathList = listOf("img1.png", "img2.jpg"),
+                fileInfoTreeMap = fileInfoTreeMap,
+            )
+        assertEquals(3072L, item.size)
+        assertEquals(2L, item.count)
+        assertTrue(item.hash.isNotEmpty())
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/presist/FileInfoTreeTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/presist/FileInfoTreeTest.kt
@@ -1,0 +1,247 @@
+package com.crosspaste.presist
+
+import com.crosspaste.utils.getJsonUtils
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FileInfoTreeTest {
+
+    private val jsonUtils = getJsonUtils()
+
+    // --- SingleFileInfoTree ---
+
+    @Test
+    fun `SingleFileInfoTree isFile returns true`() {
+        val tree = SingleFileInfoTree(size = 100L, hash = "abc")
+        assertTrue(tree.isFile())
+    }
+
+    @Test
+    fun `SingleFileInfoTree getCount returns 1`() {
+        val tree = SingleFileInfoTree(size = 100L, hash = "abc")
+        assertEquals(1L, tree.getCount())
+    }
+
+    @Test
+    fun `SingleFileInfoTree getPasteFileList returns single file`() {
+        val tree = SingleFileInfoTree(size = 100L, hash = "abc")
+        val files = tree.getPasteFileList("/test/file.txt".toPath())
+        assertEquals(1, files.size)
+    }
+
+    @Test
+    fun `SingleFileInfoTree preserves size and hash`() {
+        val tree = SingleFileInfoTree(size = 42L, hash = "myhash")
+        assertEquals(42L, tree.size)
+        assertEquals("myhash", tree.hash)
+    }
+
+    // --- DirFileInfoTree ---
+
+    @Test
+    fun `DirFileInfoTree isFile returns false`() {
+        val tree =
+            DirFileInfoTree(
+                tree = mapOf("a.txt" to SingleFileInfoTree(10, "h1")),
+                size = 10L,
+                hash = "dirhash",
+            )
+        assertFalse(tree.isFile())
+    }
+
+    @Test
+    fun `DirFileInfoTree getCount returns total file count`() {
+        val tree =
+            DirFileInfoTree(
+                tree =
+                    mapOf(
+                        "a.txt" to SingleFileInfoTree(10, "h1"),
+                        "b.txt" to SingleFileInfoTree(20, "h2"),
+                    ),
+                size = 30L,
+                hash = "dirhash",
+            )
+        assertEquals(2L, tree.getCount())
+    }
+
+    @Test
+    fun `DirFileInfoTree nested directory getCount`() {
+        val inner =
+            DirFileInfoTree(
+                tree =
+                    mapOf(
+                        "c.txt" to SingleFileInfoTree(5, "h3"),
+                        "d.txt" to SingleFileInfoTree(5, "h4"),
+                    ),
+                size = 10L,
+                hash = "innerhash",
+            )
+        val outer =
+            DirFileInfoTree(
+                tree =
+                    mapOf(
+                        "a.txt" to SingleFileInfoTree(10, "h1"),
+                        "subdir" to inner,
+                    ),
+                size = 20L,
+                hash = "outerhash",
+            )
+        assertEquals(3L, outer.getCount())
+    }
+
+    @Test
+    fun `DirFileInfoTree getPasteFileList returns all files with correct paths`() {
+        val tree =
+            DirFileInfoTree(
+                tree =
+                    mapOf(
+                        "a.txt" to SingleFileInfoTree(10, "h1"),
+                        "b.txt" to SingleFileInfoTree(20, "h2"),
+                    ),
+                size = 30L,
+                hash = "dirhash",
+            )
+        val files = tree.getPasteFileList("/root".toPath())
+        assertEquals(2, files.size)
+    }
+
+    @Test
+    fun `DirFileInfoTree nested getPasteFileList flattens correctly`() {
+        val inner =
+            DirFileInfoTree(
+                tree =
+                    mapOf(
+                        "c.txt" to SingleFileInfoTree(5, "h3"),
+                    ),
+                size = 5L,
+                hash = "innerhash",
+            )
+        val outer =
+            DirFileInfoTree(
+                tree =
+                    mapOf(
+                        "a.txt" to SingleFileInfoTree(10, "h1"),
+                        "sub" to inner,
+                    ),
+                size = 15L,
+                hash = "outerhash",
+            )
+        val files = outer.getPasteFileList("/root".toPath())
+        assertEquals(2, files.size)
+    }
+
+    @Test
+    fun `DirFileInfoTree iterator returns sorted entries`() {
+        val tree =
+            DirFileInfoTree(
+                tree =
+                    mapOf(
+                        "c.txt" to SingleFileInfoTree(5, "h3"),
+                        "a.txt" to SingleFileInfoTree(10, "h1"),
+                        "b.txt" to SingleFileInfoTree(20, "h2"),
+                    ),
+                size = 35L,
+                hash = "dirhash",
+            )
+        val names =
+            tree
+                .iterator()
+                .asSequence()
+                .map { it.first }
+                .toList()
+        assertEquals(listOf("a.txt", "b.txt", "c.txt"), names)
+    }
+
+    // --- FileInfoTreeBuilder ---
+
+    @Test
+    fun `FileInfoTreeBuilder builds DirFileInfoTree with correct size`() {
+        val builder = FileInfoTreeBuilder()
+        builder.addFileInfoTree("a.txt", SingleFileInfoTree(100, "h1"))
+        builder.addFileInfoTree("b.txt", SingleFileInfoTree(200, "h2"))
+        val tree = builder.build("/test".toPath())
+
+        assertFalse(tree.isFile())
+        assertEquals(300L, tree.size)
+        assertEquals(2L, tree.getCount())
+    }
+
+    @Test
+    fun `FileInfoTreeBuilder empty build produces directory with hash from path name`() {
+        val builder = FileInfoTreeBuilder()
+        val tree = builder.build("/mydir".toPath())
+
+        assertFalse(tree.isFile())
+        assertEquals(0L, tree.size)
+        assertTrue(tree.hash.isNotEmpty())
+    }
+
+    @Test
+    fun `FileInfoTreeBuilder computes hash from child hashes`() {
+        val builder = FileInfoTreeBuilder()
+        builder.addFileInfoTree("x.txt", SingleFileInfoTree(10, "hash_x"))
+        val tree = builder.build("/dir".toPath())
+
+        assertTrue(tree.hash.isNotEmpty())
+    }
+
+    // --- Serialization ---
+
+    @Test
+    fun `SingleFileInfoTree serialization roundtrip`() {
+        val original = SingleFileInfoTree(size = 42L, hash = "test_hash")
+        val json = jsonUtils.JSON.encodeToString(original as FileInfoTree)
+        val restored = jsonUtils.JSON.decodeFromString<FileInfoTree>(json)
+
+        assertTrue(restored is SingleFileInfoTree)
+        assertEquals(42L, restored.size)
+        assertEquals("test_hash", restored.hash)
+    }
+
+    @Test
+    fun `DirFileInfoTree serialization roundtrip`() {
+        val original: FileInfoTree =
+            DirFileInfoTree(
+                tree =
+                    mapOf(
+                        "file1.txt" to SingleFileInfoTree(10, "h1"),
+                        "file2.txt" to SingleFileInfoTree(20, "h2"),
+                    ),
+                size = 30L,
+                hash = "dir_hash",
+            )
+        val json = jsonUtils.JSON.encodeToString(original)
+        val restored = jsonUtils.JSON.decodeFromString<FileInfoTree>(json)
+
+        assertTrue(restored is DirFileInfoTree)
+        assertEquals(30L, restored.size)
+        assertEquals(2L, restored.getCount())
+    }
+
+    @Test
+    fun `nested DirFileInfoTree serialization roundtrip`() {
+        val inner: FileInfoTree =
+            DirFileInfoTree(
+                tree = mapOf("inner.txt" to SingleFileInfoTree(5, "hi")),
+                size = 5L,
+                hash = "inner_hash",
+            )
+        val outer: FileInfoTree =
+            DirFileInfoTree(
+                tree =
+                    mapOf(
+                        "outer.txt" to SingleFileInfoTree(10, "ho"),
+                        "subdir" to inner,
+                    ),
+                size = 15L,
+                hash = "outer_hash",
+            )
+        val json = jsonUtils.JSON.encodeToString(outer)
+        val restored = jsonUtils.JSON.decodeFromString<FileInfoTree>(json)
+
+        assertEquals(2L, restored.getCount())
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/presist/FilesIndexTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/presist/FilesIndexTest.kt
@@ -1,0 +1,177 @@
+package com.crosspaste.presist
+
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class FilesIndexTest {
+
+    // --- FilesIndexBuilder single file ---
+
+    @Test
+    fun `single file smaller than chunk fits in one chunk`() {
+        val builder = FilesIndexBuilder(chunkSize = 1024)
+        builder.addFile("/file.txt".toPath(), size = 500)
+        val index = builder.build()
+
+        assertEquals(1, index.getChunkCount())
+        val chunk = index.getChunk(0)
+        assertNotNull(chunk)
+        assertEquals(1, chunk.fileChunks.size)
+        assertEquals(500L, chunk.fileChunks[0].size)
+        assertEquals(0L, chunk.fileChunks[0].offset)
+    }
+
+    @Test
+    fun `single file equal to chunk size fits in one chunk`() {
+        val builder = FilesIndexBuilder(chunkSize = 1024)
+        builder.addFile("/file.txt".toPath(), size = 1024)
+        val index = builder.build()
+
+        assertEquals(1, index.getChunkCount())
+    }
+
+    @Test
+    fun `single file larger than chunk splits across chunks`() {
+        val builder = FilesIndexBuilder(chunkSize = 100)
+        builder.addFile("/big.txt".toPath(), size = 250)
+        val index = builder.build()
+
+        assertEquals(3, index.getChunkCount())
+
+        val chunk0 = index.getChunk(0)!!
+        assertEquals(1, chunk0.fileChunks.size)
+        assertEquals(0L, chunk0.fileChunks[0].offset)
+        assertEquals(100L, chunk0.fileChunks[0].size)
+
+        val chunk1 = index.getChunk(1)!!
+        assertEquals(1, chunk1.fileChunks.size)
+        assertEquals(100L, chunk1.fileChunks[0].offset)
+        assertEquals(100L, chunk1.fileChunks[0].size)
+
+        val chunk2 = index.getChunk(2)!!
+        assertEquals(1, chunk2.fileChunks.size)
+        assertEquals(200L, chunk2.fileChunks[0].offset)
+        assertEquals(50L, chunk2.fileChunks[0].size)
+    }
+
+    // --- Multiple files ---
+
+    @Test
+    fun `multiple small files packed into one chunk`() {
+        val builder = FilesIndexBuilder(chunkSize = 1024)
+        builder.addFile("/a.txt".toPath(), size = 100)
+        builder.addFile("/b.txt".toPath(), size = 200)
+        builder.addFile("/c.txt".toPath(), size = 300)
+        val index = builder.build()
+
+        assertEquals(1, index.getChunkCount())
+        val chunk = index.getChunk(0)!!
+        assertEquals(3, chunk.fileChunks.size)
+    }
+
+    @Test
+    fun `multiple files split across chunks at boundary`() {
+        val builder = FilesIndexBuilder(chunkSize = 200)
+        builder.addFile("/a.txt".toPath(), size = 150)
+        builder.addFile("/b.txt".toPath(), size = 150)
+        val index = builder.build()
+
+        assertEquals(2, index.getChunkCount())
+
+        // First chunk: a.txt (150) + first 50 of b.txt
+        val chunk0 = index.getChunk(0)!!
+        assertEquals(2, chunk0.fileChunks.size)
+        assertEquals(150L, chunk0.fileChunks[0].size) // a.txt
+        assertEquals(50L, chunk0.fileChunks[1].size) // first part of b.txt
+
+        // Second chunk: remaining 100 of b.txt
+        val chunk1 = index.getChunk(1)!!
+        assertEquals(1, chunk1.fileChunks.size)
+        assertEquals(100L, chunk1.fileChunks[0].size)
+        assertEquals(50L, chunk1.fileChunks[0].offset)
+    }
+
+    // --- Edge cases ---
+
+    @Test
+    fun `empty builder produces zero chunks`() {
+        val builder = FilesIndexBuilder(chunkSize = 1024)
+        val index = builder.build()
+        assertEquals(0, index.getChunkCount())
+    }
+
+    @Test
+    fun `getChunk returns null for out-of-range index`() {
+        val builder = FilesIndexBuilder(chunkSize = 1024)
+        builder.addFile("/file.txt".toPath(), size = 100)
+        val index = builder.build()
+
+        assertNull(index.getChunk(1))
+        assertNull(index.getChunk(-1))
+    }
+
+    @Test
+    fun `getChunk returns null for negative index`() {
+        val builder = FilesIndexBuilder(chunkSize = 1024)
+        val index = builder.build()
+        assertNull(index.getChunk(-1))
+    }
+
+    // --- FileChunk data ---
+
+    @Test
+    fun `FileChunk preserves offset size and path`() {
+        val path = "/test/file.txt".toPath()
+        val chunk = FileChunk(offset = 100L, size = 50L, path = path)
+        assertEquals(100L, chunk.offset)
+        assertEquals(50L, chunk.size)
+        assertEquals(path, chunk.path)
+    }
+
+    @Test
+    fun `FileChunk toString contains filename`() {
+        val chunk = FileChunk(offset = 0, size = 100, path = "/test/my_file.txt".toPath())
+        val str = chunk.toString()
+        assert(str.contains("my_file.txt"))
+    }
+
+    @Test
+    fun `FilesChunk toString contains all file chunks`() {
+        val chunks =
+            FilesChunk(
+                listOf(
+                    FileChunk(0, 100, "/a.txt".toPath()),
+                    FileChunk(0, 200, "/b.txt".toPath()),
+                ),
+            )
+        val str = chunks.toString()
+        assert(str.contains("a.txt"))
+        assert(str.contains("b.txt"))
+    }
+
+    // --- Large file scenario ---
+
+    @Test
+    fun `very large file produces correct number of chunks`() {
+        val chunkSize = 1024L * 1024 // 1MB chunks
+        val fileSize = 5L * 1024 * 1024 + 512 * 1024 // 5.5MB
+        val builder = FilesIndexBuilder(chunkSize = chunkSize)
+        builder.addFile("/big.bin".toPath(), size = fileSize)
+        val index = builder.build()
+
+        assertEquals(6, index.getChunkCount()) // 5 full + 1 partial
+
+        // Verify total size adds up
+        var totalSize = 0L
+        for (i in 0 until index.getChunkCount()) {
+            val chunk = index.getChunk(i)!!
+            for (fc in chunk.fileChunks) {
+                totalSize += fc.size
+            }
+        }
+        assertEquals(fileSize, totalSize)
+    }
+}


### PR DESCRIPTION
Closes #3819

## Summary
- Add **209 new unit tests** across **11 test files** covering the core data layer (Phase 1 of test coverage improvement plan)
- Fix JVM circular class initialization issue between `PasteItem.Companion` and `TextPasteItem` by eagerly initializing `JsonUtils` in test classes
- Add `/ai/` to `.gitignore` for test plan documentation directory

## Test Coverage Added

| Test File | Tests | Coverage Area |
|---|---|---|
| TaskDaoTest | 20 | Task CRUD, state transitions, retry, cleanup |
| SecureDaoTest | 11 | SecureIO key storage operations |
| PasteDaoTest | 35 | Paste CRUD, search (FTS5), tags, batch read |
| PasteDataTest | 25+ | PasteData model methods, serialization |
| PasteCollectionTest | 7 | Collection construction, ordering, serialization |
| PasteTypeTest | 21 | Type enum, TYPES list, MAP_TYPES, priorities |
| CreatePasteItemHelperTest | 25+ | All paste item factory methods |
| FileInfoTreeTest | 16 | File tree structures, nested dirs, serialization |
| FilesIndexTest | 12 | File chunking logic, edge cases |
| DtoSerializationTest | 22+ | All DTO roundtrip serialization |
| PasteTaskExtraInfoTest | 11 | Polymorphic PasteTaskExtraInfo serialization |

## Test plan
- [x] All 209 tests pass individually
- [x] All 209 tests pass together with `--rerun` flag
- [x] Tests coexist with existing test suite (SerializerTest, SyncIntegrationTest)
- [x] ktlintFormat passes with no issues

🤖 Generated with [Claude Code](https://claude.ai/code)