### PR TITLE
:hammer: Remove deprecated title parameter from AppFileChooser (#4014)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppFileChooser.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppFileChooser.kt
@@ -9,7 +9,6 @@ interface AppFileChooser {
 
     fun openFileChooser(
         fileSelectionMode: FileSelectionMode,
-        title: String? = null,
         initPath: Path? = null,
         cancel: (() -> Unit)? = null,
         action: (Any) -> Unit,

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppFileChooser.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppFileChooser.kt
@@ -24,7 +24,6 @@ class DesktopAppFileChooser(
 
     override fun openFileChooser(
         fileSelectionMode: FileSelectionMode,
-        title: String?,
         initPath: Path?,
         cancel: (() -> Unit)?,
         action: (Any) -> Unit,
@@ -38,7 +37,6 @@ class DesktopAppFileChooser(
                             FileSelectionMode.FILE_ONLY -> {
                                 FileKit
                                     .openFilePicker(
-                                        title = title,
                                         directory = initPath?.let { path -> PlatformFile(path.toFile()) },
                                     )?.let { platformFile ->
                                         action(platformFile.file.toOkioPath(true))
@@ -49,7 +47,6 @@ class DesktopAppFileChooser(
                             FileSelectionMode.DIRECTORY_ONLY -> {
                                 FileKit
                                     .openDirectoryPicker(
-                                        title = title,
                                         directory = initPath?.let { path -> PlatformFile(path.toFile()) },
                                     )?.let { platformFile ->
                                         action(platformFile.file.toOkioPath(true))
@@ -75,7 +72,6 @@ class DesktopAppFileChooser(
     ) {
         openFileChooser(
             fileSelectionMode = FileSelectionMode.DIRECTORY_ONLY,
-            null,
             initPath,
             cancel,
             action,
@@ -89,7 +85,6 @@ class DesktopAppFileChooser(
     ) {
         openFileChooser(
             fileSelectionMode = FileSelectionMode.FILE_ONLY,
-            null,
             initPath,
             cancel,
             action,

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/DesktopStoragePathManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/DesktopStoragePathManager.kt
@@ -113,10 +113,8 @@ class DesktopStoragePathManager : StoragePathManager {
                                         duration = null,
                                     )
                                 }
-                                val chooseText = copywriter.getText("selecting_storage_directory")
                                 appFileChooser.openFileChooser(
                                     FileSelectionMode.DIRECTORY_ONLY,
-                                    chooseText,
                                     currentStoragePath,
                                 ) { path ->
 


### PR DESCRIPTION
Closes #4014

**Base branch**: `dependabot/gradle/io.github.vinceglb-filekit-dialogs-0.13.0` (requires FileKit 0.13.0 upgrade)

## Summary
- Remove `title` parameter from `AppFileChooser.openFileChooser()` interface — no longer supported by FileKit 0.13.0
- Clean up `DesktopAppFileChooser` implementation and call sites

## Test plan
- [ ] Verify file picker opens correctly without title parameter
- [ ] Verify directory picker opens correctly without title parameter
- [ ] Verify storage path selection works in settings