### PR TITLE
Fix ToStartView showing on open and not appearing when scrolled

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
@@ -104,10 +104,11 @@ fun SidePasteboardContentView() {
     var isShiftPressed by remember { mutableStateOf(false) }
     var isCtrlPressed by remember { mutableStateOf(false) }
 
-    val showToStart by remember {
+    val showToStart by remember(searchListState) {
         derivedStateOf {
             // Show "to start" button when scrolled beyond three screens
-            searchListState.firstVisibleItemIndex >= searchListState.layoutInfo.visibleItemsInfo.size * 3
+            val visibleSize = searchListState.layoutInfo.visibleItemsInfo.size
+            visibleSize > 0 && searchListState.firstVisibleItemIndex >= visibleSize * 3
         }
     }
 


### PR DESCRIPTION
Closes #4051

## Summary
- Fix `showToStart` using stale `searchListState` by changing `remember` to `remember(searchListState)` so `derivedStateOf` is recreated when the list state is rebuilt on window show/hide
- Add `visibleSize > 0` guard to prevent `0 >= 0` evaluating to `true` when no items are laid out

## Test plan
- [ ] Open search window → ToStartView should NOT appear
- [ ] Scroll to the end of a long list → ToStartView should appear
- [ ] Click ToStartView → list scrolls back to start
- [ ] Close and reopen search window → ToStartView should NOT appear