### PR TITLE
:bug: Add missing return after connectState change to prevent duplicate events

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -130,6 +130,7 @@ class GeneralSyncHandler(
                     emitEvent(SyncEvent.ResolveConnection(current, createCallback()))
                 }
             }
+            return
         }
 
         if (!hostInfoListEqual(previous.hostInfoList, current.hostInfoList)) {


### PR DESCRIPTION
## Summary
- Add `return` after `connectState` change `when` block in `GeneralSyncHandler.handleValueChange()` to prevent fall-through to subsequent `hostInfoList` and same-state checks
- When state change and hostInfoList change happen simultaneously (common during network switching), this previously caused duplicate `ResolveConnection` events for the same device

Fixes #3882