### PR TITLE
:hammer: Merge addSyncTask and addTargetedSyncTask into single method (#4021)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -115,7 +115,7 @@ class PasteReleaseService(
                 currentPaste.setPasteId(id)
                 taskSubmitter.submit {
                     addRenderingTask(id, pasteType)
-                    addSyncTask(id, pasteData.appInstanceId, maxFileSize)
+                    addSyncTask(id, maxFileSize, pasteData.appInstanceId)
 
                     if (pasteType.isFile() || pasteType.isImage()) {
                         if ((firstItem as PasteFiles).isRefFiles()) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
@@ -312,11 +312,11 @@ class DesktopPasteMenuService(
                     ContextMenuItem(syncRuntimeInfo.getDeviceDisplayName()) {
                         menuScope.launch {
                             taskSubmitter.submit {
-                                addTargetedSyncTask(
+                                addSyncTask(
                                     id = pasteData.id,
+                                    fileSize = pasteData.size,
                                     appInstanceId = appInfo.appInstanceId,
                                     targetAppInstanceId = syncRuntimeInfo.appInstanceId,
-                                    fileSize = pasteData.size,
                                 )
                             }
                         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
@@ -74,33 +74,17 @@ class DesktopTaskBuilder(
 
     override fun addSyncTask(
         id: Long,
-        appInstanceId: String,
         fileSize: Long,
+        appInstanceId: String,
+        targetAppInstanceId: String?,
     ): TaskBuilder {
         if (appControl.isFileSizeSyncEnabled(fileSize)) {
+            val targetIds = targetAppInstanceId?.let { setOf(it) } ?: setOf()
             taskIds.add(
                 taskDao.createTaskBlock(
                     id,
                     TaskType.SYNC_PASTE_TASK,
-                    SyncExtraInfo(appInstanceId),
-                ),
-            )
-        }
-        return this
-    }
-
-    override fun addTargetedSyncTask(
-        id: Long,
-        appInstanceId: String,
-        targetAppInstanceId: String,
-        fileSize: Long,
-    ): TaskBuilder {
-        if (appControl.isFileSizeSyncEnabled(fileSize)) {
-            taskIds.add(
-                taskDao.createTaskBlock(
-                    id,
-                    TaskType.SYNC_PASTE_TASK,
-                    SyncExtraInfo(appInstanceId, setOf(targetAppInstanceId)),
+                    SyncExtraInfo(appInstanceId, targetIds),
                 ),
             )
         }

--- a/shared/src/commonMain/kotlin/com/crosspaste/task/TaskSubmitter.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/task/TaskSubmitter.kt
@@ -23,15 +23,9 @@ interface TaskBuilder {
 
     fun addSyncTask(
         id: Long,
-        appInstanceId: String,
         fileSize: Long,
-    ): TaskBuilder
-
-    fun addTargetedSyncTask(
-        id: Long,
         appInstanceId: String,
-        targetAppInstanceId: String,
-        fileSize: Long,
+        targetAppInstanceId: String? = null,
     ): TaskBuilder
 
     fun addRelaySyncTask(


### PR DESCRIPTION
Closes #4021

## Summary

- Merge `addSyncTask` and `addTargetedSyncTask` into a single `addSyncTask` method with optional `targetAppInstanceId` parameter
- Reorder parameters to `(id, fileSize, appInstanceId, targetAppInstanceId?)` for better readability
- Update all call sites in `PasteReleaseService`, `DesktopPasteMenuService`, and `DesktopTaskSubmitter`

## Test plan

- [ ] Verify automatic sync to all devices still works (no `targetAppInstanceId`)
- [ ] Verify targeted sync via right-click "Sync To" menu still works (with `targetAppInstanceId`)