### PR TITLE
:bug: Fix feedback loop in nearbySyncInfos combine block

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
@@ -61,14 +61,6 @@ class GeneralNearbyDeviceManager(
             val existSyncMap = syncRuntimeInfos.associateBy { info -> info.appInstanceId }
 
             infosMap.values
-                .forEach { info ->
-                    existSyncMap[info.appInfo.appInstanceId]?.diffSyncInfo(info)?.let {
-                        if (it) {
-                            syncManager.updateSyncInfo(info)
-                        }
-                    }
-                }
-            infosMap.values
                 .filter {
                     !existSyncMap.contains(it.appInfo.appInstanceId) &&
                         !blackSyncInfos.contains(it.appInfo.appInstanceId) &&
@@ -97,6 +89,17 @@ class GeneralNearbyDeviceManager(
                     current + (appInstanceId to existSyncInfo.merge(syncInfo))
                 }
             }
+
+            syncInfos.value[appInstanceId]?.let { mergedInfo ->
+                syncManager.realTimeSyncRuntimeInfos.value
+                    .find { it.appInstanceId == appInstanceId }
+                    ?.let { existing ->
+                        if (existing.diffSyncInfo(mergedInfo)) {
+                            syncManager.updateSyncInfo(mergedInfo)
+                        }
+                    }
+            }
+
             ratingPromptManager.trackSignificantAction()
         }
     }


### PR DESCRIPTION
Closes #3876

## Summary
- Remove side effect (`syncManager.updateSyncInfo()`) from `nearbySyncInfos` combine transformer, making it a pure data transformation
- Move the diff check to `addDevice()` where it's event-driven (triggered by mDNS discovery) instead of reactive-loop-driven

## Context
The combine block was calling `syncManager.updateSyncInfo()` which triggered: DB update → flow emission → `realTimeSyncRuntimeInfos` change → the same combine re-runs. This feedback loop caused unnecessary DB writes and event churn during device discovery, potentially contributing to connection instability.

## Test plan
- [x] Verify nearby device discovery still updates synced device info when port/host changes
- [x] Verify no excessive DB writes or log spam during mDNS discovery phase
- [x] Verify `nearbySyncInfos` correctly filters out already-synced and blacklisted devices