### PR TITLE
:hammer: Add isLoading parameter to DialogActionButton

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/DialogActionButton.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/DialogActionButton.kt
@@ -1,30 +1,40 @@
 package com.crosspaste.ui.base
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults.buttonColors
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.crosspaste.ui.theme.AppUISize.medium
 
 @Composable
 fun DialogActionButton(
     text: String,
     type: DialogButtonType,
     enabled: Boolean = true,
+    isLoading: Boolean = false,
     onClick: () -> Unit,
 ) {
+    val effectiveEnabled = enabled && !isLoading
+    val content: @Composable () -> Unit = {
+        if (isLoading) {
+            CircularProgressIndicator(modifier = Modifier.size(medium))
+        } else {
+            Text(text)
+        }
+    }
+
     when (type) {
         DialogButtonType.FILLED -> {
-            Button(onClick = onClick, enabled = enabled) {
-                Text(text)
-            }
+            Button(onClick = onClick, enabled = effectiveEnabled, content = { content() })
         }
         DialogButtonType.TONAL -> {
-            FilledTonalButton(onClick = onClick, enabled = enabled) {
-                Text(text)
-            }
+            FilledTonalButton(onClick = onClick, enabled = effectiveEnabled, content = { content() })
         }
         DialogButtonType.ERROR -> {
             Button(
@@ -34,15 +44,12 @@ fun DialogActionButton(
                         containerColor = MaterialTheme.colorScheme.error,
                         contentColor = MaterialTheme.colorScheme.onError,
                     ),
-                enabled = enabled,
-            ) {
-                Text(text)
-            }
+                enabled = effectiveEnabled,
+                content = { content() },
+            )
         }
         else -> {
-            TextButton(onClick = onClick, enabled = enabled) {
-                Text(text)
-            }
+            TextButton(onClick = onClick, enabled = effectiveEnabled, content = { content() })
         }
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/AddDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/AddDeviceDialog.kt
@@ -142,7 +142,8 @@ fun AddDeviceDialog(onDismiss: () -> Unit) {
             DialogActionButton(
                 text = copywriter.getText("confirm"),
                 type = DialogButtonType.FILLED,
-                enabled = isInputValid && !isLoading,
+                enabled = isInputValid,
+                isLoading = isLoading,
             ) {
                 isLoading = true
                 coroutineScope.launch {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -18,8 +18,6 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -177,17 +175,12 @@ fun DeviceScope.TrustDeviceDialog() {
             }
         },
         confirmButton = {
-            if (isLoading) {
-                Button(onClick = {}, enabled = false) {
-                    CircularProgressIndicator(modifier = Modifier.size(medium))
-                }
-            } else {
-                DialogActionButton(
-                    text = copywriter.getText("confirm"),
-                    type = DialogButtonType.FILLED,
-                ) {
-                    confirmAction()
-                }
+            DialogActionButton(
+                text = copywriter.getText("confirm"),
+                type = DialogButtonType.FILLED,
+                isLoading = isLoading,
+            ) {
+                confirmAction()
             }
         },
         dismissButton = {


### PR DESCRIPTION
Closes #3834

## Summary

- Add `isLoading: Boolean = false` parameter to `DialogActionButton` that shows a `CircularProgressIndicator` and disables the button when `true`
- Simplify `TrustDeviceDialog` by replacing 12 lines of inline if/else loading logic with the new parameter
- Update `AddDeviceDialog` to separate `enabled` and `isLoading` concerns, gaining the loading spinner automatically

## Test plan

- [ ] Verify `TrustDeviceDialog` shows spinner when confirming token
- [ ] Verify `AddDeviceDialog` shows spinner when connecting to device
- [ ] Verify buttons are disabled during loading state
- [ ] Verify existing dialogs without `isLoading` are unaffected (default `false`)