### PR TITLE
Fix import file path collision and export silent failure

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
@@ -125,7 +125,7 @@ class PasteImportService(
         runCatching {
             val id = pasteDao.createPasteData(pasteData)
 
-            val pasteCoordinate = pasteData.getPasteCoordinate(id = index)
+            val pasteCoordinate = pasteData.getPasteCoordinate(id = id)
             val pasteAppearItem = pasteData.pasteAppearItem
             val pasteCollection = pasteData.pasteCollection
 

--- a/app/src/desktopMain/resources/i18n/de.properties
+++ b/app/src/desktopMain/resources/i18n/de.properties
@@ -74,6 +74,7 @@ expiration_cleanup=Ablaufbereinigung
 export=Exportieren
 export_fail=Export fehlgeschlagen
 export_favorites_only=Nur favorisierte Zwischenablage-Einträge exportieren
+export_partial=Export teilweise erfolgreich
 export_successful=Export erfolgreich
 extension=Erweiterung
 extract_text=Text extrahieren

--- a/app/src/desktopMain/resources/i18n/en.properties
+++ b/app/src/desktopMain/resources/i18n/en.properties
@@ -74,6 +74,7 @@ expiration_cleanup=Expiration Cleanup
 export=Export
 export_fail=Export Fail
 export_favorites_only=Export favorited clipboard items only
+export_partial=Export Partial
 export_successful=Export Successful
 extension=Extension
 extract_text=Extract Text

--- a/app/src/desktopMain/resources/i18n/es.properties
+++ b/app/src/desktopMain/resources/i18n/es.properties
@@ -74,6 +74,7 @@ expiration_cleanup=Limpieza de expiración
 export=Exportar
 export_fail=Error al exportar
 export_favorites_only=Solo exportar elementos favoritos del portapapeles
+export_partial=Exportación parcial
 export_successful=Exportación exitosa
 extension=Extensión
 extract_text=Extraer texto

--- a/app/src/desktopMain/resources/i18n/fa.properties
+++ b/app/src/desktopMain/resources/i18n/fa.properties
@@ -74,6 +74,7 @@ expiration_cleanup=پاکسازی منقضی‌شده‌ها
 export=برون‌بری
 export_fail=برون‌بری ناموفق بود
 export_favorites_only=فقط خروجی از کلیپ‌بوردهای نشان‌گذاری شده
+export_partial=برون‌بری ناقص
 export_successful=برون‌بری با موفقیت انجام شد
 extension=افزونه
 extract_text=استخراج متن

--- a/app/src/desktopMain/resources/i18n/fr.properties
+++ b/app/src/desktopMain/resources/i18n/fr.properties
@@ -74,6 +74,7 @@ expiration_cleanup=Nettoyage par expiration
 export=Exporter
 export_fail=Échec de l'exportation
 export_favorites_only=Exporter uniquement les éléments favoris du presse-papiers
+export_partial=Exportation partielle
 export_successful=Exportation réussie
 extension=Extension
 extract_text=Extraire le texte

--- a/app/src/desktopMain/resources/i18n/ja.properties
+++ b/app/src/desktopMain/resources/i18n/ja.properties
@@ -74,6 +74,7 @@ expiration_cleanup=有効期限クリーンアップ
 export=エクスポート
 export_fail=エクスポート失敗
 export_favorites_only=お気に入りのクリップボード履歴のみエクスポート
+export_partial=エクスポート一部成功
 export_successful=エクスポート成功
 extension=拡張機能
 extract_text=テキストを抽出

--- a/app/src/desktopMain/resources/i18n/ko.properties
+++ b/app/src/desktopMain/resources/i18n/ko.properties
@@ -74,6 +74,7 @@ expiration_cleanup=만료정리
 export=내보내기
 export_fail=내보내기실패
 export_favorites_only=즐겨찾기한 클립보드 기록만 내보내기
+export_partial=내보내기 부분 성공
 export_successful=내보내기성공
 extension=확장 기능
 extract_text=텍스트 추출

--- a/app/src/desktopMain/resources/i18n/zh.properties
+++ b/app/src/desktopMain/resources/i18n/zh.properties
@@ -74,6 +74,7 @@ expiration_cleanup=过期清理
 export=导出
 export_fail=导出失败
 export_favorites_only=仅导出收藏的剪贴板
+export_partial=导出部分成功
 export_successful=导出成功
 extension=扩展
 extract_text=提取文本

--- a/app/src/desktopMain/resources/i18n/zh_hant.properties
+++ b/app/src/desktopMain/resources/i18n/zh_hant.properties
@@ -73,6 +73,7 @@ expiration_cleanup=過期清理
 export=匯出
 export_fail=匯出失敗
 export_favorites_only=僅匯出收藏的剪貼簿
+export_partial=匯出部分成功
 export_successful=匯出成功
 extension=擴展
 extract_text=提取文字


### PR DESCRIPTION
## Summary
- Fix `PasteImportService` using line index instead of DB ID for `getPasteCoordinate`, causing file path collisions on re-import
- Fix `PasteExportService` to properly handle partial export failures: track `exportError` flag to distinguish full success / partial success / complete failure, and add `export_partial` i18n notification across all 9 locales

Closes #3899

## Test plan
- [x] `./gradlew ktlintFormat` passes
- [x] `./gradlew app:desktopTest` — all tests pass