### PR TITLE
Fix flaky tests: replace Thread.sleep with runTest

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
@@ -19,6 +19,7 @@ class TaskExecutor(
     singleTypeTaskExecutors: List<SingleTypeTaskExecutor>,
     private val taskDao: TaskDao,
     maxConcurrentTasks: Int = 10,
+    private val scope: CoroutineScope = CoroutineScope(cpuDispatcher + SupervisorJob()),
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -27,8 +28,6 @@ class TaskExecutor(
     private val taskShardedFlow = MutableSharedFlow<Long>()
 
     private val executionSemaphore = Channel<Unit>(maxConcurrentTasks)
-
-    private val scope = CoroutineScope(cpuDispatcher + SupervisorJob())
 
     init {
         scope.launch(CoroutineName("TaskExecutor")) {

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
@@ -202,8 +202,6 @@ class PasteDaoTest {
         val pasteData = createTestPasteData()
         val id = pasteDao.createPasteData(pasteData)
         val before = pasteDao.getNoDeletePasteData(id)!!.createTime
-
-        Thread.sleep(10)
         pasteDao.updateCreateTime(id)
 
         val after = pasteDao.getNoDeletePasteData(id)!!.createTime

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/task/TaskDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/task/TaskDaoTest.kt
@@ -156,7 +156,6 @@ class TaskDaoTest {
     fun `executingTask updates modifyTime`() = runTest {
         val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
         val taskBefore = taskDao.getTask(taskId)!!
-        Thread.sleep(10)
         taskDao.executingTask(taskId)
         val taskAfter = taskDao.getTask(taskId)!!
         assert(taskAfter.modifyTime >= taskBefore.modifyTime)

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/TaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/TaskExecutorTest.kt
@@ -6,10 +6,16 @@ import com.crosspaste.db.task.TaskType
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TaskExecutorTest {
 
     private fun createMockTask(
@@ -26,102 +32,135 @@ class TaskExecutorTest {
         )
 
     @Test
-    fun `empty executor list creates valid executor`() {
-        val taskDao: TaskDao = mockk(relaxed = true)
-        val executor = TaskExecutor(emptyList(), taskDao)
-        executor.shutdown()
-    }
-
-    @Test
-    fun `executor maps task types correctly`() {
-        val mockExecutor1: SingleTypeTaskExecutor = mockk(relaxed = true)
-        val mockExecutor2: SingleTypeTaskExecutor = mockk(relaxed = true)
-        coEvery { mockExecutor1.taskType } returns TaskType.DELETE_PASTE_TASK
-        coEvery { mockExecutor2.taskType } returns TaskType.CLEAN_TASK_TASK
-
-        val taskDao: TaskDao = mockk(relaxed = true)
-        val executor = TaskExecutor(listOf(mockExecutor1, mockExecutor2), taskDao)
-
-        // Verify it was created successfully with both executors
-        executor.shutdown()
-    }
-
-    @Test
-    fun `submitTask emits task id and executes`() {
-        val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
-        coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
-        coEvery { singleExecutor.executeTask(any(), any(), any(), any()) } coAnswers {
-            @Suppress("UNCHECKED_CAST")
-            val successCallback = it.invocation.args[1] as (suspend (String?) -> Unit)
-            successCallback(null)
+    fun `empty executor list creates valid executor`() =
+        runTest {
+            val taskDao: TaskDao = mockk(relaxed = true)
+            val executor =
+                TaskExecutor(
+                    emptyList(),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+            executor.shutdown()
         }
 
-        val taskDao: TaskDao = mockk(relaxed = true)
-        val task = createMockTask()
-        coEvery { taskDao.getTask(1L) } returns task
-
-        val executor = TaskExecutor(listOf(singleExecutor), taskDao, maxConcurrentTasks = 5)
-
-        runBlocking { executor.submitTask(1L) }
-        // TaskExecutor processes tasks on cpuDispatcher - wait for real async processing
-        Thread.sleep(3000)
-
-        coVerify { taskDao.executingTask(1L) }
-        coVerify { singleExecutor.executeTask(any(), any(), any(), any()) }
-        coVerify { taskDao.successTask(1L, any()) }
-
-        executor.shutdown()
-    }
-
     @Test
-    fun `submitTask with null task from dao skips execution`() {
-        val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
-        coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+    fun `executor maps task types correctly`() =
+        runTest {
+            val mockExecutor1: SingleTypeTaskExecutor = mockk(relaxed = true)
+            val mockExecutor2: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { mockExecutor1.taskType } returns TaskType.DELETE_PASTE_TASK
+            coEvery { mockExecutor2.taskType } returns TaskType.CLEAN_TASK_TASK
 
-        val taskDao: TaskDao = mockk(relaxed = true)
-        coEvery { taskDao.getTask(99L) } returns null
+            val taskDao: TaskDao = mockk(relaxed = true)
+            val executor =
+                TaskExecutor(
+                    listOf(mockExecutor1, mockExecutor2),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
 
-        val executor = TaskExecutor(listOf(singleExecutor), taskDao)
-
-        runBlocking { executor.submitTask(99L) }
-        Thread.sleep(1000)
-
-        coVerify(exactly = 0) { taskDao.executingTask(any()) }
-
-        executor.shutdown()
-    }
-
-    @Test
-    fun `task failure calls failureTask on dao`() {
-        val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
-        coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
-        coEvery { singleExecutor.executeTask(any(), any(), any(), any()) } coAnswers {
-            @Suppress("UNCHECKED_CAST")
-            val failCallback = it.invocation.args[2] as (suspend (String, Boolean) -> Unit)
-            failCallback("""{"type":"base","executionHistories":[]}""", false)
+            executor.shutdown()
         }
 
-        val taskDao: TaskDao = mockk(relaxed = true)
-        val task = createMockTask()
-        coEvery { taskDao.getTask(1L) } returns task
+    @Test
+    fun `submitTask emits task id and executes`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+            coEvery { singleExecutor.executeTask(any(), any(), any(), any()) } coAnswers {
+                @Suppress("UNCHECKED_CAST")
+                val successCallback = it.invocation.args[1] as (suspend (String?) -> Unit)
+                successCallback(null)
+            }
 
-        val executor = TaskExecutor(listOf(singleExecutor), taskDao)
+            val taskDao: TaskDao = mockk(relaxed = true)
+            val task = createMockTask()
+            coEvery { taskDao.getTask(1L) } returns task
 
-        runBlocking { executor.submitTask(1L) }
-        Thread.sleep(3000)
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    maxConcurrentTasks = 5,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
 
-        coVerify { taskDao.failureTask(1L, false, any()) }
+            executor.submitTask(1L)
+            advanceUntilIdle()
 
-        executor.shutdown()
-    }
+            coVerify { taskDao.executingTask(1L) }
+            coVerify { singleExecutor.executeTask(any(), any(), any(), any()) }
+            coVerify { taskDao.successTask(1L, any()) }
+
+            executor.shutdown()
+        }
 
     @Test
-    fun `shutdown cancels scope`() {
-        val taskDao: TaskDao = mockk(relaxed = true)
-        val executor = TaskExecutor(emptyList(), taskDao)
-        executor.shutdown()
-        // After shutdown, the executor should not process new tasks
-        // We just verify no exception is thrown during shutdown
-        assertTrue(true)
-    }
+    fun `submitTask with null task from dao skips execution`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+            coEvery { taskDao.getTask(99L) } returns null
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.submitTask(99L)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { taskDao.executingTask(any()) }
+
+            executor.shutdown()
+        }
+
+    @Test
+    fun `task failure calls failureTask on dao`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+            coEvery { singleExecutor.executeTask(any(), any(), any(), any()) } coAnswers {
+                @Suppress("UNCHECKED_CAST")
+                val failCallback = it.invocation.args[2] as (suspend (String, Boolean) -> Unit)
+                failCallback("""{"type":"base","executionHistories":[]}""", false)
+            }
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+            val task = createMockTask()
+            coEvery { taskDao.getTask(1L) } returns task
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.submitTask(1L)
+            advanceUntilIdle()
+
+            coVerify { taskDao.failureTask(1L, false, any()) }
+
+            executor.shutdown()
+        }
+
+    @Test
+    fun `shutdown cancels scope`() =
+        runTest {
+            val taskDao: TaskDao = mockk(relaxed = true)
+            val executor =
+                TaskExecutor(
+                    emptyList(),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+            executor.shutdown()
+            assertTrue(true)
+        }
 }


### PR DESCRIPTION
Closes #3857

## Summary
- Make `TaskExecutor.scope` an injectable constructor parameter so tests can provide a test dispatcher
- Rewrite `TaskExecutorTest` to use `runTest` + `advanceUntilIdle()` with `UnconfinedTestDispatcher` instead of `Thread.sleep(1000-3000)`
- Remove unnecessary `Thread.sleep(10)` calls in `PasteDaoTest` and `TaskDaoTest`

## Test plan
- [x] All 6 `TaskExecutorTest` tests pass consistently (verified 3 consecutive runs)
- [x] `PasteDaoTest` and `TaskDaoTest` pass without `Thread.sleep`
- [x] No remaining `Thread.sleep` calls in test files

🤖 Generated with [Claude Code](https://claude.ai/code)