### PR TITLE
:bug: Fix SQLITE_BUSY errors by serializing SyncRuntimeInfoDao writes

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/db/DesktopDriverFactory.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/db/DesktopDriverFactory.kt
@@ -32,8 +32,7 @@ class DesktopDriverFactory(
                 isAutoCommit = true
                 poolName = "CrossPastePool"
 
-                addDataSourceProperty("busy_timeout", "10000")
-                connectionInitSql = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;"
+                connectionInitSql = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA busy_timeout=10000;"
             }
 
         val hikariDataSource = HikariDataSource(config)

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SqlSyncRuntimeInfoDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SqlSyncRuntimeInfoDao.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 class SqlSyncRuntimeInfoDao(
@@ -19,6 +21,8 @@ class SqlSyncRuntimeInfoDao(
     private val jsonUtils = getJsonUtils()
 
     private val syncRuntimeInfoDatabaseQueries = database.syncRuntimeInfoDatabaseQueries
+
+    private val writeMutex = Mutex()
 
     private val updateNotifier = Channel<String>(Channel.UNLIMITED)
 
@@ -72,8 +76,10 @@ class SqlSyncRuntimeInfoDao(
     ): String? =
         withContext(ioDispatcher) {
             val change =
-                database.transactionWithResult {
-                    updateAction(syncRuntimeInfo)
+                writeMutex.withLock {
+                    database.transactionWithResult {
+                        updateAction(syncRuntimeInfo)
+                    }
                 }
             if (change) {
                 updateNotifier.trySend(syncRuntimeInfo.appInstanceId)
@@ -129,9 +135,11 @@ class SqlSyncRuntimeInfoDao(
     override suspend fun deleteSyncRuntimeInfo(appInstanceId: String) {
         withContext(ioDispatcher) {
             val deleted =
-                database.transactionWithResult {
-                    syncRuntimeInfoDatabaseQueries.deleteSyncRuntimeInfo(appInstanceId)
-                    syncRuntimeInfoDatabaseQueries.change().executeAsOne() > 0
+                writeMutex.withLock {
+                    database.transactionWithResult {
+                        syncRuntimeInfoDatabaseQueries.deleteSyncRuntimeInfo(appInstanceId)
+                        syncRuntimeInfoDatabaseQueries.change().executeAsOne() > 0
+                    }
                 }
             if (deleted) {
                 updateNotifier.trySend(appInstanceId)
@@ -147,89 +155,98 @@ class SqlSyncRuntimeInfoDao(
     ) {
         withContext(ioDispatcher) {
             val changed =
-                database.transactionWithResult {
-                    val now = nowEpochMilliseconds()
-                    val existing =
-                        syncRuntimeInfoDatabaseQueries
-                            .getSyncRuntimeInfo(
-                                syncInfo.appInfo.appInstanceId,
-                                SyncRuntimeInfo::mapper,
-                            ).executeAsOneOrNull()
+                writeMutex.withLock {
+                    database.transactionWithResult {
+                        val now = nowEpochMilliseconds()
+                        val existing =
+                            syncRuntimeInfoDatabaseQueries
+                                .getSyncRuntimeInfo(
+                                    syncInfo.appInfo.appInstanceId,
+                                    SyncRuntimeInfo::mapper,
+                                ).executeAsOneOrNull()
 
-                    if (existing != null) {
-                        val hostInfoList = (existing.hostInfoList + syncInfo.endpointInfo.hostInfoList).distinct()
+                        if (existing != null) {
+                            val hostInfoList = (existing.hostInfoList + syncInfo.endpointInfo.hostInfoList).distinct()
 
-                        val connectNetworkPrefixLength: Long? = connectInfo?.networkPrefixLength?.toLong()
-                        val connectHostAddress: String? = connectInfo?.hostAddress
-                        val connectState: Long = if (connectInfo != null) SyncState.CONNECTED.toLong() else -1L
+                            val connectNetworkPrefixLength: Long? = connectInfo?.networkPrefixLength?.toLong()
+                            val connectHostAddress: String? = connectInfo?.hostAddress
+                            val connectState: Long = if (connectInfo != null) SyncState.CONNECTED.toLong() else -1L
 
-                        val hostInfoChanged =
-                            !SyncRuntimeInfo.hostInfoListEqual(
-                                existing.hostInfoList,
-                                hostInfoList,
-                            )
-                        val syncInfoChanged = existing.diffSyncInfo(syncInfo)
-                        val connectChanged =
-                            connectInfo != null &&
-                                (
-                                    existing.connectHostAddress != connectHostAddress ||
-                                        existing.connectNetworkPrefixLength?.toLong() != connectNetworkPrefixLength ||
-                                        existing.connectState.toLong() != connectState
+                            val hostInfoChanged =
+                                !SyncRuntimeInfo.hostInfoListEqual(
+                                    existing.hostInfoList,
+                                    hostInfoList,
                                 )
+                            val syncInfoChanged = existing.diffSyncInfo(syncInfo)
+                            val connectChanged =
+                                connectInfo != null &&
+                                    (
+                                        existing.connectHostAddress != connectHostAddress ||
+                                            existing.connectNetworkPrefixLength?.toLong() !=
+                                            connectNetworkPrefixLength ||
+                                            existing.connectState.toLong() != connectState
+                                    )
 
-                        if (!hostInfoChanged && !syncInfoChanged && !connectChanged) {
-                            return@transactionWithResult false
+                            if (!hostInfoChanged && !syncInfoChanged && !connectChanged) {
+                                return@transactionWithResult false
+                            }
+
+                            val hostInfoArrayJson = jsonUtils.JSON.encodeToString(hostInfoList)
+                            syncRuntimeInfoDatabaseQueries.updateSyncInfo(
+                                syncInfo.appInfo.appVersion,
+                                syncInfo.appInfo.userName,
+                                syncInfo.endpointInfo.deviceId,
+                                syncInfo.endpointInfo.deviceName,
+                                syncInfo.endpointInfo.platform.name,
+                                syncInfo.endpointInfo.platform.arch,
+                                syncInfo.endpointInfo.platform.bitMode
+                                    .toLong(),
+                                syncInfo.endpointInfo.platform.version,
+                                hostInfoArrayJson,
+                                syncInfo.endpointInfo.port.toLong(),
+                                syncInfo.endpointInfo.port.toLong(),
+                                connectNetworkPrefixLength,
+                                connectHostAddress,
+                                connectState,
+                                connectState,
+                                now,
+                                syncInfo.appInfo.appInstanceId,
+                            )
+                            true
+                        } else {
+                            val connectNetworkPrefixLength: Long? = connectInfo?.networkPrefixLength?.toLong()
+                            val connectHostAddress: String? = connectInfo?.hostAddress
+                            val connectState: Long =
+                                if (connectInfo !=
+                                    null
+                                ) {
+                                    SyncState.CONNECTED.toLong()
+                                } else {
+                                    SyncState.DISCONNECTED.toLong()
+                                }
+
+                            val hostInfoArrayJson = jsonUtils.JSON.encodeToString(syncInfo.endpointInfo.hostInfoList)
+                            syncRuntimeInfoDatabaseQueries.createSyncRuntimeInfo(
+                                syncInfo.appInfo.appInstanceId,
+                                syncInfo.appInfo.appVersion,
+                                syncInfo.appInfo.userName,
+                                syncInfo.endpointInfo.deviceId,
+                                syncInfo.endpointInfo.deviceName,
+                                syncInfo.endpointInfo.platform.name,
+                                syncInfo.endpointInfo.platform.arch,
+                                syncInfo.endpointInfo.platform.bitMode
+                                    .toLong(),
+                                syncInfo.endpointInfo.platform.version,
+                                hostInfoArrayJson,
+                                syncInfo.endpointInfo.port.toLong(),
+                                connectNetworkPrefixLength,
+                                connectHostAddress,
+                                connectState,
+                                now,
+                                now,
+                            )
+                            true
                         }
-
-                        val hostInfoArrayJson = jsonUtils.JSON.encodeToString(hostInfoList)
-                        syncRuntimeInfoDatabaseQueries.updateSyncInfo(
-                            syncInfo.appInfo.appVersion,
-                            syncInfo.appInfo.userName,
-                            syncInfo.endpointInfo.deviceId,
-                            syncInfo.endpointInfo.deviceName,
-                            syncInfo.endpointInfo.platform.name,
-                            syncInfo.endpointInfo.platform.arch,
-                            syncInfo.endpointInfo.platform.bitMode
-                                .toLong(),
-                            syncInfo.endpointInfo.platform.version,
-                            hostInfoArrayJson,
-                            syncInfo.endpointInfo.port.toLong(),
-                            syncInfo.endpointInfo.port.toLong(),
-                            connectNetworkPrefixLength,
-                            connectHostAddress,
-                            connectState,
-                            connectState,
-                            now,
-                            syncInfo.appInfo.appInstanceId,
-                        )
-                        true
-                    } else {
-                        val connectNetworkPrefixLength: Long? = connectInfo?.networkPrefixLength?.toLong()
-                        val connectHostAddress: String? = connectInfo?.hostAddress
-                        val connectState: Long =
-                            if (connectInfo != null) SyncState.CONNECTED.toLong() else SyncState.DISCONNECTED.toLong()
-
-                        val hostInfoArrayJson = jsonUtils.JSON.encodeToString(syncInfo.endpointInfo.hostInfoList)
-                        syncRuntimeInfoDatabaseQueries.createSyncRuntimeInfo(
-                            syncInfo.appInfo.appInstanceId,
-                            syncInfo.appInfo.appVersion,
-                            syncInfo.appInfo.userName,
-                            syncInfo.endpointInfo.deviceId,
-                            syncInfo.endpointInfo.deviceName,
-                            syncInfo.endpointInfo.platform.name,
-                            syncInfo.endpointInfo.platform.arch,
-                            syncInfo.endpointInfo.platform.bitMode
-                                .toLong(),
-                            syncInfo.endpointInfo.platform.version,
-                            hostInfoArrayJson,
-                            syncInfo.endpointInfo.port.toLong(),
-                            connectNetworkPrefixLength,
-                            connectHostAddress,
-                            connectState,
-                            now,
-                            now,
-                        )
-                        true
                     }
                 }
 


### PR DESCRIPTION
Closes #3993

## Summary

- **Move `busy_timeout` to `connectionInitSql`** as a PRAGMA so it's reliably applied on every HikariCP pooled connection (previously set via `addDataSourceProperty` which may not translate to the SQLite PRAGMA)
- **Add `Mutex` to serialize write operations** in `SqlSyncRuntimeInfoDao` (`updateTemplate`, `deleteSyncRuntimeInfo`, `insertOrUpdateSyncInfo`) to prevent concurrent SQLite transactions from competing for the write lock

## Root Cause

Multiple concurrent JmDNS service resolutions trigger simultaneous `insertOrUpdateSyncInfo` calls via fire-and-forget `realTimeSyncScope.launch`. Each coroutine gets a different connection from HikariCP, causing `SQLITE_BUSY` and `SQLITE_BUSY_SNAPSHOT` errors. The `SQLITE_BUSY_SNAPSHOT` variant cannot be resolved by `busy_timeout` — it requires transaction retry.

## Test plan

- [ ] Verify app starts without SQLITE_BUSY exceptions in logs
- [ ] Confirm multiple device discoveries resolve without database errors
- [ ] Check sync state updates work correctly under concurrent load