### PR TITLE
:bug: Fix HTML/RTF search content returning raw markup

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -9,6 +9,7 @@ import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.paste.item.PasteItemProperties
 import com.crosspaste.paste.item.bindItem
+import com.crosspaste.paste.item.extractSearchContent
 import com.crosspaste.paste.plugin.process.PasteProcessPlugin
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.task.TaskBuilder
@@ -104,7 +105,7 @@ class PasteReleaseService(
                         pasteSearchContent =
                             searchContentService.createSearchContent(
                                 pasteData.source,
-                                firstItem.getSearchContent(),
+                                firstItem.extractSearchContent(),
                             ),
                         size = size,
                         hash = hash,

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
@@ -10,6 +10,7 @@ import com.crosspaste.paste.PasteState
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.clear
 import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.paste.item.extractSearchContent
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.task.TaskSubmitter
 import com.crosspaste.utils.DateUtils
@@ -116,7 +117,7 @@ class SqlPasteDao(
                     pasteData.createTime,
                     searchContentService.createSearchContent(
                         pasteData.source,
-                        pasteData.pasteAppearItem?.getSearchContent(),
+                        pasteData.pasteAppearItem?.extractSearchContent(),
                     ),
                     (pasteState ?: pasteData.pasteState).toLong(),
                     pasteData.remote,
@@ -132,7 +133,7 @@ class SqlPasteDao(
                 pasteData.pasteCollection.toJson(),
                 searchContentService.createSearchContent(
                     pasteData.source,
-                    pasteData.pasteAppearItem?.getSearchContent(),
+                    pasteData.pasteAppearItem?.extractSearchContent(),
                 ),
                 pasteData.id,
             )

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItemExt.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItemExt.kt
@@ -86,3 +86,14 @@ val HtmlPasteItem.truncatedPreviewHtml: String
 val RtfPasteItem.truncatedPreviewHtml: String
     get() = rtfUtils.rtfToHtml(rtf)?.let { htmlUtils.truncateForPreview(it) } ?: ""
 
+/**
+ * Extract plain-text search content from a PasteItem.
+ * For HtmlPasteItem/RtfPasteItem, parses the markup to get readable text.
+ * For all others, delegates to [PasteItem.getSearchContent].
+ */
+fun PasteItem.extractSearchContent(): String? =
+    when (this) {
+        is HtmlPasteItem -> htmlUtils.getHtmlText(html)?.lowercase()
+        is RtfPasteItem -> rtfUtils.getText(rtf)?.lowercase()
+        else -> getSearchContent()
+    }


### PR DESCRIPTION
Closes #4061

## Summary
- Add `PasteItem.extractSearchContent()` extension in shared that parses HTML/RTF markup into plain text using `htmlUtils`/`rtfUtils`
- Replace `getSearchContent()` calls in `SqlPasteDao` (2 sites) and `PasteReleaseService` (1 site) with `extractSearchContent()`
- Other item types (text, url, color, files, images) delegate to the original `getSearchContent()` unchanged

## Test plan
- [x] `shared:compileKotlinDesktop` passes
- [x] `app:compileKotlinDesktop` passes
- [x] `app:desktopTest` — all tests pass