### PR TITLE
Extract PasteDaoApi interface from PasteDao

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -27,7 +27,7 @@ class PasteDao(
     private val searchContentService: SearchContentService,
     private val taskSubmitter: TaskSubmitter,
     private val userDataPathProvider: UserDataPathProvider,
-) {
+) : PasteDaoApi {
 
     private val logger = KotlinLogging.logger {}
 
@@ -35,7 +35,7 @@ class PasteDao(
 
     private val markDeleteBatchNum = 50L
 
-    fun getNoDeletePasteDataBlock(id: Long): PasteData? {
+    override fun getNoDeletePasteDataBlock(id: Long): PasteData? {
         return pasteDatabaseQueries.getPasteData(
             id,
             listOf(PasteState.LOADING.toLong(), PasteState.LOADED.toLong()),
@@ -44,7 +44,7 @@ class PasteDao(
     }
 
     @Suppress("unused")
-    fun getNoDeletePasteDataFlow(id: Long): Flow<PasteData?> {
+    override fun getNoDeletePasteDataFlow(id: Long): Flow<PasteData?> {
         return pasteDatabaseQueries.getPasteData(
             id,
             listOf(PasteState.LOADING.toLong(), PasteState.LOADED.toLong()),
@@ -58,11 +58,11 @@ class PasteDao(
             .flowOn(ioDispatcher)
     }
 
-    suspend fun getNoDeletePasteData(id: Long): PasteData? = withContext(ioDispatcher) {
+    override suspend fun getNoDeletePasteData(id: Long): PasteData? = withContext(ioDispatcher) {
         getNoDeletePasteDataBlock(id)
     }
 
-    suspend fun getLoadingPasteData(id: Long): PasteData? = withContext(ioDispatcher) {
+    override suspend fun getLoadingPasteData(id: Long): PasteData? = withContext(ioDispatcher) {
         pasteDatabaseQueries.getPasteData(
             id,
             listOf(PasteState.LOADING.toLong()),
@@ -70,7 +70,7 @@ class PasteDao(
         ).executeAsOneOrNull()
     }
 
-    fun getLoadedPasteDataBlock(id: Long): PasteData? {
+    override fun getLoadedPasteDataBlock(id: Long): PasteData? {
         return pasteDatabaseQueries.getPasteData(
             id,
             listOf(PasteState.LOADED.toLong()),
@@ -78,12 +78,12 @@ class PasteDao(
         ).executeAsOneOrNull()
     }
 
-    suspend fun getLatestLoadedPasteData(): PasteData? = withContext(ioDispatcher) {
+    override suspend fun getLatestLoadedPasteData(): PasteData? = withContext(ioDispatcher) {
         pasteDatabaseQueries.getLatestLoadedPasteData(PasteData::mapper)
             .executeAsOneOrNull()
     }
 
-    suspend fun getDeletePasteData(id: Long): PasteData? = withContext(ioDispatcher) {
+    override suspend fun getDeletePasteData(id: Long): PasteData? = withContext(ioDispatcher) {
         pasteDatabaseQueries.getPasteData(
             id,
             listOf(PasteState.DELETED.toLong()),
@@ -91,14 +91,14 @@ class PasteDao(
         ).executeAsOneOrNull()
     }
 
-    suspend fun setFavorite(
+    override suspend fun setFavorite(
         pasteId: Long,
         favorite: Boolean,
     ): Unit = withContext(ioDispatcher) {
         pasteDatabaseQueries.updateFavorite(favorite, pasteId)
     }
 
-    suspend fun createPasteData(pasteData: PasteData, pasteState: Int? = null): Long = withContext(ioDispatcher) {
+    override suspend fun createPasteData(pasteData: PasteData, pasteState: Int?): Long = withContext(ioDispatcher) {
         database.transactionWithResult {
             pasteDatabaseQueries.createPasteDataEntity(
                 pasteData.appInstanceId,
@@ -121,7 +121,7 @@ class PasteDao(
         }
     }
 
-    suspend fun updateFilePath(pasteData: PasteData) = withContext(ioDispatcher) {
+    override suspend fun updateFilePath(pasteData: PasteData): Unit = withContext(ioDispatcher) {
         pasteDatabaseQueries.updateRemotePasteDataWithFile(
             pasteData.pasteAppearItem?.toJson(),
             pasteData.pasteCollection.toJson(),
@@ -149,7 +149,7 @@ class PasteDao(
         }
     }
 
-    suspend fun markAllDeleteExceptFavorite(): Result<Unit> {
+    override suspend fun markAllDeleteExceptFavorite(): Result<Unit> {
         return runCatching {
             batchMarkDelete {
                 pasteDatabaseQueries.queryNoFavorite(markDeleteBatchNum)
@@ -159,7 +159,7 @@ class PasteDao(
         }
     }
 
-    suspend fun markDeletePasteData(id: Long): Result<Unit> = withContext(ioDispatcher) {
+    override suspend fun markDeletePasteData(id: Long): Result<Unit> = withContext(ioDispatcher) {
         runCatching {
             taskSubmitter.submit {
                 database.transaction {
@@ -172,7 +172,7 @@ class PasteDao(
         }
     }
 
-    suspend fun cutPasteData(id: Long, delayMillis: Long) = withContext(ioDispatcher) {
+    override suspend fun cutPasteData(id: Long, delayMillis: Long): Unit = withContext(ioDispatcher) {
         runCatching {
             taskSubmitter.submit {
                 database.transaction {
@@ -185,7 +185,7 @@ class PasteDao(
         }
     }
 
-    suspend fun deletePasteData(id: Long) = withContext(ioDispatcher) {
+    override suspend fun deletePasteData(id: Long): Unit = withContext(ioDispatcher) {
         getDeletePasteData(id)?.let {
             it.clear(userDataPathProvider)
             pasteDatabaseQueries.deletePasteData(listOf(id))
@@ -193,7 +193,7 @@ class PasteDao(
     }
 
     @Suppress("unused")
-    fun getPasteDataFlow(limit: Long): Flow<List<PasteData>> {
+    override fun getPasteDataFlow(limit: Long): Flow<List<PasteData>> {
         return pasteDatabaseQueries.getPasteDataListLimit(limit, PasteData::mapper)
             .asFlow()
             .map { it.executeAsList() }
@@ -204,7 +204,7 @@ class PasteDao(
             .flowOn(ioDispatcher)
     }
 
-    fun getSameHashPasteDataIds(hash: String, pasteType: Int, excludeId: Long): List<Long> {
+    override fun getSameHashPasteDataIds(hash: String, pasteType: Int, excludeId: Long): List<Long> {
         return pasteDatabaseQueries.getSameHashPasteDataIds(
             hash,
             pasteType.toLong(),
@@ -213,16 +213,16 @@ class PasteDao(
         ).executeAsList()
     }
 
-    suspend fun markDeleteByCleanTime(
+    override suspend fun markDeleteByCleanTime(
         cleanTime: Long,
-        pasteType: Int? = null,
+        pasteType: Int?,
     ) {
         batchMarkDelete {
             pasteDatabaseQueries.queryByCleanTime(cleanTime, pasteType?.toLong(), markDeleteBatchNum)
         }
     }
 
-    suspend fun getSize(allOrFavorite: Boolean = false): Long = withContext(ioDispatcher) {
+    override suspend fun getSize(allOrFavorite: Boolean): Long = withContext(ioDispatcher) {
         if (allOrFavorite) {
             pasteDatabaseQueries.getSize().executeAsOne().SUM ?: 0L
         } else {
@@ -230,19 +230,19 @@ class PasteDao(
         }
     }
 
-    suspend fun getMinPasteDataCreateTime(): Long? = withContext(ioDispatcher) {
+    override suspend fun getMinPasteDataCreateTime(): Long? = withContext(ioDispatcher) {
         pasteDatabaseQueries.getMinCreateTime().executeAsOneOrNull()?.MIN
     }
 
-    suspend fun updateCreateTime(id: Long): Unit = withContext(ioDispatcher) {
+    override suspend fun updateCreateTime(id: Long): Unit = withContext(ioDispatcher) {
         pasteDatabaseQueries.updateCreateTime(id = id, time = DateUtils.nowEpochMilliseconds())
     }
 
-    suspend fun updatePasteAppearItem(
+    override suspend fun updatePasteAppearItem(
         id: Long,
         pasteItem: PasteItem,
         pasteSearchContent: String,
-        addedSize: Long = 0L,
+        addedSize: Long,
     ): Result<Unit> = withContext(ioDispatcher) {
         database.transactionWithResult {
             pasteDatabaseQueries.updatePasteAppearItem(
@@ -262,15 +262,15 @@ class PasteDao(
         }
     }
 
-    suspend fun updatePasteState(id: Long, pasteState: Int) = withContext(ioDispatcher) {
+    override suspend fun updatePasteState(id: Long, pasteState: Int): Unit = withContext(ioDispatcher) {
         pasteDatabaseQueries.updatePasteDataState(pasteState.toLong(), id)
     }
 
-    suspend fun getSizeByTimeLessThan(time: Long): Long = withContext(ioDispatcher) {
+    override suspend fun getSizeByTimeLessThan(time: Long): Long = withContext(ioDispatcher) {
         pasteDatabaseQueries.getSizeByTimeLessThan(time).executeAsOne().SUM ?: 0L
     }
 
-    suspend fun findCleanTimeByCumulativeSize(targetSize: Long): Long? = withContext(ioDispatcher) {
+    override suspend fun findCleanTimeByCumulativeSize(targetSize: Long): Long? = withContext(ioDispatcher) {
         var cumulativeSize = 0L
         var afterTime = -1L
         var afterId = -1L
@@ -335,13 +335,13 @@ class PasteDao(
         }
     }
 
-    suspend fun searchPasteData(
+    override suspend fun searchPasteData(
         searchTerms: List<String>,
-        local: Boolean? = null,
-        favorite: Boolean? = null,
-        pasteType: Int? = null,
-        sort: Boolean = true,
-        tag: Long? = null,
+        local: Boolean?,
+        favorite: Boolean?,
+        pasteType: Int?,
+        sort: Boolean,
+        tag: Long?,
         limit: Int,
     ): List<PasteData> = withContext(ioDispatcher) {
         logExecutionTime(logger, "searchPasteData") {
@@ -350,13 +350,13 @@ class PasteDao(
         }
     }
 
-    fun searchPasteDataFlow(
+    override fun searchPasteDataFlow(
         searchTerms: List<String>,
-        local: Boolean? = null,
-        favorite: Boolean? = null,
-        pasteType: Int? = null,
-        sort: Boolean = true,
-        tag: Long? = null,
+        local: Boolean?,
+        favorite: Boolean?,
+        pasteType: Int?,
+        sort: Boolean,
+        tag: Long?,
         limit: Int,
     ): Flow<List<PasteData>> {
         return logExecutionTime(logger, "searchPasteData") {
@@ -374,17 +374,17 @@ class PasteDao(
         }
     }
 
-    suspend fun searchBySource(source: String): List<PasteData> = withContext(ioDispatcher) {
+    override suspend fun searchBySource(source: String): List<PasteData> = withContext(ioDispatcher) {
         pasteDatabaseQueries.searchBySource(source, mapper = PasteData::mapper)
             .executeAsList()
     }
 
-    suspend fun getDistinctSources(): List<String> = withContext(ioDispatcher) {
+    override suspend fun getDistinctSources(): List<String> = withContext(ioDispatcher) {
         pasteDatabaseQueries.getDistinctSources(appInfo.appInstanceId)
             .executeAsList()
     }
 
-    suspend fun getPasteResourceInfo(favorite: Boolean? = null): PasteResourceInfo = withContext(ioDispatcher) {
+    override suspend fun getPasteResourceInfo(favorite: Boolean?): PasteResourceInfo = withContext(ioDispatcher) {
         val builder = PasteResourceInfoBuilder()
         val doAdd: (PasteData) -> Unit = { pasteData ->
             if (favorite == null || favorite == pasteData.favorite) {
@@ -405,8 +405,8 @@ class PasteDao(
         builder.build()
     }
 
-    suspend fun batchReadPasteData(
-        batchNum: Long = 1000L,
+    override suspend fun batchReadPasteData(
+        batchNum: Long,
         readPasteDataList: suspend (Long, Long) -> List<PasteData>,
         dealPasteData: (PasteData) -> Unit): Long = withContext(ioDispatcher) {
         var id = -1L
@@ -422,7 +422,7 @@ class PasteDao(
         count
     }
 
-    suspend fun getExportPasteData(
+    override suspend fun getExportPasteData(
         id: Long,
         limit: Long,
         pasteExportParam: PasteExportParam,
@@ -436,7 +436,7 @@ class PasteDao(
         ).executeAsList()
     }
 
-    suspend fun getExportNum(pasteExportParam: PasteExportParam): Long = withContext(ioDispatcher) {
+    override suspend fun getExportNum(pasteExportParam: PasteExportParam): Long = withContext(ioDispatcher) {
         pasteDatabaseQueries.getExportNum(
             pasteExportParam.types,
             pasteExportParam.onlyFavorite,

--- a/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDaoApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDaoApi.kt
@@ -1,0 +1,121 @@
+package com.crosspaste.db.paste
+
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteExportParam
+import com.crosspaste.paste.item.PasteItem
+import kotlinx.coroutines.flow.Flow
+
+interface PasteDaoApi {
+
+    fun getNoDeletePasteDataBlock(id: Long): PasteData?
+
+    fun getNoDeletePasteDataFlow(id: Long): Flow<PasteData?>
+
+    suspend fun getNoDeletePasteData(id: Long): PasteData?
+
+    suspend fun getLoadingPasteData(id: Long): PasteData?
+
+    fun getLoadedPasteDataBlock(id: Long): PasteData?
+
+    suspend fun getLatestLoadedPasteData(): PasteData?
+
+    suspend fun getDeletePasteData(id: Long): PasteData?
+
+    suspend fun setFavorite(
+        pasteId: Long,
+        favorite: Boolean,
+    )
+
+    suspend fun createPasteData(
+        pasteData: PasteData,
+        pasteState: Int? = null,
+    ): Long
+
+    suspend fun updateFilePath(pasteData: PasteData)
+
+    suspend fun markAllDeleteExceptFavorite(): Result<Unit>
+
+    suspend fun markDeletePasteData(id: Long): Result<Unit>
+
+    suspend fun cutPasteData(
+        id: Long,
+        delayMillis: Long,
+    )
+
+    suspend fun deletePasteData(id: Long)
+
+    fun getPasteDataFlow(limit: Long): Flow<List<PasteData>>
+
+    fun getSameHashPasteDataIds(
+        hash: String,
+        pasteType: Int,
+        excludeId: Long,
+    ): List<Long>
+
+    suspend fun markDeleteByCleanTime(
+        cleanTime: Long,
+        pasteType: Int? = null,
+    )
+
+    suspend fun getSize(allOrFavorite: Boolean = false): Long
+
+    suspend fun getMinPasteDataCreateTime(): Long?
+
+    suspend fun updateCreateTime(id: Long)
+
+    suspend fun updatePasteAppearItem(
+        id: Long,
+        pasteItem: PasteItem,
+        pasteSearchContent: String,
+        addedSize: Long = 0L,
+    ): Result<Unit>
+
+    suspend fun updatePasteState(
+        id: Long,
+        pasteState: Int,
+    )
+
+    suspend fun getSizeByTimeLessThan(time: Long): Long
+
+    suspend fun findCleanTimeByCumulativeSize(targetSize: Long): Long?
+
+    suspend fun searchPasteData(
+        searchTerms: List<String>,
+        local: Boolean? = null,
+        favorite: Boolean? = null,
+        pasteType: Int? = null,
+        sort: Boolean = true,
+        tag: Long? = null,
+        limit: Int,
+    ): List<PasteData>
+
+    fun searchPasteDataFlow(
+        searchTerms: List<String>,
+        local: Boolean? = null,
+        favorite: Boolean? = null,
+        pasteType: Int? = null,
+        sort: Boolean = true,
+        tag: Long? = null,
+        limit: Int,
+    ): Flow<List<PasteData>>
+
+    suspend fun searchBySource(source: String): List<PasteData>
+
+    suspend fun getDistinctSources(): List<String>
+
+    suspend fun getPasteResourceInfo(favorite: Boolean? = null): PasteResourceInfo
+
+    suspend fun batchReadPasteData(
+        batchNum: Long = 1000L,
+        readPasteDataList: suspend (Long, Long) -> List<PasteData>,
+        dealPasteData: (PasteData) -> Unit,
+    ): Long
+
+    suspend fun getExportPasteData(
+        id: Long,
+        limit: Long,
+        pasteExportParam: PasteExportParam,
+    ): List<PasteData>
+
+    suspend fun getExportNum(pasteExportParam: PasteExportParam): Long
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -3,7 +3,7 @@ package com.crosspaste.net
 import com.crosspaste.app.AppControl
 import com.crosspaste.app.AppInfo
 import com.crosspaste.app.AppTokenApi
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.exception.ExceptionHandler
 import com.crosspaste.net.plugin.ServerDecryptionPluginFactory
@@ -41,7 +41,7 @@ open class DefaultServerModule(
     private val nearbyDeviceManager: NearbyDeviceManager,
     private val networkInterfaceService: NetworkInterfaceService,
     private val pasteboardService: PasteboardService,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val secureKeyPairSerializer: SecureKeyPairSerializer,
     private val secureStore: SecureStore,
     private val syncApi: SyncApi,

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
@@ -2,7 +2,7 @@ package com.crosspaste.net.routing
 
 import com.crosspaste.app.AppFileType
 import com.crosspaste.app.AppInfo
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.dto.pull.PullFileRequest
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.paste.CacheManager
@@ -19,7 +19,7 @@ import io.ktor.utils.io.*
 fun Routing.pullRouting(
     appInfo: AppInfo,
     cacheManager: CacheManager,
-    pasteDao: PasteDao,
+    pasteDao: PasteDaoApi,
     syncRoutingApi: SyncRoutingApi,
     userDataPathProvider: UserDataPathProvider,
 ) {

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/CacheManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/CacheManager.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.paste
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FilesIndex
@@ -12,7 +12,7 @@ interface CacheManager {
 
     val dateUtils: DateUtils
 
-    val pasteDao: PasteDao
+    val pasteDao: PasteDaoApi
 
     val userDataPathProvider: UserDataPathProvider
 

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/CurrentPaste.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/CurrentPaste.kt
@@ -1,13 +1,13 @@
 package com.crosspaste.paste
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 abstract class CurrentPaste {
 
     protected val logger = KotlinLogging.logger {}
 
-    abstract val pasteDao: PasteDao
+    abstract val pasteDao: PasteDaoApi
 
     abstract suspend fun setPasteId(
         id: Long,

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/GuidePasteDataService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/GuidePasteDataService.kt
@@ -2,7 +2,7 @@ package com.crosspaste.paste
 
 import com.crosspaste.app.AppInfo
 import com.crosspaste.app.AppLaunchState
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
@@ -19,7 +19,7 @@ abstract class GuidePasteDataService(
     private val appInfo: AppInfo,
     private val appLaunchState: AppLaunchState,
     private val copywriter: GlobalCopywriter,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val searchContentService: SearchContentService,
 ) {
 

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
@@ -1,7 +1,7 @@
 package com.crosspaste.paste
 
 import com.crosspaste.app.AppInfo
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.paste.item.PasteItem.Companion.copy
@@ -16,7 +16,7 @@ import kotlin.reflect.KClass
 class PasteCollector(
     itemCount: Int,
     private val appInfo: AppInfo,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val pasteReleaseService: PasteReleaseService,
     private val dragAndDrop: Boolean = false,
 ) {

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteExportService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteExportService.kt
@@ -1,7 +1,7 @@
 package com.crosspaste.paste
 
 import com.crosspaste.app.AppFileType
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.exception.PasteException
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.notification.MessageType
@@ -24,7 +24,7 @@ import okio.Path
 
 class PasteExportService(
     private val notificationManager: NotificationManager,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val userDataPathProvider: UserDataPathProvider,
 ) {
     private val logger = KotlinLogging.logger { }

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
@@ -1,7 +1,7 @@
 package com.crosspaste.paste
 
 import com.crosspaste.app.AppFileType
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.exception.PasteException
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.notification.MessageType
@@ -24,7 +24,7 @@ import okio.Path
 
 class PasteImportService(
     private val notificationManager: NotificationManager,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val searchContentService: SearchContentService,
     private val userDataPathProvider: UserDataPathProvider,
 ) {

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -3,7 +3,7 @@ package com.crosspaste.paste
 import com.crosspaste.Database
 import com.crosspaste.app.AppFileType
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.paste.item.PasteItemProperties
@@ -23,7 +23,7 @@ class PasteReleaseService(
     private val commonConfigManager: CommonConfigManager,
     private val currentPaste: CurrentPaste,
     private val database: Database,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val pasteProcessPlugins: List<PasteProcessPlugin>,
     private val searchContentService: SearchContentService,
     private val taskSubmitter: TaskSubmitter,

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/item/UpdatePasteItemHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/item/UpdatePasteItemHelper.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.paste.item
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.item.CreatePasteItemHelper.copy
@@ -8,7 +8,7 @@ import com.crosspaste.paste.item.CreatePasteItemHelper.createColorPasteItem
 import kotlinx.serialization.json.put
 
 class UpdatePasteItemHelper(
-    val pasteDao: PasteDao,
+    val pasteDao: PasteDaoApi,
     val searchContentService: SearchContentService,
 ) {
     suspend fun updateColor(

--- a/app/src/commonMain/kotlin/com/crosspaste/task/CleanPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/CleanPasteTaskExecutor.kt
@@ -2,7 +2,7 @@ package com.crosspaste.task
 
 import com.crosspaste.clean.CleanTime
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.BaseExtraInfo
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskType
@@ -17,7 +17,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 class CleanPasteTaskExecutor(
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val configManager: CommonConfigManager,
 ) : SingleTypeTaskExecutor {
 

--- a/app/src/commonMain/kotlin/com/crosspaste/task/DelayedDeletePasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/DelayedDeletePasteTaskExecutor.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.task
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.DelayedDeleteExtraInfo
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskType
@@ -14,7 +14,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class DelayedDeletePasteTaskExecutor(
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val scope: CoroutineScope = CoroutineScope(cpuDispatcher + SupervisorJob()),
 ) : SingleTypeTaskExecutor {
 

--- a/app/src/commonMain/kotlin/com/crosspaste/task/DeletePasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/DeletePasteTaskExecutor.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.task
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.BaseExtraInfo
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskType
@@ -11,7 +11,7 @@ import com.crosspaste.utils.TaskUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 class DeletePasteTaskExecutor(
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
 ) : SingleTypeTaskExecutor {
 
     private val logger = KotlinLogging.logger {}

--- a/app/src/commonMain/kotlin/com/crosspaste/task/OpenGraphTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/OpenGraphTaskExecutor.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.task
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.BaseExtraInfo
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskType
@@ -13,7 +13,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 
 class OpenGraphTaskExecutor(
     lazyUrlRenderingService: Lazy<RenderingService<String>>,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
 ) : SingleTypeTaskExecutor {
 
     private val logger = KotlinLogging.logger {}

--- a/app/src/commonMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.task
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.PullExtraInfo
 import com.crosspaste.db.task.TaskType
@@ -35,7 +35,7 @@ import io.ktor.http.*
 import io.ktor.utils.io.*
 
 class PullFileTaskExecutor(
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val pullClientApi: PullClientApi,
     private val userDataPathProvider: UserDataPathProvider,
     private val pasteSyncProcessManager: PasteSyncProcessManager<Long>,

--- a/app/src/commonMain/kotlin/com/crosspaste/task/PullIconTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/PullIconTaskExecutor.kt
@@ -1,7 +1,7 @@
 package com.crosspaste.task
 
 import com.crosspaste.app.AppFileType
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.BaseExtraInfo
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskType
@@ -25,7 +25,7 @@ import io.ktor.utils.io.*
 import okio.Path
 
 class PullIconTaskExecutor(
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val userDataPathProvider: UserDataPathProvider,
     private val pullClientApi: PullClientApi,
     private val syncManager: SyncManager,

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -4,7 +4,7 @@ import com.crosspaste.app.AppControl
 import com.crosspaste.app.AppInfo
 import com.crosspaste.config.AppConfig
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.SyncExtraInfo
 import com.crosspaste.db.task.TaskType
@@ -36,7 +36,7 @@ class SyncPasteTaskExecutor(
     private val appControl: AppControl,
     private val appInfo: AppInfo,
     private val configManager: CommonConfigManager,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val pasteClientApi: PasteClientApi,
     private val syncManager: SyncManager,
 ) : SingleTypeTaskExecutor {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
@@ -1,7 +1,7 @@
 package com.crosspaste.ui.model
 
 import androidx.lifecycle.viewModelScope
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteTag
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 class GeneralPasteSearchViewModel(
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     pasteTagDao: PasteTagDao,
     private val searchContentService: SearchContentService,
 ) : PasteSearchViewModel() {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/settings/StorageSettingsContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/settings/StorageSettingsContentView.kt
@@ -20,7 +20,7 @@ import com.composables.icons.materialsymbols.rounded.Percent
 import com.composables.icons.materialsymbols.rounded.Storage
 import com.crosspaste.clean.CleanTime
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.ui.LocalThemeExtState
 import com.crosspaste.ui.base.Counter
@@ -36,7 +36,7 @@ import org.koin.compose.koinInject
 fun StorageSettingsContentView(storagePathManager: StoragePathManager? = null) {
     val configManager = koinInject<CommonConfigManager>()
     val copywriter = koinInject<GlobalCopywriter>()
-    val pasteDao = koinInject<PasteDao>()
+    val pasteDao = koinInject<PasteDaoApi>()
     val themeExt = LocalThemeExtState.current
 
     val config by configManager.config.collectAsState()

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/settings/StorageStatisticsScope.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/settings/StorageStatisticsScope.kt
@@ -3,14 +3,14 @@ package com.crosspaste.ui.settings
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 
 class StorageStatisticsScope(
-    val pasteDao: PasteDao,
+    val pasteDao: PasteDaoApi,
     val scope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
 ) {
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -45,6 +45,7 @@ import com.crosspaste.db.DesktopDriverFactory
 import com.crosspaste.db.DriverFactory
 import com.crosspaste.db.createDatabase
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.db.secure.SecureDao
 import com.crosspaste.db.secure.SecureIO
@@ -317,7 +318,7 @@ class DesktopModule(
         module {
             single<DriverFactory> { DesktopDriverFactory(get()) }
             single<Database> { createDatabase(get()) }
-            single<PasteDao> {
+            single<PasteDaoApi> {
                 PasteDao(
                     appInfo = get(),
                     database = get(),

--- a/app/src/desktopMain/kotlin/com/crosspaste/listener/DesktopShortKeysAction.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/listener/DesktopShortKeysAction.kt
@@ -4,7 +4,7 @@ import com.crosspaste.app.AppFileChooser
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.app.WindowTrigger
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.listener.DesktopShortcutKeys.Companion.HIDE_WINDOW
 import com.crosspaste.listener.DesktopShortcutKeys.Companion.PASTE_LOCAL_LAST
 import com.crosspaste.listener.DesktopShortcutKeys.Companion.PASTE_PLAIN_TEXT
@@ -33,7 +33,7 @@ class DesktopShortKeysAction(
     private val currentPaste: CurrentPaste,
     private val notificationManager: NotificationManager,
     private val pasteboardService: PasteboardService,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
 ) : ShortcutKeysAction {
 
     private val logger = KotlinLogging.logger {}

--- a/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpResourceProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpResourceProvider.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.mcp
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.PasteColor
 import com.crosspaste.paste.item.PasteFiles
@@ -11,7 +11,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
 
 class McpResourceProvider(
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
 ) {
 
     fun registerResources(server: Server) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpToolProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpToolProvider.kt
@@ -2,7 +2,7 @@ package com.crosspaste.mcp
 
 import androidx.compose.ui.graphics.toArgb
 import com.crosspaste.app.AppInfo
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
@@ -47,7 +47,7 @@ import okio.Path.Companion.toPath
 
 class McpToolProvider(
     private val appInfo: AppInfo,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val pasteTagDao: PasteTagDao,
     private val searchContentService: SearchContentService,
 ) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopServerModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopServerModule.kt
@@ -3,7 +3,7 @@ package com.crosspaste.net
 import com.crosspaste.app.AppControl
 import com.crosspaste.app.AppInfo
 import com.crosspaste.app.AppTokenApi
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.net.exception.ExceptionHandler
 import com.crosspaste.net.plugin.ServerDecryptionPluginFactory
 import com.crosspaste.net.plugin.ServerEncryptPluginFactory
@@ -26,7 +26,7 @@ class DesktopServerModule(
     nearbyDeviceManager: NearbyDeviceManager,
     networkInterfaceService: NetworkInterfaceService,
     pasteboardService: PasteboardService,
-    pasteDao: PasteDao,
+    pasteDao: PasteDaoApi,
     secureKeyPairSerializer: SecureKeyPairSerializer,
     secureStore: SecureStore,
     syncApi: SyncApi,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopCacheManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopCacheManager.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.paste
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FilesIndex
 import com.crosspaste.utils.DateUtils
@@ -11,7 +11,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.TimeUnit
 
 class DesktopCacheManager(
-    override val pasteDao: PasteDao,
+    override val pasteDao: PasteDaoApi,
     override val userDataPathProvider: UserDataPathProvider,
 ) : CacheManager {
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopCurrentPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopCurrentPaste.kt
@@ -1,15 +1,15 @@
 package com.crosspaste.paste
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import java.util.concurrent.atomic.AtomicReference
 
 class DesktopCurrentPaste(
-    private val lazyPasteDao: Lazy<PasteDao>,
+    private val lazyPasteDao: Lazy<PasteDaoApi>,
 ) : CurrentPaste() {
 
     private val currentId: AtomicReference<Long?> = AtomicReference<Long?>()
 
-    override val pasteDao: PasteDao by lazy { lazyPasteDao.value }
+    override val pasteDao: PasteDaoApi by lazy { lazyPasteDao.value }
 
     override suspend fun setPasteId(
         id: Long,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopGuidePasteDataService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopGuidePasteDataService.kt
@@ -2,14 +2,14 @@ package com.crosspaste.paste
 
 import com.crosspaste.app.AppInfo
 import com.crosspaste.app.AppLaunchState
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.i18n.GlobalCopywriter
 
 class DesktopGuidePasteDataService(
     appInfo: AppInfo,
     appLaunchState: AppLaunchState,
     copywriter: GlobalCopywriter,
-    pasteDao: PasteDao,
+    pasteDao: PasteDaoApi,
     searchContentService: SearchContentService,
 ) : GuidePasteDataService(appInfo, appLaunchState, copywriter, pasteDao, searchContentService) {
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
@@ -13,7 +13,7 @@ import com.composables.icons.materialsymbols.rounded.Check
 import com.crosspaste.app.AppWindowManager
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.app.WindowTrigger
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.image.OCRModule
@@ -47,7 +47,7 @@ class DesktopPasteMenuService(
     private val copywriter: GlobalCopywriter,
     private val notificationManager: NotificationManager,
     private val pasteboardService: PasteboardService,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val pasteTagDao: PasteTagDao,
     private val pasteSearchViewModel: PasteSearchViewModel,
     private val ocrModule: OCRModule,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
@@ -1,14 +1,14 @@
 package com.crosspaste.paste
 
 import com.crosspaste.app.AppInfo
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.paste.plugin.type.PasteTypePlugin
 import com.crosspaste.utils.LoggerExtension.logSuspendExecutionTime
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 class DesktopTransferableConsumer(
     private val appInfo: AppInfo,
-    private val pasteDao: PasteDao,
+    private val pasteDao: PasteDaoApi,
     private val pasteReleaseService: PasteReleaseService,
     pasteTypePlugins: List<PasteTypePlugin>,
 ) : TransferableConsumer {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/BubbleWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/BubbleWindow.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
 import com.crosspaste.app.DesktopAppWindowManager
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.paste.PasteData
 import com.crosspaste.platform.macos.MacAppUtils
 import com.crosspaste.ui.DesktopContext.BubbleWindowContext
@@ -125,7 +125,7 @@ private class BubbleShape(
 @Composable
 fun BubbleWindow(windowIcon: Painter?) {
     val appWindowManager = koinInject<DesktopAppWindowManager>()
-    val pasteDao = koinInject<PasteDao>()
+    val pasteDao = koinInject<PasteDaoApi>()
     val pasteSearchViewModel = koinInject<PasteSearchViewModel>()
     val pasteSelectionViewModel = koinInject<PasteSelectionViewModel>()
     val platform = getPlatformUtils().platform
@@ -307,7 +307,7 @@ fun BubbleWindow(windowIcon: Painter?) {
 @Composable
 private fun BubbleWindowContent(
     pasteId: Long,
-    pasteDao: PasteDao,
+    pasteDao: PasteDaoApi,
     onEscape: () -> Unit,
     tailCenterFraction: Float,
 ) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/sourcecontrol/SourceControlContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/sourcecontrol/SourceControlContentView.kt
@@ -36,7 +36,7 @@ import coil3.size.Precision
 import coil3.size.Scale
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.config.DesktopConfigManager
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.image.coil.AppSourceItem
 import com.crosspaste.image.coil.ImageLoaders
@@ -58,7 +58,7 @@ import org.koin.compose.koinInject
 fun SourceControlContentView() {
     val configManager = koinInject<DesktopConfigManager>()
     val copywriter = koinInject<GlobalCopywriter>()
-    val pasteDao = koinInject<PasteDao>()
+    val pasteDao = koinInject<PasteDaoApi>()
     val sourceExclusionService = koinInject<DesktopSourceExclusionService>()
     val appWindowManager = koinInject<DesktopAppWindowManager>()
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SidePasteTitleView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SidePasteTitleView.kt
@@ -43,7 +43,7 @@ import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Bookmark
 import com.composables.icons.materialsymbols.roundedfilled.Bookmark
 import com.crosspaste.app.AppControl
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.image.DesktopIconColorExtractor
 import com.crosspaste.paste.item.PasteItem
@@ -73,7 +73,7 @@ fun PasteDataScope.SidePasteTitleView() {
     val appControl = koinInject<AppControl>()
     val copywriter = koinInject<GlobalCopywriter>()
     val desktopIconColorExtractor = koinInject<DesktopIconColorExtractor>()
-    val pasteDao = koinInject<PasteDao>()
+    val pasteDao = koinInject<PasteDaoApi>()
     val updatePasteItemHelper = koinInject<UpdatePasteItemHelper>()
 
     val pasteItem = getPasteItem(PasteItem::class)

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
@@ -1,7 +1,7 @@
 package com.crosspaste.paste
 
 import com.crosspaste.app.AppInfo
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.paste.plugin.type.PasteTypePlugin
 import com.crosspaste.utils.getJsonUtils
@@ -27,7 +27,7 @@ class PasteCollectorTest {
             appRevision = "abc",
             userName = "testUser",
         )
-    private val pasteDao: PasteDao = mockk(relaxed = true)
+    private val pasteDao: PasteDaoApi = mockk(relaxed = true)
     private val pasteReleaseService: PasteReleaseService = mockk(relaxed = true)
 
     private interface TestPasteTypePlugin : PasteTypePlugin

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/CleanPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/CleanPasteTaskExecutorTest.kt
@@ -3,7 +3,7 @@ package com.crosspaste.task
 import com.crosspaste.clean.CleanTime
 import com.crosspaste.config.AppConfig
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.BaseExtraInfo
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskType
@@ -21,7 +21,7 @@ class CleanPasteTaskExecutorTest {
     private val jsonUtils = getJsonUtils()
 
     private class TestDeps {
-        val pasteDao: PasteDao = mockk(relaxed = true)
+        val pasteDao: PasteDaoApi = mockk(relaxed = true)
         val configManager: CommonConfigManager = mockk(relaxed = true)
 
         init {

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/DeletePasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/DeletePasteTaskExecutorTest.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.task
 
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.BaseExtraInfo
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskType
@@ -16,7 +16,9 @@ class DeletePasteTaskExecutorTest {
 
     private val jsonUtils = getJsonUtils()
 
-    private fun createExecutor(pasteDao: PasteDao = mockk(relaxed = true)): Pair<DeletePasteTaskExecutor, PasteDao> {
+    private fun createExecutor(
+        pasteDao: PasteDaoApi = mockk(relaxed = true),
+    ): Pair<DeletePasteTaskExecutor, PasteDaoApi> {
         val executor = DeletePasteTaskExecutor(pasteDao)
         return executor to pasteDao
     }
@@ -61,7 +63,7 @@ class DeletePasteTaskExecutorTest {
     @Test
     fun `valid pasteDataId calls deletePasteData and returns success`() =
         runTest {
-            val pasteDao: PasteDao = mockk(relaxed = true)
+            val pasteDao: PasteDaoApi = mockk(relaxed = true)
             val (executor, _) = createExecutor(pasteDao)
             val task = createPasteTask(pasteDataId = 42L)
 
@@ -74,7 +76,7 @@ class DeletePasteTaskExecutorTest {
     @Test
     fun `exception during delete returns failure`() =
         runTest {
-            val pasteDao: PasteDao = mockk(relaxed = true)
+            val pasteDao: PasteDaoApi = mockk(relaxed = true)
             coEvery { pasteDao.deletePasteData(any()) } throws RuntimeException("DB error")
             val (executor, _) = createExecutor(pasteDao)
             val task = createPasteTask(pasteDataId = 1L)
@@ -88,7 +90,7 @@ class DeletePasteTaskExecutorTest {
     @Test
     fun `multiple deletes with same id are serialized via mutex`() =
         runTest {
-            val pasteDao: PasteDao = mockk(relaxed = true)
+            val pasteDao: PasteDaoApi = mockk(relaxed = true)
             val (executor, _) = createExecutor(pasteDao)
             val task1 = createPasteTask(pasteDataId = 1L)
             val task2 = createPasteTask(pasteDataId = 1L)

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
@@ -4,7 +4,7 @@ import com.crosspaste.app.AppControl
 import com.crosspaste.app.AppInfo
 import com.crosspaste.config.AppConfig
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.paste.PasteDaoApi
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.SyncExtraInfo
 import com.crosspaste.db.task.TaskType
@@ -43,7 +43,7 @@ class SyncPasteTaskExecutorTest {
                 userName = "testUser",
             )
         val configManager: CommonConfigManager = mockk(relaxed = true)
-        val pasteDao: PasteDao = mockk(relaxed = true)
+        val pasteDao: PasteDaoApi = mockk(relaxed = true)
         val pasteClientApi: PasteClientApi = mockk(relaxed = true)
         val syncManager: SyncManager = mockk(relaxed = true)
 


### PR DESCRIPTION
Closes #3944

## Summary

- **Extract `PasteDaoApi` interface** — all 33 public methods from `PasteDao` now defined in the interface
- **`PasteDao` implements `PasteDaoApi`** — all methods marked `override`, default params moved to interface
- **Update Koin binding** — `single<PasteDao>` → `single<PasteDaoApi>`
- **Update 38 consumer files** — all depend on interface instead of concrete class
- Integration tests (`PasteDaoTest`, `McpToolProviderTest`, `McpResourceProviderTest`) keep using concrete `PasteDao`

## Test plan

- [x] `./gradlew ktlintFormat` — passes
- [x] `./gradlew app:desktopTest --tests "com.crosspaste.db.paste.*"` — passes
- [x] `./gradlew app:desktopTest --tests "com.crosspaste.paste.*"` — passes
- [x] `./gradlew app:desktopTest --tests "com.crosspaste.task.*"` — passes
- [x] `./gradlew app:desktopTest --tests "com.crosspaste.mcp.*"` — passes