### PR TITLE
Refactor PasteDao: extract PasteReleaseService and PasteTagDao

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -3,61 +3,39 @@ package com.crosspaste.db.paste
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.coroutines.asFlow
 import com.crosspaste.Database
-import com.crosspaste.app.AppFileType
 import com.crosspaste.app.AppInfo
-import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.paste.CurrentPaste
-import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteExportParam
 import com.crosspaste.paste.PasteState
-import com.crosspaste.paste.PasteTag
 import com.crosspaste.paste.SearchContentService
-import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.paste.item.PasteItem
-import com.crosspaste.paste.item.PasteItemProperties
-import com.crosspaste.paste.plugin.process.PasteProcessPlugin
 import com.crosspaste.path.UserDataPathProvider
-import com.crosspaste.task.TaskBuilder
 import com.crosspaste.task.TaskSubmitter
 import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.LoggerExtension.logExecutionTime
-import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.coroutines.withContext
-import kotlin.time.ExperimentalTime
 
 class PasteDao(
     private val appInfo: AppInfo,
-    private val commonConfigManager: CommonConfigManager,
-    private val currentPaste: CurrentPaste,
     private val database: Database,
-    private val pasteProcessPlugins: List<PasteProcessPlugin>,
     private val searchContentService: SearchContentService,
     private val taskSubmitter: TaskSubmitter,
     private val userDataPathProvider: UserDataPathProvider,
 ) {
 
-    companion object {
-        private val fileUtils = getFileUtils()
-    }
-
     private val logger = KotlinLogging.logger {}
 
     private val pasteDatabaseQueries = database.pasteDatabaseQueries
 
-    private val tagDatabaseQueries = database.tagDatabaseQueries
-
     private val markDeleteBatchNum = 50L
 
-    private fun getNoDeletePasteDataBlock(id: Long): PasteData? {
+    fun getNoDeletePasteDataBlock(id: Long): PasteData? {
         return pasteDatabaseQueries.getPasteData(
             id,
             listOf(PasteState.LOADING.toLong(), PasteState.LOADED.toLong()),
@@ -226,86 +204,13 @@ class PasteDao(
             .flowOn(ioDispatcher)
     }
 
-    fun getAllTagsFlow(): Flow<List<PasteTag>> {
-        return tagDatabaseQueries.getAllTags(PasteTag::mapper)
-            .asFlow()
-            .map { it.executeAsList() }
-            .catch { e ->
-                logger.error(e) { "Error executing getAllTagsFlow query: ${e.message}" }
-                emit(listOf())
-            }
-            .flowOn(ioDispatcher)
-    }
-
-    suspend fun getMaxSortOrder(): Long = withContext(ioDispatcher) {
-        tagDatabaseQueries.maxSortOrder().executeAsOne()
-    }
-
-    suspend fun createPasteTag(name: String, color: Long): Long = withContext(ioDispatcher) {
-        database.transactionWithResult {
-            val maxSortOrder = tagDatabaseQueries.maxSortOrder().executeAsOne()
-            val newSortOrder = maxSortOrder + 1
-            tagDatabaseQueries.createTag(name, color, newSortOrder)
-            tagDatabaseQueries.getLastId().executeAsOne()
-        }
-    }
-
-    suspend fun updatePasteTagName(id: Long, name: String) = withContext(ioDispatcher) {
-        tagDatabaseQueries.updateTagName(name, id)
-    }
-
-    suspend fun updatePasteTagColor(id: Long, color: Long) = withContext(ioDispatcher) {
-        tagDatabaseQueries.updateTagColor(color, id)
-    }
-
-    private fun pinPasteTag(pasteDataId: Long, pasteTagId: Long) {
-        tagDatabaseQueries.pinPasteTag(pasteDataId, pasteTagId)
-    }
-
-    private fun unPinPasteTag(pasteDataId: Long, pasteTagId: Long) {
-        tagDatabaseQueries.unPinPasteTag(pasteDataId, pasteTagId)
-    }
-
-    fun switchPinPasteTagBlock(pasteDataId: Long, pasteTagId: Long) {
-        database.transaction {
-            val pinned = tagDatabaseQueries.isPinnedPasteTag(pasteDataId, pasteTagId).executeAsOne()
-            if (pinned) {
-                unPinPasteTag(pasteDataId, pasteTagId)
-            } else {
-                pinPasteTag(pasteDataId, pasteTagId)
-            }
-        }
-    }
-
-    fun getPasteTagsBlock(pasteDataId: Long): List<Long>  {
-        return tagDatabaseQueries.getPasteTags(pasteDataId).executeAsList()
-    }
-
-    fun deletePasteTagBlock(id: Long) {
-        tagDatabaseQueries.deleteTag(id)
-    }
-
-    @OptIn(ExperimentalTime::class)
-    private fun TaskBuilder.markDeleteSameHash(
-        newPasteDataId: Long,
-        newPasteDataType: Int,
-        newPasteDataHash: String,
-    ) {
-        if (newPasteDataHash.isEmpty()) {
-            return
-        }
-
-        val idList = pasteDatabaseQueries.getSameHashPasteDataIds(
-            newPasteDataHash,
-            newPasteDataType.toLong(),
+    fun getSameHashPasteDataIds(hash: String, pasteType: Int, excludeId: Long): List<Long> {
+        return pasteDatabaseQueries.getSameHashPasteDataIds(
+            hash,
+            pasteType.toLong(),
             DateUtils.getOffsetDay(days = -1),
-            newPasteDataId,
+            excludeId,
         ).executeAsList()
-
-        database.transaction {
-            pasteDatabaseQueries.markDeletePasteData(idList)
-            addDeletePasteTasks(idList)
-        }
     }
 
     suspend fun markDeleteByCleanTime(
@@ -477,161 +382,6 @@ class PasteDao(
     suspend fun getDistinctSources(): List<String> = withContext(ioDispatcher) {
         pasteDatabaseQueries.getDistinctSources(appInfo.appInstanceId)
             .executeAsList()
-    }
-
-    suspend fun releaseRemotePasteData(
-        pasteData: PasteData,
-        tryWritePasteboard: (PasteData) -> Unit,
-    ): Result<Unit> {
-        return runCatching {
-            val remotePasteDataId = pasteData.id
-            val isFileType = pasteData.isFileType()
-            val existIconFile: Boolean? =
-                pasteData.source?.let {
-                    fileUtils.existFile(userDataPathProvider.resolve("$it.png", AppFileType.ICON))
-                }
-
-            val pasteState = if (isFileType) {
-                PasteState.LOADING
-            } else {
-                PasteState.LOADED
-            }
-
-            val id = createPasteData(pasteData, pasteState)
-
-            taskSubmitter.submit {
-                if (!isFileType) {
-                    markDeleteSameHash(id, pasteData.pasteType, pasteData.hash)
-                    addRenderingTask(id, pasteData.getType())
-                    tryWritePasteboard(pasteData)
-                } else {
-                    val pasteFiles = pasteData.getPasteItem(PasteFiles::class)
-
-                    if (pasteFiles == null) {
-                        logger.warn { "File-type paste $id has no PasteFiles item, skipping" }
-                        return@submit
-                    }
-
-                    val fileSize = pasteFiles.size
-                    val maxBackupFileSize =
-                        fileUtils.bytesSize(
-                            commonConfigManager.getCurrentConfig().maxBackupFileSize,
-                        )
-
-                    val syncToDownload =
-                        fileSize > maxBackupFileSize ||
-                            pasteData.pasteAppearItem?.extraInfo
-                                ?.get(PasteItemProperties.SYNC_TO_DOWNLOAD)
-                                ?.jsonPrimitive?.booleanOrNull == true
-
-                    val pasteCoordinate = pasteData.getPasteCoordinate(id)
-                    val pasteAppearItem = pasteData.pasteAppearItem
-                    val pasteCollection = pasteData.pasteCollection
-
-                    val newPasteAppearItem = pasteAppearItem?.bind(pasteCoordinate, syncToDownload)
-                    val newPasteCollection = pasteCollection.bind(pasteCoordinate, syncToDownload)
-
-                    val newPasteData = pasteData.copy(
-                        id = id,
-                        pasteAppearItem = newPasteAppearItem,
-                        pasteCollection = newPasteCollection,
-                    )
-
-                    updateFilePath(newPasteData)
-
-                    addPullFileTask(id, remotePasteDataId)
-                    addRelaySyncTask(id, newPasteData.appInstanceId)
-                }
-
-                existIconFile?.let {
-                    addPullIconTask(id, it)
-                }
-            }
-        }.onFailure { e ->
-            logger.error(e) { "Release remote paste data failed" }
-        }
-    }
-
-    suspend fun releaseRemotePasteDataWithFile(
-        id: Long,
-        tryWritePasteboard: (PasteData) -> Unit,
-    ): Result<Unit> = withContext(ioDispatcher) {
-        runCatching {
-            taskSubmitter.submit {
-                database.transactionWithResult {
-                    pasteDatabaseQueries.updatePasteDataState(PasteState.LOADED.toLong(), id)
-                    getNoDeletePasteDataBlock(id)
-                }?.let {
-                    markDeleteSameHash(id, it.pasteType, it.hash)
-                    addRelaySyncTask(id, it.appInstanceId)
-                    tryWritePasteboard(it)
-                }
-            }
-        }.onFailure { e ->
-            logger.error(e) { "Release remote paste data with file failed" }
-        }
-    }
-
-    suspend fun releaseLocalPasteData(id: Long, pasteItems: List<PasteItem>) = withContext(ioDispatcher) {
-        getLoadingPasteData(id)?.let { pasteData ->
-            var pasteAppearItems = pasteItems
-            for (pastePlugin in pasteProcessPlugins) {
-                pasteAppearItems = pastePlugin.process(
-                    pasteData.getPasteCoordinate(),
-                    pasteAppearItems,
-                    pasteData.source,
-                )
-            }
-
-            if (pasteAppearItems.isEmpty()) {
-                markDeletePasteData(id)
-                return@let
-            }
-
-            val size = pasteAppearItems.sumOf { it.size }
-            val maxFileSize = pasteAppearItems.filter { it is PasteFiles }
-                .maxByOrNull { it.size }
-                ?.size ?: 0
-            // first item as pasteAppearItem
-            // remaining items as pasteContent
-            val firstItem: PasteItem = pasteAppearItems.first()
-            val remainingItems: List<PasteItem> = pasteAppearItems.drop(1)
-
-            val hash = firstItem.hash
-            val pasteType = firstItem.getPasteType()
-
-            val change = database.transactionWithResult {
-                pasteDatabaseQueries.updatePasteDataToLoaded(
-                    pasteAppearItem = firstItem.toJson(),
-                    pasteCollection = PasteCollection(remainingItems).toJson(),
-                    pasteType = pasteType.type.toLong(),
-                    pasteSearchContent = searchContentService.createSearchContent(
-                        pasteData.source,
-                        firstItem.getSearchContent(),
-                    ),
-                    size = size,
-                    hash = hash,
-                    id = id,
-                )
-                pasteDatabaseQueries.change().executeAsOne() > 0
-            }
-
-            if (change) {
-                currentPaste.setPasteId(id)
-                taskSubmitter.submit {
-                    addRenderingTask(id, pasteType)
-                    addSyncTask(id, pasteData.appInstanceId, maxFileSize)
-
-                    if (pasteType.isFile() || pasteType.isImage()) {
-                        if ((firstItem as PasteFiles).isRefFiles()) {
-                            markDeleteSameHash(id, pasteType.type, hash)
-                        }
-                    } else {
-                        markDeleteSameHash(id, pasteType.type, hash)
-                    }
-                }
-            }
-        }
     }
 
     suspend fun getPasteResourceInfo(favorite: Boolean? = null): PasteResourceInfo = withContext(ioDispatcher) {

--- a/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteTagDao.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteTagDao.kt
@@ -1,0 +1,80 @@
+package com.crosspaste.db.paste
+
+import app.cash.sqldelight.coroutines.asFlow
+import com.crosspaste.Database
+import com.crosspaste.paste.PasteTag
+import com.crosspaste.utils.ioDispatcher
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+class PasteTagDao(
+    private val database: Database,
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val tagDatabaseQueries = database.tagDatabaseQueries
+
+    fun getAllTagsFlow(): Flow<List<PasteTag>> {
+        return tagDatabaseQueries.getAllTags(PasteTag::mapper)
+            .asFlow()
+            .map { it.executeAsList() }
+            .catch { e ->
+                logger.error(e) { "Error executing getAllTagsFlow query: ${e.message}" }
+                emit(listOf())
+            }
+            .flowOn(ioDispatcher)
+    }
+
+    suspend fun getMaxSortOrder(): Long = withContext(ioDispatcher) {
+        tagDatabaseQueries.maxSortOrder().executeAsOne()
+    }
+
+    suspend fun createPasteTag(name: String, color: Long): Long = withContext(ioDispatcher) {
+        database.transactionWithResult {
+            val maxSortOrder = tagDatabaseQueries.maxSortOrder().executeAsOne()
+            val newSortOrder = maxSortOrder + 1
+            tagDatabaseQueries.createTag(name, color, newSortOrder)
+            tagDatabaseQueries.getLastId().executeAsOne()
+        }
+    }
+
+    suspend fun updatePasteTagName(id: Long, name: String) = withContext(ioDispatcher) {
+        tagDatabaseQueries.updateTagName(name, id)
+    }
+
+    suspend fun updatePasteTagColor(id: Long, color: Long) = withContext(ioDispatcher) {
+        tagDatabaseQueries.updateTagColor(color, id)
+    }
+
+    fun switchPinPasteTagBlock(pasteDataId: Long, pasteTagId: Long) {
+        database.transaction {
+            val pinned = tagDatabaseQueries.isPinnedPasteTag(pasteDataId, pasteTagId).executeAsOne()
+            if (pinned) {
+                unPinPasteTag(pasteDataId, pasteTagId)
+            } else {
+                pinPasteTag(pasteDataId, pasteTagId)
+            }
+        }
+    }
+
+    fun getPasteTagsBlock(pasteDataId: Long): List<Long> {
+        return tagDatabaseQueries.getPasteTags(pasteDataId).executeAsList()
+    }
+
+    fun deletePasteTagBlock(id: Long) {
+        tagDatabaseQueries.deleteTag(id)
+    }
+
+    private fun pinPasteTag(pasteDataId: Long, pasteTagId: Long) {
+        tagDatabaseQueries.pinPasteTag(pasteDataId, pasteTagId)
+    }
+
+    private fun unPinPasteTag(pasteDataId: Long, pasteTagId: Long) {
+        tagDatabaseQueries.unPinPasteTag(pasteDataId, pasteTagId)
+    }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
@@ -17,6 +17,7 @@ class PasteCollector(
     itemCount: Int,
     private val appInfo: AppInfo,
     private val pasteDao: PasteDao,
+    private val pasteReleaseService: PasteReleaseService,
     private val dragAndDrop: Boolean = false,
 ) {
 
@@ -120,7 +121,7 @@ class PasteCollector(
                                 }
                             }
                     }
-                    pasteDao.releaseLocalPasteData(id, pasteItems)
+                    pasteReleaseService.releaseLocalPasteData(id, pasteItems)
                 }.onFailure { e ->
                     logger.error(e) { "Failed to complete paste $id" }
                     markDeletePasteData(id)

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -1,0 +1,230 @@
+package com.crosspaste.paste
+
+import com.crosspaste.Database
+import com.crosspaste.app.AppFileType
+import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.item.PasteFiles
+import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.paste.item.PasteItemProperties
+import com.crosspaste.paste.plugin.process.PasteProcessPlugin
+import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.task.TaskBuilder
+import com.crosspaste.task.TaskSubmitter
+import com.crosspaste.utils.getFileUtils
+import com.crosspaste.utils.ioDispatcher
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.time.ExperimentalTime
+
+class PasteReleaseService(
+    private val commonConfigManager: CommonConfigManager,
+    private val currentPaste: CurrentPaste,
+    private val database: Database,
+    private val pasteDao: PasteDao,
+    private val pasteProcessPlugins: List<PasteProcessPlugin>,
+    private val searchContentService: SearchContentService,
+    private val taskSubmitter: TaskSubmitter,
+    private val userDataPathProvider: UserDataPathProvider,
+) {
+
+    companion object {
+        private val fileUtils = getFileUtils()
+    }
+
+    private val logger = KotlinLogging.logger {}
+
+    @OptIn(ExperimentalTime::class)
+    private fun TaskBuilder.markDeleteSameHash(
+        newPasteDataId: Long,
+        newPasteDataType: Int,
+        newPasteDataHash: String,
+    ) {
+        if (newPasteDataHash.isEmpty()) {
+            return
+        }
+
+        val idList =
+            pasteDao.getSameHashPasteDataIds(
+                newPasteDataHash,
+                newPasteDataType,
+                newPasteDataId,
+            )
+
+        database.transaction {
+            database.pasteDatabaseQueries.markDeletePasteData(idList)
+            addDeletePasteTasks(idList)
+        }
+    }
+
+    suspend fun releaseLocalPasteData(
+        id: Long,
+        pasteItems: List<PasteItem>,
+    ) = withContext(ioDispatcher) {
+        pasteDao.getLoadingPasteData(id)?.let { pasteData ->
+            var pasteAppearItems = pasteItems
+            for (pastePlugin in pasteProcessPlugins) {
+                pasteAppearItems =
+                    pastePlugin.process(
+                        pasteData.getPasteCoordinate(),
+                        pasteAppearItems,
+                        pasteData.source,
+                    )
+            }
+
+            if (pasteAppearItems.isEmpty()) {
+                pasteDao.markDeletePasteData(id)
+                return@let
+            }
+
+            val size = pasteAppearItems.sumOf { it.size }
+            val maxFileSize =
+                pasteAppearItems
+                    .filter { it is PasteFiles }
+                    .maxByOrNull { it.size }
+                    ?.size ?: 0
+            // first item as pasteAppearItem
+            // remaining items as pasteContent
+            val firstItem: PasteItem = pasteAppearItems.first()
+            val remainingItems: List<PasteItem> = pasteAppearItems.drop(1)
+
+            val hash = firstItem.hash
+            val pasteType = firstItem.getPasteType()
+
+            val change =
+                database.transactionWithResult {
+                    database.pasteDatabaseQueries.updatePasteDataToLoaded(
+                        pasteAppearItem = firstItem.toJson(),
+                        pasteCollection = PasteCollection(remainingItems).toJson(),
+                        pasteType = pasteType.type.toLong(),
+                        pasteSearchContent =
+                            searchContentService.createSearchContent(
+                                pasteData.source,
+                                firstItem.getSearchContent(),
+                            ),
+                        size = size,
+                        hash = hash,
+                        id = id,
+                    )
+                    database.pasteDatabaseQueries.change().executeAsOne() > 0
+                }
+
+            if (change) {
+                currentPaste.setPasteId(id)
+                taskSubmitter.submit {
+                    addRenderingTask(id, pasteType)
+                    addSyncTask(id, pasteData.appInstanceId, maxFileSize)
+
+                    if (pasteType.isFile() || pasteType.isImage()) {
+                        if ((firstItem as PasteFiles).isRefFiles()) {
+                            markDeleteSameHash(id, pasteType.type, hash)
+                        }
+                    } else {
+                        markDeleteSameHash(id, pasteType.type, hash)
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun releaseRemotePasteData(
+        pasteData: PasteData,
+        tryWritePasteboard: (PasteData) -> Unit,
+    ): Result<Unit> {
+        return runCatching {
+            val remotePasteDataId = pasteData.id
+            val isFileType = pasteData.isFileType()
+            val existIconFile: Boolean? =
+                pasteData.source?.let {
+                    fileUtils.existFile(userDataPathProvider.resolve("$it.png", AppFileType.ICON))
+                }
+
+            val pasteState =
+                if (isFileType) {
+                    PasteState.LOADING
+                } else {
+                    PasteState.LOADED
+                }
+
+            val id = pasteDao.createPasteData(pasteData, pasteState)
+
+            taskSubmitter.submit {
+                if (!isFileType) {
+                    markDeleteSameHash(id, pasteData.pasteType, pasteData.hash)
+                    addRenderingTask(id, pasteData.getType())
+                    tryWritePasteboard(pasteData)
+                } else {
+                    val pasteFiles = pasteData.getPasteItem(PasteFiles::class)
+
+                    if (pasteFiles == null) {
+                        logger.warn { "File-type paste $id has no PasteFiles item, skipping" }
+                        return@submit
+                    }
+
+                    val fileSize = pasteFiles.size
+                    val maxBackupFileSize =
+                        fileUtils.bytesSize(
+                            commonConfigManager.getCurrentConfig().maxBackupFileSize,
+                        )
+
+                    val syncToDownload =
+                        fileSize > maxBackupFileSize ||
+                            pasteData.pasteAppearItem
+                                ?.extraInfo
+                                ?.get(PasteItemProperties.SYNC_TO_DOWNLOAD)
+                                ?.jsonPrimitive
+                                ?.booleanOrNull == true
+
+                    val pasteCoordinate = pasteData.getPasteCoordinate(id)
+                    val pasteAppearItem = pasteData.pasteAppearItem
+                    val pasteCollection = pasteData.pasteCollection
+
+                    val newPasteAppearItem = pasteAppearItem?.bind(pasteCoordinate, syncToDownload)
+                    val newPasteCollection = pasteCollection.bind(pasteCoordinate, syncToDownload)
+
+                    val newPasteData =
+                        pasteData.copy(
+                            id = id,
+                            pasteAppearItem = newPasteAppearItem,
+                            pasteCollection = newPasteCollection,
+                        )
+
+                    pasteDao.updateFilePath(newPasteData)
+
+                    addPullFileTask(id, remotePasteDataId)
+                    addRelaySyncTask(id, newPasteData.appInstanceId)
+                }
+
+                existIconFile?.let {
+                    addPullIconTask(id, it)
+                }
+            }
+        }.onFailure { e ->
+            logger.error(e) { "Release remote paste data failed" }
+        }
+    }
+
+    suspend fun releaseRemotePasteDataWithFile(
+        id: Long,
+        tryWritePasteboard: (PasteData) -> Unit,
+    ): Result<Unit> =
+        withContext(ioDispatcher) {
+            runCatching {
+                taskSubmitter.submit {
+                    database
+                        .transactionWithResult {
+                            database.pasteDatabaseQueries.updatePasteDataState(PasteState.LOADED.toLong(), id)
+                            pasteDao.getNoDeletePasteDataBlock(id)
+                        }?.let {
+                            markDeleteSameHash(id, it.pasteType, it.hash)
+                            addRelaySyncTask(id, it.appInstanceId)
+                            tryWritePasteboard(it)
+                        }
+                }
+            }.onFailure { e ->
+                logger.error(e) { "Release remote paste data with file failed" }
+            }
+        }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteboardService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteboardService.kt
@@ -1,7 +1,6 @@
 package com.crosspaste.paste
 
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.paste.item.PasteItem
 import io.github.oshai.kotlinlogging.KLogger
 import kotlinx.coroutines.CoroutineScope
@@ -14,7 +13,7 @@ interface PasteboardService : PasteboardMonitor {
 
     var owner: Boolean
 
-    val pasteDao: PasteDao
+    val pasteReleaseService: PasteReleaseService
 
     val configManager: CommonConfigManager
 
@@ -53,6 +52,4 @@ interface PasteboardService : PasteboardMonitor {
     suspend fun tryWriteRemotePasteboard(pasteData: PasteData): Result<Unit?>
 
     suspend fun tryWriteRemotePasteboardWithFile(pasteData: PasteData): Result<Unit?>
-
-    suspend fun clearRemotePasteboard(pasteData: PasteData): Result<Unit?>
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
@@ -265,7 +265,7 @@ class PullFileTaskExecutor(
         if (!needRetry) {
             logger.error { "exist pull chunk fail" }
             cleanupPullFiles(pasteData)
-            pasteboardService.clearRemotePasteboard(pasteData)
+            pasteDao.markDeletePasteData(pasteData.id)
             soundService.errorSound()
         }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
@@ -2,6 +2,7 @@ package com.crosspaste.ui.model
 
 import androidx.lifecycle.viewModelScope
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteTag
 import com.crosspaste.paste.SearchContentService
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.stateIn
 
 class GeneralPasteSearchViewModel(
     private val pasteDao: PasteDao,
+    pasteTagDao: PasteTagDao,
     private val searchContentService: SearchContentService,
 ) : PasteSearchViewModel() {
 
@@ -24,7 +26,7 @@ class GeneralPasteSearchViewModel(
     override val convertTerm: (String) -> List<String> = searchContentService::createSearchTerms
 
     override val tagList: StateFlow<List<PasteTag>> =
-        pasteDao
+        pasteTagDao
             .getAllTagsFlow()
             .stateIn(
                 scope = viewModelScope,

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -45,6 +45,7 @@ import com.crosspaste.db.DesktopDriverFactory
 import com.crosspaste.db.DriverFactory
 import com.crosspaste.db.createDatabase
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.db.secure.SecureDao
 import com.crosspaste.db.secure.SecureIO
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
@@ -131,6 +132,7 @@ import com.crosspaste.paste.PasteExportParamFactory
 import com.crosspaste.paste.PasteExportService
 import com.crosspaste.paste.PasteImportParamFactory
 import com.crosspaste.paste.PasteImportService
+import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteSyncProcessManager
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.paste.SearchContentService
@@ -318,27 +320,13 @@ class DesktopModule(
             single<PasteDao> {
                 PasteDao(
                     appInfo = get(),
-                    commonConfigManager = get(),
-                    currentPaste = get(),
                     database = get(),
-                    pasteProcessPlugins =
-                        listOf(
-                            RemoveInvalidPlugin,
-                            DistinctPlugin(get()),
-                            GenerateTextPlugin,
-                            GenerateUrlPlugin,
-                            TextToColorPlugin,
-                            FilesToImagesPlugin(get()),
-                            FileToUrlPlugin(get()),
-                            RemoveFolderImagePlugin(get()),
-                            RemoveHtmlImagePlugin(get()),
-                            SortPlugin,
-                        ),
                     searchContentService = get(),
                     taskSubmitter = get(),
                     userDataPathProvider = get(),
                 )
             }
+            single<PasteTagDao> { PasteTagDao(get()) }
             single<SecureIO> { SecureDao(get()) }
             single<SyncRuntimeInfoDao> { SyncRuntimeInfoDao(get()) }
             single<TaskDao> { TaskDao(get()) }
@@ -349,8 +337,8 @@ class DesktopModule(
         module {
             single<ExceptionHandler> { DesktopExceptionHandler() }
             single<FaviconLoader> { DesktopFaviconLoader(get(), get()) }
-            single<McpToolProvider> { McpToolProvider(get(), get(), get()) }
             single<McpResourceProvider> { McpResourceProvider(get()) }
+            single<McpToolProvider> { McpToolProvider(get(), get(), get(), get()) }
             single<McpServer> {
                 DesktopMcpServer(
                     mcpPort = (get<DesktopConfigManager>().getCurrentConfig()).mcpServerPort,
@@ -465,10 +453,34 @@ class DesktopModule(
                 OpenGraphService(get(), get<ImageHandler<BufferedImage>>(), get(), get(), get())
             }
             single<DesktopPasteMenuService> {
-                DesktopPasteMenuService(get(), get(), get(), get(), get(), get(), get(), get(), get())
+                DesktopPasteMenuService(get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
             }
             single<DesktopPasteTagMenuService> {
                 DesktopPasteTagMenuService(get(), get())
+            }
+            single<PasteReleaseService> {
+                PasteReleaseService(
+                    commonConfigManager = get(),
+                    currentPaste = get(),
+                    database = get(),
+                    pasteDao = get(),
+                    pasteProcessPlugins =
+                        listOf(
+                            RemoveInvalidPlugin,
+                            DistinctPlugin(get()),
+                            GenerateTextPlugin,
+                            GenerateUrlPlugin,
+                            TextToColorPlugin,
+                            FilesToImagesPlugin(get()),
+                            FileToUrlPlugin(get()),
+                            RemoveFolderImagePlugin(get()),
+                            RemoveHtmlImagePlugin(get()),
+                            SortPlugin,
+                        ),
+                    searchContentService = get(),
+                    taskSubmitter = get(),
+                    userDataPathProvider = get(),
+                )
             }
             single<GenerateImageService> { GenerateImageService() }
             single<GuidePasteDataService> { DesktopGuidePasteDataService(get(), get(), get(), get(), get()) }
@@ -477,7 +489,18 @@ class DesktopModule(
                 if (headless) {
                     HeadlessPasteboardService(get(), get())
                 } else {
-                    getDesktopPasteboardService(get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
+                    getDesktopPasteboardService(
+                        get(),
+                        get(),
+                        get(),
+                        get(),
+                        get(),
+                        get(),
+                        get(),
+                        get(),
+                        get(),
+                        get(),
+                    )
                 }
             }
             single<PasteExportParamFactory<Path>> { DesktopPasteExportParamFactory() }
@@ -508,6 +531,7 @@ class DesktopModule(
             single<TaskSubmitter> { DesktopTaskSubmitter(get(), get(), get(), lazy { get() }) }
             single<TransferableConsumer> {
                 DesktopTransferableConsumer(
+                    get(),
                     get(),
                     get(),
                     listOf(
@@ -598,7 +622,7 @@ class DesktopModule(
                 if (marketingMode) {
                     MarketingPasteSearchViewModel(get())
                 } else {
-                    GeneralPasteSearchViewModel(get(), get())
+                    GeneralPasteSearchViewModel(get(), get(), get())
                 }
             }
             single<PasteSelectionViewModel> { PasteSelectionViewModel(get(), get(), get()) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessPasteboardService.kt
@@ -1,8 +1,8 @@
 package com.crosspaste.headless
 
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.utils.ioDispatcher
@@ -14,7 +14,7 @@ import kotlinx.coroutines.channels.Channel
 
 class HeadlessPasteboardService(
     override val configManager: CommonConfigManager,
-    override val pasteDao: PasteDao,
+    override val pasteReleaseService: PasteReleaseService,
 ) : PasteboardService {
 
     override val logger: KLogger = KotlinLogging.logger {}
@@ -65,19 +65,16 @@ class HeadlessPasteboardService(
         }
 
     override suspend fun tryWriteRemotePasteboard(pasteData: PasteData): Result<Unit?> =
-        pasteDao.releaseRemotePasteData(pasteData) {
+        pasteReleaseService.releaseRemotePasteData(pasteData) {
             remotePasteboardChannel.trySend {
                 tryWritePasteboard(pasteData = it, localOnly = true)
             }
         }
 
     override suspend fun tryWriteRemotePasteboardWithFile(pasteData: PasteData): Result<Unit?> =
-        pasteDao.releaseRemotePasteDataWithFile(pasteData.id) {
+        pasteReleaseService.releaseRemotePasteDataWithFile(pasteData.id) {
             remotePasteboardChannel.trySend {
                 tryWritePasteboard(pasteData = it, localOnly = true)
             }
         }
-
-    override suspend fun clearRemotePasteboard(pasteData: PasteData): Result<Unit?> =
-        pasteDao.markDeletePasteData(pasteData.id)
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpToolProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpToolProvider.kt
@@ -3,6 +3,7 @@ package com.crosspaste.mcp
 import androidx.compose.ui.graphics.toArgb
 import com.crosspaste.app.AppInfo
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteState
@@ -47,6 +48,7 @@ import okio.Path.Companion.toPath
 class McpToolProvider(
     private val appInfo: AppInfo,
     private val pasteDao: PasteDao,
+    private val pasteTagDao: PasteTagDao,
     private val searchContentService: SearchContentService,
 ) {
     private val fileUtils = getFileUtils()
@@ -235,7 +237,7 @@ class McpToolProvider(
             name = "list_tags",
             description = "List all clipboard tags for organizing paste items.",
         ) { _ ->
-            val tags = pasteDao.getAllTagsFlow().first()
+            val tags = pasteTagDao.getAllTagsFlow().first()
             val text =
                 if (tags.isEmpty()) {
                     "No tags found."

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/AbstractPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/AbstractPasteboardService.kt
@@ -103,7 +103,7 @@ abstract class AbstractPasteboardService :
     }
 
     override suspend fun tryWriteRemotePasteboard(pasteData: PasteData): Result<Unit?> =
-        pasteDao.releaseRemotePasteData(pasteData) { storePasteData ->
+        pasteReleaseService.releaseRemotePasteData(pasteData) { storePasteData ->
             remotePasteboardChannel
                 .trySend {
                     tryWritePasteboard(
@@ -122,7 +122,7 @@ abstract class AbstractPasteboardService :
         }
 
     override suspend fun tryWriteRemotePasteboardWithFile(pasteData: PasteData): Result<Unit?> =
-        pasteDao.releaseRemotePasteDataWithFile(pasteData.id) { storePasteData ->
+        pasteReleaseService.releaseRemotePasteDataWithFile(pasteData.id) { storePasteData ->
             remotePasteboardChannel
                 .trySend {
                     tryWritePasteboard(
@@ -139,9 +139,6 @@ abstract class AbstractPasteboardService :
                     logger.error(e) { "Failed to send remote pasteboard task to channel" }
                 }
         }
-
-    override suspend fun clearRemotePasteboard(pasteData: PasteData): Result<Unit?> =
-        pasteDao.markDeletePasteData(pasteData.id)
 
     @Synchronized
     override fun toggle() {

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
@@ -14,6 +14,7 @@ import com.crosspaste.app.AppWindowManager
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.app.WindowTrigger
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.image.OCRModule
 import com.crosspaste.notification.MessageType
@@ -47,6 +48,7 @@ class DesktopPasteMenuService(
     private val notificationManager: NotificationManager,
     private val pasteboardService: PasteboardService,
     private val pasteDao: PasteDao,
+    private val pasteTagDao: PasteTagDao,
     private val pasteSearchViewModel: PasteSearchViewModel,
     private val ocrModule: OCRModule,
     private val uiSupport: UISupport,
@@ -253,13 +255,13 @@ class DesktopPasteMenuService(
                     },
                 )
             } else {
-                val tagIdList = pasteDao.getPasteTagsBlock(pasteData.id)
+                val tagIdList = pasteTagDao.getPasteTagsBlock(pasteData.id)
 
                 tagList.map { tag ->
                     MaterialContextMenuItem(
                         label = tag.name,
                         onClick = {
-                            pasteDao.switchPinPasteTagBlock(pasteData.id, tag.id)
+                            pasteTagDao.switchPinPasteTagBlock(pasteData.id, tag.id)
                         },
                         leadingIcon = {
                             Box(

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteTagMenuService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteTagMenuService.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.ui.paste.PasteTagScope
 import com.crosspaste.ui.theme.AppUISize.large2X
@@ -31,7 +31,7 @@ import kotlinx.coroutines.launch
 
 class DesktopPasteTagMenuService(
     private val copywriter: GlobalCopywriter,
-    private val pasteDao: PasteDao,
+    private val pasteTagDao: PasteTagDao,
 ) {
 
     fun menuItemsProvider(tagScope: PasteTagScope): () -> List<ContextMenuItem> =
@@ -40,10 +40,10 @@ class DesktopPasteTagMenuService(
                 ContextMenuItem(copywriter.getText("rename")) {
                     tagScope.startEditing()
                 },
-                TagColorsMenuItem(tagScope, pasteDao),
+                TagColorsMenuItem(tagScope, pasteTagDao),
                 ContextMenuDivider,
                 ContextMenuItem(copywriter.getText("delete")) {
-                    pasteDao.deletePasteTagBlock(tagScope.tag.id)
+                    pasteTagDao.deletePasteTagBlock(tagScope.tag.id)
                 },
             )
         }
@@ -51,7 +51,7 @@ class DesktopPasteTagMenuService(
 
 class TagColorsMenuItem(
     private val tagScope: PasteTagScope,
-    private val pasteDao: PasteDao,
+    private val pasteTagDao: PasteTagDao,
 ) : GenericContextMenuItem() {
     @Composable
     override fun Content(
@@ -76,7 +76,7 @@ class TagColorsMenuItem(
                     isSelected = isSelected,
                     onClick = {
                         scope.launch {
-                            pasteDao.updatePasteTagColor(tagScope.tag.id, colorVal)
+                            pasteTagDao.updatePasteTagColor(tagScope.tag.id, colorVal)
                         }
                         onDismissRequest()
                     },

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteboardService.kt
@@ -2,7 +2,6 @@ package com.crosspaste.paste
 
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.platform.Platform
 import com.crosspaste.sound.SoundService
@@ -14,7 +13,7 @@ fun getDesktopPasteboardService(
     notificationManager: NotificationManager,
     pasteConsumer: TransferableConsumer,
     pasteProducer: TransferableProducer,
-    pasteDao: PasteDao,
+    pasteReleaseService: PasteReleaseService,
     platform: Platform,
     soundService: SoundService,
     sourceExclusionService: DesktopSourceExclusionService,
@@ -27,7 +26,7 @@ fun getDesktopPasteboardService(
             notificationManager,
             pasteConsumer,
             pasteProducer,
-            pasteDao,
+            pasteReleaseService,
             soundService,
             sourceExclusionService,
         )
@@ -39,7 +38,7 @@ fun getDesktopPasteboardService(
             notificationManager,
             pasteConsumer,
             pasteProducer,
-            pasteDao,
+            pasteReleaseService,
             platform,
             soundService,
             sourceExclusionService,
@@ -52,7 +51,7 @@ fun getDesktopPasteboardService(
             notificationManager,
             pasteConsumer,
             pasteProducer,
-            pasteDao,
+            pasteReleaseService,
             soundService,
             sourceExclusionService,
         )

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
@@ -9,6 +9,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 class DesktopTransferableConsumer(
     private val appInfo: AppInfo,
     private val pasteDao: PasteDao,
+    private val pasteReleaseService: PasteReleaseService,
     pasteTypePlugins: List<PasteTypePlugin>,
 ) : TransferableConsumer {
 
@@ -48,7 +49,8 @@ class DesktopTransferableConsumer(
                     return@logSuspendExecutionTime
                 }
 
-                val pasteCollector = PasteCollector(dataFlavorMap.size, appInfo, pasteDao, dragAndDrop)
+                val pasteCollector =
+                    PasteCollector(dataFlavorMap.size, appInfo, pasteDao, pasteReleaseService, dragAndDrop)
 
                 preCollect(dataFlavorMap, pasteTransferable, pasteCollector)
                 pasteCollector.createPrePasteData(source, remote = remote)?.also { id ->

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/LinuxPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/LinuxPasteboardService.kt
@@ -2,7 +2,6 @@ package com.crosspaste.paste
 
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.platform.linux.api.X11Api
 import com.crosspaste.platform.linux.api.XFixes
@@ -31,7 +30,7 @@ class LinuxPasteboardService(
     override val notificationManager: NotificationManager,
     override val pasteConsumer: TransferableConsumer,
     override val pasteProducer: TransferableProducer,
-    override val pasteDao: PasteDao,
+    override val pasteReleaseService: PasteReleaseService,
     override val soundService: SoundService,
     override val sourceExclusionService: DesktopSourceExclusionService,
 ) : AbstractPasteboardService() {

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
@@ -3,7 +3,6 @@ package com.crosspaste.paste
 import com.crosspaste.app.AppName
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.platform.macos.api.MacosApi
 import com.crosspaste.sound.SoundService
@@ -27,7 +26,7 @@ class MacosPasteboardService(
     override val notificationManager: NotificationManager,
     override val pasteConsumer: TransferableConsumer,
     override val pasteProducer: TransferableProducer,
-    override val pasteDao: PasteDao,
+    override val pasteReleaseService: PasteReleaseService,
     override val soundService: SoundService,
     override val sourceExclusionService: DesktopSourceExclusionService,
 ) : AbstractPasteboardService() {

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
@@ -3,7 +3,6 @@ package com.crosspaste.paste
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.config.DesktopConfigManager
-import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.paste.item.PasteText
@@ -38,7 +37,7 @@ class WindowsPasteboardService(
     override val notificationManager: NotificationManager,
     override val pasteConsumer: TransferableConsumer,
     override val pasteProducer: TransferableProducer,
-    override val pasteDao: PasteDao,
+    override val pasteReleaseService: PasteReleaseService,
     private val platform: Platform,
     override val soundService: SoundService,
     override val sourceExclusionService: DesktopSourceExclusionService,

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/SearchTagsView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/SearchTagsView.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Add
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.paste.DesktopPasteTagMenuService
 import com.crosspaste.paste.PasteTag
@@ -44,7 +44,7 @@ import org.koin.compose.koinInject
 @Composable
 fun SearchTagsView() {
     val copywriter = koinInject<GlobalCopywriter>()
-    val pasteDao = koinInject<PasteDao>()
+    val pasteTagDao = koinInject<PasteTagDao>()
     val pasteSearchViewModel = koinInject<PasteSearchViewModel>()
     val tagMenuService = koinInject<DesktopPasteTagMenuService>()
 
@@ -87,9 +87,9 @@ fun SearchTagsView() {
             if (editingMap[tag.id] == true) {
                 tagScope.EditableTagChip { name ->
                     if (name.isBlank()) {
-                        pasteDao.deletePasteTagBlock(tag.id)
+                        pasteTagDao.deletePasteTagBlock(tag.id)
                     } else {
-                        pasteDao.updatePasteTagName(tag.id, name)
+                        pasteTagDao.updatePasteTagName(tag.id, name)
                     }
                     tagScope.stopEditing()
                 }
@@ -116,7 +116,7 @@ fun SearchTagsView() {
                 scope.EditableTagChip { name ->
                     newTag = null
                     if (!name.isBlank()) {
-                        pasteDao.createPasteTag(name, it.color)
+                        pasteTagDao.createPasteTag(name, it.color)
                     }
                     PasteTagScope.resetEditing()
                 }
@@ -130,7 +130,7 @@ fun SearchTagsView() {
                         newTag =
                             createDefaultPasteTag(
                                 name = copywriter.getText("unnamed"),
-                                maxSortOrder = pasteDao.getMaxSortOrder(),
+                                maxSortOrder = pasteTagDao.getMaxSortOrder(),
                             )
                         PasteTagScope.resetEditing()
                     }

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
@@ -2,10 +2,8 @@ package com.crosspaste.db.paste
 
 import app.cash.turbine.test
 import com.crosspaste.app.AppInfo
-import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.TestDriverFactory
 import com.crosspaste.db.createDatabase
-import com.crosspaste.paste.CurrentPaste
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteState
@@ -52,8 +50,6 @@ class PasteDaoTest {
         }
     }
 
-    private val commonConfigManager: CommonConfigManager = mockk(relaxed = true)
-    private val currentPaste: CurrentPaste = mockk(relaxed = true)
     private val taskSubmitter: TaskSubmitter = mockk(relaxed = true)
     private val userDataPathProvider = mockk<com.crosspaste.path.UserDataPathProvider>(relaxed = true)
 
@@ -61,14 +57,13 @@ class PasteDaoTest {
 
     private val pasteDao = PasteDao(
         appInfo = appInfo,
-        commonConfigManager = commonConfigManager,
-        currentPaste = currentPaste,
         database = database,
-        pasteProcessPlugins = listOf(),
         searchContentService = searchContentService,
         taskSubmitter = taskSubmitter,
         userDataPathProvider = userDataPathProvider,
     )
+
+    private val pasteTagDao = PasteTagDao(database)
 
     private fun createTestPasteData(
         text: String = "hello world",
@@ -378,16 +373,16 @@ class PasteDaoTest {
 
     @Test
     fun `createPasteTag returns valid id`() = runTest {
-        val tagId = pasteDao.createPasteTag("important", 0xFF0000L)
+        val tagId = pasteTagDao.createPasteTag("important", 0xFF0000L)
         assertTrue(tagId > 0)
     }
 
     @Test
     fun `updatePasteTagName changes tag name`() = runTest {
-        val tagId = pasteDao.createPasteTag("old_name", 0xFF0000L)
-        pasteDao.updatePasteTagName(tagId, "new_name")
+        val tagId = pasteTagDao.createPasteTag("old_name", 0xFF0000L)
+        pasteTagDao.updatePasteTagName(tagId, "new_name")
         // Verify through flow
-        pasteDao.getAllTagsFlow().test {
+        pasteTagDao.getAllTagsFlow().test {
             val tags = awaitItem()
             val tag = tags.find { it.id == tagId }
             assertNotNull(tag)
@@ -398,9 +393,9 @@ class PasteDaoTest {
 
     @Test
     fun `updatePasteTagColor changes tag color`() = runTest {
-        val tagId = pasteDao.createPasteTag("tag", 0xFF0000L)
-        pasteDao.updatePasteTagColor(tagId, 0x00FF00L)
-        pasteDao.getAllTagsFlow().test {
+        val tagId = pasteTagDao.createPasteTag("tag", 0xFF0000L)
+        pasteTagDao.updatePasteTagColor(tagId, 0x00FF00L)
+        pasteTagDao.getAllTagsFlow().test {
             val tags = awaitItem()
             val tag = tags.find { it.id == tagId }
             assertNotNull(tag)
@@ -413,29 +408,29 @@ class PasteDaoTest {
     fun `switchPinPasteTagBlock toggles pin state`() = runTest {
         val pasteData = createTestPasteData()
         val pasteId = pasteDao.createPasteData(pasteData)
-        val tagId = pasteDao.createPasteTag("tag1", 0xFF0000L)
+        val tagId = pasteTagDao.createPasteTag("tag1", 0xFF0000L)
 
         // Initially not pinned
-        var pinned = pasteDao.getPasteTagsBlock(pasteId)
+        var pinned = pasteTagDao.getPasteTagsBlock(pasteId)
         assertFalse(pinned.contains(tagId))
 
         // Pin
-        pasteDao.switchPinPasteTagBlock(pasteId, tagId)
-        pinned = pasteDao.getPasteTagsBlock(pasteId)
+        pasteTagDao.switchPinPasteTagBlock(pasteId, tagId)
+        pinned = pasteTagDao.getPasteTagsBlock(pasteId)
         assertTrue(pinned.contains(tagId))
 
         // Unpin
-        pasteDao.switchPinPasteTagBlock(pasteId, tagId)
-        pinned = pasteDao.getPasteTagsBlock(pasteId)
+        pasteTagDao.switchPinPasteTagBlock(pasteId, tagId)
+        pinned = pasteTagDao.getPasteTagsBlock(pasteId)
         assertFalse(pinned.contains(tagId))
     }
 
     @Test
     fun `deletePasteTagBlock removes tag`() = runTest {
-        val tagId = pasteDao.createPasteTag("to_delete", 0xFF0000L)
-        pasteDao.deletePasteTagBlock(tagId)
+        val tagId = pasteTagDao.createPasteTag("to_delete", 0xFF0000L)
+        pasteTagDao.deletePasteTagBlock(tagId)
 
-        pasteDao.getAllTagsFlow().test {
+        pasteTagDao.getAllTagsFlow().test {
             val tags = awaitItem()
             assertNull(tags.find { it.id == tagId })
             cancelAndIgnoreRemainingEvents()
@@ -444,11 +439,11 @@ class PasteDaoTest {
 
     @Test
     fun `getMaxSortOrder returns max sort order`() = runTest {
-        val initialMax = pasteDao.getMaxSortOrder()
-        pasteDao.createPasteTag("tag1", 0xFF0000L)
-        val afterFirst = pasteDao.getMaxSortOrder()
-        pasteDao.createPasteTag("tag2", 0x00FF00L)
-        val afterSecond = pasteDao.getMaxSortOrder()
+        val initialMax = pasteTagDao.getMaxSortOrder()
+        pasteTagDao.createPasteTag("tag1", 0xFF0000L)
+        val afterFirst = pasteTagDao.getMaxSortOrder()
+        pasteTagDao.createPasteTag("tag2", 0x00FF00L)
+        val afterSecond = pasteTagDao.getMaxSortOrder()
 
         assertTrue(afterFirst > initialMax)
         assertTrue(afterSecond > afterFirst)
@@ -458,11 +453,11 @@ class PasteDaoTest {
 
     @Test
     fun `getAllTagsFlow emits on tag creation`() = runTest {
-        pasteDao.getAllTagsFlow().test {
+        pasteTagDao.getAllTagsFlow().test {
             val initial = awaitItem()
             assertTrue(initial.isEmpty())
 
-            pasteDao.createPasteTag("new_tag", 0xFF0000L)
+            pasteTagDao.createPasteTag("new_tag", 0xFF0000L)
 
             val updated = awaitItem()
             assertEquals(1, updated.size)

--- a/app/src/desktopTest/kotlin/com/crosspaste/mcp/McpResourceProviderTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/mcp/McpResourceProviderTest.kt
@@ -1,11 +1,9 @@
 package com.crosspaste.mcp
 
 import com.crosspaste.app.AppInfo
-import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.TestDriverFactory
 import com.crosspaste.db.createDatabase
 import com.crosspaste.db.paste.PasteDao
-import com.crosspaste.paste.CurrentPaste
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteState
@@ -58,8 +56,6 @@ class McpResourceProviderTest {
                 }
         }
 
-    private val commonConfigManager: CommonConfigManager = mockk(relaxed = true)
-    private val currentPaste: CurrentPaste = mockk(relaxed = true)
     private val taskSubmitter: TaskSubmitter = mockk(relaxed = true)
     private val userDataPathProvider: UserDataPathProvider = mockk(relaxed = true)
 
@@ -68,10 +64,7 @@ class McpResourceProviderTest {
     private val pasteDao =
         PasteDao(
             appInfo = appInfo,
-            commonConfigManager = commonConfigManager,
-            currentPaste = currentPaste,
             database = database,
-            pasteProcessPlugins = listOf(),
             searchContentService = searchContentService,
             taskSubmitter = taskSubmitter,
             userDataPathProvider = userDataPathProvider,

--- a/app/src/desktopTest/kotlin/com/crosspaste/mcp/McpToolProviderTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/mcp/McpToolProviderTest.kt
@@ -1,11 +1,10 @@
 package com.crosspaste.mcp
 
 import com.crosspaste.app.AppInfo
-import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.TestDriverFactory
 import com.crosspaste.db.createDatabase
 import com.crosspaste.db.paste.PasteDao
-import com.crosspaste.paste.CurrentPaste
+import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteState
@@ -58,8 +57,6 @@ class McpToolProviderTest {
                 }
         }
 
-    private val commonConfigManager: CommonConfigManager = mockk(relaxed = true)
-    private val currentPaste: CurrentPaste = mockk(relaxed = true)
     private val taskSubmitter: TaskSubmitter = mockk(relaxed = true)
     private val userDataPathProvider: UserDataPathProvider = mockk(relaxed = true)
 
@@ -68,19 +65,19 @@ class McpToolProviderTest {
     private val pasteDao =
         PasteDao(
             appInfo = appInfo,
-            commonConfigManager = commonConfigManager,
-            currentPaste = currentPaste,
             database = database,
-            pasteProcessPlugins = listOf(),
             searchContentService = searchContentService,
             taskSubmitter = taskSubmitter,
             userDataPathProvider = userDataPathProvider,
         )
 
+    private val pasteTagDao = PasteTagDao(database)
+
     private val provider =
         McpToolProvider(
             appInfo = appInfo,
             pasteDao = pasteDao,
+            pasteTagDao = pasteTagDao,
             searchContentService = searchContentService,
         )
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
@@ -28,6 +28,7 @@ class PasteCollectorTest {
             userName = "testUser",
         )
     private val pasteDao: PasteDao = mockk(relaxed = true)
+    private val pasteReleaseService: PasteReleaseService = mockk(relaxed = true)
 
     private interface TestPasteTypePlugin : PasteTypePlugin
 
@@ -35,13 +36,13 @@ class PasteCollectorTest {
 
     @Test
     fun `needPreCollectionItem returns true when not collected yet`() {
-        val collector = PasteCollector(1, appInfo, pasteDao)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
         assertTrue(collector.needPreCollectionItem(0, TestPasteTypePlugin::class))
     }
 
     @Test
     fun `needPreCollectionItem returns false after preCollectItem`() {
-        val collector = PasteCollector(1, appInfo, pasteDao)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
         val item = createTextPasteItem(text = "test")
         collector.preCollectItem(0, TestPasteTypePlugin::class, item)
         assertFalse(collector.needPreCollectionItem(0, TestPasteTypePlugin::class))
@@ -51,13 +52,13 @@ class PasteCollectorTest {
 
     @Test
     fun `needUpdateCollectItem returns true when not updated yet`() {
-        val collector = PasteCollector(1, appInfo, pasteDao)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
         assertTrue(collector.needUpdateCollectItem(0, TestPasteTypePlugin::class))
     }
 
     @Test
     fun `needUpdateCollectItem returns false after updateCollectItem`() {
-        val collector = PasteCollector(1, appInfo, pasteDao)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
         val item = createTextPasteItem(text = "test")
         collector.preCollectItem(0, TestPasteTypePlugin::class, item)
         collector.updateCollectItem(0, TestPasteTypePlugin::class) { it }
@@ -68,7 +69,7 @@ class PasteCollectorTest {
 
     @Test
     fun `preCollectItem stores item at correct index`() {
-        val collector = PasteCollector(3, appInfo, pasteDao)
+        val collector = PasteCollector(3, appInfo, pasteDao, pasteReleaseService)
         val item = createTextPasteItem(text = "item2")
         collector.preCollectItem(1, TestPasteTypePlugin::class, item)
 
@@ -82,7 +83,7 @@ class PasteCollectorTest {
 
     @Test
     fun `updateCollectItem applies transform to pre-collected item`() {
-        val collector = PasteCollector(1, appInfo, pasteDao)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
         val item = createTextPasteItem(text = "original")
         collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 
@@ -95,7 +96,7 @@ class PasteCollectorTest {
 
     @Test
     fun `updateCollectItem without pre-collect does nothing`() {
-        val collector = PasteCollector(1, appInfo, pasteDao)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
         // Try to update without pre-collecting - should not crash
         collector.updateCollectItem(0, TestPasteTypePlugin::class) { it }
         // needUpdateCollectItem should still be true since no pre-collect happened
@@ -106,7 +107,7 @@ class PasteCollectorTest {
 
     @Test
     fun `collectError records error`() {
-        val collector = PasteCollector(1, appInfo, pasteDao)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
         collector.collectError(1L, 0, RuntimeException("test error"))
         // Error recorded, but we can't directly assert existError
         // We verify indirectly through completeCollect behavior
@@ -117,7 +118,7 @@ class PasteCollectorTest {
     @Test
     fun `createPrePasteData with no items returns null`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
             val result = collector.createPrePasteData(null, false)
             assertNull(result)
         }
@@ -125,7 +126,7 @@ class PasteCollectorTest {
     @Test
     fun `createPrePasteData with items calls pasteDao createPasteData`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 
@@ -142,7 +143,7 @@ class PasteCollectorTest {
     @Test
     fun `completeCollect with no items marks paste for deletion`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
             collector.completeCollect(1L)
             coVerify { pasteDao.markDeletePasteData(1L) }
         }
@@ -150,19 +151,19 @@ class PasteCollectorTest {
     @Test
     fun `completeCollect with items calls releaseLocalPasteData`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 
             collector.completeCollect(1L)
 
-            coVerify { pasteDao.releaseLocalPasteData(1L, any()) }
+            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any()) }
         }
 
     @Test
     fun `completeCollect with all indices errored marks paste for deletion`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
             collector.collectError(1L, 0, RuntimeException("error"))
@@ -175,7 +176,7 @@ class PasteCollectorTest {
     @Test
     fun `completeCollect with partial errors releases remaining items`() =
         runTest {
-            val collector = PasteCollector(2, appInfo, pasteDao)
+            val collector = PasteCollector(2, appInfo, pasteDao, pasteReleaseService)
             val item0 = createTextPasteItem(text = "test0")
             val item1 = createTextPasteItem(text = "test1")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item0)
@@ -187,17 +188,17 @@ class PasteCollectorTest {
             collector.completeCollect(1L)
 
             // Should still release since not all active indices errored
-            coVerify { pasteDao.releaseLocalPasteData(1L, any()) }
+            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any()) }
         }
 
     @Test
     fun `completeCollect with exception marks paste for deletion`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 
-            coEvery { pasteDao.releaseLocalPasteData(any(), any()) } throws RuntimeException("release error")
+            coEvery { pasteReleaseService.releaseLocalPasteData(any(), any()) } throws RuntimeException("release error")
 
             collector.completeCollect(1L)
 


### PR DESCRIPTION
Closes #3925

## Summary
- Extract `PasteReleaseService` from `PasteDao` — handles release orchestration (`releaseLocalPasteData`, `releaseRemotePasteData`, `releaseRemotePasteDataWithFile`, `markDeleteSameHash`)
- Extract `PasteTagDao` from `PasteDao` — handles tag CRUD & pin/unpin operations
- Remove `clearRemotePasteboard` from `PasteboardService` — `PullFileTaskExecutor` now calls `pasteDao.markDeletePasteData()` directly
- Remove unused `pasteDao` from `PasteboardService` interface and all implementations
- Remove unused `CommonConfigManager` from `PasteDao` constructor
- Update all callers, DI registration, and tests

## Test plan
- [x] `./gradlew ktlintFormat` passes
- [x] `./gradlew app:desktopTest` passes (946 tests)
- [x] No remaining `pasteDao.releaseXxx` or `pasteDao.xxxTag` calls outside new classes
- [x] No remaining `pasteboardService.clearRemotePasteboard` calls