### PR TITLE
:hammer: Redesign FilledDropdown component to match prototype design

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/FilledDropdown.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/FilledDropdown.kt
@@ -1,23 +1,21 @@
 package com.crosspaste.ui.base
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuAnchorType
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,16 +23,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.rememberTextMeasurer
-import com.crosspaste.ui.theme.AppUISize.medium
-import com.crosspaste.ui.theme.AppUISize.xxxxLarge
+import androidx.compose.ui.unit.sp
+import com.composables.icons.materialsymbols.MaterialSymbols
+import com.composables.icons.materialsymbols.rounded.Check
+import com.composables.icons.materialsymbols.rounded.Expand_more
+import com.crosspaste.ui.theme.AppUISize.small
+import com.crosspaste.ui.theme.AppUISize.small3X
+import com.crosspaste.ui.theme.AppUISize.tiny2X
+import com.crosspaste.ui.theme.AppUISize.tiny5X
+import com.crosspaste.ui.theme.AppUISize.tinyRoundedCornerShape
+import com.crosspaste.ui.theme.AppUISize.xxLarge
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FilledDropdown(
     selectedIndex: Int,
@@ -43,130 +44,84 @@ fun FilledDropdown(
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-
     val selectedOptionText = options.getOrNull(selectedIndex) ?: ""
-
-    val textMeasurer = rememberTextMeasurer()
-    val textStyle =
-        MaterialTheme.typography.bodyLarge.copy(
-            fontWeight = FontWeight.Medium,
-            fontFamily = FontFamily.Monospace,
-        )
-    val density = LocalDensity.current
-
-    val calculatedWidth =
-        remember(options, textStyle) {
-            val maxTextWidthPx =
-                options.maxOfOrNull {
-                    textMeasurer.measure(it, style = textStyle).size.width
-                } ?: 0
-
-            with(density) {
-                maxTextWidthPx.toDp() + medium + xxxxLarge
-            }
-        }
-
-    val interactionSource = remember { MutableInteractionSource() }
+    val colorScheme = MaterialTheme.colorScheme
 
     Box(
         modifier = modifier.wrapContentWidth(),
         contentAlignment = Alignment.CenterEnd,
     ) {
-        ExposedDropdownMenuBox(
-            expanded = expanded,
-            onExpandedChange = { expanded = !expanded },
-            modifier = Modifier.width(calculatedWidth),
+        Surface(
+            shape = tinyRoundedCornerShape,
+            color = colorScheme.surface,
+            border = BorderStroke(tiny5X, colorScheme.outlineVariant),
         ) {
-            val colors =
-                TextFieldDefaults.colors(
-                    focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                    disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                    focusedIndicatorColor = MaterialTheme.colorScheme.primary,
-                    unfocusedIndicatorColor = MaterialTheme.colorScheme.outlineVariant,
-                )
-
-            BasicTextField(
-                value = selectedOptionText,
-                onValueChange = {},
-                readOnly = true,
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(tiny2X),
                 modifier =
                     Modifier
-                        .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                        .fillMaxWidth()
-                        .height(xxxxLarge),
-                textStyle =
-                    textStyle.copy(
-                        color = MaterialTheme.colorScheme.onSurface,
-                    ),
-                interactionSource = interactionSource,
-                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                decorationBox = { innerTextField ->
-                    TextFieldDefaults.DecorationBox(
-                        value = selectedOptionText,
-                        innerTextField = innerTextField,
-                        enabled = true,
-                        singleLine = true,
-                        visualTransformation = VisualTransformation.None,
-                        interactionSource = interactionSource,
-                        trailingIcon = {
-                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-                        },
-                        colors = colors,
-                        contentPadding = PaddingValues(start = medium),
-                        container = {
-                            TextFieldDefaults.Container(
-                                enabled = true,
-                                isError = false,
-                                interactionSource = interactionSource,
-                                colors = colors,
-                                shape = MaterialTheme.shapes.extraSmall,
-                            )
-                        },
-                    )
-                },
-            )
-
-            ExposedDropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false },
-                modifier = Modifier.background(MaterialTheme.colorScheme.surfaceContainer),
+                        .clip(tinyRoundedCornerShape)
+                        .clickable { expanded = !expanded }
+                        .padding(horizontal = small3X, vertical = tiny2X),
             ) {
-                options.forEachIndexed { index, selectionOption ->
-                    val isSelected = index == selectedIndex
-                    DropdownMenuItem(
-                        text = {
-                            Text(
-                                text = selectionOption,
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                                color =
-                                    if (isSelected) {
-                                        MaterialTheme.colorScheme.onSecondaryContainer
-                                    } else {
-                                        MaterialTheme.colorScheme.onSurface
-                                    },
-                            )
-                        },
-                        onClick = {
-                            expanded = false
-                            onSelected(index)
-                        },
-                        colors =
-                            MenuDefaults.itemColors(
-                                textColor = MaterialTheme.colorScheme.onSurface,
-                            ),
-                        modifier =
-                            Modifier.background(
+                Text(
+                    text = selectedOptionText,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = colorScheme.onSurface,
+                )
+                Icon(
+                    imageVector = MaterialSymbols.Rounded.Expand_more,
+                    contentDescription = "Expand",
+                    modifier = Modifier.size(small),
+                    tint = colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            containerColor = colorScheme.surface,
+            shape = tinyRoundedCornerShape,
+        ) {
+            options.forEachIndexed { index, option ->
+                val isSelected = index == selectedIndex
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = option,
+                            fontSize = 13.sp,
+                            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
+                            color =
                                 if (isSelected) {
-                                    MaterialTheme.colorScheme.secondaryContainer
+                                    colorScheme.primary
                                 } else {
-                                    MaterialTheme.colorScheme.surfaceContainer
+                                    colorScheme.onSurface
                                 },
-                            ),
-                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
-                    )
-                }
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onSelected(index)
+                    },
+                    trailingIcon =
+                        if (isSelected) {
+                            {
+                                Icon(
+                                    imageVector = MaterialSymbols.Rounded.Check,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(small),
+                                    tint = colorScheme.primary,
+                                )
+                            }
+                        } else {
+                            null
+                        },
+                    contentPadding = PaddingValues(horizontal = small3X, vertical = tiny2X),
+                    modifier = Modifier.height(xxLarge),
+                )
             }
         }
     }


### PR DESCRIPTION
Closes #3999

## Summary
- Replace heavy `ExposedDropdownMenuBox` + `BasicTextField` + `TextFieldDefaults.DecorationBox` with compact `Surface` trigger + `DropdownMenu`
- Use rounded rectangle (8dp) with 1dp outline border, consistent with Counter component style
- Compact sizing: 13sp font, 14dp chevron icon, minimal padding
- Fix hover/ripple shape clipped to rounded corners via `Modifier.clip()`
- Set `containerColor` and `shape` on `DropdownMenu` to match trigger, eliminating edge color mismatch
- Compact menu items with fixed 32dp height and matching content padding
- Selected item indicated by primary-colored text + check icon
- Replace manual text width measurement with intrinsic sizing
- Use `AppUISize` constants throughout

## Test plan
- [ ] Verify dropdown trigger renders with rounded rectangle and border
- [ ] Verify hover/ripple clips to rounded corners
- [ ] Verify dropdown menu background matches trigger (no edge color mismatch)
- [ ] Verify menu items are compact and visually consistent with trigger
- [ ] Verify selection works and selected item shows primary text + check icon