### PR TITLE
:hammer: Remove getSearchContent/getSummary from PasteItem, introduce PasteItemReader and PasteDataHelper

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/GuidePasteDataService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/GuidePasteDataService.kt
@@ -7,6 +7,7 @@ import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
 import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.utils.getCodecsUtils
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
@@ -20,6 +21,7 @@ abstract class GuidePasteDataService(
     private val appLaunchState: AppLaunchState,
     private val copywriter: GlobalCopywriter,
     private val pasteDao: PasteDao,
+    private val pasteItemReader: PasteItemReader,
     private val searchContentService: SearchContentService,
 ) {
 
@@ -62,7 +64,7 @@ abstract class GuidePasteDataService(
                                 pasteSearchContent =
                                     searchContentService.createSearchContent(
                                         pasteData.source,
-                                        pasteItem.getSearchContent(),
+                                        pasteItemReader.getSearchContent(pasteItem),
                                     ),
                                 addedSize = newPasteItem.size - oldSize,
                             )

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
@@ -6,8 +6,8 @@ import com.crosspaste.exception.PasteException
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.notification.MessageType
 import com.crosspaste.notification.NotificationManager
-import com.crosspaste.paste.bindItems
 import com.crosspaste.paste.item.PasteFiles
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.paste.item.bindItem
 import com.crosspaste.paste.item.getFilePaths
 import com.crosspaste.path.UserDataPathProvider
@@ -28,6 +28,7 @@ import okio.Path
 class PasteImportService(
     private val notificationManager: NotificationManager,
     private val pasteDao: PasteDao,
+    private val pasteItemReader: PasteItemReader,
     private val searchContentService: SearchContentService,
     private val userDataPathProvider: UserDataPathProvider,
 ) {
@@ -155,7 +156,7 @@ class PasteImportService(
                     pasteSearchContent =
                         searchContentService.createSearchContent(
                             pasteData.source,
-                            newPasteAppearItem?.getSearchContent(),
+                            newPasteAppearItem?.let { pasteItemReader.getSearchContent(it) },
                         ),
                 )
 

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -4,12 +4,11 @@ import com.crosspaste.Database
 import com.crosspaste.app.AppFileType
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.paste.PasteDao
-import com.crosspaste.paste.bindItems
 import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.paste.item.PasteItemProperties
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.paste.item.bindItem
-import com.crosspaste.paste.item.extractSearchContent
 import com.crosspaste.paste.plugin.process.PasteProcessPlugin
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.task.TaskBuilder
@@ -27,6 +26,7 @@ class PasteReleaseService(
     private val currentPaste: CurrentPaste,
     private val database: Database,
     private val pasteDao: PasteDao,
+    private val pasteItemReader: PasteItemReader,
     private val pasteProcessPlugins: List<PasteProcessPlugin>,
     private val searchContentService: SearchContentService,
     private val taskSubmitter: TaskSubmitter,
@@ -105,7 +105,7 @@ class PasteReleaseService(
                         pasteSearchContent =
                             searchContentService.createSearchContent(
                                 pasteData.source,
-                                firstItem.extractSearchContent(),
+                                pasteItemReader.getSearchContent(firstItem),
                             ),
                         size = size,
                         hash = hash,

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/item/UpdatePasteItemHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/item/UpdatePasteItemHelper.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.put
 
 class UpdatePasteItemHelper(
     val pasteDao: PasteDao,
+    val pasteItemReader: PasteItemReader,
     val searchContentService: SearchContentService,
 ) {
     suspend fun updateColor(
@@ -29,7 +30,7 @@ class UpdatePasteItemHelper(
                 pasteSearchContent =
                     searchContentService.createSearchContent(
                         pasteData.source,
-                        newPasteItem.getSearchContent(),
+                        pasteItemReader.getSearchContent(newPasteItem),
                     ),
             ).map {
                 newPasteItem
@@ -58,7 +59,7 @@ class UpdatePasteItemHelper(
                 pasteSearchContent =
                     searchContentService.createSearchContent(
                         pasteData.source,
-                        newPasteItem.getSearchContent(),
+                        pasteItemReader.getSearchContent(newPasteItem),
                     ),
                 addedSize = newPasteItem.size - htmlPasteItem.size,
             ).map {
@@ -79,7 +80,7 @@ class UpdatePasteItemHelper(
                 pasteSearchContent =
                     searchContentService.createSearchContent(
                         pasteData.source,
-                        newPasteItem.getSearchContent(),
+                        pasteItemReader.getSearchContent(newPasteItem),
                     ),
                 addedSize = newPasteItem.size - textPasteItem.size,
             ).map {
@@ -104,9 +105,9 @@ class UpdatePasteItemHelper(
                 pasteSearchContent =
                     searchContentService.createSearchContent(
                         pasteData.source,
-                        listOf(
+                        listOfNotNull(
                             title,
-                            newUrlPasteItem.getSearchContent(),
+                            pasteItemReader.getSearchContent(newUrlPasteItem),
                         ),
                     ),
                 addedSize = title.length.toLong(),
@@ -133,10 +134,10 @@ class UpdatePasteItemHelper(
                 pasteSearchContent =
                     searchContentService.createSearchContent(
                         pasteData.source,
-                        listOf(
+                        listOfNotNull(
                             name,
-                            newPasteItem.getSearchContent(),
-                        ).mapNotNull { it },
+                            pasteItemReader.getSearchContent(newPasteItem),
+                        ),
                     ),
                 addedSize = name.length.toLong(),
             ).map {

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/process/GenerateTextPlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/process/GenerateTextPlugin.kt
@@ -4,10 +4,13 @@ import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.paste.item.HtmlPasteItem
 import com.crosspaste.paste.item.PasteCoordinate
 import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.paste.item.RtfPasteItem
 import com.crosspaste.paste.item.TextPasteItem
 
-object GenerateTextPlugin : PasteProcessPlugin {
+class GenerateTextPlugin(
+    private val pasteItemReader: PasteItemReader,
+) : PasteProcessPlugin {
     override fun process(
         pasteCoordinate: PasteCoordinate,
         pasteItems: List<PasteItem>,
@@ -17,7 +20,8 @@ object GenerateTextPlugin : PasteProcessPlugin {
             pasteItems.all { it !is TextPasteItem }
         ) {
             pasteItems.filterIsInstance<HtmlPasteItem>().firstOrNull()?.let {
-                val text = it.getText()
+                val text = pasteItemReader.getText(it)
+                if (text.isEmpty()) return pasteItems
                 return pasteItems +
                     createTextPasteItem(
                         text = text,
@@ -29,7 +33,8 @@ object GenerateTextPlugin : PasteProcessPlugin {
             pasteItems.all { it !is TextPasteItem }
         ) {
             pasteItems.filterIsInstance<RtfPasteItem>().firstOrNull()?.let {
-                val text = it.getText()
+                val text = pasteItemReader.getText(it)
+                if (text.isEmpty()) return pasteItems
                 return pasteItems +
                     createTextPasteItem(
                         text = text,

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -97,6 +97,7 @@ class DesktopModule(
                 SqlPasteDao(
                     appInfo = get(),
                     database = get(),
+                    pasteItemReader = get(),
                     searchContentService = get(),
                     taskSubmitter = get(),
                     userDataPathProvider = get(),

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -46,8 +46,8 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
     module {
         single<ExceptionHandler> { DesktopExceptionHandler() }
         single<FaviconLoader> { DesktopFaviconLoader(get(), get()) }
-        single<McpResourceProvider> { McpResourceProvider(get()) }
-        single<McpToolProvider> { McpToolProvider(get(), get(), get(), get()) }
+        single<McpResourceProvider> { McpResourceProvider(get(), get()) }
+        single<McpToolProvider> { McpToolProvider(get(), get(), get(), get(), get(), get()) }
         single<McpServer> {
             DesktopMcpServer(
                 mcpPort = (get<DesktopConfigManager>().getCurrentConfig()).mcpServerPort,

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
@@ -17,6 +17,7 @@ import com.crosspaste.paste.DesktopSourceExclusionService
 import com.crosspaste.paste.DesktopTransferableConsumer
 import com.crosspaste.paste.DesktopTransferableProducer
 import com.crosspaste.paste.GuidePasteDataService
+import com.crosspaste.paste.PasteDataHelper
 import com.crosspaste.paste.PasteExportParamFactory
 import com.crosspaste.paste.PasteExportService
 import com.crosspaste.paste.PasteImportParamFactory
@@ -28,6 +29,8 @@ import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.TransferableConsumer
 import com.crosspaste.paste.TransferableProducer
 import com.crosspaste.paste.getDesktopPasteboardService
+import com.crosspaste.paste.item.DefaultPasteItemReader
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.paste.item.UpdatePasteItemHelper
 import com.crosspaste.paste.plugin.process.DistinctPlugin
 import com.crosspaste.paste.plugin.process.FileToUrlPlugin
@@ -102,11 +105,12 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
                 currentPaste = get(),
                 database = get(),
                 pasteDao = get(),
+                pasteItemReader = get(),
                 pasteProcessPlugins =
                     listOf(
                         RemoveInvalidPlugin,
                         DistinctPlugin(get()),
-                        GenerateTextPlugin,
+                        GenerateTextPlugin(get()),
                         GenerateUrlPlugin,
                         TextToColorPlugin,
                         FilesToImagesPlugin(get()),
@@ -121,7 +125,7 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
             )
         }
         single<GenerateImageService> { GenerateImageService() }
-        single<GuidePasteDataService> { DesktopGuidePasteDataService(get(), get(), get(), get(), get()) }
+        single<GuidePasteDataService> { DesktopGuidePasteDataService(get(), get(), get(), get(), get(), get()) }
         single<DesktopSourceExclusionService> { DesktopSourceExclusionService(get()) }
         single<PasteboardService> {
             if (headless) {
@@ -144,8 +148,10 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
         single<PasteExportParamFactory<Path>> { DesktopPasteExportParamFactory() }
         single<PasteExportService> { PasteExportService(get(), get(), get()) }
         single<PasteImportParamFactory<Path>> { DesktopPasteImportParamFactory() }
-        single<PasteImportService> { PasteImportService(get(), get(), get(), get()) }
+        single<PasteImportService> { PasteImportService(get(), get(), get(), get(), get()) }
         single<PasteSyncProcessManager<Long>> { DefaultPasteSyncProcessManager() }
+        single<PasteItemReader> { DefaultPasteItemReader() }
+        single<PasteDataHelper> { PasteDataHelper(get()) }
         single<SearchContentService> { DesktopSearchContentService() }
         single<TaskExecutor> {
             TaskExecutor(
@@ -196,6 +202,6 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
             )
         }
         single<UpdatePasteItemHelper> {
-            UpdatePasteItemHelper(get(), get())
+            UpdatePasteItemHelper(get(), get(), get())
         }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpResourceProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpResourceProvider.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.mcp
 
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.PasteDataHelper
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.PasteColor
 import com.crosspaste.paste.item.PasteFiles
@@ -12,6 +13,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
 
 class McpResourceProvider(
     private val pasteDao: PasteDao,
+    private val pasteDataHelper: PasteDataHelper,
 ) {
 
     fun registerResources(server: Server) {
@@ -118,7 +120,7 @@ class McpResourceProvider(
                 }
             }
             else -> {
-                appendLine(pasteData.getSummary("Loading...", "Unknown"))
+                appendLine(pasteDataHelper.getSummary(pasteData, "Loading...", "Unknown"))
             }
         }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpToolProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpToolProvider.kt
@@ -6,6 +6,7 @@ import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteDataHelper
 import com.crosspaste.paste.PasteState
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.SearchContentService
@@ -19,6 +20,7 @@ import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
 import com.crosspaste.paste.item.PasteColor
 import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.paste.item.PasteText
 import com.crosspaste.paste.item.PasteUrl
 import com.crosspaste.paste.plugin.type.DesktopFilesTypePlugin
@@ -48,6 +50,8 @@ import okio.Path.Companion.toPath
 class McpToolProvider(
     private val appInfo: AppInfo,
     private val pasteDao: PasteDao,
+    private val pasteDataHelper: PasteDataHelper,
+    private val pasteItemReader: PasteItemReader,
     private val pasteTagDao: PasteTagDao,
     private val searchContentService: SearchContentService,
 ) {
@@ -147,7 +151,7 @@ class McpToolProvider(
                             appendLine("Favorite: ${item.favorite}")
                             appendLine("Size: ${item.size} bytes")
                             appendLine("Created: ${item.createTime}")
-                            appendLine("Summary: ${item.getSummary("Loading...", "Unknown")}")
+                            appendLine("Summary: ${pasteDataHelper.getSummary(item, "Loading...", "Unknown")}")
                             appendLine()
                         }
                     }
@@ -497,11 +501,13 @@ class McpToolProvider(
                 if (text != null) {
                     sb.appendLine((text as PasteText).text)
                 } else {
-                    sb.appendLine(pasteData.pasteAppearItem?.getSummary() ?: "(no text representation)")
+                    val summary = pasteData.pasteAppearItem?.let { pasteItemReader.getSummary(it) }
+                    sb.appendLine(summary?.ifEmpty { null } ?: "(no text representation)")
                 }
             }
             else -> {
-                sb.appendLine(pasteData.pasteAppearItem?.getSummary() ?: "(unknown content)")
+                val summary = pasteData.pasteAppearItem?.let { pasteItemReader.getSummary(it) }
+                sb.appendLine(summary?.ifEmpty { null } ?: "(unknown content)")
             }
         }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopGuidePasteDataService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopGuidePasteDataService.kt
@@ -4,14 +4,16 @@ import com.crosspaste.app.AppInfo
 import com.crosspaste.app.AppLaunchState
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.i18n.GlobalCopywriter
+import com.crosspaste.paste.item.PasteItemReader
 
 class DesktopGuidePasteDataService(
     appInfo: AppInfo,
     appLaunchState: AppLaunchState,
     copywriter: GlobalCopywriter,
     pasteDao: PasteDao,
+    pasteItemReader: PasteItemReader,
     searchContentService: SearchContentService,
-) : GuidePasteDataService(appInfo, appLaunchState, copywriter, pasteDao, searchContentService) {
+) : GuidePasteDataService(appInfo, appLaunchState, copywriter, pasteDao, pasteItemReader, searchContentService) {
 
     override val guideKey: String = "desktop_guide_"
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.paste.item.HtmlPasteItem
-import com.crosspaste.paste.item.truncatedPreviewHtml
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.ui.LocalThemeState
 import com.crosspaste.ui.paste.PasteDataScope
 import com.crosspaste.ui.theme.AppUISize.small2X
@@ -25,6 +25,7 @@ import org.koin.compose.koinInject
 @Composable
 fun PasteDataScope.HtmlSidePreviewView() {
     val copywriter = koinInject<GlobalCopywriter>()
+    val pasteItemReader = koinInject<PasteItemReader>()
     val htmlPasteItem = getPasteItem(HtmlPasteItem::class)
 
     val backgroundColor by remember(pasteData.id) {
@@ -45,10 +46,12 @@ fun PasteDataScope.HtmlSidePreviewView() {
             MaterialTheme.colorScheme.background
         }
 
+    val charCount by remember(pasteData.id) { mutableStateOf(pasteItemReader.getText(htmlPasteItem).length) }
+
     SidePasteLayoutView(
         pasteBottomContent = {
             BottomGradient(
-                text = copywriter.getText("character_count", "${htmlPasteItem.getText().length}"),
+                text = copywriter.getText("character_count", "$charCount"),
                 backgroundColor = htmlBackground,
             )
         },
@@ -56,7 +59,7 @@ fun PasteDataScope.HtmlSidePreviewView() {
         val state = rememberRichTextState()
 
         LaunchedEffect(htmlPasteItem.hash) {
-            state.setHtml(htmlPasteItem.truncatedPreviewHtml)
+            pasteItemReader.getPreviewHtml(htmlPasteItem)?.let { state.setHtml(it) }
         }
         RichText(
             color = richTextColor,

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
@@ -12,8 +12,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.crosspaste.i18n.GlobalCopywriter
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.paste.item.RtfPasteItem
-import com.crosspaste.paste.item.truncatedPreviewHtml
 import com.crosspaste.ui.LocalThemeState
 import com.crosspaste.ui.paste.PasteDataScope
 import com.crosspaste.ui.theme.AppUISize.small2X
@@ -25,6 +25,7 @@ import org.koin.compose.koinInject
 @Composable
 fun PasteDataScope.RtfSidePreviewView() {
     val copywriter = koinInject<GlobalCopywriter>()
+    val pasteItemReader = koinInject<PasteItemReader>()
     val rtfPasteItem = getPasteItem(RtfPasteItem::class)
 
     val backgroundColor by remember(pasteData.id) {
@@ -45,10 +46,12 @@ fun PasteDataScope.RtfSidePreviewView() {
             MaterialTheme.colorScheme.background
         }
 
+    val charCount by remember(pasteData.id) { mutableStateOf(pasteItemReader.getText(rtfPasteItem).length) }
+
     SidePasteLayoutView(
         pasteBottomContent = {
             BottomGradient(
-                text = copywriter.getText("character_count", "${rtfPasteItem.getText().length}"),
+                text = copywriter.getText("character_count", "$charCount"),
                 backgroundColor = rtfBackground,
             )
         },
@@ -56,7 +59,7 @@ fun PasteDataScope.RtfSidePreviewView() {
         val state = rememberRichTextState()
 
         LaunchedEffect(rtfPasteItem.hash) {
-            state.setHtml(rtfPasteItem.truncatedPreviewHtml)
+            pasteItemReader.getPreviewHtml(rtfPasteItem)?.let { state.setHtml(it) }
         }
 
         RichText(

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
@@ -10,6 +10,7 @@ import com.crosspaste.paste.PasteState
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.DefaultPasteItemReader
 import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
 import com.crosspaste.paste.plugin.type.DesktopTextTypePlugin
 import com.crosspaste.task.TaskSubmitter
@@ -55,9 +56,12 @@ class PasteDaoTest {
 
     private val database = createDatabase(TestDriverFactory())
 
+    private val pasteItemReader = DefaultPasteItemReader()
+
     private val pasteDao = SqlPasteDao(
         appInfo = appInfo,
         database = database,
+        pasteItemReader = pasteItemReader,
         searchContentService = searchContentService,
         taskSubmitter = taskSubmitter,
         userDataPathProvider = userDataPathProvider,

--- a/app/src/desktopTest/kotlin/com/crosspaste/mcp/McpResourceProviderTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/mcp/McpResourceProviderTest.kt
@@ -6,11 +6,13 @@ import com.crosspaste.db.createDatabase
 import com.crosspaste.db.paste.SqlPasteDao
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteDataHelper
 import com.crosspaste.paste.PasteState
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
+import com.crosspaste.paste.item.DefaultPasteItemReader
 import com.crosspaste.paste.plugin.type.DesktopTextTypePlugin
 import com.crosspaste.paste.plugin.type.DesktopUrlTypePlugin
 import com.crosspaste.path.UserDataPathProvider
@@ -62,16 +64,21 @@ class McpResourceProviderTest {
 
     private val database = createDatabase(TestDriverFactory())
 
+    private val pasteItemReader = DefaultPasteItemReader()
+
     private val pasteDao =
         SqlPasteDao(
             appInfo = appInfo,
             database = database,
+            pasteItemReader = pasteItemReader,
             searchContentService = searchContentService,
             taskSubmitter = taskSubmitter,
             userDataPathProvider = userDataPathProvider,
         )
 
-    private val provider = McpResourceProvider(pasteDao)
+    private val pasteDataHelper = PasteDataHelper(pasteItemReader)
+
+    private val provider = McpResourceProvider(pasteDao, pasteDataHelper)
 
     private fun createServer(): Server {
         val server =

--- a/app/src/desktopTest/kotlin/com/crosspaste/mcp/McpToolProviderTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/mcp/McpToolProviderTest.kt
@@ -7,10 +7,12 @@ import com.crosspaste.db.paste.SqlPasteDao
 import com.crosspaste.db.paste.SqlPasteTagDao
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteDataHelper
 import com.crosspaste.paste.PasteState
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.DefaultPasteItemReader
 import com.crosspaste.paste.plugin.type.DesktopTextTypePlugin
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.task.TaskSubmitter
@@ -63,10 +65,13 @@ class McpToolProviderTest {
 
     private val database = createDatabase(TestDriverFactory())
 
+    private val pasteItemReader = DefaultPasteItemReader()
+
     private val pasteDao =
         SqlPasteDao(
             appInfo = appInfo,
             database = database,
+            pasteItemReader = pasteItemReader,
             searchContentService = searchContentService,
             taskSubmitter = taskSubmitter,
             userDataPathProvider = userDataPathProvider,
@@ -74,10 +79,14 @@ class McpToolProviderTest {
 
     private val pasteTagDao = SqlPasteTagDao(database)
 
+    private val pasteDataHelper = PasteDataHelper(pasteItemReader)
+
     private val provider =
         McpToolProvider(
             appInfo = appInfo,
             pasteDao = pasteDao,
+            pasteDataHelper = pasteDataHelper,
+            pasteItemReader = pasteItemReader,
             pasteTagDao = pasteTagDao,
             searchContentService = searchContentService,
         )

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteDataTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteDataTest.kt
@@ -3,9 +3,9 @@ package com.crosspaste.paste
 import com.crosspaste.paste.item.ColorPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createHtmlPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.DefaultPasteItemReader
 import com.crosspaste.paste.item.PasteText
 import com.crosspaste.utils.DateUtils
-import com.crosspaste.utils.getJsonUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 
 class PasteDataTest {
 
-    private val jsonUtils = getJsonUtils()
+    private val pasteDataHelper = PasteDataHelper(DefaultPasteItemReader())
 
     private fun createTestPasteData(
         text: String = "test",
@@ -188,38 +188,37 @@ class PasteDataTest {
         assertEquals(100, coord.id)
     }
 
-    // --- getSummary ---
+    // --- getSummary (via PasteDataHelper) ---
 
     @Test
     fun `getSummary returns loading string when LOADING`() {
         val pd = createTestPasteData(pasteState = PasteState.LOADING)
-        assertEquals("Loading...", pd.getSummary("Loading...", "Unknown"))
+        assertEquals("Loading...", pasteDataHelper.getSummary(pd, "Loading...", "Unknown"))
     }
 
     @Test
     fun `getSummary returns text content for TEXT type`() {
         val pd = createTestPasteData(text = "hello world")
-        val summary = pd.getSummary("Loading...", "Unknown")
+        val summary = pasteDataHelper.getSummary(pd, "Loading...", "Unknown")
         assertEquals("hello world", summary)
     }
 
     @Test
-    fun `getSummary for HTML type prefers text item from collection`() {
+    fun `getSummary for HTML type extracts text from html`() {
         val htmlItem = createHtmlPasteItem(html = "<p>Hello</p>")
-        val textItem = createTextPasteItem(text = "Hello plain")
         val pd =
             PasteData(
                 appInstanceId = "test",
                 pasteAppearItem = htmlItem,
-                pasteCollection = PasteCollection(listOf(textItem)),
+                pasteCollection = PasteCollection(listOf()),
                 pasteType = PasteType.HTML_TYPE.type,
                 size = htmlItem.size,
                 hash = htmlItem.hash,
                 pasteState = PasteState.LOADED,
                 createTime = DateUtils.nowEpochMilliseconds(),
             )
-        val summary = pd.getSummary("Loading...", "Unknown")
-        assertEquals("Hello plain", summary)
+        val summary = pasteDataHelper.getSummary(pd, "Loading...", "Unknown")
+        assertTrue(summary.contains("Hello"))
     }
 
     // --- toJson / fromJson roundtrip ---
@@ -245,31 +244,5 @@ class PasteDataTest {
     @Test
     fun `fromJson returns null for empty json`() {
         assertNull(PasteData.fromJson("{}"))
-    }
-
-    // --- buildRawSearchContent ---
-
-    @Test
-    fun `buildRawSearchContent with both source and content`() {
-        val result = PasteData.buildRawSearchContent("Chrome", "hello")
-        assertEquals("chrome hello", result)
-    }
-
-    @Test
-    fun `buildRawSearchContent with source only`() {
-        val result = PasteData.buildRawSearchContent("Chrome", null)
-        assertEquals("chrome", result)
-    }
-
-    @Test
-    fun `buildRawSearchContent with content only`() {
-        val result = PasteData.buildRawSearchContent(null, "hello")
-        assertEquals("hello", result)
-    }
-
-    @Test
-    fun `buildRawSearchContent with both null`() {
-        val result = PasteData.buildRawSearchContent(null, null)
-        assertNull(result)
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteExportImportServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteExportImportServiceTest.kt
@@ -9,6 +9,7 @@ import com.crosspaste.paste.item.CreatePasteItemHelper.createRtfPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
 import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.paste.item.PasteText
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.getCodecsUtils
@@ -364,6 +365,6 @@ class PasteExportImportServiceTest {
             val restored = PasteData.fromJson(json)
             assertNotNull(restored)
             assertEquals(PasteType.TEXT_TYPE.type, restored.pasteType)
-            assertEquals("service export test", restored.pasteAppearItem?.getSummary())
+            assertEquals("service export test", (restored.pasteAppearItem as? PasteText)?.text)
         }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/plugin/process/GenerateTextPluginTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/plugin/process/GenerateTextPluginTest.kt
@@ -2,6 +2,7 @@ package com.crosspaste.paste.plugin.process
 
 import com.crosspaste.paste.item.CreatePasteItemHelper.createHtmlPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.DefaultPasteItemReader
 import com.crosspaste.paste.item.HtmlPasteItem
 import com.crosspaste.paste.item.PasteCoordinate
 import com.crosspaste.paste.item.PasteItem
@@ -16,18 +17,21 @@ class GenerateTextPluginTest {
     @Suppress("unused")
     private val jsonUtils = getJsonUtils()
 
+    private val pasteItemReader = DefaultPasteItemReader()
+    private val plugin = GenerateTextPlugin(pasteItemReader)
+
     private val coord = PasteCoordinate(id = 1L, appInstanceId = "test")
 
     @Test
     fun `empty list returns empty`() {
-        val result = GenerateTextPlugin.process(coord, emptyList(), null)
+        val result = plugin.process(coord, emptyList(), null)
         assertTrue(result.isEmpty())
     }
 
     @Test
     fun `list with text only returns unchanged`() {
         val textItem = createTextPasteItem(text = "hello")
-        val result = GenerateTextPlugin.process(coord, listOf(textItem), null)
+        val result = plugin.process(coord, listOf(textItem), null)
         assertEquals(1, result.size)
         assertTrue(result[0] is TextPasteItem)
     }
@@ -36,7 +40,7 @@ class GenerateTextPluginTest {
     fun `html without text generates text item`() {
         val htmlItem = createHtmlPasteItem(html = "<p>hello world</p>")
         val items: List<PasteItem> = listOf(htmlItem)
-        val result = GenerateTextPlugin.process(coord, items, null)
+        val result = plugin.process(coord, items, null)
         assertEquals(2, result.size)
         assertTrue(result.any { it is HtmlPasteItem })
         assertTrue(result.any { it is TextPasteItem })
@@ -47,7 +51,7 @@ class GenerateTextPluginTest {
         val htmlItem = createHtmlPasteItem(html = "<p>hello</p>")
         val textItem = createTextPasteItem(text = "existing")
         val items: List<PasteItem> = listOf(htmlItem, textItem)
-        val result = GenerateTextPlugin.process(coord, items, null)
+        val result = plugin.process(coord, items, null)
         assertEquals(2, result.size)
         // No new text item added
         assertEquals(1, result.count { it is TextPasteItem })
@@ -56,7 +60,7 @@ class GenerateTextPluginTest {
     @Test
     fun `text-only list returns unchanged`() {
         val textItem = createTextPasteItem(text = "plain text")
-        val result = GenerateTextPlugin.process(coord, listOf(textItem), null)
+        val result = plugin.process(coord, listOf(textItem), null)
         assertEquals(1, result.size)
         assertTrue(result[0] is TextPasteItem)
     }
@@ -65,7 +69,7 @@ class GenerateTextPluginTest {
     fun `generated text from html has content`() {
         val htmlItem = createHtmlPasteItem(html = "<b>bold text</b>")
         val items: List<PasteItem> = listOf(htmlItem)
-        val result = GenerateTextPlugin.process(coord, items, null)
+        val result = plugin.process(coord, items, null)
         val textItem = result.filterIsInstance<TextPasteItem>().first()
         assertTrue(textItem.text.isNotEmpty())
     }

--- a/app/src/desktopTest/kotlin/com/crosspaste/serializer/SerializerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/serializer/SerializerTest.kt
@@ -48,7 +48,8 @@ class SerializerTest {
         assertEquals(textPasteItem.text, newTextPasteItem.text)
         assertEquals(textPasteItem.hash, newTextPasteItem.hash)
         assertEquals(textPasteItem.identifiers, newTextPasteItem.identifiers)
-        assertEquals(pasteData.pasteSearchContent, newPasteData.pasteSearchContent)
+        // pasteSearchContent is transient and not serialized; deserializer sets it to null
+        assertEquals(null, newPasteData.pasteSearchContent)
         assertEquals(pasteData.pasteType, newPasteData.pasteType)
         assertEquals(pasteData.hash, newPasteData.hash)
         assertEquals(PasteState.LOADING, newPasteData.pasteState)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CliModule.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CliModule.kt
@@ -19,7 +19,10 @@ import com.crosspaste.db.sync.SqlSyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.task.SqlTaskDao
 import com.crosspaste.db.task.TaskDao
+import com.crosspaste.paste.PasteDataHelper
 import com.crosspaste.paste.SearchContentService
+import com.crosspaste.paste.item.DefaultPasteItemReader
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.path.PlatformUserDataPathProvider
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.task.TaskSubmitter
@@ -57,6 +60,8 @@ val cliDatabaseModule =
         single<Database> { createDatabase(get()) }
 
         // No-op services for CLI
+        single<PasteItemReader> { DefaultPasteItemReader() }
+        single<PasteDataHelper> { PasteDataHelper(get()) }
         single<SearchContentService> { NoOpSearchContentService() }
         single<TaskSubmitter> { NoOpTaskSubmitter() }
 
@@ -65,6 +70,7 @@ val cliDatabaseModule =
             SqlPasteDao(
                 appInfo = get(),
                 database = get(),
+                pasteItemReader = get(),
                 searchContentService = get(),
                 taskSubmitter = get(),
                 userDataPathProvider = get(),

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -2,7 +2,9 @@ package com.crosspaste.cli.commands
 
 import com.crosspaste.db.paste.PasteTagDao
 import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteDataHelper
 import com.crosspaste.paste.PasteType
+import com.crosspaste.paste.item.PasteItemReader
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -35,6 +37,7 @@ inline fun <reified T> CliktCommand.getDao(): T = KoinPlatform.getKoin().get()
 
 fun PasteData.toSummaryDto(): PasteSummaryDto {
     val pasteTagDao = KoinPlatform.getKoin().get<PasteTagDao>()
+    val pasteDataHelper = KoinPlatform.getKoin().get<PasteDataHelper>()
     return PasteSummaryDto(
         id = id,
         typeName = getTypeName(),
@@ -42,13 +45,14 @@ fun PasteData.toSummaryDto(): PasteSummaryDto {
         size = size,
         tagged = pasteTagDao.getPasteTagsBlock(id).isNotEmpty(),
         createTime = createTime,
-        preview = getSummary("Loading...", ""),
+        preview = pasteDataHelper.getSummary(this, "Loading...", ""),
         remote = remote,
     )
 }
 
 fun PasteData.toDetailResponse(): PasteDetailResponse {
     val pasteTagDao = KoinPlatform.getKoin().get<PasteTagDao>()
+    val pasteItemReader = KoinPlatform.getKoin().get<PasteItemReader>()
     return PasteDetailResponse(
         id = id,
         typeName = getTypeName(),
@@ -58,7 +62,7 @@ fun PasteData.toDetailResponse(): PasteDetailResponse {
         createTime = createTime,
         remote = remote,
         hash = hash,
-        content = pasteAppearItem?.getSummary(),
+        content = pasteAppearItem?.let { pasteItemReader.getSummary(it) },
     )
 }
 

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
@@ -104,16 +104,6 @@ data class PasteData(
                 pasteState.toInt(),
                 remote,
             )
-
-        fun buildRawSearchContent(
-            source: String?,
-            pasteItemSearchContent: String?,
-        ): String? =
-            source?.let {
-                pasteItemSearchContent?.let {
-                    "${source.lowercase()} $pasteItemSearchContent"
-                } ?: source.lowercase()
-            } ?: pasteItemSearchContent
     }
 
     fun getType(): PasteType = PasteType.fromType(pasteType)
@@ -173,39 +163,6 @@ data class PasteData(
 
     fun getPasteCoordinate(id: Long? = null): PasteCoordinate =
         PasteCoordinate(id ?: this.id, appInstanceId, createTime)
-
-    fun getSummary(
-        loading: String,
-        unknown: String,
-    ): String =
-        if (this.pasteState == PasteState.LOADING) {
-            loading
-        } else {
-            val type = PasteType.fromType(this.pasteType)
-            when (type) {
-                PasteType.TEXT_TYPE,
-                PasteType.COLOR_TYPE,
-                PasteType.URL_TYPE,
-                PasteType.FILE_TYPE,
-                PasteType.IMAGE_TYPE,
-                -> {
-                    this.pasteAppearItem?.getSummary() ?: unknown
-                }
-                PasteType.HTML_TYPE,
-                PasteType.RTF_TYPE,
-                -> {
-                    getPasteAppearItems().firstOrNull { it is PasteText }?.let {
-                        val pasteText = it as PasteText
-                        pasteText.text.trim()
-                    } ?: run {
-                        pasteAppearItem?.getSummary() ?: unknown
-                    }
-                }
-                else -> {
-                    unknown
-                }
-            }
-        }
 
     fun toJson(): String =
         buildJsonObject {

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/ColorPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/ColorPasteItem.kt
@@ -32,10 +32,6 @@ class ColorPasteItem(
 
     override fun getPasteType(): PasteType = PasteType.COLOR_TYPE
 
-    override fun getSearchContent(): String = toHexString()
-
-    override fun getSummary(): String = toHexString()
-
     override fun copy(extraInfo: JsonObject?): ColorPasteItem =
         createColorPasteItem(
             identifiers = identifiers,

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/FilesPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/FilesPasteItem.kt
@@ -64,16 +64,6 @@ data class FilesPasteItem(
 
     override fun getPasteType(): PasteType = PasteType.FILE_TYPE
 
-    override fun getSearchContent(): String =
-        fileInfoTreeMap.keys.joinToString(separator = " ") {
-            it.lowercase()
-        }
-
-    override fun getSummary(): String =
-        relativePathList.joinToString(separator = ", ") {
-            it.substringAfterLast("/")
-        }
-
     override fun applyRenameMap(renameMap: Map<String, String>): FilesPasteItem {
         val (newRelativePathList, newFileInfoTreeMap) = computeRenamedFileData(renameMap)
         return copy(relativePathList = newRelativePathList, fileInfoTreeMap = newFileInfoTreeMap)

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/HtmlPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/HtmlPasteItem.kt
@@ -31,8 +31,6 @@ class HtmlPasteItem(
         extraInfo = getExtraInfoFromJson(jsonObject),
     )
 
-    override fun getText(): String = html
-
     override fun getBackgroundColor(): Int =
         extraInfo?.let { json ->
             runCatching {
@@ -48,10 +46,6 @@ class HtmlPasteItem(
         )
 
     override fun getPasteType(): PasteType = PasteType.HTML_TYPE
-
-    override fun getSearchContent(): String = getText()
-
-    override fun getSummary(): String = getText()
 
     override fun isValid(): Boolean =
         hash.isNotEmpty() &&

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
@@ -64,16 +64,6 @@ data class ImagesPasteItem(
 
     override fun getPasteType(): PasteType = PasteType.IMAGE_TYPE
 
-    override fun getSearchContent(): String =
-        fileInfoTreeMap.keys.joinToString(separator = " ") {
-            it.lowercase()
-        }
-
-    override fun getSummary(): String =
-        relativePathList.joinToString(separator = ", ") {
-            it.substringAfterLast("/")
-        }
-
     override fun applyRenameMap(renameMap: Map<String, String>): ImagesPasteItem {
         val (newRelativePathList, newFileInfoTreeMap) = computeRenamedFileData(renameMap)
         return copy(relativePathList = newRelativePathList, fileInfoTreeMap = newFileInfoTreeMap)

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteHtml.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteHtml.kt
@@ -4,7 +4,5 @@ interface PasteHtml {
 
     val html: String
 
-    fun getText(): String
-
     fun getBackgroundColor(): Int
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItem.kt
@@ -92,14 +92,10 @@ sealed interface PasteItem {
 
     fun getPasteType(): PasteType
 
-    fun getSearchContent(): String?
-
     fun getUserEditName(): String? =
         extraInfo?.let { extraInfo ->
             extraInfo[PasteItemProperties.NAME]?.jsonPrimitive?.content
         }
-
-    fun getSummary(): String
 
     fun getMarketingPath(): String? =
         extraInfo?.let { extraInfo ->

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItemReader.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItemReader.kt
@@ -1,0 +1,41 @@
+package com.crosspaste.paste.item
+
+/**
+ * Platform-specific reader for extracting parsed content from PasteItems.
+ *
+ * PasteItem stores raw data (HTML markup, RTF markup, etc.).
+ * PasteItemReader provides platform-dependent parsing to extract
+ * human-readable text, search content, summaries, and preview HTML.
+ *
+ * Each platform implements this interface with its own parsing tools:
+ * - Desktop: ksoup for HTML, RtfUtils for RTF
+ * - JS/Web: browser DOM API
+ * - Mobile: shared with Desktop or custom implementation
+ */
+interface PasteItemReader {
+
+    /**
+     * Extract plain text from a PasteItem.
+     * For HTML/RTF items, parses markup to return readable text.
+     * For Text/URL/Color items, returns the raw value directly.
+     */
+    fun getText(pasteItem: PasteItem): String
+
+    /**
+     * Get search-friendly content from a PasteItem.
+     * For HTML/RTF items, extracts and lowercases plain text.
+     * For other types, returns the natural search representation.
+     */
+    fun getSearchContent(pasteItem: PasteItem): String?
+
+    /**
+     * Get a human-readable summary of a PasteItem.
+     */
+    fun getSummary(pasteItem: PasteItem): String
+
+    /**
+     * Get truncated HTML suitable for rich-text preview rendering.
+     * Returns null for non-HTML/RTF types.
+     */
+    fun getPreviewHtml(pasteItem: PasteItem): String?
+}

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteRtf.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteRtf.kt
@@ -4,9 +4,5 @@ interface PasteRtf : PasteCoordinateBinder {
 
     val rtf: String
 
-    fun getText(): String
-
-    fun getHtml(): String
-
     fun getBackgroundColor(): Int
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/RtfPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/RtfPasteItem.kt
@@ -31,10 +31,6 @@ class RtfPasteItem(
         extraInfo = getExtraInfoFromJson(jsonObject),
     )
 
-    override fun getText(): String = rtf
-
-    override fun getHtml(): String = ""
-
     override fun getBackgroundColor(): Int =
         extraInfo?.let { json ->
             runCatching {
@@ -52,10 +48,6 @@ class RtfPasteItem(
         )
 
     override fun getPasteType(): PasteType = PasteType.RTF_TYPE
-
-    override fun getSearchContent(): String = rtf.lowercase()
-
-    override fun getSummary(): String = rtf
 
     override fun isValid(): Boolean =
         hash.isNotEmpty() &&

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/TextPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/TextPasteItem.kt
@@ -32,10 +32,6 @@ class TextPasteItem(
 
     override fun getPasteType(): PasteType = PasteType.TEXT_TYPE
 
-    override fun getSearchContent(): String = text.lowercase()
-
-    override fun getSummary(): String = text
-
     override fun copy(extraInfo: JsonObject?): TextPasteItem =
         createTextPasteItem(
             identifiers = identifiers,

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/UrlPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/UrlPasteItem.kt
@@ -37,10 +37,6 @@ class UrlPasteItem(
 
     override fun getPasteType(): PasteType = PasteType.URL_TYPE
 
-    override fun getSearchContent(): String = url.lowercase()
-
-    override fun getSummary(): String = url
-
     override fun copy(extraInfo: JsonObject?): UrlPasteItem =
         createUrlPasteItem(
             identifiers = identifiers,

--- a/core/src/commonMain/kotlin/com/crosspaste/serializer/PasteDataSerializer.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/serializer/PasteDataSerializer.kt
@@ -67,11 +67,6 @@ class PasteDataSerializer : KSerializer<PasteData> {
             size = size,
             hash = hash,
             createTime = DateUtils.nowEpochMilliseconds(),
-            pasteSearchContent =
-                PasteData.buildRawSearchContent(
-                    source,
-                    pasteAppearItem?.getSearchContent(),
-                ),
             pasteState = PasteState.LOADING,
             remote = true,
         )

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
@@ -10,7 +10,7 @@ import com.crosspaste.paste.PasteState
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.clear
 import com.crosspaste.paste.item.PasteItem
-import com.crosspaste.paste.item.extractSearchContent
+import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.task.TaskSubmitter
 import com.crosspaste.utils.DateUtils
@@ -26,6 +26,7 @@ import kotlinx.coroutines.withContext
 class SqlPasteDao(
     private val appInfo: AppInfo,
     private val database: Database,
+    private val pasteItemReader: PasteItemReader,
     private val searchContentService: SearchContentService,
     private val taskSubmitter: TaskSubmitter,
     private val userDataPathProvider: UserDataPathProvider,
@@ -117,7 +118,7 @@ class SqlPasteDao(
                     pasteData.createTime,
                     searchContentService.createSearchContent(
                         pasteData.source,
-                        pasteData.pasteAppearItem?.extractSearchContent(),
+                        pasteData.pasteAppearItem?.let { pasteItemReader.getSearchContent(it) },
                     ),
                     (pasteState ?: pasteData.pasteState).toLong(),
                     pasteData.remote,
@@ -133,7 +134,7 @@ class SqlPasteDao(
                 pasteData.pasteCollection.toJson(),
                 searchContentService.createSearchContent(
                     pasteData.source,
-                    pasteData.pasteAppearItem?.extractSearchContent(),
+                    pasteData.pasteAppearItem?.let { pasteItemReader.getSearchContent(it) },
                 ),
                 pasteData.id,
             )

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteDataHelper.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/PasteDataHelper.kt
@@ -1,0 +1,21 @@
+package com.crosspaste.paste
+
+import com.crosspaste.paste.item.PasteItemReader
+
+class PasteDataHelper(
+    private val pasteItemReader: PasteItemReader,
+) {
+
+    fun getSummary(
+        pasteData: PasteData,
+        loading: String,
+        unknown: String,
+    ): String =
+        if (pasteData.pasteState == PasteState.LOADING) {
+            loading
+        } else {
+            pasteData.pasteAppearItem?.let {
+                pasteItemReader.getText(it).ifEmpty { null }
+            } ?: unknown
+        }
+}

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/DefaultPasteItemReader.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/DefaultPasteItemReader.kt
@@ -1,0 +1,41 @@
+package com.crosspaste.paste.item
+
+import com.crosspaste.utils.getHtmlUtils
+import com.crosspaste.utils.getRtfUtils
+
+class DefaultPasteItemReader : PasteItemReader {
+
+    private val htmlUtils by lazy { getHtmlUtils() }
+    private val rtfUtils by lazy { getRtfUtils() }
+
+    override fun getText(pasteItem: PasteItem): String =
+        when (pasteItem) {
+            is HtmlPasteItem -> htmlUtils.getHtmlText(pasteItem.html) ?: ""
+            is RtfPasteItem -> rtfUtils.getText(pasteItem.rtf) ?: ""
+            is TextPasteItem -> pasteItem.text
+            is UrlPasteItem -> pasteItem.url
+            is ColorPasteItem -> pasteItem.toHexString()
+            is FilesPasteItem -> pasteItem.relativePathList.joinToString(", ") { it.substringAfterLast("/") }
+            is ImagesPasteItem -> pasteItem.relativePathList.joinToString(", ") { it.substringAfterLast("/") }
+        }
+
+    override fun getSearchContent(pasteItem: PasteItem): String? =
+        when (pasteItem) {
+            is HtmlPasteItem -> htmlUtils.getHtmlText(pasteItem.html)?.lowercase()
+            is RtfPasteItem -> rtfUtils.getText(pasteItem.rtf)?.lowercase()
+            is TextPasteItem -> pasteItem.text.lowercase()
+            is UrlPasteItem -> pasteItem.url.lowercase()
+            is ColorPasteItem -> pasteItem.toHexString()
+            is FilesPasteItem -> pasteItem.fileInfoTreeMap.keys.joinToString(" ") { it.lowercase() }
+            is ImagesPasteItem -> pasteItem.fileInfoTreeMap.keys.joinToString(" ") { it.lowercase() }
+        }
+
+    override fun getSummary(pasteItem: PasteItem): String = getText(pasteItem)
+
+    override fun getPreviewHtml(pasteItem: PasteItem): String? =
+        when (pasteItem) {
+            is HtmlPasteItem -> htmlUtils.truncateForPreview(pasteItem.html)
+            is RtfPasteItem -> rtfUtils.rtfToHtml(pasteItem.rtf)?.let { htmlUtils.truncateForPreview(it) }
+            else -> null
+        }
+}

--- a/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItemExt.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItemExt.kt
@@ -3,8 +3,6 @@ package com.crosspaste.paste.item
 import com.crosspaste.app.AppFileType
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.getFileUtils
-import com.crosspaste.utils.getHtmlUtils
-import com.crosspaste.utils.getRtfUtils
 import okio.Path
 import okio.Path.Companion.toPath
 
@@ -73,27 +71,4 @@ fun PasteItem.bindItem(
             )
         }
         else -> this.bind(pasteCoordinate, syncToDownload)
-    }
-
-// --- HTML/RTF text extraction extensions ---
-
-private val htmlUtils by lazy { getHtmlUtils() }
-private val rtfUtils by lazy { getRtfUtils() }
-
-val HtmlPasteItem.truncatedPreviewHtml: String
-    get() = htmlUtils.truncateForPreview(html)
-
-val RtfPasteItem.truncatedPreviewHtml: String
-    get() = rtfUtils.rtfToHtml(rtf)?.let { htmlUtils.truncateForPreview(it) } ?: ""
-
-/**
- * Extract plain-text search content from a PasteItem.
- * For HtmlPasteItem/RtfPasteItem, parses the markup to get readable text.
- * For all others, delegates to [PasteItem.getSearchContent].
- */
-fun PasteItem.extractSearchContent(): String? =
-    when (this) {
-        is HtmlPasteItem -> htmlUtils.getHtmlText(html)?.lowercase()
-        is RtfPasteItem -> rtfUtils.getText(rtf)?.lowercase()
-        else -> getSearchContent()
     }


### PR DESCRIPTION
Closes #4066

## Summary

- Remove `getSearchContent()` and `getSummary()` from `PasteItem` interface and all 7 subclass implementations (HTML/RTF had dummy `null`/`""` returns)
- Move all text extraction, search content, and summary logic into `PasteItemReader` (platform-specific) and new `PasteDataHelper` class
- Change `PasteItemReader.getText()` return type from `String?` to `String`
- `PasteDataSerializer` no longer computes `pasteSearchContent` (set to `null`, computed at persistence time by `SqlPasteDao`)
- Cache `charCount` in `HtmlSidePreviewView`/`RtfSidePreviewView` with `remember(pasteData.id)` to avoid re-parsing on recomposition

## Test plan

- [x] All 969 desktop tests pass
- [x] Desktop + CLI compilation succeeds with no warnings
- [ ] Verify clipboard search works correctly for all paste types
- [ ] Verify HTML/RTF paste summaries display correctly in MCP and CLI