### PR TITLE
:bug: Fix export count off-by-one, import failure handling and orphaned DB entries

### DIFF
--- a/app/src/desktopMain/resources/i18n/de.properties
+++ b/app/src/desktopMain/resources/i18n/de.properties
@@ -106,6 +106,7 @@ in_downloads=Im Download-Ordner
 import=Importieren
 import_data_merge_notice=Importierte Daten werden mit bestehenden Zwischenablage-Einträgen zusammengeführt
 import_fail=Import fehlgeschlagen
+import_partial=Import teilweise erfolgreich
 import_successful=Import erfolgreich
 incompatible_with_device=Inkompatibel mit verbundenem Gerät
 input_note_name=Notizname eingeben

--- a/app/src/desktopMain/resources/i18n/en.properties
+++ b/app/src/desktopMain/resources/i18n/en.properties
@@ -106,6 +106,7 @@ in_downloads=In Downloads
 import=Import
 import_data_merge_notice=Imported data will be merged with existing clipboard records
 import_fail=Import Fail
+import_partial=Import Partial
 import_successful=Import Successful
 incompatible_with_device=Incompatible with connected device
 input_note_name=Input Note Name

--- a/app/src/desktopMain/resources/i18n/es.properties
+++ b/app/src/desktopMain/resources/i18n/es.properties
@@ -106,6 +106,7 @@ in_downloads=En Descargas
 import=Importar
 import_data_merge_notice=Los datos importados se fusionarán con los registros del portapapeles existentes
 import_fail=Error al importar
+import_partial=Importación parcial
 import_successful=Importación exitosa
 incompatible_with_device=Incompatible con el dispositivo conectado
 input_note_name=Introducir nombre de nota

--- a/app/src/desktopMain/resources/i18n/fa.properties
+++ b/app/src/desktopMain/resources/i18n/fa.properties
@@ -106,6 +106,7 @@ in_downloads=در پوشه دانلود
 import=درون‌ریزی
 import_data_merge_notice=داده‌های وارد شده با رکوردهای کلیپ‌بورد موجود ترکیب خواهند شد
 import_fail=درون‌ریزی ناموفق بود
+import_partial=درون‌ریزی ناقص
 import_successful=درون‌ریزی با موفقیت انجام شد
 incompatible_with_device=ناسازگار با دستگاه متصل
 input_note_name=نام یادداشت را وارد کنید

--- a/app/src/desktopMain/resources/i18n/fr.properties
+++ b/app/src/desktopMain/resources/i18n/fr.properties
@@ -106,6 +106,7 @@ in_downloads=Dans les Téléchargements
 import=Importer
 import_data_merge_notice=Les données importées seront fusionnées avec les enregistrements du presse-papiers existants
 import_fail=Échec de l'importation
+import_partial=Importation partielle
 import_successful=Importation réussie
 incompatible_with_device=Incompatible avec l'appareil connecté
 input_note_name=Saisir le nom de la note

--- a/app/src/desktopMain/resources/i18n/ja.properties
+++ b/app/src/desktopMain/resources/i18n/ja.properties
@@ -106,6 +106,7 @@ in_downloads=ダウンロードフォルダ内
 import=インポート
 import_data_merge_notice=インポートされたデータは既存のクリップボード履歴と統合されます
 import_fail=インポート失敗
+import_partial=インポート一部成功
 import_successful=インポート成功
 incompatible_with_device=接続されたデバイスと互換性がありません
 input_note_name=ノート名を入力

--- a/app/src/desktopMain/resources/i18n/ko.properties
+++ b/app/src/desktopMain/resources/i18n/ko.properties
@@ -106,6 +106,7 @@ in_downloads=다운로드 폴더에 있음
 import=가져오기
 import_data_merge_notice=가져온 데이터가 기존 클립보드 기록과 병합됩니다
 import_fail=가져오기실패
+import_partial=가져오기 부분 성공
 import_successful=가져오기성공
 incompatible_with_device=연결된 장치와 호환되지 않음
 input_note_name=메모명입력

--- a/app/src/desktopMain/resources/i18n/zh.properties
+++ b/app/src/desktopMain/resources/i18n/zh.properties
@@ -106,6 +106,7 @@ in_downloads=在下载目录中
 import=导入
 import_data_merge_notice=导入数据将与现有剪贴板记录合并
 import_fail=导入失败
+import_partial=导入部分成功
 import_successful=导入成功
 incompatible_with_device=与连接设备不兼容
 input_note_name=输入备注名

--- a/app/src/desktopMain/resources/i18n/zh_hant.properties
+++ b/app/src/desktopMain/resources/i18n/zh_hant.properties
@@ -105,6 +105,7 @@ in_downloads=在下載目錄中
 import=匯入
 import_data_merge_notice=匯入資料將與現有剪貼簿記錄合併
 import_fail=匯入失敗
+import_partial=匯入部分成功
 import_successful=匯入成功
 incompatible_with_device=與連接設備不兼容
 input_note_name=輸入備註名稱


### PR DESCRIPTION
Closes #3907

## Summary
- **Export off-by-one**: Rename `count` to `nextIndex`, derive `exportedCount = nextIndex - 1` for `.count` file, progress calculation (`< exportCount` instead of `!= exportCount`), and notification checks
- **Import failure notification**: Track `successCount` separately from `totalCount`, show partial/full/fail/empty notifications accordingly
- **Import orphaned DB entries**: Mark failed imports as `PasteState.DELETED` so cleanup task can reclaim them
- **Import progress stalls**: Move `updateProgress()` outside the success-only branch so progress always advances
- Add `import_partial` i18n key across all 9 locales

## Test plan
- [x] `./gradlew ktlintFormat` passes
- [x] `./gradlew app:desktopTest` — all 209 tests pass