### PR TITLE
Support headless mode for CLI-only environments

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -49,6 +49,9 @@ import com.crosspaste.db.secure.SecureDao
 import com.crosspaste.db.secure.SecureIO
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.task.TaskDao
+import com.crosspaste.headless.HeadlessPasteboardService
+import com.crosspaste.headless.headlessUiModule
+import com.crosspaste.headless.headlessViewModelModule
 import com.crosspaste.i18n.DesktopGlobalCopywriter
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.image.DesktopFaviconLoader
@@ -245,6 +248,7 @@ class DesktopModule(
     private val deviceUtils: DeviceUtils,
     private val klogger: KLogger,
     private val platform: Platform,
+    private val headless: Boolean = false,
 ) : CrossPasteModule {
 
     val marketingMode = getAppEnvUtils().isDevelopment() && DevConfig.marketingMode
@@ -466,7 +470,11 @@ class DesktopModule(
             single<GenerateImageService> { GenerateImageService() }
             single<GuidePasteDataService> { DesktopGuidePasteDataService(get(), get(), get(), get(), get()) }
             single<PasteboardService> {
-                getDesktopPasteboardService(get(), get(), get(), get(), get(), get(), get(), get(), get())
+                if (headless) {
+                    HeadlessPasteboardService(get(), get())
+                } else {
+                    getDesktopPasteboardService(get(), get(), get(), get(), get(), get(), get(), get(), get())
+                }
             }
             single<PasteExportParamFactory<Path>> { DesktopPasteExportParamFactory() }
             single<PasteExportService> { PasteExportService(get(), get(), get()) }
@@ -594,16 +602,30 @@ class DesktopModule(
     // Application.kt
     fun initKoinApplication(): KoinApplication =
         GlobalContext.startKoin {
-            modules(
-                appModule(),
-                extensionModule(),
-                sqlDelightModule(),
-                networkModule(),
-                securityModule(),
-                pasteTypePluginModule(),
-                pasteComponentModule(),
-                uiModule(),
-                viewModelModule(),
-            )
+            if (headless) {
+                modules(
+                    appModule(),
+                    extensionModule(),
+                    sqlDelightModule(),
+                    networkModule(),
+                    securityModule(),
+                    pasteTypePluginModule(),
+                    pasteComponentModule(),
+                    headlessUiModule(),
+                    headlessViewModelModule(),
+                )
+            } else {
+                modules(
+                    appModule(),
+                    extensionModule(),
+                    sqlDelightModule(),
+                    networkModule(),
+                    securityModule(),
+                    pasteTypePluginModule(),
+                    pasteComponentModule(),
+                    uiModule(),
+                    viewModelModule(),
+                )
+            }
         }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessAppTokenService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessAppTokenService.kt
@@ -1,0 +1,13 @@
+package com.crosspaste.headless
+
+import com.crosspaste.app.AppTokenService
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+class HeadlessAppTokenService : AppTokenService() {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun preShowToken() {
+        logger.info { "Token: ${token.value.concatToString()}" }
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessAppWindowManager.kt
@@ -1,0 +1,10 @@
+package com.crosspaste.headless
+
+import com.crosspaste.app.AppWindowManager
+
+class HeadlessAppWindowManager : AppWindowManager() {
+
+    override suspend fun toPaste() {
+        // No-op in headless mode
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessModule.kt
@@ -1,0 +1,28 @@
+package com.crosspaste.headless
+
+import com.crosspaste.app.AppTokenApi
+import com.crosspaste.app.AppWindowManager
+import com.crosspaste.app.DesktopRatingPromptManager
+import com.crosspaste.app.RatingPromptManager
+import com.crosspaste.i18n.DesktopGlobalCopywriter
+import com.crosspaste.i18n.GlobalCopywriter
+import com.crosspaste.notification.NotificationManager
+import com.crosspaste.sound.SoundService
+import com.crosspaste.sync.TokenCache
+import com.crosspaste.sync.TokenCacheApi
+import com.crosspaste.ui.base.UISupport
+import org.koin.dsl.module
+
+fun headlessUiModule() =
+    module {
+        single<AppTokenApi> { HeadlessAppTokenService() }
+        single<AppWindowManager> { HeadlessAppWindowManager() }
+        single<GlobalCopywriter> { DesktopGlobalCopywriter(get(), lazy { get() }, get()) }
+        single<NotificationManager> { HeadlessNotificationManager(get()) }
+        single<RatingPromptManager> { DesktopRatingPromptManager() }
+        single<SoundService> { HeadlessSoundService() }
+        single<TokenCacheApi> { TokenCache }
+        single<UISupport> { HeadlessUISupport() }
+    }
+
+fun headlessViewModelModule() = module {}

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessNotificationManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessNotificationManager.kt
@@ -1,0 +1,22 @@
+package com.crosspaste.headless
+
+import com.crosspaste.i18n.GlobalCopywriter
+import com.crosspaste.notification.Message
+import com.crosspaste.notification.NotificationManager
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.atomic.AtomicInteger
+
+class HeadlessNotificationManager(
+    copywriter: GlobalCopywriter,
+) : NotificationManager(copywriter) {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val idGenerator = AtomicInteger(0)
+
+    override fun getMessageId(): Int = idGenerator.incrementAndGet()
+
+    override fun doSendNotification(message: Message) {
+        logger.info { "[${message.messageType}] ${message.title}${message.message?.let { " - $it" } ?: ""}" }
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessPasteboardService.kt
@@ -1,0 +1,83 @@
+package com.crosspaste.headless
+
+import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteboardService
+import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.utils.ioDispatcher
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+
+class HeadlessPasteboardService(
+    override val configManager: CommonConfigManager,
+    override val pasteDao: PasteDao,
+) : PasteboardService {
+
+    override val logger: KLogger = KotlinLogging.logger {}
+
+    override var owner: Boolean = false
+
+    override val remotePasteboardChannel: Channel<suspend () -> Result<Unit?>> = Channel(Channel.CONFLATED)
+
+    override val serviceScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob())
+
+    override fun start() {
+        logger.info { "Headless pasteboard service started (no clipboard monitoring)" }
+        startRemotePasteboardListener()
+    }
+
+    override fun stop() {
+        logger.info { "Headless pasteboard service stopped" }
+    }
+
+    override fun toggle() {
+        val enablePasteboardListening = configManager.getCurrentConfig().enablePasteboardListening
+        if (enablePasteboardListening) {
+            stop()
+        } else {
+            start()
+        }
+        configManager.updateConfig("enablePasteboardListening", !enablePasteboardListening)
+    }
+
+    override suspend fun tryWritePasteboard(
+        id: Long?,
+        pasteItem: PasteItem,
+        localOnly: Boolean,
+        updateCreateTime: Boolean,
+    ): Result<Unit?> =
+        runCatching {
+            logger.info { "Headless mode: paste item stored to DB only (no system clipboard)" }
+        }
+
+    override suspend fun tryWritePasteboard(
+        pasteData: PasteData,
+        localOnly: Boolean,
+        primary: Boolean,
+        updateCreateTime: Boolean,
+    ): Result<Unit?> =
+        runCatching {
+            logger.info { "Headless mode: paste data stored to DB only (no system clipboard)" }
+        }
+
+    override suspend fun tryWriteRemotePasteboard(pasteData: PasteData): Result<Unit?> =
+        pasteDao.releaseRemotePasteData(pasteData) {
+            remotePasteboardChannel.trySend {
+                tryWritePasteboard(pasteData = it, localOnly = true)
+            }
+        }
+
+    override suspend fun tryWriteRemotePasteboardWithFile(pasteData: PasteData): Result<Unit?> =
+        pasteDao.releaseRemotePasteDataWithFile(pasteData.id) {
+            remotePasteboardChannel.trySend {
+                tryWritePasteboard(pasteData = it, localOnly = true)
+            }
+        }
+
+    override suspend fun clearRemotePasteboard(pasteData: PasteData): Result<Unit?> =
+        pasteDao.markDeletePasteData(pasteData.id)
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessSoundService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessSoundService.kt
@@ -1,0 +1,22 @@
+package com.crosspaste.headless
+
+import com.crosspaste.sound.SoundService
+
+class HeadlessSoundService : SoundService {
+
+    override fun errorSound() {
+        // No-op in headless mode
+    }
+
+    override fun successSound() {
+        // No-op in headless mode
+    }
+
+    override fun enablePasteboardListening() {
+        // No-op in headless mode
+    }
+
+    override fun disablePasteboardListening() {
+        // No-op in headless mode
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessUISupport.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessUISupport.kt
@@ -1,0 +1,59 @@
+package com.crosspaste.headless
+
+import com.crosspaste.paste.PasteData
+import com.crosspaste.ui.base.UISupport
+import io.github.oshai.kotlinlogging.KotlinLogging
+import okio.Path
+
+class HeadlessUISupport : UISupport {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun openUrlInBrowser(url: String) {
+        logger.info { "Headless mode: cannot open URL in browser: $url" }
+    }
+
+    override fun getCrossPasteWebUrl(path: String): String = "https://crosspaste.com/$path"
+
+    override fun openEmailClient(email: String?) {
+        logger.info { "Headless mode: cannot open email client" }
+    }
+
+    override fun openHtml(
+        id: Long,
+        html: String,
+    ) {
+        logger.info { "Headless mode: cannot open HTML viewer" }
+    }
+
+    override fun browseFile(filePath: Path) {
+        logger.info { "Headless mode: cannot browse file: $filePath" }
+    }
+
+    override fun openColorPicker(pasteData: PasteData) {
+        logger.info { "Headless mode: cannot open color picker" }
+    }
+
+    override fun openImage(imagePath: Path) {
+        logger.info { "Headless mode: cannot open image: $imagePath" }
+    }
+
+    override fun openText(pasteData: PasteData) {
+        logger.info { "Headless mode: cannot open text viewer" }
+    }
+
+    override fun openRtf(pasteData: PasteData) {
+        logger.info { "Headless mode: cannot open RTF viewer" }
+    }
+
+    override fun openPasteData(
+        pasteData: PasteData,
+        index: Int,
+    ) {
+        logger.info { "Headless mode: cannot open paste data viewer" }
+    }
+
+    override fun jumpPrivacyAccessibility() {
+        logger.info { "Headless mode: cannot open privacy accessibility settings" }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `--headless` flag to run CrossPaste without GUI, enabling use in SSH servers, Docker containers, and headless Linux environments
- Core services (database, networking, sync, MCP server) run normally while GUI-dependent services are replaced with no-op/logging implementations
- Main thread blocks with `CountDownLatch` + shutdown hook for clean signal-based exit

### New files (7):
- `HeadlessNotificationManager` — logs instead of displaying desktop notifications
- `HeadlessPasteboardService` — DB-only storage without system clipboard monitoring
- `HeadlessAppWindowManager` — no-op window management
- `HeadlessAppTokenService` — logs token to console instead of showing UI
- `HeadlessUISupport` — no-op browser/file operations
- `HeadlessSoundService` — no-op sound
- `HeadlessModule` — Koin module providing all headless bindings

### Modified files (2):
- `CrossPaste.kt` — parse `--headless`, conditional startup, `runHeadless()`
- `DesktopModule.kt` — conditional DI module loading based on headless flag

Closes #3863
Supersedes #3864

## Test plan
- [ ] Build passes: `./gradlew build`
- [ ] Tests pass: `./gradlew app:desktopTest`
- [ ] Normal mode (no `--headless`): GUI works as before
- [ ] Headless mode (`--headless`): starts without GUI, logs "Running in headless mode", HTTP server responds

🤖 Generated with [Claude Code](https://claude.ai/code)