### PR TITLE
:hammer: Rewrite CLI commands from HTTP to direct DAO and native access

### DIFF
--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/CliAdapters.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/CliAdapters.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import okio.FileSystem
 import okio.Path
 
@@ -59,7 +62,7 @@ data class CliReadOnlyAppConfig(
 }
 
 /**
- * Read-only ConfigManager for CLI. Loads config from the desktop app's appConfig.json.
+ * ConfigManager for CLI. Reads/writes the desktop app's appConfig.json.
  */
 class CliConfigManager(
     nativePathProvider: NativePlatformPathProvider,
@@ -71,42 +74,69 @@ class CliConfigManager(
             isLenient = true
         }
 
-    private val appConfig: AppConfig =
-        run {
-            val configPath = nativePathProvider.getDefaultUserDataPath().resolve("appConfig.json")
-            try {
-                val content = FileSystem.SYSTEM.read(configPath) { readUtf8() }
-                json.decodeFromString<CliReadOnlyAppConfig>(content)
-            } catch (_: Exception) {
-                CliReadOnlyAppConfig()
-            }
+    private val prettyJson =
+        Json {
+            prettyPrint = true
         }
+
+    private val configPath: okio.Path =
+        nativePathProvider.getDefaultUserDataPath().resolve("appConfig.json")
+
+    private val _config = MutableStateFlow<AppConfig>(loadConfigFromFile())
 
     override val deviceUtils: DeviceUtils =
         object : DeviceUtils {
-            override fun createAppInstanceId(): String = appConfig.appInstanceId
+            override fun createAppInstanceId(): String = _config.value.appInstanceId
 
             override fun getDeviceId(): String = ""
 
             override fun getDeviceName(): String = "CLI"
         }
 
-    override val config: StateFlow<AppConfig> = MutableStateFlow(appConfig)
+    override val config: StateFlow<AppConfig> = _config
 
-    override fun loadConfig(): AppConfig = appConfig
+    override fun loadConfig(): AppConfig = _config.value
+
+    private fun loadConfigFromFile(): AppConfig =
+        try {
+            val content = FileSystem.SYSTEM.read(configPath) { readUtf8() }
+            json.decodeFromString<CliReadOnlyAppConfig>(content)
+        } catch (_: Exception) {
+            CliReadOnlyAppConfig()
+        }
 
     override fun updateConfig(
         key: String,
         value: Any,
     ) {
-        // CLI is read-only
+        val rawMap =
+            try {
+                val content = FileSystem.SYSTEM.read(configPath) { readUtf8() }
+                json.parseToJsonElement(content).jsonObject.toMutableMap()
+            } catch (_: Exception) {
+                mutableMapOf()
+            }
+
+        rawMap[key] =
+            when (value) {
+                is Boolean -> JsonPrimitive(value)
+                is Int -> JsonPrimitive(value)
+                is Long -> JsonPrimitive(value)
+                is String -> JsonPrimitive(value)
+                else -> JsonPrimitive(value.toString())
+            }
+
+        val newContent =
+            prettyJson.encodeToString(JsonObject.serializer(), JsonObject(rawMap))
+        FileSystem.SYSTEM.write(configPath) { writeUtf8(newContent) }
+        _config.value = loadConfigFromFile()
     }
 
     override fun updateConfig(
         keys: List<String>,
         values: List<Any>,
     ) {
-        // CLI is read-only
+        keys.zip(values).forEach { (k, v) -> updateConfig(k, v) }
     }
 }
 

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/CliModule.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/CliModule.kt
@@ -2,14 +2,8 @@ package com.crosspaste.cli
 
 import com.crosspaste.Database
 import com.crosspaste.app.AppInfo
-import com.crosspaste.cli.api.CliClient
-import com.crosspaste.cli.commands.AppAutoStarter
-import com.crosspaste.cli.platform.AppLauncher
-import com.crosspaste.cli.platform.AppReadinessChecker
-import com.crosspaste.cli.platform.CliAppPathProvider
 import com.crosspaste.cli.platform.CliConfigReader
 import com.crosspaste.cli.platform.NativePlatformPathProvider
-import com.crosspaste.cli.platform.createAppLauncher
 import com.crosspaste.cli.platform.createNativePlatformPathProvider
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.DriverFactory
@@ -36,11 +30,6 @@ val cliModule =
     module {
         single<NativePlatformPathProvider> { createNativePlatformPathProvider() }
         singleOf(::CliConfigReader)
-        factory { CliClient(get()) }
-        singleOf(::CliAppPathProvider)
-        single<AppLauncher> { createAppLauncher(get()) }
-        singleOf(::AppReadinessChecker)
-        singleOf(::AppAutoStarter)
     }
 
 val cliDatabaseModule =

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -1,16 +1,12 @@
 package com.crosspaste.cli.commands
 
-import com.crosspaste.cli.api.AppNotRunningException
-import com.crosspaste.cli.api.CliClient
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteType
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
-import io.ktor.client.call.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
-import org.koin.core.Koin
 import org.koin.mp.KoinPlatform
 
 const val CLI_VERSION = "1.2.7"
@@ -21,70 +17,50 @@ val cliJson =
         prettyPrint = true
     }
 
-fun CliktCommand.runWithClient(block: suspend (CliClient) -> Unit) {
-    val koin = KoinPlatform.getKoin()
-    val client =
-        try {
-            koin.get<CliClient>()
-        } catch (_: AppNotRunningException) {
-            if (!attemptAutoStart(koin)) {
-                throw ProgramResult(1)
-            }
-            try {
-                koin.get<CliClient>()
-            } catch (_: AppNotRunningException) {
-                echo("CrossPaste is not running.", err = true)
-                throw ProgramResult(1)
-            }
-        }
-
+fun CliktCommand.runWithDao(block: suspend () -> Unit) {
     runBlocking {
-        client.use {
-            try {
-                block(it)
-            } catch (_: AppNotRunningException) {
-                if (!attemptAutoStart(koin)) {
-                    throw ProgramResult(1)
-                }
-                val retryClient =
-                    try {
-                        koin.get<CliClient>()
-                    } catch (_: AppNotRunningException) {
-                        echo("CrossPaste is not running.", err = true)
-                        throw ProgramResult(1)
-                    }
-                retryClient.use { freshClient ->
-                    block(freshClient)
-                }
-            } catch (e: ProgramResult) {
-                throw e
-            } catch (e: Exception) {
-                echo("Error: ${e.message}", err = true)
-                throw ProgramResult(1)
-            }
+        try {
+            block()
+        } catch (e: ProgramResult) {
+            throw e
+        } catch (e: Exception) {
+            echo("Error: ${e.message}", err = true)
+            throw ProgramResult(1)
         }
     }
 }
 
-private fun CliktCommand.attemptAutoStart(koin: Koin): Boolean {
-    val autoStarter = koin.get<AppAutoStarter>()
-    return runBlocking {
-        autoStarter.startAndWait { message, isError -> echo(message, err = isError) }
-    }
-}
+inline fun <reified T> CliktCommand.getDao(): T = KoinPlatform.getKoin().get()
 
-suspend fun CliktCommand.handleResponse(
-    response: HttpResponse,
-    onSuccess: suspend (HttpResponse) -> Unit,
-) {
-    if (response.status == HttpStatusCode.OK) {
-        onSuccess(response)
-    } else {
-        val body = response.body<String>()
-        echo("Error: ${response.status} - $body", err = true)
-        throw ProgramResult(1)
+fun PasteData.toSummaryDto(): PasteSummaryDto =
+    PasteSummaryDto(
+        id = id,
+        typeName = getTypeName(),
+        source = source,
+        size = size,
+        favorite = favorite,
+        createTime = createTime,
+        preview = getSummary("Loading...", ""),
+        remote = remote,
+    )
+
+fun PasteData.toDetailResponse(): PasteDetailResponse =
+    PasteDetailResponse(
+        id = id,
+        typeName = getTypeName(),
+        source = source,
+        size = size,
+        favorite = favorite,
+        createTime = createTime,
+        remote = remote,
+        hash = hash,
+        content = pasteAppearItem?.getSummary(),
+    )
+
+fun resolveTypeFilter(type: String?): Int? =
+    type?.let { name ->
+        PasteType.TYPES.firstOrNull { it.name.equals(name, ignoreCase = true) }?.type
     }
-}
 
 @OptIn(ExperimentalForeignApi::class)
 fun formatRelativeTime(epochMillis: Long): String {

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/ConfigCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/ConfigCommand.kt
@@ -1,24 +1,18 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
+import com.crosspaste.config.AppConfig
+import com.crosspaste.config.CommonConfigManager
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
-import io.ktor.client.call.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
 
 @Serializable
 data class ConfigEntryDto(
-    val key: String,
-    val value: String,
-)
-
-@Serializable
-data class ConfigUpdateRequest(
     val key: String,
     val value: String,
 )
@@ -37,20 +31,19 @@ class ConfigCommand : CliktCommand(name = "config") {
 
     override fun run() {
         if (currentContext.invokedSubcommand != null) return
-        runWithClient { client ->
-            val response = client.get("/cli/config")
-            handleResponse(response) { resp ->
-                val entries = resp.body<List<ConfigEntryDto>>()
-                if (ctx.json) {
-                    echo(
-                        cliJson.encodeToString(
-                            ListSerializer(ConfigEntryDto.serializer()),
-                            entries,
-                        ),
-                    )
-                } else {
-                    printConfig(entries)
-                }
+        runWithDao {
+            val configManager = getDao<CommonConfigManager>()
+            val entries = configManager.getCurrentConfig().toEntries()
+
+            if (ctx.json) {
+                echo(
+                    cliJson.encodeToString(
+                        ListSerializer(ConfigEntryDto.serializer()),
+                        entries,
+                    ),
+                )
+            } else {
+                printConfig(entries)
             }
         }
     }
@@ -74,15 +67,49 @@ class ConfigSetCommand : CliktCommand(name = "set") {
     private val value by argument(help = "New value")
 
     override fun run() =
-        runWithClient { client ->
-            val body =
-                Json.encodeToString(
-                    ConfigUpdateRequest.serializer(),
-                    ConfigUpdateRequest(key = key, value = value),
-                )
-            val response = client.put("/cli/config", body)
-            handleResponse(response) {
-                echo("Config '$key' set to '$value'.")
-            }
+        runWithDao {
+            val configManager = getDao<CommonConfigManager>()
+            val parsed = parseConfigValue(value)
+            configManager.updateConfig(key, parsed)
+            echo("Config '$key' set to '$value'.")
         }
 }
+
+@Suppress("MagicNumber")
+fun AppConfig.toEntries(): List<ConfigEntryDto> =
+    listOf(
+        ConfigEntryDto("port", port.toString()),
+        ConfigEntryDto("language", language),
+        ConfigEntryDto("enablePasteboardListening", enablePasteboardListening.toString()),
+        ConfigEntryDto("enableEncryptSync", enableEncryptSync.toString()),
+        ConfigEntryDto("enableExpirationCleanup", enableExpirationCleanup.toString()),
+        ConfigEntryDto("imageCleanTimeIndex", imageCleanTimeIndex.toString()),
+        ConfigEntryDto("fileCleanTimeIndex", fileCleanTimeIndex.toString()),
+        ConfigEntryDto("enableThresholdCleanup", enableThresholdCleanup.toString()),
+        ConfigEntryDto("maxStorage", maxStorage.toString()),
+        ConfigEntryDto("cleanupPercentage", cleanupPercentage.toString()),
+        ConfigEntryDto("enableDiscovery", enableDiscovery.toString()),
+        ConfigEntryDto("enableSkipPreLaunchPasteboardContent", enableSkipPreLaunchPasteboardContent.toString()),
+        ConfigEntryDto("enableSoundEffect", enableSoundEffect.toString()),
+        ConfigEntryDto("pastePrimaryTypeOnly", pastePrimaryTypeOnly.toString()),
+        ConfigEntryDto("enabledSyncFileSizeLimit", enabledSyncFileSizeLimit.toString()),
+        ConfigEntryDto("maxSyncFileSize", maxSyncFileSize.toString()),
+        ConfigEntryDto("maxBackupFileSize", maxBackupFileSize.toString()),
+        ConfigEntryDto("useDefaultStoragePath", useDefaultStoragePath.toString()),
+        ConfigEntryDto("storagePath", storagePath),
+        ConfigEntryDto("enableSyncText", enableSyncText.toString()),
+        ConfigEntryDto("enableSyncUrl", enableSyncUrl.toString()),
+        ConfigEntryDto("enableSyncHtml", enableSyncHtml.toString()),
+        ConfigEntryDto("enableSyncRtf", enableSyncRtf.toString()),
+        ConfigEntryDto("enableSyncImage", enableSyncImage.toString()),
+        ConfigEntryDto("enableSyncFile", enableSyncFile.toString()),
+        ConfigEntryDto("enableSyncColor", enableSyncColor.toString()),
+    )
+
+private fun parseConfigValue(value: String): Any =
+    when {
+        value.equals("true", ignoreCase = true) -> true
+        value.equals("false", ignoreCase = true) -> false
+        value.toLongOrNull() != null -> value.toLong()
+        else -> value
+    }

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/CopyCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/CopyCommand.kt
@@ -2,27 +2,44 @@ package com.crosspaste.cli.commands
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.arguments.argument
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-
-@Serializable
-data class CopyRequest(
-    val text: String,
-)
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.fputs
+import platform.posix.pclose
+import platform.posix.popen
+import kotlin.experimental.ExperimentalNativeApi
 
 class CopyCommand : CliktCommand(name = "copy") {
 
-    override fun help(context: Context): String = "Copy text to the clipboard via CrossPaste"
+    override fun help(context: Context): String = "Copy text to the system clipboard"
 
     private val text by argument(help = "Text to copy to clipboard")
 
-    override fun run() =
-        runWithClient { client ->
-            val body = Json.encodeToString(CopyRequest.serializer(), CopyRequest(text = text))
-            val response = client.post("/cli/clipboard/write", body)
-            handleResponse(response) {
-                echo("Copied to clipboard.")
-            }
+    override fun run() {
+        try {
+            copyToSystemClipboard(text)
+            echo("Copied to clipboard.")
+        } catch (e: Exception) {
+            echo("Error: ${e.message}", err = true)
+            throw ProgramResult(1)
         }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+private fun copyToSystemClipboard(text: String) {
+    val command =
+        when (Platform.osFamily) {
+            OsFamily.MACOSX -> "pbcopy"
+            OsFamily.LINUX -> "xclip -selection clipboard"
+            OsFamily.WINDOWS -> "clip.exe"
+            else -> error("Unsupported platform for clipboard operations")
+        }
+    val pipe = popen(command, "w") ?: error("Failed to run '$command'. Is it installed?")
+    fputs(text, pipe)
+    val exitCode = pclose(pipe)
+    if (exitCode != 0) {
+        error("Clipboard command '$command' failed (exit $exitCode)")
+    }
 }

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/DeleteCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/DeleteCommand.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.cli.commands
 
+import com.crosspaste.db.paste.PasteDao
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.argument
@@ -12,10 +13,11 @@ class DeleteCommand : CliktCommand(name = "delete") {
     private val id by argument(help = "Paste ID to delete").long()
 
     override fun run() =
-        runWithClient { client ->
-            val response = client.delete("/cli/paste/$id")
-            handleResponse(response) {
-                echo("Paste #$id deleted.")
-            }
+        runWithDao {
+            val pasteDao = getDao<PasteDao>()
+            pasteDao
+                .markDeletePasteData(id)
+                .onSuccess { echo("Paste #$id deleted.") }
+                .onFailure { echo("Failed to delete paste #$id: ${it.message}", err = true) }
         }
 }

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/DevicesCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/DevicesCommand.kt
@@ -1,10 +1,10 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
+import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.requireObject
-import io.ktor.client.call.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 
@@ -29,20 +29,34 @@ class DevicesCommand : CliktCommand(name = "devices") {
     private val ctx by requireObject<CliContext>()
 
     override fun run() =
-        runWithClient { client ->
-            val response = client.get("/cli/devices")
-            handleResponse(response) { resp ->
-                val devices = resp.body<List<DeviceSummary>>()
-                if (ctx.json) {
-                    echo(
-                        cliJson.encodeToString(
-                            ListSerializer(DeviceSummary.serializer()),
-                            devices,
-                        ),
+        runWithDao {
+            val syncDao = getDao<SyncRuntimeInfoDao>()
+            val infos = syncDao.getAllSyncRuntimeInfos()
+            val devices =
+                infos.map { info ->
+                    DeviceSummary(
+                        appInstanceId = info.appInstanceId,
+                        deviceName = info.deviceName,
+                        noteName = info.noteName,
+                        platform = info.platform.name,
+                        appVersion = info.appVersion,
+                        connectState = info.connectState,
+                        connectHostAddress = info.connectHostAddress,
+                        port = info.port,
+                        allowSend = info.allowSend,
+                        allowReceive = info.allowReceive,
                     )
-                } else {
-                    printDevices(devices)
                 }
+
+            if (ctx.json) {
+                echo(
+                    cliJson.encodeToString(
+                        ListSerializer(DeviceSummary.serializer()),
+                        devices,
+                    ),
+                )
+            } else {
+                printDevices(devices)
             }
         }
 

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/FavCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/FavCommand.kt
@@ -1,7 +1,9 @@
 package com.crosspaste.cli.commands
 
+import com.crosspaste.db.paste.PasteDao
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.types.long
 
@@ -12,10 +14,16 @@ class FavCommand : CliktCommand(name = "fav") {
     private val id by argument(help = "Paste ID to toggle favorite").long()
 
     override fun run() =
-        runWithClient { client ->
-            val response = client.put("/cli/paste/$id/favorite")
-            handleResponse(response) {
-                echo("Paste #$id favorite toggled.")
+        runWithDao {
+            val pasteDao = getDao<PasteDao>()
+            val paste = pasteDao.getNoDeletePasteData(id)
+            if (paste == null) {
+                echo("Paste #$id not found.", err = true)
+                throw ProgramResult(1)
             }
+            val newFavorite = !paste.favorite
+            pasteDao.setFavorite(id, newFavorite)
+            val status = if (newFavorite) "favorited" else "unfavorited"
+            echo("Paste #$id $status.")
         }
 }

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/HistoryCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/HistoryCommand.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
+import com.crosspaste.db.paste.PasteDao
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.requireObject
@@ -8,7 +9,6 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
-import io.ktor.client.call.*
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -42,19 +42,29 @@ class HistoryCommand : CliktCommand(name = "history") {
     private val favorite by option("--favorite", "-f", help = "Show only favorites").flag()
 
     override fun run() =
-        runWithClient { client ->
-            var path = "/cli/paste/list?limit=$limit"
-            type?.let { path += "&type=$it" }
-            if (favorite) path += "&favorite=true"
+        runWithDao {
+            val pasteDao = getDao<PasteDao>()
+            val pasteType = resolveTypeFilter(type)
+            val favoriteFilter = if (favorite) true else null
 
-            val response = client.get(path)
-            handleResponse(response) { resp ->
-                val list = resp.body<PasteListResponse>()
-                if (ctx.json) {
-                    echo(cliJson.encodeToString(PasteListResponse.serializer(), list))
-                } else {
-                    printList(list)
-                }
+            val results =
+                pasteDao.searchPasteData(
+                    searchTerms = listOf(),
+                    favorite = favoriteFilter,
+                    pasteType = pasteType,
+                    limit = limit,
+                )
+            val total = pasteDao.getActiveCount()
+            val list =
+                PasteListResponse(
+                    items = results.map { it.toSummaryDto() },
+                    total = total,
+                )
+
+            if (ctx.json) {
+                echo(cliJson.encodeToString(PasteListResponse.serializer(), list))
+            } else {
+                printList(list)
             }
         }
 

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
@@ -1,13 +1,13 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
+import com.crosspaste.db.paste.PasteDao
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.types.long
-import io.ktor.client.call.*
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -32,16 +32,25 @@ class PasteCommand : CliktCommand(name = "paste") {
     private val id by argument(help = "Paste ID to show (omit for most recent)").long().optional()
 
     override fun run() =
-        runWithClient { client ->
-            val path = if (id != null) "/cli/paste/$id" else "/cli/paste/current"
-            val response = client.get(path)
-            handleResponse(response) { resp ->
-                val detail = resp.body<PasteDetailResponse>()
-                if (ctx.json) {
-                    echo(cliJson.encodeToString(PasteDetailResponse.serializer(), detail))
+        runWithDao {
+            val pasteDao = getDao<PasteDao>()
+            val pasteData =
+                if (id != null) {
+                    pasteDao.getNoDeletePasteData(id!!)
                 } else {
-                    printDetail(detail)
+                    pasteDao.getLatestLoadedPasteData()
                 }
+
+            if (pasteData == null) {
+                echo("Paste not found.", err = true)
+                return@runWithDao
+            }
+
+            val detail = pasteData.toDetailResponse()
+            if (ctx.json) {
+                echo(cliJson.encodeToString(PasteDetailResponse.serializer(), detail))
+            } else {
+                printDetail(detail)
             }
         }
 

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/SearchCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/SearchCommand.kt
@@ -1,6 +1,8 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.SearchContentService
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.requireObject
@@ -8,7 +10,6 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
-import io.ktor.client.call.*
 
 class SearchCommand : CliktCommand(name = "search") {
 
@@ -23,18 +24,28 @@ class SearchCommand : CliktCommand(name = "search") {
     private val type by option("--type", "-t", help = "Filter by type (text, link, image, file, html, rtf, color)")
 
     override fun run() =
-        runWithClient { client ->
-            var path = "/cli/paste/search?q=${encodeQuery(query)}&limit=$limit"
-            type?.let { path += "&type=$it" }
+        runWithDao {
+            val pasteDao = getDao<PasteDao>()
+            val searchContentService = getDao<SearchContentService>()
+            val searchTerms = searchContentService.createSearchTerms(query)
+            val pasteType = resolveTypeFilter(type)
 
-            val response = client.get(path)
-            handleResponse(response) { resp ->
-                val list = resp.body<PasteListResponse>()
-                if (ctx.json) {
-                    echo(cliJson.encodeToString(PasteListResponse.serializer(), list))
-                } else {
-                    printResults(list)
-                }
+            val results =
+                pasteDao.searchPasteData(
+                    searchTerms = searchTerms,
+                    pasteType = pasteType,
+                    limit = limit,
+                )
+            val list =
+                PasteListResponse(
+                    items = results.map { it.toSummaryDto() },
+                    total = results.size.toLong(),
+                )
+
+            if (ctx.json) {
+                echo(cliJson.encodeToString(PasteListResponse.serializer(), list))
+            } else {
+                printResults(list)
             }
         }
 
@@ -57,5 +68,3 @@ class SearchCommand : CliktCommand(name = "search") {
         }
     }
 }
-
-private fun encodeQuery(query: String): String = query.replace(" ", "%20").replace("&", "%26").replace("=", "%3D")

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/StatusCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/StatusCommand.kt
@@ -1,10 +1,13 @@
 package com.crosspaste.cli.commands
 
+import com.crosspaste.app.AppInfo
 import com.crosspaste.cli.CliContext
+import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.requireObject
-import io.ktor.client.call.*
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -24,15 +27,30 @@ class StatusCommand : CliktCommand(name = "status") {
     private val ctx by requireObject<CliContext>()
 
     override fun run() =
-        runWithClient { client ->
-            val response = client.get("/cli/status")
-            handleResponse(response) { resp ->
-                val status = resp.body<StatusResponse>()
-                if (ctx.json) {
-                    echo(cliJson.encodeToString(StatusResponse.serializer(), status))
-                } else {
-                    printStatus(status)
-                }
+        runWithDao {
+            val appInfo = getDao<AppInfo>()
+            val configManager = getDao<CommonConfigManager>()
+            val pasteDao = getDao<PasteDao>()
+            val syncDao = getDao<SyncRuntimeInfoDao>()
+
+            val config = configManager.getCurrentConfig()
+            val pasteCount = pasteDao.getActiveCount()
+            val deviceCount = syncDao.getAllSyncRuntimeInfos().size
+
+            val status =
+                StatusResponse(
+                    appVersion = appInfo.appVersion,
+                    appInstanceId = appInfo.appInstanceId,
+                    port = config.port,
+                    pasteboardListening = config.enablePasteboardListening,
+                    deviceCount = deviceCount,
+                    pasteCount = pasteCount,
+                )
+
+            if (ctx.json) {
+                echo(cliJson.encodeToString(StatusResponse.serializer(), status))
+            } else {
+                printStatus(status)
             }
         }
 

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/TagsCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/TagsCommand.kt
@@ -1,28 +1,23 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
+import com.crosspaste.db.paste.PasteTagDao
+import com.crosspaste.paste.PasteTag
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.types.long
-import io.ktor.client.call.*
+import kotlinx.coroutines.flow.first
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
 
 @Serializable
 data class TagSummary(
     val id: Long,
     val name: String,
     val color: Long,
-)
-
-@Serializable
-data class CreateTagRequest(
-    val name: String,
-    val color: Long? = null,
 )
 
 class TagsCommand : CliktCommand(name = "tags") {
@@ -39,20 +34,20 @@ class TagsCommand : CliktCommand(name = "tags") {
 
     override fun run() {
         if (currentContext.invokedSubcommand != null) return
-        runWithClient { client ->
-            val response = client.get("/cli/tags")
-            handleResponse(response) { resp ->
-                val tags = resp.body<List<TagSummary>>()
-                if (ctx.json) {
-                    echo(
-                        cliJson.encodeToString(
-                            ListSerializer(TagSummary.serializer()),
-                            tags,
-                        ),
-                    )
-                } else {
-                    printTags(tags)
-                }
+        runWithDao {
+            val tagDao = getDao<PasteTagDao>()
+            val tags = tagDao.getAllTagsFlow().first()
+            val summaries = tags.map { TagSummary(id = it.id, name = it.name, color = it.color) }
+
+            if (ctx.json) {
+                echo(
+                    cliJson.encodeToString(
+                        ListSerializer(TagSummary.serializer()),
+                        summaries,
+                    ),
+                )
+            } else {
+                printTags(summaries)
             }
         }
     }
@@ -77,17 +72,12 @@ class TagCreateCommand : CliktCommand(name = "create") {
     private val name by argument(help = "Tag name")
 
     override fun run() =
-        runWithClient { client ->
-            val body =
-                Json.encodeToString(
-                    CreateTagRequest.serializer(),
-                    CreateTagRequest(name = name),
-                )
-            val response = client.post("/cli/tags", body)
-            handleResponse(response) { resp ->
-                val tag = resp.body<TagSummary>()
-                echo("Tag '${tag.name}' created (id=${tag.id}).")
-            }
+        runWithDao {
+            val tagDao = getDao<PasteTagDao>()
+            val maxSortOrder = tagDao.getMaxSortOrder()
+            val color = PasteTag.getColor(maxSortOrder + 1)
+            val newId = tagDao.createPasteTag(name, color)
+            echo("Tag '$name' created (id=$newId).")
         }
 }
 
@@ -98,10 +88,9 @@ class TagDeleteCommand : CliktCommand(name = "delete") {
     private val id by argument(help = "Tag ID to delete").long()
 
     override fun run() =
-        runWithClient { client ->
-            val response = client.delete("/cli/tags/$id")
-            handleResponse(response) {
-                echo("Tag #$id deleted.")
-            }
+        runWithDao {
+            val tagDao = getDao<PasteTagDao>()
+            tagDao.deletePasteTagBlock(id)
+            echo("Tag #$id deleted.")
         }
 }

--- a/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/VersionCommand.kt
+++ b/cli/src/nativeMain/kotlin/com/crosspaste/cli/commands/VersionCommand.kt
@@ -4,55 +4,25 @@ import com.crosspaste.cli.CliContext
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.requireObject
-import io.ktor.client.call.*
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class VersionInfo(
     val cliVersion: String,
-    val appVersion: String?,
-    val appRunning: Boolean,
 )
 
 class VersionCommand : CliktCommand(name = "version") {
 
-    override fun help(context: Context): String = "Show CLI and app version"
+    override fun help(context: Context): String = "Show CLI version"
 
     private val ctx by requireObject<CliContext>()
 
     override fun run() {
-        val cliVersion = CLI_VERSION
-        var appVersion: String? = null
-        var appRunning = false
-
-        try {
-            runWithClient { client ->
-                val response = client.get("/cli/status")
-                handleResponse(response) { resp ->
-                    val status = resp.body<StatusResponse>()
-                    appVersion = status.appVersion
-                    appRunning = true
-                }
-            }
-        } catch (_: Exception) {
-            // App not running - that's fine
-        }
-
+        val info = VersionInfo(cliVersion = CLI_VERSION)
         if (ctx.json) {
-            val info =
-                VersionInfo(
-                    cliVersion = cliVersion,
-                    appVersion = appVersion,
-                    appRunning = appRunning,
-                )
             echo(cliJson.encodeToString(VersionInfo.serializer(), info))
         } else {
-            echo("CLI version:  $cliVersion")
-            if (appRunning) {
-                echo("App version:  $appVersion")
-            } else {
-                echo("App version:  (not running)")
-            }
+            echo("CLI version:  ${info.cliVersion}")
         }
     }
 }


### PR DESCRIPTION
Closes #3951

## Summary
- Rewrite all CLI commands from Ktor HTTP client to direct DAO database access and native platform APIs
- CLI no longer requires the desktop app to be running for most operations
- `CliConfigManager` upgraded from read-only to read-write (appConfig.json)
- `CopyCommand` uses native clipboard via `popen(pbcopy/xclip/clip.exe)`
- Removed legacy HTTP infrastructure (`runWithClient`, `handleResponse`, `CliClient`, `AppAutoStarter` DI)

## Commands migrated

| Command | Before (HTTP) | After (Direct) |
|---------|--------------|----------------|
| history | `GET /cli/paste/list` | `PasteDao.searchPasteData()` |
| search | `GET /cli/paste/search` | `SearchContentService` + `PasteDao` |
| paste | `GET /cli/paste/{id}` | `PasteDao.getNoDeletePasteData()` |
| status | `GET /cli/status` | `AppInfo` + `ConfigManager` + DAOs |
| delete | `DELETE /cli/paste/{id}` | `PasteDao.markDeletePasteData()` |
| fav | `PUT /cli/paste/{id}/favorite` | `PasteDao.setFavorite()` |
| tags | `GET/POST/DELETE /cli/tags` | `PasteTagDao` methods |
| config | `GET/PUT /cli/config` | `CommonConfigManager` |
| devices | `GET /cli/devices` | `SyncRuntimeInfoDao` |
| version | `GET /cli/status` | Direct `CLI_VERSION` |
| copy | `POST /cli/clipboard/write` | Native `popen(pbcopy)` |

## Test plan
- [x] `./gradlew ktlintFormat` passes
- [x] `./gradlew cli:compileKotlinNative` passes
- [x] `./gradlew cli:linkDebugExecutableNative` passes
- [x] `./gradlew app:compileKotlinDesktop` passes
- [x] `./gradlew app:desktopTest` — all tests pass
- [x] Smoke test: `crosspaste-cli.kexe version` → `CLI version: 1.2.7`
- [x] Smoke test: `crosspaste-cli.kexe copy "hello"` → text copied to system clipboard