### PR TITLE
:bug: Fix CLI cross-platform build failures for Windows and cross-compilation (#4030)

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -89,6 +89,11 @@ kotlin {
 
     sourceSets {
         val cliNativeMain by getting {
+            if (isMingwX64) {
+                kotlin.srcDir("src/mingwNativeMain/kotlin")
+            } else {
+                kotlin.srcDir("src/posixNativeMain/kotlin")
+            }
             dependencies {
                 implementation(project(":shared"))
                 implementation(libs.clikt)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CopyCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CopyCommand.kt
@@ -1,13 +1,10 @@
 package com.crosspaste.cli.commands
 
+import com.crosspaste.cli.platform.pipeToCommand
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.arguments.argument
-import kotlinx.cinterop.ExperimentalForeignApi
-import platform.posix.fputs
-import platform.posix.pclose
-import platform.posix.popen
 import kotlin.experimental.ExperimentalNativeApi
 
 class CopyCommand : CliktCommand(name = "copy") {
@@ -27,7 +24,7 @@ class CopyCommand : CliktCommand(name = "copy") {
     }
 }
 
-@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+@OptIn(ExperimentalNativeApi::class)
 private fun copyToSystemClipboard(text: String) {
     val command =
         when (Platform.osFamily) {
@@ -36,10 +33,5 @@ private fun copyToSystemClipboard(text: String) {
             OsFamily.WINDOWS -> "clip.exe"
             else -> error("Unsupported platform for clipboard operations")
         }
-    val pipe = popen(command, "w") ?: error("Failed to run '$command'. Is it installed?")
-    fputs(text, pipe)
-    val exitCode = pclose(pipe)
-    if (exitCode != 0) {
-        error("Clipboard command '$command' failed (exit $exitCode)")
-    }
+    pipeToCommand(command, text)
 }

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/ClipboardPipe.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/ClipboardPipe.kt
@@ -1,0 +1,19 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix._pclose
+import platform.posix._popen
+import platform.posix.fputs
+
+@OptIn(ExperimentalForeignApi::class)
+fun pipeToCommand(
+    command: String,
+    text: String,
+) {
+    val pipe = _popen(command, "w") ?: error("Failed to run '$command'. Is it installed?")
+    fputs(text, pipe)
+    val exitCode = _pclose(pipe)
+    if (exitCode != 0) {
+        error("Clipboard command '$command' failed (exit $exitCode)")
+    }
+}

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/ClipboardPipe.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/ClipboardPipe.kt
@@ -1,0 +1,19 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.fputs
+import platform.posix.pclose
+import platform.posix.popen
+
+@OptIn(ExperimentalForeignApi::class)
+fun pipeToCommand(
+    command: String,
+    text: String,
+) {
+    val pipe = popen(command, "w") ?: error("Failed to run '$command'. Is it installed?")
+    fputs(text, pipe)
+    val exitCode = pclose(pipe)
+    if (exitCode != 0) {
+        error("Clipboard command '$command' failed (exit $exitCode)")
+    }
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -46,13 +46,26 @@ kotlin {
     val isArm64 = System.getProperty("os.arch") == "aarch64"
     val isMingwX64 = hostOs.startsWith("Windows")
 
-    when {
-        hostOs == "Mac OS X" && isArm64 -> macosArm64("nativeApp")
-        hostOs == "Mac OS X" && !isArm64 -> macosX64("nativeApp")
-        hostOs == "Linux" && isArm64 -> linuxArm64("nativeApp")
-        hostOs == "Linux" && !isArm64 -> linuxX64("nativeApp")
-        isMingwX64 -> mingwX64("nativeApp")
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
+    val cliTarget = project.findProperty("cli.target") as? String
+
+    if (cliTarget != null) {
+        when (cliTarget) {
+            "macosArm64" -> macosArm64("nativeApp")
+            "macosX64" -> macosX64("nativeApp")
+            "linuxArm64" -> linuxArm64("nativeApp")
+            "linuxX64" -> linuxX64("nativeApp")
+            "mingwX64" -> mingwX64("nativeApp")
+            else -> throw GradleException("Unsupported CLI target: $cliTarget")
+        }
+    } else {
+        when {
+            hostOs == "Mac OS X" && isArm64 -> macosArm64("nativeApp")
+            hostOs == "Mac OS X" && !isArm64 -> macosX64("nativeApp")
+            hostOs == "Linux" && isArm64 -> linuxArm64("nativeApp")
+            hostOs == "Linux" && !isArm64 -> linuxX64("nativeApp")
+            isMingwX64 -> mingwX64("nativeApp")
+            else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
Closes #4030

## Summary
- Extract platform-specific `popen`/`pclose` calls into `posixNativeMain` and `mingwNativeMain` source directories to fix Windows (mingwX64) build failure where `popen`/`pclose` don't exist in `platform.posix`
- Update `shared/build.gradle.kts` to respect `cli.target` property for native target selection, fixing cross-compilation variant mismatch
- Conditionally include the correct platform source directory in `cli/build.gradle.kts`

## Test plan
- [x] Verified `cli:compileKotlinCliNative` succeeds on macOS (host target)
- [x] Verified `cli:compileKotlinCliNative -Pcli.target=macosX64` cross-compilation succeeds on ARM Mac
- [ ] Verify Windows CI build passes
- [ ] Verify Linux CI build passes