### PR TITLE
:art: Add missing @Volatile explicit imports

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/secure/SecureSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/secure/SecureSession.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.secure
 
 import kotlinx.coroutines.sync.Mutex
+import kotlin.concurrent.Volatile
 
 data class SecureSession(
     val mutex: Mutex = Mutex(),

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/PasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/PasteSearchViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 
 abstract class PasteSearchViewModel : ViewModel() {
 


### PR DESCRIPTION
Closes #3917

## Summary

- Add explicit `import kotlin.concurrent.Volatile` to `SecureSession.kt` and `PasteSearchViewModel.kt`
- Both files use the `@Volatile` annotation but were missing the explicit import, which can cause compilation issues with newer Kotlin versions