### PR TITLE
:zap: Use content hash as LaunchedEffect key to avoid equals on large HTML strings

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
@@ -56,7 +56,7 @@ fun PasteDataScope.HtmlSidePreviewView() {
     ) {
         val state = rememberRichTextState()
 
-        LaunchedEffect(htmlPasteItem.html) {
+        LaunchedEffect(htmlPasteItem.hash) {
             state.setHtml(htmlPasteItem.truncatedPreviewHtml)
         }
         RichText(

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
@@ -56,7 +56,7 @@ fun PasteDataScope.RtfSidePreviewView() {
     ) {
         val state = rememberRichTextState()
 
-        LaunchedEffect(rtfPasteItem.getHtml()) {
+        LaunchedEffect(rtfPasteItem.hash) {
             state.setHtml(rtfPasteItem.truncatedPreviewHtml)
         }
 


### PR DESCRIPTION
## Summary
- Replace `htmlPasteItem.html` and `rtfPasteItem.getHtml()` with their pre-computed `hash` field as `LaunchedEffect` keys
- Avoids `equals()` comparison on potentially large HTML strings during every Compose recomposition
- Follow-up optimization to #3938

## Test plan
- [ ] Verify HTML side preview renders correctly
- [ ] Verify RTF side preview renders correctly
- [ ] Scroll through paste list with HTML/RTF items and confirm no lag