### PR TITLE
:bug: Bypass event channel for exit notifications to ensure delivery

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -199,7 +199,11 @@ class GeneralSyncHandler(
     }
 
     override suspend fun notifyExit() {
-        emitEvent(SyncEvent.NotifyExit(currentSyncRuntimeInfo))
+        val completionSignal = CompletableDeferred<Unit>()
+        emitEvent(SyncEvent.NotifyExit(currentSyncRuntimeInfo, completionSignal))
+        withTimeoutOrNull(5000) {
+            completionSignal.await()
+        }
         cancelScope()
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -3,6 +3,7 @@ package com.crosspaste.sync
 import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.dto.sync.SyncInfo
+import kotlinx.coroutines.CompletableDeferred
 
 sealed interface SyncEvent {
 
@@ -83,6 +84,7 @@ sealed interface SyncEvent {
 
     data class NotifyExit(
         override val syncRuntimeInfo: SyncRuntimeInfo,
+        val completionSignal: CompletableDeferred<Unit> = CompletableDeferred(),
     ) : SyncRunTimeInfoEvent {
         override fun toString(): String = "NotifyExit ${syncRuntimeInfo.appInstanceId}"
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -105,6 +105,7 @@ class SyncResolver(
 
                     is SyncEvent.NotifyExit -> {
                         syncRuntimeInfo.notifyExit()
+                        event.completionSignal.complete(Unit)
                     }
 
                     is SyncEvent.MarkExit -> {


### PR DESCRIPTION
## Summary
- `NotifyExit` event now carries a `CompletableDeferred<Unit>` completion signal
- `GeneralSyncHandler.notifyExit()` sends the event through the normal event channel, then awaits the completion signal (with 5s timeout) before calling `cancelScope()`
- `SyncResolver` completes the signal after processing the `NotifyExit` event (network notification sent)
- `SyncRoutingApi.notifyExit()` uses `runBlocking` + `withTimeout(5000)` to await all handlers, which now correctly waits for the network notifications to finish before `stop()` cancels `realTimeSyncScope`

Fixes #3884