### PR TITLE
Fix flaky crypto tests that assume wrong-key decryption always throws

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/secure/SecureMessageProcessorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/secure/SecureMessageProcessorTest.kt
@@ -201,11 +201,14 @@ class SecureMessageProcessorTest {
             val modifiedEncrypted = encrypted.clone()
             modifiedEncrypted[i] = (modifiedEncrypted[i] + 1).toByte()
 
-            runCatching {
-                bProcessor.decrypt(modifiedEncrypted)
-            }.onFailure { e ->
-                println("Expected exception with modified data at position $i: ${e.javaClass.name} - ${e.message}")
-            }
+            // AES/CBC with tampered ciphertext usually throws an exception, but with
+            // ~1/256 probability the padding remains valid and decryption "succeeds"
+            // with garbage plaintext.
+            val result = runCatching { bProcessor.decrypt(modifiedEncrypted) }
+            assertTrue(
+                result.isFailure || !result.getOrThrow().contentEquals(message),
+                "Modified data at position $i should either fail decryption or produce different plaintext",
+            )
         }
     }
 
@@ -333,15 +336,20 @@ class SecureMessageProcessorTest {
         val message = "Test message".encodeToByteArray()
         val encrypted = aProcessor.encrypt(message)
 
-        val exception =
-            assertFailsWith<PasteException> {
-                wrongProcessor.decrypt(encrypted)
-            }
-
+        // AES/CBC with wrong key usually throws an exception (wrapped as PasteException),
+        // but with ~1/256 probability the padding remains valid and decryption "succeeds"
+        // with garbage plaintext.
+        val result = runCatching { wrongProcessor.decrypt(encrypted) }
         assertTrue(
-            exception.match(StandardErrorCode.DECRYPT_FAIL),
-            "Decryption with wrong key pair should throw DECRYPT_FAIL exception",
+            result.isFailure || !result.getOrThrow().contentEquals(message),
+            "Decryption with wrong key pair should either fail or produce different plaintext",
         )
+        if (result.isFailure) {
+            assertTrue(
+                result.exceptionOrNull() is PasteException,
+                "Exception should be PasteException",
+            )
+        }
     }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/EncryptUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/EncryptUtilsTest.kt
@@ -48,13 +48,18 @@ class EncryptUtilsTest {
     }
 
     @Test
-    fun `decrypt with wrong key throws exception`() {
+    fun `decrypt with wrong key fails or produces wrong plaintext`() {
         val key1 = EncryptUtils.generateAESKey()
         val key2 = EncryptUtils.generateAESKey()
         val data = "secret message".toByteArray()
         val encrypted = EncryptUtils.encryptData(key1, data)
+        // AES/CBC with wrong key usually throws BadPaddingException, but with ~1/256
+        // probability the padding happens to be valid and decryption "succeeds" with garbage.
         val result = runCatching { EncryptUtils.decryptData(key2, encrypted) }
-        assertTrue(result.isFailure, "Decrypting with wrong key should fail")
+        assertTrue(
+            result.isFailure || !result.getOrThrow().contentEquals(data),
+            "Decrypting with wrong key should either fail or produce different plaintext",
+        )
     }
 
     @Test


### PR DESCRIPTION
Closes #4044

## Summary
- Fix `EncryptUtilsTest.decrypt with wrong key` - was asserting `isFailure` only
- Fix `SecureMessageProcessorTest.testWithModifiedData` - had no assertions (silently swallowed exceptions)
- Fix `SecureMessageProcessorTest.testDecryptionWithWrongKeyPair` - used `assertFailsWith` which fails when decryption doesn't throw

AES/CBC with PKCS5Padding has ~1/256 probability of producing valid padding when decrypting with a wrong key or tampered ciphertext. All three tests now accept either exception OR different plaintext as valid outcomes.

## Test plan
- [x] `EncryptUtilsTest` passes
- [x] `SecureMessageProcessorTest` passes