### PR TITLE
:bug: Recreate LazyListState on window open to reliably reset scroll position

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
@@ -18,9 +18,9 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.contentColorFor
@@ -89,7 +89,10 @@ fun SidePasteboardContentView() {
     val searchResult by pasteSearchViewModel.searchResults.collectAsState()
     val selectedIndexes by pasteSelectionViewModel.selectedIndexes.collectAsState()
 
-    val searchListState = rememberLazyListState()
+    // Recreate scroll state on each show/hide transition so every window open starts at position 0.
+    // scrollToItem(0) is unreliable when the window is hidden because the layout engine skips
+    // hidden windows, so we create a fresh LazyListState instead.
+    val searchListState = remember(searchWindowInfo.show) { LazyListState() }
     pasteSelectionViewModel.searchListState = searchListState
     val adapter = rememberScrollbarAdapter(scrollState = searchListState)
     var showScrollbar by remember { mutableStateOf(false) }
@@ -108,19 +111,15 @@ fun SidePasteboardContentView() {
         }
     }
 
-    // Reset scroll position when window hides, so next open starts at position 0
-    // without any visible scroll-back.
+    // Reset key modifier state when the window opens.
     LaunchedEffect(searchWindowInfo.show) {
-        if (!searchWindowInfo.show) {
-            pasteSelectionViewModel.initSelectIndex()
-            searchListState.scrollToItem(0)
-        } else {
+        if (searchWindowInfo.show) {
             isCtrlPressed = false
             isShiftPressed = false
         }
     }
 
-    // Reset scroll position when search parameters change while window is visible.
+    // Reset selection and scroll position when search parameters change while window is visible.
     LaunchedEffect(
         inputSearch,
         searchBaseParams.favorite,


### PR DESCRIPTION
Closes #3965

## Summary
- Replace `rememberLazyListState()` with `remember(searchWindowInfo.show) { LazyListState() }` to create a fresh scroll state on each window open
- Remove unreliable `scrollToItem(0)` call during window hide (layout engine skips hidden windows, making it a no-op)

## Root Cause
The `Window` composable uses `visible = false` to hide the search window, keeping composables in the tree. `scrollToItem(0)` called during hide is silently ignored because the layout engine doesn't process hidden windows. On reopen, `rememberLazyListState()` returns the same state with the old scroll position.

## Test plan
- Open search window, scroll right, press ESC to hide, reopen — verify scroll position is at the beginning
- Open search window, change search filters — verify scroll resets
- Open search window, use keyboard navigation — verify it still works correctly