### PR TITLE
:wrench: Add kotlin-js-store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ app/build/
 app/dylib/
 app/jbr/
 logs/
+kotlin-js-store/
 node_modules/
 output*/
 /.claude/commands/


### PR DESCRIPTION
Closes #3963

## Summary
- Add `kotlin-js-store/` to `.gitignore` to exclude Kotlin/JS build cache from version control

## Test plan
- Verify `kotlin-js-store/` directory is no longer tracked by git