### PR TITLE
:bug: Fix encrypted file pull failure, retry duplicate files, and missing cleanup

### DIFF
--- a/shared/src/commonMain/kotlin/com/crosspaste/path/UserDataPathProvider.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/path/UserDataPathProvider.kt
@@ -77,6 +77,7 @@ class UserDataPathProvider(
         pasteFiles: PasteFiles,
         isPull: Boolean,
         filesIndexBuilder: FilesIndexBuilder?,
+        resolveConflicts: Boolean = true,
     ): Map<String, String> {
         val renameMap = mutableMapOf<String, String>()
         val isDownloadDir = pasteFiles.basePath != null
@@ -98,7 +99,7 @@ class UserDataPathProvider(
             val originalName = filePath.name
             fileInfoTreeMap[originalName]?.let { fileInfoTree ->
                 val resolvedName =
-                    if (isPull && isDownloadDir) {
+                    if (isPull && isDownloadDir && resolveConflicts) {
                         val resolved = fileUtils.resolveNonConflictFileName(basePath, originalName)
                         if (resolved != originalName) {
                             renameMap[originalName] = resolved


### PR DESCRIPTION
Closes #3915

## Summary

- **ClientDecryptPlugin**: Fix race condition where `isClosedForRead` returns `false` but `readInt()` throws `IOException` ("Not enough data available") when the channel closes between the check and the read. Catch `IOException` to handle normal end-of-stream gracefully.
- **PullFileTaskExecutor**: Skip filename conflict resolution on retry (`pullChunks.isNotEmpty()`) so retries reuse the same file paths and preserve partial data from successful chunks, instead of creating duplicate files like `photo(1).jpg`.
- **PullFileTaskExecutor**: Add `cleanupPullFiles()` to delete pre-allocated/partially-written files when all 3 retry attempts are exhausted — managed storage directories are deleted recursively, download directory files are deleted individually.
- **UserDataPathProvider**: Add `resolveConflicts` parameter to `resolve()` to support skipping conflict resolution during retries.

## Test plan

- [x] All 209 existing desktop tests pass
- [x] Code compiles cleanly
- [x] ktlintFormat passes
- [x] Manual test: encrypted file sync with intentional network interruption — verify no duplicate files on retry
- [x] Manual test: verify files are cleaned up after 3 failed pull attempts