### PR TITLE
Fix image side preview crop fill and blurry decode size

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/ImageDisplayStrategy.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/ImageDisplayStrategy.kt
@@ -20,6 +20,19 @@ interface ImageDisplayStrategy {
     ): DisplayResult
 
     /**
+     * Calculates the optimal decode size for image loading, ensuring the decoded
+     * image is large enough for the chosen display strategy (e.g. crop vs fit).
+     *
+     * @param srcSize The dimensions of the source image.
+     * @param dstSize The dimensions of the destination display area.
+     * @return The size at which the image should be decoded.
+     */
+    fun computeRequestSize(
+        srcSize: Size,
+        dstSize: Size,
+    ): Size
+
+    /**
      * Result of the display strategy calculation.
      *
      * @property contentScale How the image should be scaled.

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/SmartImageDisplayStrategy.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/SmartImageDisplayStrategy.kt
@@ -44,6 +44,22 @@ class SmartImageDisplayStrategy(
         }
     }
 
+    override fun computeRequestSize(
+        srcSize: Size,
+        dstSize: Size,
+    ): Size {
+        val scaleX = dstSize.width / srcSize.width
+        val scaleY = dstSize.height / srcSize.height
+        val ratioDifference = abs(scaleX - scaleY) / max(scaleX, scaleY)
+        val scale =
+            if (ratioDifference < aspectRatioDifferenceThreshold) {
+                max(scaleX, scaleY)
+            } else {
+                min(scaleX, scaleY)
+            }
+        return Size(srcSize.width * scale, srcSize.height * scale)
+    }
+
     private object CropContentScale : ContentScale {
         override fun computeScaleFactor(
             srcSize: Size,

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -21,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
@@ -121,19 +121,32 @@ fun PasteDataScope.ImageSidePreviewView() {
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
+            val imgSize = intSize
+            val requestSize =
+                remember(targetSizePx, imgSize) {
+                    if (imgSize != null && imgSize.width > 0 && imgSize.height > 0) {
+                        smartImageDisplayStrategy.computeRequestSize(
+                            srcSize = Size(imgSize.width.toFloat(), imgSize.height.toFloat()),
+                            dstSize = targetSizePx,
+                        )
+                    } else {
+                        targetSizePx
+                    }
+                }
+
             val request =
-                remember(pasteFileCoordinate, targetSizePx) {
+                remember(pasteFileCoordinate, requestSize) {
                     ImageRequest
                         .Builder(platformContext)
                         .data(ImageItem(pasteFileCoordinate, false))
-                        .size(width = targetSizePx.width.toInt(), height = targetSizePx.height.toInt())
+                        .size(width = requestSize.width.toInt(), height = requestSize.height.toInt())
                         .precision(Precision.INEXACT)
                         .crossfade(true)
                         .build()
                 }
 
             SubcomposeAsyncImage(
-                modifier = Modifier.wrapContentSize(),
+                modifier = Modifier.fillMaxSize().clipToBounds(),
                 model = request,
                 imageLoader = userImageLoader,
                 contentDescription = "imageType",


### PR DESCRIPTION
Closes #4040

## Summary
- Change `Modifier.wrapContentSize()` to `Modifier.fillMaxSize().clipToBounds()` so images with aspect ratios close to the container properly fill the space with overflow clipped.
- Add `computeRequestSize()` to `ImageDisplayStrategy` / `SmartImageDisplayStrategy` to calculate the optimal Coil decode size (crop mode uses `max(scaleX, scaleY)`, fit mode uses `min`).
- Use `computeRequestSize()` in `ImageSidePreviewView` to avoid blurry upscaling in crop mode.

## Test plan
- [ ] Verify images with similar aspect ratio to the container fill the preview area (crop mode)
- [ ] Verify images with very different aspect ratios still display correctly (fit mode)
- [ ] Verify SVG images load and display correctly
- [ ] Verify long screenshots display with top-aligned scroll