### PR TITLE
:bug: Fix NotFoundNearByDevices wifi icon tint color

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/NotFoundNearByDevices.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/NotFoundNearByDevices.kt
@@ -46,7 +46,7 @@ fun NotFoundNearByDevices() {
                 imageVector = MaterialSymbols.Rounded.Wifi_find,
                 contentDescription = null,
                 modifier = Modifier.size(enormous),
-                tint = LocalThemeExtState.current.info.container,
+                tint = LocalThemeExtState.current.info.color,
             )
             Spacer(modifier = Modifier.height(medium))
             Text(


### PR DESCRIPTION
Closes #3849

## Summary
- Change wifi-find icon tint from `info.container` to `info.color` in `NotFoundNearByDevices` for better visibility

## Test plan
- [x] Open the devices tab with no nearby devices found and verify the wifi icon is clearly visible

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)