### PR TITLE
Remove unnecessary non-null assertion in CompressUtils

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/utils/CompressUtils.desktop.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/utils/CompressUtils.desktop.kt
@@ -79,7 +79,7 @@ object DesktopCompressUtils : CompressUtils {
                     val filePath = targetDir.resolve(entry.name)
                     val canonicalFile = filePath.toFile().canonicalPath
                     require(canonicalFile.startsWith(canonicalTarget)) {
-                        "Zip entry outside target dir: ${entry!!.name}"
+                        "Zip entry outside target dir: ${entry.name}"
                     }
 
                     filePath.parent?.toFile()?.mkdirs()


### PR DESCRIPTION
Closes #3853

## Summary

- Remove redundant `!!` operator on `entry` in `CompressUtils.desktop.kt` zip extraction error message, as the variable is already smart-cast as non-null

## Test plan

- [ ] Verify zip extraction still works correctly (the change is purely cosmetic)

🤖 Generated with [Claude Code](https://claude.ai/code)