### PR TITLE
:bug: Fix always-on-top push pin icon state

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/MainWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/MainWindow.kt
@@ -99,9 +99,9 @@ fun MainWindow(windowIcon: Painter?) {
                     GeneralIconButton(
                         imageVector =
                             if (alwaysOnTop) {
-                                MaterialSymbols.Rounded.Push_pin
-                            } else {
                                 MaterialSymbols.RoundedFilled.Push_pin
+                            } else {
+                                MaterialSymbols.Rounded.Push_pin
                             },
                         desc = "always_on_top",
                         colors =


### PR DESCRIPTION
Closes #3847

## Summary
- Swap push pin icon states so filled pin shows when `alwaysOnTop` is true (pinned) and regular outline pin shows when unpinned
- Previously the icons were reversed, showing the wrong visual feedback

## Test plan
- [x] Toggle the always-on-top pin button and verify the filled icon appears when pinned
- [x] Verify the outline icon appears when unpinned

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)