### PR TITLE
:white_check_mark: Add 63 unit tests for utils and platform layer (Phase 5)

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/path/DesktopMigrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/path/DesktopMigrationTest.kt
@@ -1,0 +1,183 @@
+package com.crosspaste.path
+
+import com.crosspaste.config.AppConfig
+import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.db.DriverFactory
+import com.crosspaste.notification.NotificationManager
+import io.mockk.every
+import io.mockk.mockk
+import okio.Path.Companion.toOkioPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+class DesktopMigrationTest {
+
+    private fun createMigration(storagePath: java.io.File): DesktopMigration {
+        val appConfig = mockk<AppConfig>()
+        every { appConfig.useDefaultStoragePath } returns true
+
+        val configManager = mockk<CommonConfigManager>()
+        every { configManager.getCurrentConfig() } returns appConfig
+
+        val driverFactory = mockk<DriverFactory>()
+        val notificationManager = mockk<NotificationManager>()
+        val platformProvider = mockk<PlatformUserDataPathProvider>()
+        every { platformProvider.getUserDefaultStoragePath() } returns storagePath.toOkioPath()
+
+        val userDataPathProvider = UserDataPathProvider(configManager, platformProvider)
+
+        return DesktopMigration(
+            configManager = configManager,
+            driverFactory = driverFactory,
+            notificationManager = notificationManager,
+            userDataPathProvider = userDataPathProvider,
+        )
+    }
+
+    @Test
+    fun `checkMigrationPath returns directory_not_exist for non-existent path`() {
+        val tempDir = Files.createTempDirectory("migration-test").toFile()
+        tempDir.deleteOnExit()
+        val migration = createMigration(tempDir)
+
+        val nonExistent = tempDir.resolve("does_not_exist").toOkioPath()
+        val result = migration.checkMigrationPath(nonExistent)
+        assertEquals("directory_not_exist", result)
+    }
+
+    @Test
+    fun `checkMigrationPath returns not_a_directory for file path`() {
+        val tempDir = Files.createTempDirectory("migration-test").toFile()
+        tempDir.deleteOnExit()
+        val migration = createMigration(tempDir)
+
+        val file = tempDir.resolve("file.txt")
+        file.writeText("data")
+        file.deleteOnExit()
+
+        val result = migration.checkMigrationPath(file.toOkioPath())
+        assertEquals("not_a_directory", result)
+    }
+
+    @Test
+    fun `checkMigrationPath rejects migration target that is child of current storage`() {
+        // current storage = tempDir, migration target = tempDir/child
+        // migrationPath starts with currentStoragePath → "cant_select_parent_directory"
+        val tempDir = Files.createTempDirectory("migration-test").toFile()
+        tempDir.deleteOnExit()
+        val migration = createMigration(tempDir)
+
+        val childDir = tempDir.resolve("child")
+        childDir.mkdirs()
+        childDir.deleteOnExit()
+
+        val result = migration.checkMigrationPath(childDir.toOkioPath())
+        assertEquals("cant_select_parent_directory", result)
+    }
+
+    @Test
+    fun `checkMigrationPath rejects migration target that is parent of current storage`() {
+        // current storage = nested/storage, migration target = tempDir (ancestor)
+        // currentStoragePath starts with migrationPath → "cant_select_child_directory"
+        val tempDir = Files.createTempDirectory("migration-test").toFile()
+        tempDir.deleteOnExit()
+
+        val storageDir = tempDir.resolve("nested").resolve("storage")
+        storageDir.mkdirs()
+        storageDir.deleteOnExit()
+
+        val migration = createMigration(storageDir)
+        val result = migration.checkMigrationPath(tempDir.toOkioPath())
+        assertEquals("cant_select_child_directory", result)
+    }
+
+    @Test
+    fun `checkMigrationPath returns directory_not_empty for non-empty directory`() {
+        val tempDir = Files.createTempDirectory("migration-test").toFile()
+        tempDir.deleteOnExit()
+
+        val storageDir = tempDir.resolve("storage")
+        storageDir.mkdirs()
+        storageDir.deleteOnExit()
+
+        val migrationDir = tempDir.resolve("migration")
+        migrationDir.mkdirs()
+        migrationDir.deleteOnExit()
+
+        val file = migrationDir.resolve("existing.txt")
+        file.writeText("content")
+        file.deleteOnExit()
+
+        val migration = createMigration(storageDir)
+        val result = migration.checkMigrationPath(migrationDir.toOkioPath())
+        assertEquals("directory_not_empty", result)
+    }
+
+    @Test
+    fun `checkMigrationPath ignores hidden files when checking emptiness`() {
+        val tempDir = Files.createTempDirectory("migration-test").toFile()
+        tempDir.deleteOnExit()
+
+        val storageDir = tempDir.resolve("storage")
+        storageDir.mkdirs()
+        storageDir.deleteOnExit()
+
+        val migrationDir = tempDir.resolve("migration")
+        migrationDir.mkdirs()
+        migrationDir.deleteOnExit()
+
+        // Only hidden files present - directory should be considered empty
+        val hiddenFile = migrationDir.resolve(".DS_Store")
+        hiddenFile.writeText("hidden")
+        hiddenFile.deleteOnExit()
+
+        val migration = createMigration(storageDir)
+        val result = migration.checkMigrationPath(migrationDir.toOkioPath())
+        // Should NOT be "directory_not_empty" since only hidden files exist
+        assertNotEquals("directory_not_empty", result)
+    }
+
+    @Test
+    fun `checkMigrationPath returns null for valid empty writable directory`() {
+        val tempDir = Files.createTempDirectory("migration-test").toFile()
+        tempDir.deleteOnExit()
+
+        val storageDir = tempDir.resolve("storage")
+        storageDir.mkdirs()
+        storageDir.deleteOnExit()
+
+        val migrationDir = tempDir.resolve("migration")
+        migrationDir.mkdirs()
+        migrationDir.deleteOnExit()
+
+        val migration = createMigration(storageDir)
+        val result = migration.checkMigrationPath(migrationDir.toOkioPath())
+        assertNull(result, "Valid empty writable directory should return null (no error)")
+    }
+
+    @Test
+    fun `checkMigrationPath validates write permission`() {
+        val tempDir = Files.createTempDirectory("migration-test").toFile()
+        tempDir.deleteOnExit()
+
+        val storageDir = tempDir.resolve("storage")
+        storageDir.mkdirs()
+        storageDir.deleteOnExit()
+
+        val readOnlyDir = tempDir.resolve("readonly")
+        readOnlyDir.mkdirs()
+        readOnlyDir.deleteOnExit()
+
+        readOnlyDir.setWritable(false)
+        try {
+            val migration = createMigration(storageDir)
+            val result = migration.checkMigrationPath(readOnlyDir.toOkioPath())
+            assertEquals("no_write_permission", result)
+        } finally {
+            readOnlyDir.setWritable(true)
+        }
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/CompressUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/CompressUtilsTest.kt
@@ -1,0 +1,152 @@
+package com.crosspaste.utils
+
+import okio.Path.Companion.toOkioPath
+import okio.buffer
+import okio.sink
+import okio.source
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CompressUtilsTest {
+
+    private val compressUtils = getCompressUtils()
+
+    @Test
+    fun `zipFile and unzip round-trip preserves file content`() {
+        val tempDir = Files.createTempDirectory("compress-test").toFile()
+        tempDir.deleteOnExit()
+
+        // Create source file
+        val sourceFile = tempDir.resolve("hello.txt")
+        sourceFile.writeText("Hello, CrossPaste!")
+
+        // Zip the file
+        val zipFile = tempDir.resolve("output.zip")
+        zipFile.outputStream().sink().buffer().use { sink ->
+            val result = compressUtils.zipFile(sourceFile.toOkioPath(), sink)
+            assertTrue(result.isSuccess)
+        }
+
+        // Unzip to new directory
+        val unzipDir = tempDir.resolve("unzipped")
+        unzipDir.mkdirs()
+        zipFile.inputStream().source().buffer().use { source ->
+            val result = compressUtils.unzip(source, unzipDir.toOkioPath())
+            assertTrue(result.isSuccess)
+        }
+
+        // Verify content
+        val restored = unzipDir.resolve("hello.txt")
+        assertTrue(restored.exists())
+        assertEquals("Hello, CrossPaste!", restored.readText())
+    }
+
+    @Test
+    fun `zipDir and unzip round-trip preserves directory structure`() {
+        val tempDir = Files.createTempDirectory("compress-dir-test").toFile()
+        tempDir.deleteOnExit()
+
+        // Create source directory with nested files
+        val sourceDir = tempDir.resolve("source")
+        sourceDir.mkdirs()
+        sourceDir.resolve("file1.txt").writeText("content1")
+        val subDir = sourceDir.resolve("sub")
+        subDir.mkdirs()
+        subDir.resolve("file2.txt").writeText("content2")
+
+        // Zip the directory
+        val zipFile = tempDir.resolve("dir.zip")
+        zipFile.outputStream().sink().buffer().use { sink ->
+            val result = compressUtils.zipDir(sourceDir.toOkioPath(), sink)
+            assertTrue(result.isSuccess)
+        }
+
+        // Unzip to new directory
+        val unzipDir = tempDir.resolve("restored")
+        unzipDir.mkdirs()
+        zipFile.inputStream().source().buffer().use { source ->
+            val result = compressUtils.unzip(source, unzipDir.toOkioPath())
+            assertTrue(result.isSuccess)
+        }
+
+        // Verify structure
+        assertEquals("content1", unzipDir.resolve("file1.txt").readText())
+        assertEquals("content2", unzipDir.resolve("sub").resolve("file2.txt").readText())
+    }
+
+    @Test
+    fun `zipFile fails when source is a directory`() {
+        val tempDir = Files.createTempDirectory("compress-fail-test").toFile()
+        tempDir.deleteOnExit()
+
+        val zipFile = tempDir.resolve("output.zip")
+        zipFile.outputStream().sink().buffer().use { sink ->
+            val result = compressUtils.zipFile(tempDir.toOkioPath(), sink)
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+        }
+    }
+
+    @Test
+    fun `zipDir fails when source is a file`() {
+        val tempDir = Files.createTempDirectory("compress-fail-test2").toFile()
+        tempDir.deleteOnExit()
+        val file = tempDir.resolve("file.txt")
+        file.writeText("data")
+
+        val zipFile = tempDir.resolve("output.zip")
+        zipFile.outputStream().sink().buffer().use { sink ->
+            val result = compressUtils.zipDir(file.toOkioPath(), sink)
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+        }
+    }
+
+    @Test
+    fun `unzip rejects zip entry with path traversal`() {
+        val tempDir = Files.createTempDirectory("zip-traversal-test").toFile()
+        tempDir.deleteOnExit()
+
+        // Create a malicious zip with "../escape.txt" entry
+        val zipFile = tempDir.resolve("evil.zip")
+        java.util.zip.ZipOutputStream(zipFile.outputStream()).use { zos ->
+            val entry = java.util.zip.ZipEntry("../escape.txt")
+            zos.putNextEntry(entry)
+            zos.write("malicious".toByteArray())
+            zos.closeEntry()
+        }
+
+        val targetDir = tempDir.resolve("safe")
+        targetDir.mkdirs()
+        zipFile.inputStream().source().buffer().use { source ->
+            val result = compressUtils.unzip(source, targetDir.toOkioPath())
+            assertTrue(result.isFailure, "Should reject path traversal zip entries")
+        }
+    }
+
+    @Test
+    fun `zipFile and unzip round-trip preserves binary content`() {
+        val tempDir = Files.createTempDirectory("compress-binary-test").toFile()
+        tempDir.deleteOnExit()
+
+        // Create binary file
+        val binaryData = ByteArray(1024) { (it % 256).toByte() }
+        val sourceFile = tempDir.resolve("data.bin")
+        sourceFile.writeBytes(binaryData)
+
+        // Zip -> Unzip
+        val zipFile = tempDir.resolve("binary.zip")
+        zipFile.outputStream().sink().buffer().use { sink ->
+            compressUtils.zipFile(sourceFile.toOkioPath(), sink)
+        }
+        val unzipDir = tempDir.resolve("bin-restored")
+        unzipDir.mkdirs()
+        zipFile.inputStream().source().buffer().use { source ->
+            compressUtils.unzip(source, unzipDir.toOkioPath())
+        }
+
+        assertTrue(binaryData.contentEquals(unzipDir.resolve("data.bin").readBytes()))
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/EncryptUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/EncryptUtilsTest.kt
@@ -1,0 +1,137 @@
+package com.crosspaste.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class EncryptUtilsTest {
+
+    @Test
+    fun `encrypt and decrypt round-trip preserves text data`() {
+        val key = EncryptUtils.generateAESKey()
+        val original = "Hello, CrossPaste!".toByteArray()
+        val encrypted = EncryptUtils.encryptData(key, original)
+        val decrypted = EncryptUtils.decryptData(key, encrypted)
+        assertEquals(String(original), String(decrypted))
+    }
+
+    @Test
+    fun `encrypt and decrypt round-trip preserves binary data`() {
+        val key = EncryptUtils.generateAESKey()
+        val original = ByteArray(1024) { (it % 256).toByte() }
+        val encrypted = EncryptUtils.encryptData(key, original)
+        val decrypted = EncryptUtils.decryptData(key, encrypted)
+        assertTrue(original.contentEquals(decrypted))
+    }
+
+    @Test
+    fun `encrypted data is longer than original due to IV prefix`() {
+        val key = EncryptUtils.generateAESKey()
+        val original = "short".toByteArray()
+        val encrypted = EncryptUtils.encryptData(key, original)
+        // AES CBC block size = 16 bytes for IV, plus at least 1 block for padded data
+        assertTrue(encrypted.size > original.size + 16)
+    }
+
+    @Test
+    fun `encrypting same data twice produces different ciphertext due to random IV`() {
+        val key = EncryptUtils.generateAESKey()
+        val data = "same data".toByteArray()
+        val encrypted1 = EncryptUtils.encryptData(key, data)
+        val encrypted2 = EncryptUtils.encryptData(key, data)
+        assertFalse(
+            encrypted1.contentEquals(encrypted2),
+            "Same plaintext should produce different ciphertext due to random IV",
+        )
+    }
+
+    @Test
+    fun `decrypt with wrong key throws exception`() {
+        val key1 = EncryptUtils.generateAESKey()
+        val key2 = EncryptUtils.generateAESKey()
+        val data = "secret message".toByteArray()
+        val encrypted = EncryptUtils.encryptData(key1, data)
+        val result = runCatching { EncryptUtils.decryptData(key2, encrypted) }
+        assertTrue(result.isFailure, "Decrypting with wrong key should fail")
+    }
+
+    @Test
+    fun `secretKeyToString and stringToSecretKey round-trip preserves key`() {
+        val originalKey = EncryptUtils.generateAESKey()
+        val keyString = EncryptUtils.secretKeyToString(originalKey)
+        val restoredKey = EncryptUtils.stringToSecretKey(keyString)
+        assertTrue(
+            originalKey.encoded.contentEquals(restoredKey.encoded),
+            "Key bytes should be preserved after round-trip",
+        )
+    }
+
+    @Test
+    fun `restored key can decrypt data encrypted with original key`() {
+        val originalKey = EncryptUtils.generateAESKey()
+        val data = "cross-device encryption test".toByteArray()
+        val encrypted = EncryptUtils.encryptData(originalKey, data)
+
+        // Simulate key transfer: serialize and restore
+        val keyString = EncryptUtils.secretKeyToString(originalKey)
+        val restoredKey = EncryptUtils.stringToSecretKey(keyString)
+        val decrypted = EncryptUtils.decryptData(restoredKey, encrypted)
+        assertEquals(String(data), String(decrypted))
+    }
+
+    @Test
+    fun `generated AES key is 256-bit`() {
+        val key = EncryptUtils.generateAESKey()
+        assertEquals(32, key.encoded.size, "AES-256 key should be 32 bytes")
+        assertEquals("AES", key.algorithm)
+    }
+
+    @Test
+    fun `each generated key is unique`() {
+        val key1 = EncryptUtils.generateAESKey()
+        val key2 = EncryptUtils.generateAESKey()
+        assertFalse(key1.encoded.contentEquals(key2.encoded))
+    }
+
+    @Test
+    fun `encrypt and decrypt empty data`() {
+        val key = EncryptUtils.generateAESKey()
+        val original = ByteArray(0)
+        val encrypted = EncryptUtils.encryptData(key, original)
+        val decrypted = EncryptUtils.decryptData(key, encrypted)
+        assertTrue(original.contentEquals(decrypted))
+    }
+
+    @Test
+    fun `tampered ciphertext causes decryption failure`() {
+        val key = EncryptUtils.generateAESKey()
+        val data = "important data".toByteArray()
+        val encrypted = EncryptUtils.encryptData(key, data)
+
+        // Tamper with a byte in the encrypted portion (after IV)
+        val tampered = encrypted.copyOf()
+        tampered[tampered.size - 1] = (tampered[tampered.size - 1].toInt() xor 0xFF).toByte()
+
+        val result = runCatching { EncryptUtils.decryptData(key, tampered) }
+        assertTrue(result.isFailure, "Tampered ciphertext should fail decryption")
+    }
+
+    @Test
+    fun `stringToSecretKey produces correct algorithm`() {
+        val key = EncryptUtils.generateAESKey()
+        val keyStr = EncryptUtils.secretKeyToString(key)
+        val restored = EncryptUtils.stringToSecretKey(keyStr)
+        assertEquals("AES", restored.algorithm)
+    }
+
+    @Test
+    fun `secretKeyToString produces non-empty base64 string`() {
+        val key = EncryptUtils.generateAESKey()
+        val keyStr = EncryptUtils.secretKeyToString(key)
+        assertTrue(keyStr.isNotEmpty())
+        // Base64 strings should only contain valid base64 characters
+        assertNotEquals(keyStr, String(key.encoded), "Should be base64 encoded, not raw bytes")
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/RetryUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/RetryUtilsTest.kt
@@ -1,0 +1,114 @@
+package com.crosspaste.utils
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RetryUtilsTest {
+
+    @Test
+    fun `retry returns result on first success`() {
+        val result = RetryUtils.retry(3) { "success" }
+        assertEquals("success", result)
+    }
+
+    @Test
+    fun `retry returns null when all attempts throw`() {
+        val result =
+            RetryUtils.retry<String>(3) {
+                throw RuntimeException("fail")
+            }
+        assertNull(result)
+    }
+
+    @Test
+    fun `retry succeeds on last attempt after earlier exceptions`() {
+        var attempts = 0
+        val result =
+            RetryUtils.retry(3) { attempt ->
+                attempts++
+                if (attempt < 2) throw RuntimeException("fail")
+                "recovered"
+            }
+        assertEquals("recovered", result)
+        assertEquals(3, attempts)
+    }
+
+    @Test
+    fun `retry returns null when block returns null every time`() {
+        val result = RetryUtils.retry<String?>(3) { null }
+        assertNull(result)
+    }
+
+    @Test
+    fun `retry stops immediately on non-null result`() {
+        var attempts = 0
+        val result =
+            RetryUtils.retry(5) {
+                attempts++
+                "done"
+            }
+        assertEquals("done", result)
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun `retry passes attempt index to block`() {
+        val indices = mutableListOf<Int>()
+        RetryUtils.retry<String?>(3) { attempt ->
+            indices.add(attempt)
+            null
+        }
+        assertEquals(listOf(0, 1, 2), indices)
+    }
+
+    @Test
+    fun `retry with maxRetries 1 calls block once on exception`() {
+        var attempts = 0
+        val result =
+            RetryUtils.retry<String>(1) {
+                attempts++
+                throw RuntimeException("fail")
+            }
+        assertNull(result)
+        assertEquals(1, attempts)
+    }
+
+    // --- suspendRetry ---
+
+    @Test
+    fun `suspendRetry returns result on first success`() =
+        runTest {
+            val result = RetryUtils.suspendRetry(3) { "success" }
+            assertEquals("success", result)
+        }
+
+    @Test
+    fun `suspendRetry returns null when all attempts throw`() =
+        runTest {
+            val result =
+                RetryUtils.suspendRetry<String>(3) {
+                    throw RuntimeException("fail")
+                }
+            assertNull(result)
+        }
+
+    @Test
+    fun `suspendRetry succeeds on second attempt after first exception`() =
+        runTest {
+            val result =
+                RetryUtils.suspendRetry(3) { attempt ->
+                    if (attempt == 0) throw RuntimeException("fail")
+                    "recovered"
+                }
+            assertEquals("recovered", result)
+        }
+
+    @Test
+    fun `suspendRetry returns null when block returns null every time`() =
+        runTest {
+            val result = RetryUtils.suspendRetry<String?>(3) { null }
+            assertNull(result)
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/StripedMutexTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/StripedMutexTest.kt
@@ -1,0 +1,130 @@
+package com.crosspaste.utils
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class StripedMutexTest {
+
+    @Test
+    fun `withLock executes action and returns result`() =
+        runTest {
+            val mutex = StripedMutex()
+            val result = mutex.withLock("key") { 42 }
+            assertEquals(42, result)
+        }
+
+    @Test
+    fun `same key serializes concurrent access`() =
+        runTest {
+            val mutex = StripedMutex()
+            val log = mutableListOf<String>()
+
+            val job1 =
+                async {
+                    mutex.withLock("sameKey") {
+                        log.add("start1")
+                        delay(50)
+                        log.add("end1")
+                    }
+                }
+            // Give job1 time to acquire the lock
+            delay(10)
+            val job2 =
+                async {
+                    mutex.withLock("sameKey") {
+                        log.add("start2")
+                        log.add("end2")
+                    }
+                }
+
+            job1.await()
+            job2.await()
+
+            // job2 should not start until job1 ends
+            val start2Index = log.indexOf("start2")
+            val end1Index = log.indexOf("end1")
+            assertTrue(start2Index > end1Index, "Expected start2 after end1, but got $log")
+        }
+
+    @Test
+    fun `different keys can run concurrently`() =
+        runTest {
+            val mutex = StripedMutex(stripeCount = 1024) // large count to reduce collision
+            val log = mutableListOf<String>()
+
+            val job1 =
+                async {
+                    mutex.withLock("keyA") {
+                        log.add("startA")
+                        delay(50)
+                        log.add("endA")
+                    }
+                }
+            delay(10)
+            val job2 =
+                async {
+                    mutex.withLock("keyB") {
+                        log.add("startB")
+                        delay(50)
+                        log.add("endB")
+                    }
+                }
+
+            job1.await()
+            job2.await()
+
+            // With different keys and enough stripes, B should start before A ends
+            val startBIndex = log.indexOf("startB")
+            val endAIndex = log.indexOf("endA")
+            assertTrue(startBIndex < endAIndex, "Expected keyB to start before keyA ends, but got $log")
+        }
+
+    @Test
+    fun `stripe count of 1 serializes all keys`() =
+        runTest {
+            val mutex = StripedMutex(stripeCount = 1)
+            val log = mutableListOf<String>()
+
+            val job1 =
+                async {
+                    mutex.withLock("anyKey1") {
+                        log.add("start1")
+                        delay(50)
+                        log.add("end1")
+                    }
+                }
+            delay(10)
+            val job2 =
+                async {
+                    mutex.withLock("anyKey2") {
+                        log.add("start2")
+                        log.add("end2")
+                    }
+                }
+
+            job1.await()
+            job2.await()
+
+            // With stripeCount=1, all keys share one mutex
+            val start2Index = log.indexOf("start2")
+            val end1Index = log.indexOf("end1")
+            assertTrue(start2Index > end1Index, "Expected all keys serialized with stripeCount=1, got $log")
+        }
+
+    @Test
+    fun `negative hashCode keys do not cause index out of bounds`() =
+        runTest {
+            val mutex = StripedMutex(stripeCount = 4)
+            // Object with negative hashCode
+            val key =
+                object {
+                    override fun hashCode(): Int = Int.MIN_VALUE
+                }
+            val result = mutex.withLock(key) { "ok" }
+            assertEquals("ok", result)
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/TxtRecordUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/TxtRecordUtilsTest.kt
@@ -1,0 +1,124 @@
+package com.crosspaste.utils
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.dto.sync.EndpointInfo
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.platform.Platform
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TxtRecordUtilsTest {
+
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    private fun createTestSyncInfo(): SyncInfo =
+        SyncInfo(
+            appInfo =
+                AppInfo(
+                    appInstanceId = "test-instance-123",
+                    appVersion = "1.2.3",
+                    appRevision = "abc123",
+                    userName = "testuser",
+                ),
+            endpointInfo =
+                EndpointInfo(
+                    deviceId = "device-456",
+                    deviceName = "TestDevice",
+                    platform = Platform("macOS", "aarch64", 64, "14.0"),
+                    hostInfoList = emptyList(),
+                    port = 13129,
+                ),
+        )
+
+    @Test
+    fun `encode and decode round-trip preserves SyncInfo`() {
+        val original = createTestSyncInfo()
+        val encoded = TxtRecordUtils.encodeToTxtRecordDict(original)
+        val byteArrayMap = encoded.mapValues { (_, v) -> v.encodeToByteArray() }
+        val decoded = TxtRecordUtils.decodeFromTxtRecordDict<SyncInfo>(byteArrayMap)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `encoding produces sequential numeric keys starting from 0`() {
+        val syncInfo = createTestSyncInfo()
+        val encoded = TxtRecordUtils.encodeToTxtRecordDict(syncInfo)
+        val keys = encoded.keys.map { it.toInt() }.sorted()
+        assertEquals((0 until encoded.size).toList(), keys)
+    }
+
+    @Test
+    fun `chunk size controls value lengths`() {
+        val syncInfo = createTestSyncInfo()
+        val chunkSize = 32
+        val encoded = TxtRecordUtils.encodeToTxtRecordDict(syncInfo, chunkSize = chunkSize)
+        // All values except possibly the last should be exactly chunkSize
+        val values = encoded.entries.sortedBy { it.key.toInt() }.map { it.value }
+        for (i in 0 until values.size - 1) {
+            assertEquals(chunkSize, values[i].length, "Chunk $i should be exactly $chunkSize chars")
+        }
+        assertTrue(values.last().length <= chunkSize, "Last chunk should be <= chunkSize")
+    }
+
+    @Test
+    fun `larger chunk size produces fewer entries`() {
+        val syncInfo = createTestSyncInfo()
+        val smallChunk = TxtRecordUtils.encodeToTxtRecordDict(syncInfo, chunkSize = 32)
+        val largeChunk = TxtRecordUtils.encodeToTxtRecordDict(syncInfo, chunkSize = 256)
+        assertTrue(
+            largeChunk.size <= smallChunk.size,
+            "Larger chunk size should produce fewer or equal entries",
+        )
+    }
+
+    @Test
+    fun `decode reassembles chunks in numeric order regardless of map iteration order`() {
+        val original = createTestSyncInfo()
+        val encoded = TxtRecordUtils.encodeToTxtRecordDict(original, chunkSize = 32)
+
+        // Create a reversed-order map to verify sorting works
+        val reversed = LinkedHashMap<String, ByteArray>()
+        encoded.entries.sortedByDescending { it.key.toInt() }.forEach { (k, v) ->
+            reversed[k] = v.encodeToByteArray()
+        }
+
+        val decoded = TxtRecordUtils.decodeFromTxtRecordDict<SyncInfo>(reversed)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `encode produces non-empty map for any serializable object`() {
+        val syncInfo = createTestSyncInfo()
+        val encoded = TxtRecordUtils.encodeToTxtRecordDict(syncInfo)
+        assertTrue(encoded.isNotEmpty())
+        encoded.values.forEach { assertTrue(it.isNotEmpty(), "Each chunk should be non-empty") }
+    }
+
+    @Test
+    fun `round-trip preserves unicode content in user name`() {
+        val original =
+            SyncInfo(
+                appInfo =
+                    AppInfo(
+                        appInstanceId = "id",
+                        appVersion = "1.0",
+                        appRevision = "rev",
+                        userName = "user",
+                    ),
+                endpointInfo =
+                    EndpointInfo(
+                        deviceId = "dev",
+                        deviceName = "dev",
+                        platform = Platform("macOS", "aarch64", 64, "14.0"),
+                        hostInfoList = emptyList(),
+                        port = 8080,
+                    ),
+            )
+        val encoded = TxtRecordUtils.encodeToTxtRecordDict(original)
+        val byteArrayMap = encoded.mapValues { (_, v) -> v.encodeToByteArray() }
+        val decoded = TxtRecordUtils.decodeFromTxtRecordDict<SyncInfo>(byteArrayMap)
+        assertEquals(original.appInfo.userName, decoded.appInfo.userName)
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/UrlUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/UrlUtilsTest.kt
@@ -1,0 +1,78 @@
+package com.crosspaste.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UrlUtilsTest {
+
+    private val urlUtils = getUrlUtils()
+
+    @Test
+    fun `isValidUrl accepts standard HTTP URL`() {
+        assertTrue(urlUtils.isValidUrl("http://example.com"))
+    }
+
+    @Test
+    fun `isValidUrl accepts HTTPS URL`() {
+        assertTrue(urlUtils.isValidUrl("https://example.com/path?query=1"))
+    }
+
+    @Test
+    fun `isValidUrl rejects plain text`() {
+        assertFalse(urlUtils.isValidUrl("not a url"))
+    }
+
+    @Test
+    fun `isValidUrl rejects empty string`() {
+        assertFalse(urlUtils.isValidUrl(""))
+    }
+
+    @Test
+    fun `isValidUrl rejects string with only scheme`() {
+        // "http://" alone is not a valid URL
+        assertFalse(urlUtils.isValidUrl("http://"))
+    }
+
+    @Test
+    fun `isValidUrl accepts FTP URL`() {
+        assertTrue(urlUtils.isValidUrl("ftp://files.example.com/readme.txt"))
+    }
+
+    @Test
+    fun `isValidUrl rejects relative path`() {
+        assertFalse(urlUtils.isValidUrl("/relative/path"))
+    }
+
+    @Test
+    fun `removeUrlScheme strips http scheme`() {
+        assertEquals("example.com/path", urlUtils.removeUrlScheme("http://example.com/path"))
+    }
+
+    @Test
+    fun `removeUrlScheme strips https scheme`() {
+        assertEquals("example.com", urlUtils.removeUrlScheme("https://example.com"))
+    }
+
+    @Test
+    fun `removeUrlScheme returns unchanged string without scheme`() {
+        assertEquals("example.com", urlUtils.removeUrlScheme("example.com"))
+    }
+
+    @Test
+    fun `removeUrlScheme handles ftp scheme`() {
+        assertEquals("files.example.com/f.txt", urlUtils.removeUrlScheme("ftp://files.example.com/f.txt"))
+    }
+
+    @Test
+    fun `removeUrlScheme handles string with only separator`() {
+        assertEquals("", urlUtils.removeUrlScheme("://"))
+    }
+
+    @Test
+    fun `removeUrlScheme picks first occurrence of separator`() {
+        // "http://host://weird" -> "host://weird"
+        assertEquals("host://weird", urlUtils.removeUrlScheme("http://host://weird"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add 63 unit tests across 7 new test files covering the utils and platform layer (Phase 5 of the test plan)
- Tests focus on verifying CrossPaste business logic: retry strategies, concurrent mutex behavior, URL validation, zip compression with path traversal protection, TXT record encoding/chunking, AES encryption round-trips, and data migration path validation
- All 827 total tests pass (63 new + 764 existing)

### New Test Files
| File | Tests | What it verifies |
|------|-------|-----------------|
| `RetryUtilsTest` | 11 | Retry/suspendRetry: null-on-failure semantics, attempt index, retry-on-null |
| `StripedMutexTest` | 5 | Striped locking: same-key serialization, different-key concurrency, negative hashCode safety |
| `UrlUtilsTest` | 13 | URL validation (http/https/ftp/invalid), scheme removal edge cases |
| `CompressUtilsTest` | 6 | Zip/unzip round-trip, directory structure preservation, **path traversal attack rejection**, binary content |
| `TxtRecordUtilsTest` | 7 | Encode/decode round-trip with SyncInfo, chunk size control, numeric key ordering |
| `EncryptUtilsTest` | 13 | AES-256 encrypt/decrypt round-trip, random IV uniqueness, wrong-key failure, key serialization, **tampered ciphertext detection** |
| `DesktopMigrationTest` | 8 | Migration path validation: non-existent/not-directory/child/parent/non-empty/hidden-files/writable checks |

## Test plan
- [x] All 827 tests pass (`./gradlew app:desktopTest`)
- [x] Code formatted with ktlintFormat

🤖 Generated with [Claude Code](https://claude.ai/code)