### PR TITLE
:bug: Fix SecureStore double-check locking and session lifecycle bugs

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/secure/GeneralSecureStore.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/secure/GeneralSecureStore.kt
@@ -41,7 +41,6 @@ class GeneralSecureStore(
         session.mutex.withLock {
             session.processor = null
             secureIO.deleteCryptPublicKey(appInstanceId)
-            sessions.remove(appInstanceId)
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/secure/SecureSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/secure/SecureSession.kt
@@ -4,5 +4,5 @@ import kotlinx.coroutines.sync.Mutex
 
 data class SecureSession(
     val mutex: Mutex = Mutex(),
-    var processor: SecureMessageProcessor? = null,
+    @Volatile var processor: SecureMessageProcessor? = null,
 )


### PR DESCRIPTION
Closes #3905

## Summary
- Add `@Volatile` to `SecureSession.processor` to fix broken double-check locking in `getMessageProcessor()` — without it, threads can read stale cached processor values after key rotation
- Remove `sessions.remove(appInstanceId)` from `deleteCryptPublicKey()` to prevent orphaned session references that defeat mutual exclusion guarantees

## Test plan
- [x] `./gradlew ktlintFormat` passes
- [x] `./gradlew app:desktopTest` — all 209 tests pass