### PR TITLE
:hammer: Convert withTimeout/withTimeoutOrNull Long overloads to Duration

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRoutingApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRoutingApi.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
 
 interface SyncRoutingApi {
 
@@ -29,7 +30,7 @@ interface SyncRoutingApi {
         // Ensure that all notifications are completed before exiting, with a timeout
         runBlocking {
             runCatching {
-                withTimeout(5000) {
+                withTimeout(5.seconds) {
                     getSyncHandlers()
                         .values
                         .map { syncHandler ->

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/DefaultPasteSyncProcessManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/DefaultPasteSyncProcessManager.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
 
 class DefaultPasteSyncProcessManager : PasteSyncProcessManager<Long> {
 
@@ -54,7 +55,7 @@ class DefaultPasteSyncProcessManager : PasteSyncProcessManager<Long> {
                     .map { task ->
                         async {
                             semaphore.withPermit {
-                                withTimeout(60_000L) {
+                                withTimeout(60.seconds) {
                                     val result = task()
                                     if (result.second is SuccessResult) {
                                         process.success(result.first)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration.Companion.seconds
 
 class GeneralSyncHandler(
     syncRuntimeInfo: SyncRuntimeInfo,
@@ -169,7 +170,7 @@ class GeneralSyncHandler(
 
             emitEvent(SyncEvent.ResolveConnection(currentSyncRuntimeInfo, callback))
 
-            withTimeoutOrNull(5000) {
+            withTimeoutOrNull(5.seconds) {
                 completionSignal.await()
             }
 
@@ -210,7 +211,7 @@ class GeneralSyncHandler(
     override suspend fun notifyExit() {
         val completionSignal = CompletableDeferred<Unit>()
         emitEvent(SyncEvent.NotifyExit(currentSyncRuntimeInfo, completionSignal))
-        withTimeoutOrNull(5000) {
+        withTimeoutOrNull(5.seconds) {
             completionSignal.await()
         }
         cancelScope()

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -69,6 +69,7 @@ import org.koin.core.KoinApplication
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.named
 import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.seconds
 
 class CrossPaste {
 
@@ -208,7 +209,7 @@ class CrossPaste {
         }
 
         private suspend fun shutdownAllServices() {
-            withTimeoutOrNull(5000L) {
+            withTimeoutOrNull(5.seconds) {
                 supervisorScope {
                     val jobs =
                         buildList {

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowsLazyClipboard.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowsLazyClipboard.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 class WindowsLazyClipboard : AutoCloseable {
@@ -102,14 +103,14 @@ class WindowsLazyClipboard : AutoCloseable {
             }
 
         runBlocking {
-            withTimeout(5000) { ready.await() }
+            withTimeout(5.seconds) { ready.await() }
         }
     }
 
     override fun close() {
         hwnd?.let { user32.PostMessage(it, WM_CLOSE, null, null) }
         runBlocking {
-            withTimeoutOrNull(3000) { messageLoopJob?.join() }
+            withTimeoutOrNull(3.seconds) { messageLoopJob?.join() }
         }
         scope.cancel()
         windowDispatcher.close()
@@ -130,7 +131,7 @@ class WindowsLazyClipboard : AutoCloseable {
 
         user32.PostMessage(w, WM_WRITE_FILES, null, null)
         return runBlocking {
-            withTimeoutOrNull(5000) { deferred.await() } ?: -1
+            withTimeoutOrNull(5.seconds) { deferred.await() } ?: -1
         }
     }
 


### PR DESCRIPTION
Closes #4093

## Summary
- Replace all `withTimeout(Long)` and `withTimeoutOrNull(Long)` calls with `kotlin.time.Duration` equivalents (e.g., `5.seconds`, `60.seconds`)
- Remove unused `milliseconds` import in `GeneralSyncHandler.kt`
- Eliminates Kotlin compiler warnings about deprecated Long overloads

## Changed files
- `SyncRoutingApi.kt` — `withTimeout(5000)` → `withTimeout(5.seconds)`
- `DefaultPasteSyncProcessManager.kt` — `withTimeout(60_000L)` → `withTimeout(60.seconds)`
- `GeneralSyncHandler.kt` — `withTimeoutOrNull(5000)` / `withTimeoutOrNull(5000.milliseconds)` → `withTimeoutOrNull(5.seconds)`
- `CrossPaste.kt` — `withTimeoutOrNull(5000L)` → `withTimeoutOrNull(5.seconds)`
- `WindowsLazyClipboard.kt` — `withTimeout(5000)` / `withTimeoutOrNull(3000)` / `withTimeoutOrNull(5000)` → Duration equivalents