### PR TITLE
:hammer: Abstract TrustDeviceView in DeviceScope for platform-specific pairing

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceScope.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceScope.kt
@@ -15,4 +15,7 @@ interface DeviceScope : PlatformScope {
 
     @Composable
     fun DeviceConnectView()
+
+    @Composable
+    fun TrustDeviceView()
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -67,7 +67,7 @@ fun DevicesContentView(guideContent: (@Composable () -> Unit)? = null) {
             remember(it) {
                 deviceScopeFactory.createDeviceScope(it)
             }
-        scope.TrustDeviceDialog()
+        scope.TrustDeviceView()
     }
 
     InnerScaffold(

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/devices/DesktopDeviceScope.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/devices/DesktopDeviceScope.kt
@@ -19,6 +19,11 @@ class DesktopDeviceScope(
 ) : DeviceScope {
 
     @Composable
+    override fun TrustDeviceView() {
+        TrustDeviceDialog()
+    }
+
+    @Composable
     override fun DeviceConnectView() {
         val navigationManager = koinInject<NavigationManager>()
 


### PR DESCRIPTION
Closes #4097

## Summary
- Add `@Composable fun TrustDeviceView()` to `DeviceScope` interface as platform abstraction point for the trust/pairing flow
- Desktop implementation (`DesktopDeviceScope`) delegates to existing `TrustDeviceDialog()`
- `DevicesContentView` now calls `scope.TrustDeviceView()` instead of `scope.TrustDeviceDialog()`

This enables mobile platforms to provide a camera-based QR scanning experience by overriding `TrustDeviceView()` with a scanner UI that calls `handler.showPairingCode()` on the remote device.