### PR TITLE
:arrow_up: Bump version to 1.2.9

### DIFF
--- a/app/src/desktopMain/resources/crosspaste-version.properties
+++ b/app/src/desktopMain/resources/crosspaste-version.properties
@@ -1,1 +1,1 @@
-version=1.2.8
+version=1.2.9


### PR DESCRIPTION
Closes #4028

Update the application version from 1.2.8 to 1.2.9 in `crosspaste-version.properties`.