### PR TITLE
:hammer: Redesign Counter component to match prototype stepper design

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/Counter.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/Counter.kt
@@ -1,21 +1,24 @@
 package com.crosspaste.ui.base
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,16 +26,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Add
 import com.composables.icons.materialsymbols.rounded.Remove
+import com.crosspaste.ui.theme.AppUISize.giant
+import com.crosspaste.ui.theme.AppUISize.medium
+import com.crosspaste.ui.theme.AppUISize.tiny
+import com.crosspaste.ui.theme.AppUISize.tiny5X
+import com.crosspaste.ui.theme.AppUISize.tinyRoundedCornerShape
+import com.crosspaste.ui.theme.AppUISize.xLarge
+import com.crosspaste.ui.theme.AppUISize.xxxLarge
 
 @Composable
 fun Counter(
@@ -44,93 +54,118 @@ fun Counter(
     var count by remember { mutableStateOf(defaultValue) }
     val colorScheme = MaterialTheme.colorScheme
 
-    // M3 Container: Rounded Pill shape with Surface Variant background
     Surface(
         modifier = Modifier.wrapContentSize(),
-        shape = CircleShape,
-        color = colorScheme.surfaceVariant,
-        tonalElevation = 2.dp,
+        shape = tinyRoundedCornerShape,
+        color = colorScheme.surface,
+        border = BorderStroke(tiny5X, colorScheme.outlineVariant),
     ) {
         Row(
-            modifier = Modifier.padding(4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
+            modifier = Modifier.height(xxxLarge),
         ) {
-            // Minus Button
-            IconButton(
-                onClick = {
-                    val newCount = count - 1
-                    if (rule(newCount)) {
-                        count = newCount
-                        onChange(newCount)
-                    }
-                },
-                modifier = Modifier.size(40.dp),
-            ) {
-                Icon(
-                    imageVector = MaterialSymbols.Rounded.Remove,
-                    contentDescription = "Decrease",
-                    tint = colorScheme.primary,
-                )
-            }
-
-            // Numeric Input and Unit
-            Row(
-                modifier = Modifier.padding(horizontal = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                // We use BasicTextField for a cleaner "no-border" look inside the pill
-                BasicTextField(
-                    value = count.toString(),
-                    onValueChange = { s ->
-                        if (s.isEmpty()) {
-                            // Handle empty state if needed, or set to 0
-                        } else if (s.all { it.isDigit() }) {
-                            val newCount = s.toLongOrNull() ?: count
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier =
+                    Modifier
+                        .size(xxxLarge)
+                        .clip(
+                            RoundedCornerShape(
+                                topStart = tiny,
+                                bottomStart = tiny,
+                            ),
+                        ).clickable {
+                            val newCount = count - 1
                             if (rule(newCount)) {
                                 count = newCount
                                 onChange(newCount)
                             }
-                        }
-                    },
-                    textStyle =
-                        TextStyle(
-                            color = colorScheme.onSurface,
-                            fontSize = 18.sp,
-                            fontWeight = FontWeight.Medium,
-                            textAlign = TextAlign.End,
-                        ),
-                    cursorBrush = SolidColor(colorScheme.primary),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    modifier = Modifier.width(IntrinsicSize.Min).widthIn(min = 32.dp),
+                        },
+            ) {
+                Icon(
+                    imageVector = MaterialSymbols.Rounded.Remove,
+                    contentDescription = "Decrease",
+                    modifier = Modifier.size(medium),
+                    tint = colorScheme.onSurfaceVariant,
                 )
+            }
 
-                if (unit.isNotEmpty()) {
-                    Text(
-                        text = unit,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = colorScheme.onSurfaceVariant,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(start = 4.dp, end = 4.dp),
+            VerticalDivider(
+                thickness = tiny5X,
+                color = colorScheme.outlineVariant,
+            )
+
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.widthIn(min = giant),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    BasicTextField(
+                        value = count.toString(),
+                        onValueChange = { s ->
+                            if (s.isNotEmpty() && s.all { it.isDigit() }) {
+                                val newCount = s.toLongOrNull() ?: count
+                                if (rule(newCount)) {
+                                    count = newCount
+                                    onChange(newCount)
+                                }
+                            }
+                        },
+                        textStyle =
+                            TextStyle(
+                                color = colorScheme.onSurface,
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Medium,
+                                textAlign = TextAlign.End,
+                            ),
+                        cursorBrush = SolidColor(colorScheme.primary),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.width(IntrinsicSize.Min).widthIn(min = xLarge),
                     )
+
+                    if (unit.isNotEmpty()) {
+                        Text(
+                            text = " $unit",
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = colorScheme.onSurface,
+                        )
+                    }
                 }
             }
 
-            // Plus Button
-            IconButton(
-                onClick = {
-                    val newCount = count + 1
-                    if (rule(newCount)) {
-                        count = newCount
-                        onChange(newCount)
-                    }
-                },
-                modifier = Modifier.size(40.dp),
+            VerticalDivider(
+                thickness = tiny5X,
+                color = colorScheme.outlineVariant,
+            )
+
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier =
+                    Modifier
+                        .size(xxxLarge)
+                        .clip(
+                            RoundedCornerShape(
+                                topEnd = tiny,
+                                bottomEnd = tiny,
+                            ),
+                        ).clickable {
+                            val newCount = count + 1
+                            if (rule(newCount)) {
+                                count = newCount
+                                onChange(newCount)
+                            }
+                        },
             ) {
                 Icon(
                     imageVector = MaterialSymbols.Rounded.Add,
                     contentDescription = "Increase",
-                    tint = colorScheme.primary,
+                    modifier = Modifier.size(medium),
+                    tint = colorScheme.onSurfaceVariant,
                 )
             }
         }


### PR DESCRIPTION
Closes #3997

## Summary
- Replace pill shape (`CircleShape`) with rounded rectangle and 1dp outline border
- Add `VerticalDivider` separators between minus button, value area, and plus button
- Make layout more compact: 36dp height, 16dp icons, 13sp font size
- Fix hover/ripple clip shape to match container corners (left-rounded for minus, right-rounded for plus)
- Replace all magic `dp` values with `AppUISize` constants

## Test plan
- [ ] Verify Counter renders with rounded rectangle shape and border
- [ ] Verify vertical dividers appear between sections
- [ ] Verify hover/ripple effect clips correctly to container corners
- [ ] Verify increment/decrement and manual input still work