### PR TITLE
:hammer: Extract platform-specific number keyboard options for iOS compatibility

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/Counter.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/Counter.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,7 +29,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import com.composables.icons.materialsymbols.MaterialSymbols
@@ -123,7 +121,7 @@ fun Counter(
                                 textAlign = TextAlign.End,
                             ),
                         cursorBrush = SolidColor(colorScheme.primary),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        keyboardOptions = numberKeyboardOptions(),
                         modifier = Modifier.width(IntrinsicSize.Min).widthIn(min = xLarge),
                     )
 

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/KeyboardUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/KeyboardUtils.kt
@@ -1,0 +1,8 @@
+package com.crosspaste.ui.base
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.input.ImeAction
+
+@Composable
+expect fun numberKeyboardOptions(imeAction: ImeAction = ImeAction.Default): KeyboardOptions

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -45,7 +44,6 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.em
@@ -58,6 +56,7 @@ import com.crosspaste.sync.SyncManager
 import com.crosspaste.ui.LocalAppSizeValueState
 import com.crosspaste.ui.base.DialogActionButton
 import com.crosspaste.ui.base.DialogButtonType
+import com.crosspaste.ui.base.numberKeyboardOptions
 import com.crosspaste.ui.theme.AppUIFont.generalBodyTextStyle
 import com.crosspaste.ui.theme.AppUISize.medium
 import com.crosspaste.ui.theme.AppUISize.tiny
@@ -318,8 +317,7 @@ fun TokenInputBox(
                 textStyle = mergedTextStyle,
                 singleLine = true,
                 keyboardOptions =
-                    KeyboardOptions.Default.copy(
-                        keyboardType = KeyboardType.Number,
+                    numberKeyboardOptions(
                         imeAction = if (index == focusRequesters.size - 1) ImeAction.Done else ImeAction.Next,
                     ),
                 cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/KeyboardUtils.desktop.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/KeyboardUtils.desktop.kt
@@ -1,0 +1,10 @@
+package com.crosspaste.ui.base
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+
+@Composable
+actual fun numberKeyboardOptions(imeAction: ImeAction): KeyboardOptions =
+    KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = imeAction)


### PR DESCRIPTION
Closes #4001

## Summary
- Create `numberKeyboardOptions(imeAction)` as `expect`/`actual` function in `KeyboardUtils.kt`
- Desktop `actual` returns `KeyboardOptions(keyboardType = Number, imeAction = imeAction)`
- Mobile `actual` can customize keyboard config (e.g. add Done button on iOS number pad)
- Replace all `KeyboardType.Number` usages in `Counter.kt` and `TrustDeviceDialog.kt`

## Test plan
- [ ] Verify Counter number input still works on desktop
- [ ] Verify TrustDeviceDialog OTP input with Done/Next ime actions still works
- [ ] Verify compilation succeeds on all platforms