### PR TITLE
Add "In Downloads" indicator and hide missing file paste items

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/FilesSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/FilesSidePreviewView.kt
@@ -45,6 +45,8 @@ fun PasteDataScope.FilesSidePreviewView() {
         return
     }
 
+    val isInDownloads = remember(filesPasteItem) { filesPasteItem.isInDownloads() }
+
     val fileDisplayInfo by produceState<FileDisplayInfo?>(
         initialValue = null,
         key1 = filePaths,
@@ -58,6 +60,14 @@ fun PasteDataScope.FilesSidePreviewView() {
 
     SidePasteLayoutView(
         pasteBottomContent = {
+            val subtitle =
+                if (isInDownloads) {
+                    val inDownloadsText = copywriter.getText("in_downloads")
+                    val base = fileDisplayInfo?.subtitle ?: ""
+                    if (base.isNotEmpty()) "$inDownloadsText · $base" else inDownloadsText
+                } else {
+                    fileDisplayInfo?.subtitle ?: ""
+                }
             FileBottomSolid(
                 modifier =
                     Modifier
@@ -66,7 +76,7 @@ fun PasteDataScope.FilesSidePreviewView() {
                         .background(AppUIColors.topBackground)
                         .padding(tiny),
                 title = fileDisplayInfo?.title,
-                subtitle = fileDisplayInfo?.subtitle ?: "",
+                subtitle = subtitle,
             )
         },
     ) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
@@ -2,6 +2,7 @@ package com.crosspaste.ui.paste.side.preview
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -33,6 +34,7 @@ import coil3.request.crossfade
 import coil3.size.Precision
 import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Broken_image
+import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.image.ImageHandler
 import com.crosspaste.image.coil.ImageItem
 import com.crosspaste.image.coil.ImageLoaders
@@ -42,6 +44,7 @@ import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.ui.LocalDesktopAppSizeValueState
 import com.crosspaste.ui.base.ImageFileFormat
 import com.crosspaste.ui.base.ImageFileSize
+import com.crosspaste.ui.base.ImageInfoLabel
 import com.crosspaste.ui.base.ImageResolution
 import com.crosspaste.ui.base.SmartImageDisplayStrategy
 import com.crosspaste.ui.base.TransparentBackground
@@ -65,7 +68,11 @@ fun PasteDataScope.ImageSidePreviewView() {
 
     val smartImageDisplayStrategy = remember { SmartImageDisplayStrategy() }
 
+    val copywriter = koinInject<GlobalCopywriter>()
+
     val imagePasteItem = getPasteItem(PasteImages::class)
+
+    val isInDownloads = remember(imagePasteItem) { imagePasteItem.isInDownloads() }
 
     var index by remember(pasteData.id) { mutableStateOf(0) }
 
@@ -173,16 +180,25 @@ fun PasteDataScope.ImageSidePreviewView() {
                 },
             )
 
-            FlowRow(
+            Column(
                 modifier =
                     Modifier
                         .align(Alignment.BottomCenter)
                         .padding(bottom = small2X),
-                horizontalArrangement = Arrangement.spacedBy(tiny3X),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(tiny3X),
             ) {
-                ImageFileFormat(format = fileFormat)
-                ImageResolution(imageSize = intSize)
-                ImageFileSize(fileSize = fileSize)
+                if (isInDownloads) {
+                    ImageInfoLabel(text = copywriter.getText("in_downloads"))
+                }
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(tiny3X, Alignment.CenterHorizontally),
+                    verticalArrangement = Arrangement.spacedBy(tiny3X),
+                ) {
+                    ImageFileFormat(format = fileFormat)
+                    ImageResolution(imageSize = intSize)
+                    ImageFileSize(fileSize = fileSize)
+                }
             }
         }
     }

--- a/app/src/desktopMain/resources/i18n/de.properties
+++ b/app/src/desktopMain/resources/i18n/de.properties
@@ -99,6 +99,7 @@ html=HTML
 image=Bild
 image_retention_period=Bild-Aufbewahrungsdauer
 images=Bilder
+in_downloads=Im Download-Ordner
 import=Importieren
 import_data_merge_notice=Importierte Daten werden mit bestehenden Zwischenablage-Einträgen zusammengeführt
 import_fail=Import fehlgeschlagen

--- a/app/src/desktopMain/resources/i18n/en.properties
+++ b/app/src/desktopMain/resources/i18n/en.properties
@@ -99,6 +99,7 @@ html=Html
 image=Image
 image_retention_period=Image Retention Period
 images=Images
+in_downloads=In Downloads
 import=Import
 import_data_merge_notice=Imported data will be merged with existing clipboard records
 import_fail=Import Fail

--- a/app/src/desktopMain/resources/i18n/es.properties
+++ b/app/src/desktopMain/resources/i18n/es.properties
@@ -99,6 +99,7 @@ html=Html
 image=Imagen
 image_retention_period=Período de retención de imágenes
 images=Imágenes
+in_downloads=En Descargas
 import=Importar
 import_data_merge_notice=Los datos importados se fusionarán con los registros del portapapeles existentes
 import_fail=Error al importar

--- a/app/src/desktopMain/resources/i18n/fa.properties
+++ b/app/src/desktopMain/resources/i18n/fa.properties
@@ -99,6 +99,7 @@ html=HTML
 image=تصویر
 image_retention_period=مدت نگهداری تصویر
 images=تصاویر
+in_downloads=در پوشه دانلود
 import=درون‌ریزی
 import_data_merge_notice=داده‌های وارد شده با رکوردهای کلیپ‌بورد موجود ترکیب خواهند شد
 import_fail=درون‌ریزی ناموفق بود

--- a/app/src/desktopMain/resources/i18n/fr.properties
+++ b/app/src/desktopMain/resources/i18n/fr.properties
@@ -99,6 +99,7 @@ html=HTML
 image=Image
 image_retention_period=Période de rétention des images
 images=Images
+in_downloads=Dans les Téléchargements
 import=Importer
 import_data_merge_notice=Les données importées seront fusionnées avec les enregistrements du presse-papiers existants
 import_fail=Échec de l'importation

--- a/app/src/desktopMain/resources/i18n/ja.properties
+++ b/app/src/desktopMain/resources/i18n/ja.properties
@@ -99,6 +99,7 @@ html=Html
 image=画像
 image_retention_period=画像有効期間
 images=画像
+in_downloads=ダウンロードフォルダ内
 import=インポート
 import_data_merge_notice=インポートされたデータは既存のクリップボード履歴と統合されます
 import_fail=インポート失敗

--- a/app/src/desktopMain/resources/i18n/ko.properties
+++ b/app/src/desktopMain/resources/i18n/ko.properties
@@ -99,6 +99,7 @@ html=HTML
 image=이미지
 image_retention_period=이미지보관기간
 images=이미지
+in_downloads=다운로드 폴더에 있음
 import=가져오기
 import_data_merge_notice=가져온 데이터가 기존 클립보드 기록과 병합됩니다
 import_fail=가져오기실패

--- a/app/src/desktopMain/resources/i18n/zh.properties
+++ b/app/src/desktopMain/resources/i18n/zh.properties
@@ -99,6 +99,7 @@ html=Html
 image=图片
 image_retention_period=图片保留期限
 images=图片
+in_downloads=在下载目录中
 import=导入
 import_data_merge_notice=导入数据将与现有剪贴板记录合并
 import_fail=导入失败

--- a/app/src/desktopMain/resources/i18n/zh_hant.properties
+++ b/app/src/desktopMain/resources/i18n/zh_hant.properties
@@ -98,6 +98,7 @@ html=Html
 image=圖片
 image_retention_period=圖片保留期限
 images=圖片
+in_downloads=在下載目錄中
 import=匯入
 import_data_merge_notice=匯入資料將與現有剪貼簿記錄合併
 import_fail=匯入失敗

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/FilesPasteItem.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/FilesPasteItem.kt
@@ -142,7 +142,8 @@ data class FilesPasteItem(
             size > 0 &&
             fileInfoTreeMap.isNotEmpty() &&
             relativePathList.isNotEmpty() &&
-            relativePathList.size == fileInfoTreeMap.size
+            relativePathList.size == fileInfoTreeMap.size &&
+            hasExistingFiles()
 
     override fun toJson(): String =
         buildJsonObject {

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
@@ -142,7 +142,8 @@ data class ImagesPasteItem(
             size > 0 &&
             fileInfoTreeMap.isNotEmpty() &&
             relativePathList.isNotEmpty() &&
-            relativePathList.size == fileInfoTreeMap.size
+            relativePathList.size == fileInfoTreeMap.size &&
+            hasExistingFiles()
 
     override fun toJson(): String =
         buildJsonObject {

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
@@ -29,6 +29,19 @@ interface PasteFiles {
 
     fun isRefFiles(): Boolean = basePath != null
 
+    fun hasExistingFiles(): Boolean {
+        val base = basePath ?: return true
+        val fileUtils = getFileUtils()
+        return relativePathList.any { relativePath ->
+            fileUtils.existFile(base.toPath() / relativePath.toPath().name)
+        }
+    }
+
+    fun isInDownloads(): Boolean {
+        val base = basePath ?: return false
+        return base == getPlatformUtils().getSystemDownloadDir().toString()
+    }
+
     fun applyRenameMap(renameMap: Map<String, String>): PasteFiles
 
     fun computeRenamedFileData(renameMap: Map<String, String>): Pair<List<String>, Map<String, FileInfoTree>> {


### PR DESCRIPTION
Closes #3851

## Summary

- **"In Downloads" indicator**: When a paste item's `basePath` is the system Downloads directory, show a localized "In Downloads" label in `FilesSidePreviewView` (subtitle) and `ImageSidePreviewView` (badge)
- **Hide missing files**: When `basePath` is set (reference files) and none of the files exist on disk, hide the paste item from the clipboard list via `isValid()` returning false
- **Improved image badge layout**: Wrap `ImageSidePreviewView` badges in `Column` + `FlowRow` for proper centering and vertical spacing when wrapping
- **i18n**: Add `in_downloads` key for all 9 languages

## Test plan

- [x] Sync a file from another device with "sync to download" enabled, verify "In Downloads" appears in file preview subtitle
- [x] Sync an image from another device with "sync to download" enabled, verify "In Downloads" badge appears above format/resolution/size badges
- [x] Delete a synced file from Downloads, verify the paste item disappears from clipboard list
- [x] Verify non-download paste items (locally copied files/images) still display normally
- [x] Verify image badges center and wrap properly when space is limited

🤖 Generated with [Claude Code](https://claude.ai/code)