### PR TITLE
Fix flaky testThreeDeviceMesh by adding stabilization delay

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
@@ -198,6 +198,9 @@ class SyncIntegrationTest {
             a.start()
             b.start()
             c.start()
+            // Allow Netty event loops to stabilize after starting 3 servers
+            // in the same JVM to avoid ClosedReadChannelException from resource contention
+            kotlinx.coroutines.delay(200)
 
             // B trusts A
             trustBToA(a, b)


### PR DESCRIPTION
Closes #3977

## Summary
- Add a 200ms delay after starting 3 Netty servers in `testThreeDeviceMesh` to allow event loops to stabilize
- Prevents intermittent `ClosedReadChannelException` caused by `Dispatchers.IO` thread pool contention when multiple servers compete for resources in the same JVM

## Test plan
- [x] `testThreeDeviceMesh` passes consistently
- [x] All other `SyncIntegrationTest` tests remain passing