### PR TITLE
:sparkles: Force drag-and-drop files to sync to remote download directory

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
@@ -13,6 +13,7 @@ interface TransferableConsumer {
         pasteTransferable: PasteTransferable,
         source: String?,
         remote: Boolean,
+        dragAndDrop: Boolean = false,
     ): Result<Unit>
 
     fun getPlugin(identity: String): PasteTypePlugin?

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/process/FilesToImagesPlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/process/FilesToImagesPlugin.kt
@@ -65,6 +65,7 @@ class FilesToImagesPlugin(
                         basePath = basePath,
                         relativePathList = relativePathList,
                         fileInfoTreeMap = fileInfoTreeMap,
+                        extraInfo = pasteAppearItem.extraInfo,
                     )
                 } else {
                     pasteAppearItem

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
@@ -37,6 +37,7 @@ class DesktopTransferableConsumer(
         pasteTransferable: PasteTransferable,
         source: String?,
         remote: Boolean,
+        dragAndDrop: Boolean,
     ): Result<Unit> {
         return runCatching {
             logSuspendExecutionTime(logger, "consume") {
@@ -47,7 +48,7 @@ class DesktopTransferableConsumer(
                     return@logSuspendExecutionTime
                 }
 
-                val pasteCollector = PasteCollector(dataFlavorMap.size, appInfo, pasteDao)
+                val pasteCollector = PasteCollector(dataFlavorMap.size, appInfo, pasteDao, dragAndDrop)
 
                 preCollect(dataFlavorMap, pasteTransferable, pasteCollector)
                 pasteCollector.createPrePasteData(source, remote = remote)?.also { id ->

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/DragTargetContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/DragTargetContentView.kt
@@ -80,7 +80,7 @@ fun DragTargetContentView() {
                     val source: String? = appWindowManager.getCurrentActiveAppName()
                     val pasteTransferable = DesktopReadTransferable(transferable)
                     return runBlocking {
-                        pasteConsumer.consume(pasteTransferable, source, false)
+                        pasteConsumer.consume(pasteTransferable, source, remote = false, dragAndDrop = true)
                     }.isSuccess
                 }
             }

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteCollection.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteCollection.kt
@@ -43,11 +43,11 @@ data class PasteCollection(
 
     fun bind(
         pasteCoordinate: PasteCoordinate,
-        isLargeFile: Boolean = false,
+        syncToDownload: Boolean = false,
     ): PasteCollection =
         PasteCollection(
             pasteItems.map {
-                it.bind(pasteCoordinate, isLargeFile)
+                it.bind(pasteCoordinate, syncToDownload)
             },
         )
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/FilesPasteItem.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/FilesPasteItem.kt
@@ -92,9 +92,9 @@ data class FilesPasteItem(
     // use to adapt relative paths when relative is no storage in crossPaste
     override fun bind(
         pasteCoordinate: PasteCoordinate,
-        isLargeFile: Boolean,
+        syncToDownload: Boolean,
     ): PasteItem {
-        val (newBasePath, newRelativePathList) = bindFilePaths(pasteCoordinate, isLargeFile)
+        val (newBasePath, newRelativePathList) = bindFilePaths(pasteCoordinate, syncToDownload)
         return FilesPasteItem(
             identifiers = identifiers,
             count = count,

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
@@ -92,9 +92,9 @@ data class ImagesPasteItem(
     // use to adapt relative paths when relative is no storage in crossPaste
     override fun bind(
         pasteCoordinate: PasteCoordinate,
-        isLargeFile: Boolean,
+        syncToDownload: Boolean,
     ): PasteItem {
-        val (newBasePath, newRelativePathList) = bindFilePaths(pasteCoordinate, isLargeFile)
+        val (newBasePath, newRelativePathList) = bindFilePaths(pasteCoordinate, syncToDownload)
         return ImagesPasteItem(
             identifiers = identifiers,
             count = count,

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
@@ -39,15 +39,15 @@ interface PasteFiles {
 
     fun bindFilePaths(
         pasteCoordinate: PasteCoordinate,
-        isLargeFile: Boolean,
+        syncToDownload: Boolean,
     ): Pair<String?, List<String>> {
         val fileUtils = getFileUtils()
         val newBasePath =
-            if (isLargeFile) getPlatformUtils().getSystemDownloadDir().toString() else null
+            if (syncToDownload) getPlatformUtils().getSystemDownloadDir().toString() else null
         val newRelativePathList =
             relativePathList.map { relativePath ->
                 val fileName = relativePath.toPath().name
-                if (isLargeFile) {
+                if (syncToDownload) {
                     fileName
                 } else {
                     fileUtils.createPasteRelativePath(

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItem.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItem.kt
@@ -116,7 +116,7 @@ sealed interface PasteItem {
 
     fun bind(
         pasteCoordinate: PasteCoordinate,
-        isLargeFile: Boolean = false,
+        syncToDownload: Boolean = false,
     ): PasteItem = this
 
     fun copy(extraInfo: JsonObject? = null): PasteItem

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItemProperties.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItemProperties.kt
@@ -11,4 +11,7 @@ object PasteItemProperties {
 
     // title of the url paste item
     const val TITLE = "title"
+
+    // flag to force sync files to remote download directory
+    const val SYNC_TO_DOWNLOAD = "syncToDownload"
 }


### PR DESCRIPTION
Closes #3842

## Summary

- Add `SYNC_TO_DOWNLOAD` flag in PasteItem's `extraInfo` to mark drag-and-drop files for download directory sync
- Thread `dragAndDrop` context from `DragTargetContentView` through `TransferableConsumer` → `PasteCollector`
- Stamp the flag on `PasteFiles` items in `PasteCollector.completeCollect()` when drag-and-drop is true
- Check the flag in `PasteDao.releaseRemotePasteData()` to force download directory placement regardless of file size
- Fix `FilesToImagesPlugin` to preserve `extraInfo` when converting `FilesPasteItem` to `ImagesPasteItem`

## Test plan

- [ ] Drag files onto main window → verify `SYNC_TO_DOWNLOAD` flag is set in `extraInfo`
- [ ] Sync drag-dropped files to remote device → verify files land in download directory regardless of size
- [ ] Drag image files onto main window → verify flag persists through `FilesToImagesPlugin` conversion
- [ ] Copy files via clipboard (not drag-drop) → verify normal sync behavior (no flag set)
- [ ] Verify backward compatibility: older remote devices ignore unknown `extraInfo` keys gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)