### PR TITLE
Fix color hex format in MarketingPasteData from ARGB to RGBA

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/MarketingPasteData.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/MarketingPasteData.kt
@@ -36,7 +36,7 @@ open class MarketingPasteData(
 
     private val color =
         run {
-            val colorHex = "#FFA6D6D6"
+            val colorHex = "#A6D6D6FF"
             val pasteItem =
                 createColorPasteItem(
                     color = parseHexColor(colorHex)!!.toArgb(),


### PR DESCRIPTION
Closes #4042

## Summary
- Change color hex in `MarketingPasteData` from `#FFA6D6D6` (ARGB) to `#A6D6D6FF` (RGBA) to match the expected format of `parseHexColor`.

## Test plan
- [ ] Verify MarketingPasteData renders the correct color in the UI