### PR TITLE
:bug: Fix theme flash from light to dark on startup

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/theme/CrossPasteTheme.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/theme/CrossPasteTheme.kt
@@ -7,10 +7,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import com.crosspaste.ui.LocalThemeExtState
 import com.crosspaste.ui.LocalThemeState
 import com.crosspaste.ui.base.rememberUserSelectedFont
 import com.crosspaste.ui.base.withCustomFonts
+import com.crosspaste.ui.theme.ThemeState.Companion.createThemeState
 import org.koin.compose.koinInject
 
 object CrossPasteTheme {
@@ -29,15 +31,32 @@ object CrossPasteTheme {
             themeDetector.setSystemInDark(isSystemInDark)
         }
 
-        val themeExt = ThemeExt.buildThemeExt(themeState.isCurrentThemeDark)
+        // Use Compose-detected isSystemInDark directly to avoid theme flash on startup.
+        // DesktopThemeDetector initializes isSystemInDark to false, and the LaunchedEffect
+        // above corrects it asynchronously — but that causes one frame of wrong theme.
+        val effectiveThemeState =
+            remember(themeState, isSystemInDark) {
+                if (themeState.isSystemInDark != isSystemInDark) {
+                    createThemeState(
+                        themeColor = themeState.themeColor,
+                        isFollowSystem = themeState.isFollowSystem,
+                        isUserInDark = themeState.isUserInDark,
+                        isSystemInDark = isSystemInDark,
+                    )
+                } else {
+                    themeState
+                }
+            }
+
+        val themeExt = ThemeExt.buildThemeExt(effectiveThemeState.isCurrentThemeDark)
 
         CompositionLocalProvider(LocalThemeExtState provides themeExt) {
             MaterialTheme(
-                colorScheme = themeState.colorScheme,
+                colorScheme = effectiveThemeState.colorScheme,
                 typography = MaterialTheme.typography.withCustomFonts(userSelectedFont),
             ) {
                 CompositionLocalProvider(
-                    LocalThemeState provides themeState,
+                    LocalThemeState provides effectiveThemeState,
                 ) {
                     content()
                 }


### PR DESCRIPTION
Closes #3959

## Summary

- Fix the visible theme flash (light → dark) on app startup when the system is in dark mode
- Use `remember(themeState, isSystemInDark)` to synchronously compute `effectiveThemeState` using Compose's `isSystemInDarkTheme()` value directly, ensuring the correct theme from the very first frame
- `LaunchedEffect` is retained to sync the value back to `ThemeDetector` for other non-Compose consumers

## Root Cause

`DesktopThemeDetector` initializes `_isSystemInDark` to `false`. The `LaunchedEffect` in `CrossPasteTheme.Theme()` corrects this asynchronously, but only after the first frame has already rendered with the wrong (light) theme.

## Test plan

- [ ] Launch app with system in dark mode + "follow system" theme setting → no flash
- [ ] Launch app with system in light mode → no regression
- [ ] Toggle system dark mode while app is running → theme updates correctly
- [ ] Manual theme selection (light/dark) still works correctly