### PR TITLE
Extract SearchPasteData and QueryPasteTag interfaces from DAO layer

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
@@ -1,8 +1,8 @@
 package com.crosspaste.ui.model
 
 import androidx.lifecycle.viewModelScope
-import com.crosspaste.db.paste.PasteDao
-import com.crosspaste.db.paste.PasteTagDao
+import com.crosspaste.db.paste.QueryPasteTag
+import com.crosspaste.db.paste.SearchPasteData
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteTag
 import com.crosspaste.paste.SearchContentService
@@ -16,8 +16,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 class GeneralPasteSearchViewModel(
-    private val pasteDao: PasteDao,
-    pasteTagDao: PasteTagDao,
+    private val searchPasteData: SearchPasteData,
+    queryPasteTag: QueryPasteTag,
     private val searchContentService: SearchContentService,
 ) : PasteSearchViewModel() {
 
@@ -26,7 +26,7 @@ class GeneralPasteSearchViewModel(
     override val convertTerm: (String) -> List<String> = searchContentService::createSearchTerms
 
     override val tagList: StateFlow<List<PasteTag>> =
-        pasteTagDao
+        queryPasteTag
             .getAllTagsFlow()
             .stateIn(
                 scope = viewModelScope,
@@ -40,7 +40,7 @@ class GeneralPasteSearchViewModel(
             .distinctUntilChanged()
             .flatMapLatest { params ->
                 logger.info { "to searchPasteDataFlow $params" }
-                pasteDao
+                searchPasteData
                     .searchPasteDataFlow(
                         searchTerms = params.searchTerms,
                         favorite = if (params.favorite) true else null,

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -8,6 +8,8 @@ import com.crosspaste.db.DriverFactory
 import com.crosspaste.db.createDatabase
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.db.paste.PasteTagDao
+import com.crosspaste.db.paste.QueryPasteTag
+import com.crosspaste.db.paste.SearchPasteData
 import com.crosspaste.db.paste.SqlPasteDao
 import com.crosspaste.db.paste.SqlPasteTagDao
 import com.crosspaste.db.secure.SecureIO
@@ -101,6 +103,8 @@ class DesktopModule(
                 )
             }
             single<PasteTagDao> { SqlPasteTagDao(get()) }
+            single<QueryPasteTag> { get<PasteTagDao>() }
+            single<SearchPasteData> { get<PasteDao>() }
             single<SecureIO> { SqlSecureDao(get()) }
             single<SyncRuntimeInfoDao> { SqlSyncRuntimeInfoDao(get()) }
             single<TaskDao> { SqlTaskDao(get()) }

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -5,7 +5,7 @@ import com.crosspaste.paste.PasteExportParam
 import com.crosspaste.paste.item.PasteItem
 import kotlinx.coroutines.flow.Flow
 
-interface PasteDao {
+interface PasteDao : SearchPasteData {
 
     fun getNoDeletePasteDataBlock(id: Long): PasteData?
 
@@ -80,28 +80,6 @@ interface PasteDao {
     suspend fun getSizeByTimeLessThan(time: Long): Long
 
     suspend fun findCleanTimeByCumulativeSize(targetSize: Long): Long?
-
-    suspend fun searchPasteData(
-        searchTerms: List<String>,
-        local: Boolean? = null,
-        favorite: Boolean? = null,
-        pasteType: Int? = null,
-        sort: Boolean = true,
-        tag: Long? = null,
-        limit: Int,
-    ): List<PasteData>
-
-    fun searchPasteDataFlow(
-        searchTerms: List<String>,
-        local: Boolean? = null,
-        favorite: Boolean? = null,
-        pasteType: Int? = null,
-        sort: Boolean = true,
-        tag: Long? = null,
-        limit: Int,
-    ): Flow<List<PasteData>>
-
-    suspend fun searchBySource(source: String): List<PasteData>
 
     suspend fun getDistinctSources(): List<String>
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteTagDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteTagDao.kt
@@ -1,11 +1,6 @@
 package com.crosspaste.db.paste
 
-import com.crosspaste.paste.PasteTag
-import kotlinx.coroutines.flow.Flow
-
-interface PasteTagDao {
-
-    fun getAllTagsFlow(): Flow<List<PasteTag>>
+interface PasteTagDao : QueryPasteTag {
 
     suspend fun getMaxSortOrder(): Long
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/QueryPasteTag.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/QueryPasteTag.kt
@@ -1,0 +1,9 @@
+package com.crosspaste.db.paste
+
+import com.crosspaste.paste.PasteTag
+import kotlinx.coroutines.flow.Flow
+
+interface QueryPasteTag {
+
+    fun getAllTagsFlow(): Flow<List<PasteTag>>
+}

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SearchPasteData.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SearchPasteData.kt
@@ -1,0 +1,29 @@
+package com.crosspaste.db.paste
+
+import com.crosspaste.paste.PasteData
+import kotlinx.coroutines.flow.Flow
+
+interface SearchPasteData {
+
+    suspend fun searchPasteData(
+        searchTerms: List<String>,
+        local: Boolean? = null,
+        favorite: Boolean? = null,
+        pasteType: Int? = null,
+        sort: Boolean = true,
+        tag: Long? = null,
+        limit: Int,
+    ): List<PasteData>
+
+    fun searchPasteDataFlow(
+        searchTerms: List<String>,
+        local: Boolean? = null,
+        favorite: Boolean? = null,
+        pasteType: Int? = null,
+        sort: Boolean = true,
+        tag: Long? = null,
+        limit: Int,
+    ): Flow<List<PasteData>>
+
+    suspend fun searchBySource(source: String): List<PasteData>
+}


### PR DESCRIPTION
Closes #3955

## Summary
- Extract `SearchPasteData` interface from `PasteDao` with `searchPasteData()`, `searchPasteDataFlow()`, and `searchBySource()` methods
- Extract `QueryPasteTag` interface from `PasteTagDao` with `getAllTagsFlow()` method
- `PasteDao` and `PasteTagDao` now extend the new interfaces, preserving backward compatibility
- `GeneralPasteSearchViewModel` depends on the narrow interfaces instead of full DAOs
- DI registrations added in `DesktopModule`

## Test plan
- [ ] `./gradlew app:compileKotlinDesktop` passes
- [ ] `./gradlew app:desktopTest` passes
- [ ] `./gradlew ktlintCheck` passes