### PR TITLE
:bug: Fix pairing code countdown freeze by reordering trust completion steps (#4101)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -202,8 +202,8 @@ fun Routing.syncRouting(
                 )
             }.onSuccess { trustResponse ->
                 val host = call.request.headers["crosspaste-host"]
-                trustSyncInfo(appInstanceId, host)
                 appTokenApi.removePendingVerifier(appInstanceId)
+                trustSyncInfo(appInstanceId, host)
                 if (appTokenApi.showToken.value) {
                     appTokenApi.stopRefresh(hideToken = false)
                 }
@@ -329,8 +329,8 @@ fun Routing.syncRouting(
                 )
             }.onSuccess { response ->
                 val host = call.request.headers["crosspaste-host"]
-                trustSyncInfo(appInstanceId, host)
                 appTokenApi.removePendingVerifier(appInstanceId)
+                trustSyncInfo(appInstanceId, host)
                 if (appTokenApi.showToken.value) {
                     appTokenApi.stopRefresh(hideToken = false)
                 }


### PR DESCRIPTION
Closes #4101

## Summary
- Reorder `removePendingVerifier()` before `trustSyncInfo()` in both v1 trust and v2 confirm handlers in `SyncRouting.kt`
- Prevents a race condition where TokenView's auto-close and SyncRouting both call `stopRefresh`, double-decrementing `refreshCounter` and freezing the pairing code QR countdown at 30s

## Root Cause
`trustSyncInfo()` updates `syncRuntimeInfos` flow before `removePendingVerifier()` clears the pending set. Compose recomposes in between, sees `allResolved = true`, and triggers an extra `stopRefresh` from TokenView's `LaunchedEffect`.

## Test Plan
- [ ] Open pairing code screen, initiate trust from a remote device, verify countdown keeps ticking after trust completes
- [ ] Verify token view auto-close still works correctly when no pairing code screen is open
- [ ] Verify v2 key exchange + confirm flow works end-to-end