### PR TITLE
:bug: Fix Sparkle crash on macOS by disabling redundant scheduled check

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUpdateService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUpdateService.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import java.util.Properties
 import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
 
 class DesktopAppUpdateService(
     appInfo: AppInfo,
@@ -93,16 +94,21 @@ class DesktopAppUpdateService(
 
     private fun SoftwareUpdateController.tryTriggerUpdateUI(): Boolean =
         try {
-            when (canTriggerUpdateCheckUI()) {
-                SoftwareUpdateController.Availability.AVAILABLE -> {
-                    triggerUpdateCheckUI()
-                    true
-                }
-                else -> {
-                    logger.warn { "SoftwareUpdateController is not available, cannot trigger update check UI" }
-                    false
-                }
+            var result = false
+            SwingUtilities.invokeAndWait {
+                result =
+                    when (canTriggerUpdateCheckUI()) {
+                        SoftwareUpdateController.Availability.AVAILABLE -> {
+                            triggerUpdateCheckUI()
+                            true
+                        }
+                        else -> {
+                            logger.warn { "SoftwareUpdateController is not available, cannot trigger update check UI" }
+                            false
+                        }
+                    }
             }
+            result
         } catch (e: Exception) {
             logger.error(e) { "Failed to trigger update check UI" }
             false

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -30,7 +30,7 @@ app {
     info-plist.LSMinimumSystemVersion = 14.0.0
     info-plist.LSUIElement = true
     updates = background
-    sparkle-options.SUScheduledCheckInterval = 3600
+    sparkle-options.SUScheduledCheckInterval = 0
   }
 
   windows {


### PR DESCRIPTION
## Summary

Fixes #4085 (sub-issue of #4079)

- **Disable Sparkle's built-in scheduled check** (`SUScheduledCheckInterval = 0`): The app already has its own version check via HTTP every 2 hours, so Sparkle's 1-hour timer was redundant and caused a race condition — both could access Sparkle's internal state concurrently, leading to an assertion failure and `SIGABRT`.
- **Ensure main-thread dispatching for Sparkle API calls**: Wrap `canTriggerUpdateCheckUI()` and `triggerUpdateCheckUI()` with `SwingUtilities.invokeAndWait` to satisfy Sparkle's requirement that all API access happens on the main thread.

## Test plan

- [ ] Launch CrossPaste on macOS and leave running for several hours — verify no crash
- [ ] Trigger "Check for Update" manually — verify Sparkle UI appears correctly
- [ ] Verify Windows build is unaffected (Sparkle is macOS-only)