### PR TITLE
Fix sync retry loop and delayed connection status on passive device

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -70,7 +70,8 @@ fun Routing.syncRouting(
             }
             runCatching {
                 val syncInfo = call.receive(SyncInfo::class)
-                syncRoutingApi.updateSyncInfo(syncInfo)
+                val host = call.request.host()
+                syncRoutingApi.trustSyncInfo(syncInfo, host)
                 logger.info { "$appInstanceId heartbeat to ${appInfo.appInstanceId} success" }
             }.onSuccess {
                 successResponse(call, syncApi.VERSION)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -247,7 +247,7 @@ class GeneralSyncManager(
 
     override fun updateSyncInfo(syncInfo: SyncInfo) {
         realTimeSyncScope.launch {
-            emitEvent(SyncEvent.UpdateSyncInfo(syncInfo))
+            syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo)
         }
     }
 
@@ -256,11 +256,7 @@ class GeneralSyncManager(
         host: String?,
     ) {
         realTimeSyncScope.launch {
-            host?.let {
-                emitEvent(SyncEvent.TrustSyncInfo(syncInfo, host))
-            } ?: run {
-                emitEvent(SyncEvent.UpdateSyncInfo(syncInfo))
-            }
+            syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo, host)
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -2,7 +2,6 @@ package com.crosspaste.sync
 
 import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.db.sync.SyncRuntimeInfo
-import com.crosspaste.dto.sync.SyncInfo
 import kotlinx.coroutines.CompletableDeferred
 
 sealed interface SyncEvent {
@@ -106,18 +105,5 @@ sealed interface SyncEvent {
         val hostInfoList: List<HostInfo>,
     ) : SyncEvent {
         override fun toString(): String = "RefreshSyncInfo $appInstanceId $hostInfoList"
-    }
-
-    data class UpdateSyncInfo(
-        val syncInfo: SyncInfo,
-    ) : SyncEvent {
-        override fun toString(): String = "UpdateSyncInfo ${syncInfo.appInfo.appInstanceId}"
-    }
-
-    data class TrustSyncInfo(
-        val syncInfo: SyncInfo,
-        val host: String,
-    ) : SyncEvent {
-        override fun toString(): String = "TrustSyncInfo ${syncInfo.appInfo.appInstanceId}"
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -5,7 +5,6 @@ import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
-import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.NetworkInterfaceService
 import com.crosspaste.net.PasteBonjourService
@@ -45,8 +44,6 @@ class SyncResolver(
         when (this) {
             is SyncEvent.SyncRunTimeInfoEvent -> syncRuntimeInfo.appInstanceId
             is SyncEvent.RefreshSyncInfo -> appInstanceId
-            is SyncEvent.UpdateSyncInfo -> syncInfo.appInfo.appInstanceId
-            is SyncEvent.TrustSyncInfo -> syncInfo.appInfo.appInstanceId
             else -> error("Unknown SyncEvent type: $this")
         }
 
@@ -120,14 +117,6 @@ class SyncResolver(
                 when (event) {
                     is SyncEvent.RefreshSyncInfo -> {
                         refreshSyncInfo(event.appInstanceId, event.hostInfoList)
-                    }
-
-                    is SyncEvent.UpdateSyncInfo -> {
-                        updateSyncInfo(event.syncInfo)
-                    }
-
-                    is SyncEvent.TrustSyncInfo -> {
-                        trustSyncInfo(event.syncInfo, event.host)
                     }
 
                     else -> {
@@ -447,17 +436,6 @@ class SyncResolver(
         hostInfoList: List<HostInfo>,
     ) {
         lazyPasteBonjourService.value.refreshTarget(appInstanceId, hostInfoList)
-    }
-
-    private suspend fun updateSyncInfo(syncInfo: SyncInfo) {
-        syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo)
-    }
-
-    private suspend fun trustSyncInfo(
-        syncInfo: SyncInfo,
-        host: String,
-    ) {
-        syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo, host)
     }
 
     private suspend fun SyncRuntimeInfo.updateAllowSend(allowSend: Boolean) {

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
@@ -167,7 +167,7 @@ class GeneralSyncManagerTest {
                     every { appInfo.appInstanceId } returns "test-app-1"
                 }
 
-            coEvery { mocks.syncResolver.emitEvent(any()) } just runs
+            coEvery { mocks.syncRuntimeInfoDao.insertOrUpdateSyncInfo(any<SyncInfo>()) } just runs
 
             val childScope = CoroutineScope(coroutineContext + Job())
             val syncManager = createSyncManager(mocks, childScope)
@@ -176,7 +176,7 @@ class GeneralSyncManagerTest {
             syncManager.updateSyncInfo(syncInfo)
             advanceUntilIdle()
 
-            coVerify { mocks.syncResolver.emitEvent(any()) }
+            coVerify { mocks.syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo) }
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -998,30 +998,6 @@ class SyncResolverTest {
         }
 
     @Test
-    fun updateSyncInfo_delegatesToDao() =
-        runTest {
-            val deps = TestDeps()
-            val resolver = deps.createResolver()
-            val syncInfo = SyncTestFixtures.createSyncInfo()
-
-            resolver.emitEvent(SyncEvent.UpdateSyncInfo(syncInfo))
-
-            coVerify { deps.syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo) }
-        }
-
-    @Test
-    fun trustSyncInfo_delegatesToDaoWithHost() =
-        runTest {
-            val deps = TestDeps()
-            val resolver = deps.createResolver()
-            val syncInfo = SyncTestFixtures.createSyncInfo()
-
-            resolver.emitEvent(SyncEvent.TrustSyncInfo(syncInfo, "192.168.1.100"))
-
-            coVerify { deps.syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo, "192.168.1.100") }
-        }
-
-    @Test
     fun refreshSyncInfo_delegatesToBonjour() =
         runTest {
             val deps = TestDeps()


### PR DESCRIPTION
Closes #3911

## Summary
- Fix infinite `DISCONNECTED → CONNECTING → DISCONNECTED` retry loop caused by `NOT_MATCH_APP_INSTANCE_ID` on dual-boot machines by only emitting immediate `ResolveDisconnected` on `CONNECTED → DISCONNECTED` transitions
- Fix 5-6s delay on passive device (B) showing CONNECTED after trust by passing host in heartbeat handler and bypassing event system's `deviceMutex` for sync info updates
- Remove dead code: `UpdateSyncInfo`/`TrustSyncInfo` events and their handlers

## Test plan
- [x] Pair two devices (A enters B's token) — verify B shows CONNECTED within ~1s
- [x] Dual-boot machine: connect on Linux, switch to Windows — verify no rapid log spam, retry uses exponential backoff
- [x] Normal disconnect/reconnect (e.g., restart one device) — verify fast reconnection still works