### PR TITLE
Auto-close token view when all pending verifiers complete verification

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenApi.kt
@@ -12,9 +12,15 @@ interface AppTokenApi {
 
     val refresh: StateFlow<Boolean>
 
+    val pendingVerifiers: StateFlow<Set<String>>
+
     fun sameToken(token: Int): Boolean
 
     fun startRefresh(showToken: Boolean)
 
     fun stopRefresh(hideToken: Boolean)
+
+    fun addPendingVerifier(appInstanceId: String)
+
+    fun removePendingVerifier(appInstanceId: String)
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -33,6 +34,10 @@ abstract class AppTokenService : AppTokenApi {
     private val _showToken = MutableStateFlow(false)
 
     override val showToken: StateFlow<Boolean> = _showToken.asStateFlow()
+
+    private val _pendingVerifiers = MutableStateFlow<Set<String>>(emptySet())
+
+    override val pendingVerifiers: StateFlow<Set<String>> = _pendingVerifiers.asStateFlow()
 
     private val _token = MutableStateFlow(charArrayOf('0', '0', '0', '0', '0', '0'))
 
@@ -92,6 +97,18 @@ abstract class AppTokenService : AppTokenApi {
                     _showToken.value = false
                 }
             }
+        }
+    }
+
+    override fun addPendingVerifier(appInstanceId: String) {
+        _pendingVerifiers.update { currentSet ->
+            currentSet + appInstanceId
+        }
+    }
+
+    override fun removePendingVerifier(appInstanceId: String) {
+        _pendingVerifiers.update { currentSet ->
+            currentSet - appInstanceId
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -101,7 +101,11 @@ fun Routing.syncRouting(
     }
 
     get("/sync/showToken") {
+        val appInstanceId = call.request.headers["appInstanceId"]
         val host = call.request.host()
+        if (appInstanceId != null) {
+            appTokenApi.addPendingVerifier(appInstanceId)
+        }
         appTokenApi.startRefresh(showToken = true)
         logger.info { "show token requested from $host" }
         successResponse(call)
@@ -178,6 +182,10 @@ fun Routing.syncRouting(
             }.onSuccess { trustResponse ->
                 val host = call.request.headers["crosspaste-host"]
                 trustSyncInfo(appInstanceId, host)
+                appTokenApi.removePendingVerifier(appInstanceId)
+                if (appTokenApi.showToken.value) {
+                    appTokenApi.stopRefresh(hideToken = false)
+                }
                 successResponse(call, trustResponse)
             }.onFailure { e ->
                 logger.error(e) { "Trust request failed for $appInstanceId" }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -33,7 +34,9 @@ import androidx.compose.ui.window.PopupProperties
 import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Close
 import com.crosspaste.app.AppTokenApi
+import com.crosspaste.db.sync.SyncState
 import com.crosspaste.i18n.GlobalCopywriter
+import com.crosspaste.sync.SyncManager
 import com.crosspaste.ui.LocalAppSizeValueState
 import com.crosspaste.ui.theme.AppUISize.medium
 import com.crosspaste.ui.theme.AppUISize.small
@@ -49,9 +52,30 @@ import org.koin.compose.koinInject
 @Composable
 fun TokenView(intOffset: IntOffset) {
     val appTokenApi = koinInject<AppTokenApi>()
+    val syncManager = koinInject<SyncManager>()
     val copywriter = koinInject<GlobalCopywriter>()
     val appSizeValue = LocalAppSizeValueState.current
     val showToken by appTokenApi.showToken.collectAsState()
+
+    // Auto-close token view when all pending verifiers have completed verification
+    // (either trust succeeded, went offline, or disconnected)
+    val pending by appTokenApi.pendingVerifiers.collectAsState()
+    val syncRuntimeInfos by syncManager.realTimeSyncRuntimeInfos.collectAsState()
+
+    val allResolved =
+        showToken &&
+            pending.isNotEmpty() &&
+            pending.all { verifierId ->
+                val info = syncRuntimeInfos.find { it.appInstanceId == verifierId }
+                info != null && info.connectState != SyncState.UNVERIFIED
+            }
+
+    LaunchedEffect(allResolved) {
+        if (allResolved) {
+            pending.forEach { appTokenApi.removePendingVerifier(it) }
+            appTokenApi.stopRefresh(hideToken = true)
+        }
+    }
 
     if (showToken) {
         Popup(


### PR DESCRIPTION
Closes #3971

## Summary
- Track pending verifiers by `appInstanceId` in `AppTokenApi`/`AppTokenService` using a `StateFlow<Set<String>>`
- Register verifiers on `/sync/showToken` and unregister on `/sync/trust` success in `SyncRouting`
- Auto-close token view via `LaunchedEffect` in `TokenView` when all pending verifiers leave `UNVERIFIED` state
- On trust success, call `stopRefresh(hideToken = false)` to decrement the refresh counter without hiding the token (the `LaunchedEffect` handles hiding)

## Test plan
- [ ] Device A discovers Device B → Device B shows token popup → Device A enters correct token → Device B's token popup auto-closes
- [ ] Device A discovers Device B but Device A goes offline → Device B's token popup auto-closes (offline counts as resolved)
- [ ] Multiple devices request verification simultaneously → token popup closes only after all have resolved
- [ ] Manual close button still works during verification