### PR TITLE
Fix cleanup config mismatch: expiration cleanup guarded by wrong flag

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/clean/CleanScheduler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/clean/CleanScheduler.kt
@@ -47,7 +47,8 @@ class CleanScheduler(
 
     private suspend fun safeCleanPaste() {
         runCatching {
-            if (configManager.getCurrentConfig().enableExpirationCleanup) {
+            val config = configManager.getCurrentConfig()
+            if (config.enableExpirationCleanup || config.enableThresholdCleanup) {
                 cleanPaste()
             }
         }.onFailure { e ->

--- a/app/src/commonMain/kotlin/com/crosspaste/task/CleanPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/CleanPasteTaskExecutor.kt
@@ -34,7 +34,7 @@ class CleanPasteTaskExecutor(
     @OptIn(ExperimentalTime::class)
     override suspend fun doExecuteTask(pasteTask: PasteTask): PasteTaskResult {
         val config = configManager.getCurrentConfig()
-        if (config.enableThresholdCleanup) {
+        if (config.enableExpirationCleanup) {
             runCatching {
                 cleanLock.withLock {
                     val imageCleanTimeIndex = config.imageCleanTimeIndex

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/CleanPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/CleanPasteTaskExecutorTest.kt
@@ -26,6 +26,7 @@ class CleanPasteTaskExecutorTest {
 
         init {
             val config = mockk<AppConfig>(relaxed = true)
+            every { config.enableExpirationCleanup } returns true
             every { config.enableThresholdCleanup } returns true
             every { config.imageCleanTimeIndex } returns CleanTime.ONE_WEEK.ordinal
             every { config.fileCleanTimeIndex } returns CleanTime.ONE_MONTH.ordinal
@@ -62,10 +63,11 @@ class CleanPasteTaskExecutorTest {
     }
 
     @Test
-    fun `threshold cleanup disabled skips all cleanup`() =
+    fun `both cleanup disabled skips all cleanup`() =
         runTest {
             val deps = TestDeps()
             val config = mockk<AppConfig>(relaxed = true)
+            every { config.enableExpirationCleanup } returns false
             every { config.enableThresholdCleanup } returns false
             every { deps.configManager.getCurrentConfig() } returns config
 
@@ -76,6 +78,56 @@ class CleanPasteTaskExecutorTest {
 
             assertTrue(result is SuccessPasteTaskResult)
             coVerify(exactly = 0) { deps.pasteDao.markDeleteByCleanTime(any(), any()) }
+        }
+
+    @Test
+    fun `expiration only runs time-based cleanup but not threshold cleanup`() =
+        runTest {
+            val deps = TestDeps()
+            val config = mockk<AppConfig>(relaxed = true)
+            every { config.enableExpirationCleanup } returns true
+            every { config.enableThresholdCleanup } returns false
+            every { config.imageCleanTimeIndex } returns CleanTime.ONE_WEEK.ordinal
+            every { config.fileCleanTimeIndex } returns CleanTime.ONE_MONTH.ordinal
+            every { deps.configManager.getCurrentConfig() } returns config
+
+            val executor = deps.createExecutor()
+            val task = createPasteTask()
+
+            val result = executor.doExecuteTask(task)
+
+            assertTrue(result is SuccessPasteTaskResult)
+            // Time-based cleanup for image and file
+            coVerify(exactly = 2) { deps.pasteDao.markDeleteByCleanTime(any(), any()) }
+            // No size-based cleanup
+            coVerify(exactly = 0) { deps.pasteDao.getSize(any()) }
+        }
+
+    @Test
+    fun `threshold only runs size-based cleanup but not time-based cleanup`() =
+        runTest {
+            val deps = TestDeps()
+            val config = mockk<AppConfig>(relaxed = true)
+            every { config.enableExpirationCleanup } returns false
+            every { config.enableThresholdCleanup } returns true
+            every { config.maxStorage } returns 1024L
+            every { config.cleanupPercentage } returns 20
+            every { deps.configManager.getCurrentConfig() } returns config
+
+            // Under threshold so no actual deletion
+            coEvery { deps.pasteDao.getSize(true) } returns 100L
+            coEvery { deps.pasteDao.getSize(false) } returns 50L
+
+            val executor = deps.createExecutor()
+            val task = createPasteTask()
+
+            val result = executor.doExecuteTask(task)
+
+            assertTrue(result is SuccessPasteTaskResult)
+            // No time-based cleanup (markDeleteByCleanTime with type param)
+            coVerify(exactly = 0) { deps.pasteDao.markDeleteByCleanTime(any(), any()) }
+            // Size check was performed
+            coVerify(exactly = 1) { deps.pasteDao.getSize(true) }
         }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes #3895

- **`CleanScheduler`**: Submit `CLEAN_PASTE_TASK` when either `enableExpirationCleanup` or `enableThresholdCleanup` is enabled (was only checking `enableExpirationCleanup`)
- **`CleanPasteTaskExecutor`**: Time-based image/file cleanup now checks `enableExpirationCleanup` instead of `enableThresholdCleanup`; size-based threshold cleanup still checks `enableThresholdCleanup`
- Added 2 new tests verifying independent toggle behavior: expiration-only and threshold-only scenarios

## Test plan
- [x] All desktop tests pass (`./gradlew app:desktopTest`)
- [x] 8 `CleanPasteTaskExecutorTest` pass (including 2 new tests)
- [x] `both cleanup disabled skips all cleanup` — neither cleanup runs
- [x] `expiration only runs time-based cleanup but not threshold cleanup` — only markDeleteByCleanTime with type param called
- [x] `threshold only runs size-based cleanup but not time-based cleanup` — only getSize called, no time-based deletion
- [x] `ktlintFormat` clean