### PR TITLE
:bug: Fix devices list overlapping FAB and transparent sticky headers

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/SectionHeader.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/SectionHeader.kt
@@ -23,7 +23,7 @@ import org.koin.compose.koinInject
 @Composable
 fun SectionHeader(
     text: String,
-    backgroundColor: Color = Color.Transparent,
+    backgroundColor: Color = MaterialTheme.colorScheme.surface,
     topPadding: Dp = 0.dp,
     trailingContent: @Composable (() -> Unit)? = null,
 ) {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.ui.devices
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -33,6 +34,7 @@ import com.crosspaste.ui.base.SectionHeader
 import com.crosspaste.ui.theme.AppUISize.large2X
 import com.crosspaste.ui.theme.AppUISize.medium
 import com.crosspaste.ui.theme.AppUISize.tiny
+import com.crosspaste.ui.theme.AppUISize.titanic
 import com.crosspaste.ui.theme.AppUISize.xxLarge
 import com.crosspaste.ui.theme.AppUISize.zero
 import org.koin.compose.koinInject
@@ -93,8 +95,8 @@ fun DevicesContentView() {
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(horizontal = medium)
-                    .padding(bottom = medium),
+                    .padding(horizontal = medium),
+            contentPadding = PaddingValues(bottom = titanic),
             verticalArrangement = Arrangement.spacedBy(tiny),
         ) {
             if (syncRuntimeInfos.isNotEmpty()) {


### PR DESCRIPTION
Closes #3982

## Summary
- Add `contentPadding` with bottom spacing (`titanic` = 80dp) to the devices `LazyColumn`, so the last items can scroll above the FAB button
- Change `SectionHeader` default `backgroundColor` from `Color.Transparent` to `MaterialTheme.colorScheme.surface`, making sticky headers opaque so scrolling items don't show through

## Test plan
- [ ] Open the Devices page with multiple linked and nearby devices
- [ ] Verify all list items can be scrolled above the FAB button
- [ ] Verify sticky section headers are opaque when items scroll underneath