### PR TITLE
Fix missing add_device_manually_desc key in zh_hant

### DIFF
--- a/app/src/desktopMain/resources/i18n/zh_hant.properties
+++ b/app/src/desktopMain/resources/i18n/zh_hant.properties
@@ -5,6 +5,7 @@ accessibility_permission_title=授權全域快捷鍵支援
 action=操作
 add=新增
 add_device_manually=手動新增裝置
+add_device_manually_desc=請輸入目標裝置的 IP 位址和連接埠號以建立連線。
 add_note=新增備註
 addition_failed=新增失敗
 advanced=高級


### PR DESCRIPTION
Closes #4077

## Summary
- Add missing `add_device_manually_desc` key to `zh_hant.properties`
- All 10 language files now have 291 keys (zh_hant previously had 290)

## Test plan
- [ ] Existing `GlobalCopywriterTest.testI18nKeys` validates all keys are subset of EN — this was silently passing because the test checks `keys ⊆ enKeys`, not `enKeys ⊆ keys`