### PR TITLE
Bump version to 1.2.8

### DIFF
--- a/app/src/desktopMain/resources/crosspaste-version.properties
+++ b/app/src/desktopMain/resources/crosspaste-version.properties
@@ -1,1 +1,1 @@
-version=1.2.7
+version=1.2.8


### PR DESCRIPTION
Closes #3868

## Summary
- Bump application version from 1.2.7 to 1.2.8 for the next release

## Test plan
- [ ] Verify version displays correctly in the app