### PR TITLE
:art: Add Compose stability configuration for core module types

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,10 @@ buildscript {
     }
 }
 
+composeCompiler {
+    stabilityConfigurationFile = rootProject.layout.projectDirectory.file("compose-stability.conf")
+}
+
 ktlint {
     verbose = true
     android = false

--- a/compose-stability.conf
+++ b/compose-stability.conf
@@ -1,0 +1,10 @@
+// Classes and interfaces that should be treated as stable by the Compose compiler.
+// These were previously annotated with @Stable in the shared module before being
+// moved to the core module (which has no Compose dependency).
+
+// Sealed interface — Compose can't infer stability for interfaces
+com.crosspaste.paste.item.PasteItem
+
+// kotlinx.serialization types used in PasteItem fields
+kotlinx.serialization.json.JsonObject
+kotlinx.serialization.json.JsonElement

--- a/shared-ui/build.gradle.kts
+++ b/shared-ui/build.gradle.kts
@@ -23,6 +23,10 @@ plugins {
     alias(libs.plugins.ktlint)
 }
 
+composeCompiler {
+    stabilityConfigurationFile = rootProject.layout.projectDirectory.file("compose-stability.conf")
+}
+
 ktlint {
     verbose = true
     android = false

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -33,6 +33,10 @@ sqldelight {
     }
 }
 
+composeCompiler {
+    stabilityConfigurationFile = rootProject.layout.projectDirectory.file("compose-stability.conf")
+}
+
 ktlint {
     verbose = true
     android = false


### PR DESCRIPTION
Closes #4063

## Summary
- Add `compose-stability.conf` at project root marking `PasteItem`, `JsonObject`, and `JsonElement` as stable
- Configure `composeCompiler { stabilityConfigurationFile }` in `app`, `shared`, and `shared-ui` build files
- Prevents unnecessary recompositions after `@Stable` annotations were removed during core module extraction (#4059)

## Test plan
- [x] `shared:compileKotlinDesktop` passes
- [x] `shared-ui:compileKotlinDesktop` passes
- [x] `app:compileKotlinDesktop` passes
- [x] `app:desktopTest` — all tests pass