### PR TITLE
:art: Remove redundant casts and conversions in test files

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/db/task/PasteTaskExtraInfoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/task/PasteTaskExtraInfoTest.kt
@@ -51,7 +51,7 @@ class PasteTaskExtraInfoTest {
         val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded)
 
         assertTrue(decoded is SyncExtraInfo)
-        assertEquals("test-app-1", (decoded as SyncExtraInfo).appInstanceId)
+        assertEquals("test-app-1", decoded.appInstanceId)
         assertTrue(decoded.syncFails.isEmpty())
     }
 
@@ -83,7 +83,7 @@ class PasteTaskExtraInfoTest {
         val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded)
 
         assertTrue(decoded is PullExtraInfo)
-        assertEquals(42L, (decoded as PullExtraInfo).id)
+        assertEquals(42L, decoded.id)
     }
 
     @Test
@@ -120,7 +120,7 @@ class PasteTaskExtraInfoTest {
         val decoded = json.decodeFromString<PasteTaskExtraInfo>(encoded)
 
         assertTrue(decoded is SwitchLanguageInfo)
-        assertEquals("zh-CN", (decoded as SwitchLanguageInfo).language)
+        assertEquals("zh-CN", decoded.language)
     }
 
     // --- ExecutionHistory ---

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectionTest.kt
@@ -69,7 +69,7 @@ class PasteCollectionTest {
             listOf(
                 createTextPasteItem(text = "text content"),
                 createUrlPasteItem(url = "https://example.com"),
-                createColorPasteItem(color = 0xFF0000.toInt()),
+                createColorPasteItem(color = 0xFF0000),
             )
         val original = PasteCollection(items)
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/item/CreatePasteItemHelperTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/item/CreatePasteItemHelperTest.kt
@@ -178,7 +178,7 @@ class CreatePasteItemHelperTest {
         val original = createUrlPasteItem(identifiers = listOf("url"), url = "https://old.com")
         val copy = original.copy(url = "https://new.com")
         assertTrue(copy is UrlPasteItem)
-        assertEquals("https://new.com", (copy as UrlPasteItem).url)
+        assertEquals("https://new.com", copy.url)
     }
 
     // --- ColorPasteItem ---

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/CleanPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/CleanPasteTaskExecutorTest.kt
@@ -182,9 +182,8 @@ class CleanPasteTaskExecutorTest {
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is FailurePasteTaskResult)
-            val failResult = result as FailurePasteTaskResult
             // First execution: empty history → retries allowed
-            assertTrue(failResult.needRetry)
+            assertTrue(result.needRetry)
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/CleanTaskTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/CleanTaskTaskExecutorTest.kt
@@ -107,9 +107,8 @@ class CleanTaskTaskExecutorTest {
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is FailurePasteTaskResult)
-            val failResult = result as FailurePasteTaskResult
             // First execution (empty history) → retry allowed (history.size < 2)
-            assertTrue(failResult.needRetry)
+            assertTrue(result.needRetry)
         }
 
     @Test
@@ -142,7 +141,6 @@ class CleanTaskTaskExecutorTest {
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is FailurePasteTaskResult)
-            val failResult = result as FailurePasteTaskResult
-            assertTrue(!failResult.needRetry)
+            assertTrue(!result.needRetry)
         }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/DeletePasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/DeletePasteTaskExecutorTest.kt
@@ -82,8 +82,7 @@ class DeletePasteTaskExecutorTest {
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is FailurePasteTaskResult)
-            val failResult = result as FailurePasteTaskResult
-            assertTrue(!failResult.needRetry)
+            assertTrue(!result.needRetry)
         }
 
     @Test


### PR DESCRIPTION
Closes #3913

## Summary
- Remove 8 "No cast needed" warnings by relying on Kotlin smart casts after `assertTrue(x is Type)` contracts
- Remove 1 "Redundant call of conversion method" warning (unnecessary `.toInt()` on an `Int` literal)

## Affected files
- `PasteTaskExtraInfoTest.kt` (3 fixes)
- `PasteCollectionTest.kt` (1 fix)
- `CreatePasteItemHelperTest.kt` (1 fix)
- `CleanPasteTaskExecutorTest.kt` (1 fix)
- `CleanTaskTaskExecutorTest.kt` (2 fixes)
- `DeletePasteTaskExecutorTest.kt` (1 fix)

## Test plan
- [x] CI build passes with zero compiler warnings in test files