### PR TITLE
Initialize shared-ui and web Gradle modules

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,3 +30,5 @@ plugins {
 include(":app")
 include(":cli")
 include(":shared")
+include(":shared-ui")
+include(":web")

--- a/shared-ui/build.gradle.kts
+++ b/shared-ui/build.gradle.kts
@@ -1,0 +1,51 @@
+import java.io.FileReader
+import java.util.Properties
+
+val versionProperties = Properties()
+versionProperties.load(
+    FileReader(
+        project.projectDir
+            .toPath()
+            .parent
+            .resolve("app/src/desktopMain/resources/crosspaste-version.properties")
+            .toFile(),
+    ),
+)
+
+group = "com.crosspaste"
+version = versionProperties.getProperty("version")
+
+plugins {
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.ktlint)
+}
+
+ktlint {
+    verbose = true
+    android = false
+    ignoreFailures = false
+}
+
+kotlin {
+    jvm("desktop")
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":shared"))
+            implementation(libs.compose.foundation)
+            implementation(libs.compose.material3)
+            implementation(libs.compose.runtime)
+            implementation(libs.compose.ui)
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
+        }
+
+        val desktopMain by getting {
+            dependencies {
+            }
+        }
+    }
+}

--- a/shared-ui/src/commonMain/kotlin/com/crosspaste/ui/SharedUiModule.kt
+++ b/shared-ui/src/commonMain/kotlin/com/crosspaste/ui/SharedUiModule.kt
@@ -1,0 +1,8 @@
+package com.crosspaste.ui
+
+/**
+ * Shared UI module — cross-platform Compose components reused by desktop and web.
+ */
+object SharedUiModule {
+    const val MODULE_NAME = "shared-ui"
+}

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -1,0 +1,46 @@
+import java.io.FileReader
+import java.util.Properties
+
+val versionProperties = Properties()
+versionProperties.load(
+    FileReader(
+        project.projectDir
+            .toPath()
+            .parent
+            .resolve("app/src/desktopMain/resources/crosspaste-version.properties")
+            .toFile(),
+    ),
+)
+
+group = "com.crosspaste"
+version = versionProperties.getProperty("version")
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.ktlint)
+}
+
+ktlint {
+    verbose = true
+    android = false
+    ignoreFailures = false
+}
+
+kotlin {
+    js("web", IR) {
+        browser {
+            commonWebpackConfig {
+                outputFileName = "crosspaste-web.js"
+            }
+        }
+        binaries.executable()
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
+        }
+    }
+}

--- a/web/src/webMain/kotlin/com/crosspaste/web/WebModule.kt
+++ b/web/src/webMain/kotlin/com/crosspaste/web/WebModule.kt
@@ -1,0 +1,8 @@
+package com.crosspaste.web
+
+/**
+ * Web module — Chrome Extension with in-memory DAO and Compose UI.
+ */
+object WebModule {
+    const val MODULE_NAME = "web"
+}


### PR DESCRIPTION
Closes #3953

## Summary
- Add **shared-ui** module: KMP with `jvm("desktop")` target, Compose Multiplatform (foundation, material3, runtime, ui), depends on `:shared`. Intended for cross-platform UI components shared between desktop and web.
- Add **web** module: KMP with `js("web", IR)` target, browser output (`crosspaste-web.js`), coroutines + serialization. Intended for the Chrome Extension frontend.
- Update `settings.gradle.kts` to include both new modules.

Both modules contain placeholder source files and compile successfully alongside existing `app`, `cli`, and `shared` modules.

## Test plan
- [x] `shared-ui:compileKotlinDesktop` passes
- [x] `web:compileKotlinWeb` passes
- [x] `app:compileKotlinDesktop` still passes
- [x] `cli:compileKotlinNative` still passes
- [x] `shared:compileKotlinDesktop` still passes
- [x] ktlintFormat clean on both new modules