### PR TITLE
:hammer: Refactor SyncResolver to unified single-pass connection flow (#4103)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -55,7 +55,7 @@ class GeneralSyncHandler(
 
         job =
             syncPollingManager.startPollingResolve {
-                emitEvent(SyncEvent.ResolveConnection(currentSyncRuntimeInfo, createCallback()))
+                emitEvent(SyncEvent.Resolve(currentSyncRuntimeInfo, createCallback()))
             }
     }
 
@@ -74,21 +74,8 @@ class GeneralSyncHandler(
     }
 
     private suspend fun handleFirstValue(syncRuntimeInfo: SyncRuntimeInfo) {
-        when (syncRuntimeInfo.connectState) {
-            SyncState.DISCONNECTED,
-            SyncState.INCOMPATIBLE,
-            SyncState.UNMATCHED,
-            SyncState.UNVERIFIED,
-            -> {
-                emitEvent(SyncEvent.ResolveDisconnected(syncRuntimeInfo, createCallback()))
-            }
-            SyncState.CONNECTING -> {
-                emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createCallback()))
-            }
-            SyncState.CONNECTED -> {
-                emitEvent(SyncEvent.ResolveConnection(syncRuntimeInfo, createCallback()))
-            }
-        }
+        // The resolver handles all states — just emit a unified Resolve event
+        emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createCallback()))
     }
 
     private suspend fun handleValueChange(
@@ -96,7 +83,7 @@ class GeneralSyncHandler(
         current: SyncRuntimeInfo,
     ) {
         if (current.port != previous.port) {
-            emitEvent(SyncEvent.ResolveConnection(current, createCallback()))
+            emitEvent(SyncEvent.Resolve(current, createCallback()))
             return
         }
 
@@ -104,7 +91,7 @@ class GeneralSyncHandler(
             current.connectHostAddress != null &&
             previous.connectHostAddress != current.connectHostAddress
         ) {
-            emitEvent(SyncEvent.ResolveConnection(current, createCallback()))
+            emitEvent(SyncEvent.Resolve(current, createCallback()))
             return
         }
 
@@ -118,7 +105,7 @@ class GeneralSyncHandler(
                     // let polling handle retry with backoff to avoid tight retry loops
                     // (e.g. NOT_MATCH_APP_INSTANCE_ID on dual-boot machines).
                     if (previous.connectState == SyncState.CONNECTED) {
-                        emitEvent(SyncEvent.ResolveDisconnected(current, createCallback()))
+                        emitEvent(SyncEvent.Resolve(current, createCallback()))
                     }
                 }
                 SyncState.INCOMPATIBLE,
@@ -129,12 +116,13 @@ class GeneralSyncHandler(
                     emitEvent(SyncEvent.RefreshSyncInfo(current.appInstanceId, current.hostInfoList))
                 }
                 SyncState.CONNECTING -> {
-                    emitEvent(SyncEvent.ResolveConnecting(current, createCallback()))
+                    // No event needed — the resolver completes the full
+                    // discover → authenticate flow in a single pass.
+                    // Polling handles stuck CONNECTING state (e.g. after app restart).
                 }
 
                 SyncState.CONNECTED -> {
                     syncPollingManager.reset()
-                    emitEvent(SyncEvent.ResolveConnection(current, createCallback()))
                 }
             }
             return
@@ -142,7 +130,7 @@ class GeneralSyncHandler(
 
         if (!hostInfoListEqual(previous.hostInfoList, current.hostInfoList)) {
             if (current.connectState == SyncState.CONNECTED) {
-                emitEvent(SyncEvent.ResolveConnection(current, createCallback()))
+                emitEvent(SyncEvent.Resolve(current, createCallback()))
             }
         }
 
@@ -168,7 +156,7 @@ class GeneralSyncHandler(
                     },
                 )
 
-            emitEvent(SyncEvent.ResolveConnection(currentSyncRuntimeInfo, callback))
+            emitEvent(SyncEvent.Resolve(currentSyncRuntimeInfo, callback))
 
             withTimeoutOrNull(5.seconds) {
                 completionSignal.await()
@@ -178,7 +166,7 @@ class GeneralSyncHandler(
         }
 
     override suspend fun forceResolve() {
-        emitEvent(SyncEvent.ForceResolveConnection(currentSyncRuntimeInfo, createCallback()))
+        emitEvent(SyncEvent.ForceResolve(currentSyncRuntimeInfo, createCallback()))
     }
 
     override suspend fun updateAllowSend(allowSend: Boolean) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -14,36 +14,20 @@ sealed interface SyncEvent {
         val callback: ResolveCallback
     }
 
-    data class ResolveDisconnected(
+    data class Resolve(
         override val syncRuntimeInfo: SyncRuntimeInfo,
         override val callback: ResolveCallback,
     ) : SyncRunTimeInfoEvent,
         CallbackEvent {
-        override fun toString(): String = "ResolveDisconnected ${syncRuntimeInfo.appInstanceId}"
+        override fun toString(): String = "Resolve ${syncRuntimeInfo.appInstanceId}"
     }
 
-    data class ResolveConnecting(
+    data class ForceResolve(
         override val syncRuntimeInfo: SyncRuntimeInfo,
         override val callback: ResolveCallback,
     ) : SyncRunTimeInfoEvent,
         CallbackEvent {
-        override fun toString(): String = "ResolveConnecting ${syncRuntimeInfo.appInstanceId}"
-    }
-
-    data class ResolveConnection(
-        override val syncRuntimeInfo: SyncRuntimeInfo,
-        override val callback: ResolveCallback,
-    ) : SyncRunTimeInfoEvent,
-        CallbackEvent {
-        override fun toString(): String = "ResolveConnection ${syncRuntimeInfo.appInstanceId}"
-    }
-
-    data class ForceResolveConnection(
-        override val syncRuntimeInfo: SyncRuntimeInfo,
-        override val callback: ResolveCallback,
-    ) : SyncRunTimeInfoEvent,
-        CallbackEvent {
-        override fun toString(): String = "ForceResolveConnection ${syncRuntimeInfo.appInstanceId}"
+        override fun toString(): String = "ForceResolve ${syncRuntimeInfo.appInstanceId}"
     }
 
     data class TrustByToken(

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -77,20 +77,12 @@ class SyncResolver(
                         ?: return@runCatching
 
                 when (event) {
-                    is SyncEvent.ResolveDisconnected -> {
-                        syncRuntimeInfo.resolveDisconnected(event.callback)
+                    is SyncEvent.Resolve -> {
+                        syncRuntimeInfo.resolve(event.callback)
                     }
 
-                    is SyncEvent.ResolveConnecting -> {
-                        syncRuntimeInfo.resolveConnecting(event.callback)
-                    }
-
-                    is SyncEvent.ResolveConnection -> {
-                        syncRuntimeInfo.resolveConnection(event.callback)
-                    }
-
-                    is SyncEvent.ForceResolveConnection -> {
-                        syncRuntimeInfo.forceResolveConnection(event.callback)
+                    is SyncEvent.ForceResolve -> {
+                        syncRuntimeInfo.forceResolve(event.callback)
                     }
 
                     is SyncEvent.TrustByToken -> {
@@ -154,123 +146,192 @@ class SyncResolver(
         }
     }
 
-    private suspend fun SyncRuntimeInfo.resolveDisconnected(callback: ResolveCallback) {
-        logger.info { "Resolve disconnected $appInstanceId" }
-        telnetHelper.switchHost(hostInfoList, port)?.let { pair ->
-            val (hostInfo, versionRelation) = pair
-            logger.info { "$appInstanceId $hostInfo to connecting, versionRelation: $versionRelation" }
+    // ──────────────────────────────────────────────────────────────
+    // Unified resolution: dispatches by current state, completes the
+    // full discover → authenticate flow in a single pass to avoid
+    // unnecessary intermediate state persistence and event round-trips.
+    // ──────────────────────────────────────────────────────────────
 
-            callback.updateVersionRelation(versionRelation)
-            val isEqualVersion = versionRelation == VersionRelation.EQUAL_TO
-
-            if (isEqualVersion) {
-                syncRuntimeInfoDao.updateConnectInfo(
-                    this.copy(
-                        connectHostAddress = hostInfo.hostAddress,
-                        connectNetworkPrefixLength = hostInfo.networkPrefixLength,
-                        connectState = SyncState.CONNECTING,
-                        modifyTime = nowEpochMilliseconds(),
-                    ),
-                )
-            } else {
-                syncRuntimeInfoDao.updateConnectInfo(
-                    this.copy(
-                        connectHostAddress = hostInfo.hostAddress,
-                        connectNetworkPrefixLength = hostInfo.networkPrefixLength,
-                        connectState = SyncState.INCOMPATIBLE,
-                        modifyTime = nowEpochMilliseconds(),
-                    ),
-                )
+    private suspend fun SyncRuntimeInfo.resolve(callback: ResolveCallback) {
+        logger.info { "Resolve $appInstanceId (state=$connectState)" }
+        when (connectState) {
+            SyncState.DISCONNECTED,
+            SyncState.INCOMPATIBLE,
+            -> {
+                discoverAndConnect(callback)
             }
-        } ?: run {
-            logger.info { "$appInstanceId to disconnected, hostInfoList: $hostInfoList" }
-            syncRuntimeInfoDao.updateConnectInfo(
-                this.copy(
-                    connectState = SyncState.DISCONNECTED,
-                    modifyTime = nowEpochMilliseconds(),
-                ),
-            )
+
+            SyncState.CONNECTING,
+            SyncState.UNMATCHED,
+            -> {
+                connectHostAddress?.let { host ->
+                    authenticate(host, connectNetworkPrefixLength, callback)
+                } ?: discoverAndConnect(callback)
+            }
+
+            SyncState.UNVERIFIED -> {
+                resolveUnverified(callback)
+            }
+
+            SyncState.CONNECTED -> {
+                verifyConnection(callback)
+            }
         }
     }
 
-    private suspend fun SyncRuntimeInfo.resolveConnecting(callback: ResolveCallback) {
-        logger.info { "Resolve connecting $appInstanceId" }
-        this.connectHostAddress?.let { host ->
-            if (secureStore.existCryptPublicKey(appInstanceId)) {
-                val state = heartbeat(host, port, appInstanceId, callback)
+    /**
+     * Phase 1: Discover a reachable host and attempt full connection
+     * in one pass (telnet + heartbeat without an event round-trip).
+     */
+    private suspend fun SyncRuntimeInfo.discoverAndConnect(callback: ResolveCallback) {
+        val result =
+            telnetHelper.switchHost(hostInfoList, port) ?: run {
+                logger.info { "$appInstanceId no reachable host, hostInfoList: $hostInfoList" }
+                updateConnectState(SyncState.DISCONNECTED)
+                return
+            }
 
-                when (state) {
-                    SyncState.CONNECTED -> {
-                        logger.info { "heartbeat success $appInstanceId $host $port" }
-                        syncRuntimeInfoDao.updateConnectInfo(
-                            this.copy(
-                                connectState = SyncState.CONNECTED,
-                                modifyTime = nowEpochMilliseconds(),
-                            ),
-                        )
-                        // track significant action
-                        ratingPromptManager.trackSignificantAction()
-                        return@resolveConnecting
-                    }
-                    SyncState.UNMATCHED -> {
-                        logger.info {
-                            "heartbeat fail and connectState is unmatched, need to re verify $appInstanceId $host $port"
-                        }
-                        secureStore.deleteCryptPublicKey(appInstanceId)
-                        tryUseTokenCache(host, port)
-                    }
-                    SyncState.INCOMPATIBLE -> {
-                        logger.info {
-                            "heartbeat success and connectState is incompatible $appInstanceId $host $port"
-                        }
-                        syncRuntimeInfoDao.updateConnectInfo(
-                            this.copy(
-                                connectState = SyncState.INCOMPATIBLE,
-                                modifyTime = nowEpochMilliseconds(),
-                            ),
-                        )
-                    }
+        val (hostInfo, versionRelation) = result
+        callback.updateVersionRelation(versionRelation)
 
-                    else -> {
-                        syncRuntimeInfoDao.updateConnectInfo(
-                            this.copy(
-                                connectState = SyncState.DISCONNECTED,
-                                modifyTime = nowEpochMilliseconds(),
-                            ),
-                        )
-                    }
+        if (versionRelation != VersionRelation.EQUAL_TO) {
+            logger.info { "$appInstanceId version incompatible: $versionRelation" }
+            updateConnectState(SyncState.INCOMPATIBLE, hostInfo.hostAddress, hostInfo.networkPrefixLength)
+            return
+        }
+
+        // Host found and version compatible — set CONNECTING for UI feedback
+        logger.info { "$appInstanceId ${hostInfo.hostAddress} to connecting" }
+        updateConnectState(SyncState.CONNECTING, hostInfo.hostAddress, hostInfo.networkPrefixLength)
+
+        // Immediately attempt authentication (no event round-trip)
+        authenticate(hostInfo.hostAddress, hostInfo.networkPrefixLength, callback)
+    }
+
+    /**
+     * Phase 2: Attempt authentication via existing key or token cache.
+     * Called directly after discovery or when resuming from CONNECTING state.
+     */
+    private suspend fun SyncRuntimeInfo.authenticate(
+        host: String,
+        networkPrefixLength: Short?,
+        callback: ResolveCallback,
+    ) {
+        if (secureStore.existCryptPublicKey(appInstanceId)) {
+            val state = heartbeat(host, port, appInstanceId, callback)
+            when (state) {
+                SyncState.CONNECTED -> {
+                    logger.info { "heartbeat success $appInstanceId $host $port" }
+                    updateConnectState(SyncState.CONNECTED, host, networkPrefixLength)
+                    ratingPromptManager.trackSignificantAction()
                 }
-            } else {
-                logger.info { "not exist $appInstanceId public key, need to verify $host $port" }
-                tryUseTokenCache(host, port)
+
+                SyncState.UNMATCHED -> {
+                    logger.info { "heartbeat key mismatch $appInstanceId, re-authenticating" }
+                    secureStore.deleteCryptPublicKey(appInstanceId)
+                    tryTokenCacheOrUnverified(host, networkPrefixLength)
+                }
+
+                SyncState.INCOMPATIBLE -> {
+                    updateConnectState(SyncState.INCOMPATIBLE, host, networkPrefixLength)
+                }
+
+                else -> {
+                    updateConnectState(SyncState.DISCONNECTED)
+                }
             }
-        } ?: run {
-            logger.info { "$appInstanceId ${platform.name} to disconnected" }
-            syncRuntimeInfoDao.updateConnectInfo(
-                this.copy(
-                    connectState = SyncState.DISCONNECTED,
-                    modifyTime = nowEpochMilliseconds(),
-                ),
-            )
-        }
-    }
-
-    private suspend fun SyncRuntimeInfo.resolveConnection(callback: ResolveCallback) {
-        logger.info { "Resolve connection $appInstanceId" }
-        if (connectState == SyncState.DISCONNECTED ||
-            connectState == SyncState.INCOMPATIBLE
-        ) {
-            resolveDisconnected(callback)
         } else {
-            resolveConnecting(callback)
+            logger.info { "$appInstanceId no public key, checking token cache" }
+            tryTokenCacheOrUnverified(host, networkPrefixLength)
         }
     }
 
-    private suspend fun SyncRuntimeInfo.forceResolveConnection(callback: ResolveCallback) {
-        logger.info { "Force resolve connection $appInstanceId" }
-        refreshSyncInfo(appInstanceId, hostInfoList)
-        resolveConnection(callback)
+    /**
+     * Phase 3: Try QR-scan token cache first; fall back to UNVERIFIED
+     * so the user can manually enter a pairing code.
+     */
+    private suspend fun SyncRuntimeInfo.tryTokenCacheOrUnverified(
+        host: String,
+        networkPrefixLength: Short?,
+    ) {
+        if (trustByTokenCache()) {
+            logger.info { "trustByTokenCache success $host $port" }
+            updateConnectState(SyncState.CONNECTED, host, networkPrefixLength)
+            ratingPromptManager.trackSignificantAction()
+        } else {
+            // Verify host is still reachable before showing UNVERIFIED to user
+            telnetHelper.telnet(host, port)?.let { versionRelation ->
+                if (versionRelation == VersionRelation.EQUAL_TO) {
+                    logger.info { "$appInstanceId to unverified $host $port" }
+                    updateConnectState(SyncState.UNVERIFIED, host, networkPrefixLength)
+                } else {
+                    updateConnectState(SyncState.INCOMPATIBLE, host, networkPrefixLength)
+                }
+            } ?: updateConnectState(SyncState.DISCONNECTED)
+        }
     }
+
+    /**
+     * Handle UNVERIFIED state during polling: check if a QR token arrived
+     * or if the host is still reachable.
+     */
+    private suspend fun SyncRuntimeInfo.resolveUnverified(callback: ResolveCallback) {
+        connectHostAddress?.let { host ->
+            // Check token cache first — user may have scanned QR while waiting
+            if (trustByTokenCache()) {
+                logger.info { "trustByTokenCache success (from unverified) $host $port" }
+                updateConnectState(SyncState.CONNECTED, host, connectNetworkPrefixLength)
+                ratingPromptManager.trackSignificantAction()
+                return
+            }
+            // Verify host still reachable; only update DB if state changes
+            telnetHelper.telnet(host, port)?.let { versionRelation ->
+                callback.updateVersionRelation(versionRelation)
+                if (versionRelation != VersionRelation.EQUAL_TO) {
+                    updateConnectState(SyncState.INCOMPATIBLE, host, connectNetworkPrefixLength)
+                }
+                // If still EQUAL_TO, stay UNVERIFIED — no DB write needed
+            } ?: updateConnectState(SyncState.DISCONNECTED)
+        } ?: updateConnectState(SyncState.DISCONNECTED)
+    }
+
+    /**
+     * Verify an existing CONNECTED device is still healthy.
+     */
+    private suspend fun SyncRuntimeInfo.verifyConnection(callback: ResolveCallback) {
+        connectHostAddress?.let { host ->
+            val state = heartbeat(host, port, appInstanceId, callback)
+            when (state) {
+                SyncState.CONNECTED -> {
+                    // Still connected — no state change needed
+                }
+
+                SyncState.UNMATCHED -> {
+                    logger.info { "connection key mismatch $appInstanceId, re-authenticating" }
+                    secureStore.deleteCryptPublicKey(appInstanceId)
+                    tryTokenCacheOrUnverified(host, connectNetworkPrefixLength)
+                }
+
+                SyncState.INCOMPATIBLE -> {
+                    updateConnectState(SyncState.INCOMPATIBLE, host, connectNetworkPrefixLength)
+                }
+
+                else -> {
+                    updateConnectState(SyncState.DISCONNECTED)
+                }
+            }
+        } ?: updateConnectState(SyncState.DISCONNECTED)
+    }
+
+    private suspend fun SyncRuntimeInfo.forceResolve(callback: ResolveCallback) {
+        logger.info { "Force resolve $appInstanceId" }
+        refreshSyncInfo(appInstanceId, hostInfoList)
+        resolve(callback)
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Low-level operations (heartbeat, trust, token cache)
+    // ──────────────────────────────────────────────────────────────
 
     private suspend fun heartbeat(
         host: String,
@@ -335,55 +396,6 @@ class SyncResolver(
         }
     }
 
-    private suspend fun SyncRuntimeInfo.tryUseTokenCache(
-        host: String,
-        port: Int,
-    ) {
-        // Always attempt token cache first — it serves the QR-code scan flow
-        // where the token is delivered via physical proximity (camera), which is
-        // secure regardless of pairing protocol version.
-        if (trustByTokenCache()) {
-            logger.info { "trustByTokenCache success $host $port" }
-            syncRuntimeInfoDao.updateConnectInfo(
-                this.copy(
-                    connectState = SyncState.CONNECTED,
-                    modifyTime = nowEpochMilliseconds(),
-                ),
-            )
-            ratingPromptManager.trackSignificantAction()
-        } else {
-            connectHostAddress?.let {
-                telnetHelper.telnet(it, port)?.let { versionRelation ->
-                    if (versionRelation == VersionRelation.EQUAL_TO) {
-                        logger.info { "telnet success $host $port" }
-                        syncRuntimeInfoDao.updateConnectInfo(
-                            this.copy(
-                                connectState = SyncState.UNVERIFIED,
-                                modifyTime = nowEpochMilliseconds(),
-                            ),
-                        )
-                    } else {
-                        logger.info { "telnet fail $host $port" }
-                        syncRuntimeInfoDao.updateConnectInfo(
-                            this.copy(
-                                connectState = SyncState.INCOMPATIBLE,
-                                modifyTime = nowEpochMilliseconds(),
-                            ),
-                        )
-                    }
-                    return@tryUseTokenCache
-                }
-            }
-            syncRuntimeInfoDao.updateConnectInfo(
-                this.copy(
-                    connectState = SyncState.DISCONNECTED,
-                    modifyTime = nowEpochMilliseconds(),
-                ),
-            )
-        }
-    }
-
-    // try to use camera to scan token to trust
     private suspend fun SyncRuntimeInfo.trustByTokenCache(): Boolean {
         tokenCache.getToken(appInstanceId)?.let { token ->
             connectHostAddress?.let { host ->
@@ -541,6 +553,25 @@ class SyncResolver(
             callback(true)
             ratingPromptManager.trackSignificantAction()
         } ?: callback(false)
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────
+
+    private suspend fun SyncRuntimeInfo.updateConnectState(
+        state: Int,
+        hostAddress: String? = connectHostAddress,
+        networkPrefixLength: Short? = connectNetworkPrefixLength,
+    ) {
+        syncRuntimeInfoDao.updateConnectInfo(
+            this.copy(
+                connectHostAddress = hostAddress,
+                connectNetworkPrefixLength = networkPrefixLength,
+                connectState = state,
+                modifyTime = nowEpochMilliseconds(),
+            ),
+        )
     }
 
     private fun refreshSyncInfo(

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
@@ -42,7 +42,7 @@ class GeneralSyncHandlerTest {
     // ========== A. handleFirstValue (initial state) ==========
 
     @Test
-    fun handleFirstValue_disconnected_emitsResolveDisconnected() =
+    fun handleFirstValue_disconnected_emitsResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -51,12 +51,12 @@ class GeneralSyncHandlerTest {
             GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveDisconnected })
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     @Test
-    fun handleFirstValue_incompatible_emitsResolveDisconnected() =
+    fun handleFirstValue_incompatible_emitsResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -65,12 +65,12 @@ class GeneralSyncHandlerTest {
             GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveDisconnected })
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     @Test
-    fun handleFirstValue_unmatched_emitsResolveDisconnected() =
+    fun handleFirstValue_unmatched_emitsResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -79,12 +79,12 @@ class GeneralSyncHandlerTest {
             GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveDisconnected })
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     @Test
-    fun handleFirstValue_unverified_emitsResolveDisconnected() =
+    fun handleFirstValue_unverified_emitsResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -93,12 +93,12 @@ class GeneralSyncHandlerTest {
             GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveDisconnected })
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     @Test
-    fun handleFirstValue_connecting_emitsResolveConnecting() =
+    fun handleFirstValue_connecting_emitsResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -107,12 +107,12 @@ class GeneralSyncHandlerTest {
             GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveConnecting })
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     @Test
-    fun handleFirstValue_connected_emitsResolveConnection() =
+    fun handleFirstValue_connected_emitsResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -121,14 +121,14 @@ class GeneralSyncHandlerTest {
             GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveConnection })
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     // ========== B. handleValueChange (state transitions) ==========
 
     @Test
-    fun handleValueChange_portChange_emitsResolveConnection() =
+    fun handleValueChange_portChange_emitsResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -141,12 +141,12 @@ class GeneralSyncHandlerTest {
             handler.updateSyncRuntimeInfo(syncRuntimeInfo.copy(port = 13130))
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveConnection })
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     @Test
-    fun handleValueChange_hostAddressChange_emitsResolveConnection() =
+    fun handleValueChange_hostAddressChange_emitsResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -159,7 +159,7 @@ class GeneralSyncHandlerTest {
             handler.updateSyncRuntimeInfo(syncRuntimeInfo.copy(connectHostAddress = "192.168.1.101"))
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveConnection })
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
@@ -182,7 +182,7 @@ class GeneralSyncHandlerTest {
         }
 
     @Test
-    fun handleValueChange_stateToConnecting_emitsResolveConnecting() =
+    fun handleValueChange_stateToConnecting_noEventEmitted() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -200,12 +200,12 @@ class GeneralSyncHandlerTest {
             )
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveConnecting })
+            assertTrue(emitter.events.none { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     @Test
-    fun handleValueChange_stateToConnected_emitsResolveConnection() =
+    fun handleValueChange_stateToConnected_noResolveEvent() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -218,12 +218,12 @@ class GeneralSyncHandlerTest {
             handler.updateSyncRuntimeInfo(syncRuntimeInfo.copy(connectState = SyncState.CONNECTED))
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveConnection })
+            assertTrue(emitter.events.none { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     @Test
-    fun handleValueChange_hostInfoListChangeWhileConnected_emitsResolveConnection() =
+    fun handleValueChange_hostInfoListChangeWhileConnected_emitsResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -240,14 +240,14 @@ class GeneralSyncHandlerTest {
             )
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveConnection })
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             childScope.cancel()
         }
 
     // ========== C. API delegation ==========
 
     @Test
-    fun forceResolve_emitsForceResolveConnection() =
+    fun forceResolve_emitsForceResolve() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -260,7 +260,7 @@ class GeneralSyncHandlerTest {
             handler.forceResolve()
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            assertTrue(emitter.events.any { it is SyncEvent.ForceResolveConnection })
+            assertTrue(emitter.events.any { it is SyncEvent.ForceResolve })
             childScope.cancel()
         }
 
@@ -380,7 +380,7 @@ class GeneralSyncHandlerTest {
         }
 
     @Test
-    fun getConnectHostAddress_noAddress_emitsResolveConnectionAndWaits() =
+    fun getConnectHostAddress_noAddress_emitsResolveAndWaits() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -394,8 +394,8 @@ class GeneralSyncHandlerTest {
             // the result will be null (no address resolved within timeout)
             val address = handler.getConnectHostAddress()
 
-            // It should have emitted a ResolveConnection event
-            assertTrue(emitter.events.any { it is SyncEvent.ResolveConnection })
+            // It should have emitted a Resolve event
+            assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             assertNull(address)
             childScope.cancel()
         }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -92,7 +92,7 @@ class SyncResolverTest {
     // ========== A. resolveDisconnected ==========
 
     @Test
-    fun resolveDisconnected_switchHostReturnsEqualTo_setsConnecting() =
+    fun resolve_disconnected_switchHostEqualAndHeartbeatOk_setsConnected() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -105,15 +105,19 @@ class SyncResolverTest {
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns
                 Pair(hostInfo, VersionRelation.EQUAL_TO)
+            coEvery { deps.secureStore.existCryptPublicKey(any()) } returns true
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
+                SuccessResult(VersionRelation.EQUAL_TO)
 
-            val capturedInfo = slot<SyncRuntimeInfo>()
-            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
+            val capturedInfos = mutableListOf<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfos)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveDisconnected(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
-            assertEquals(SyncState.CONNECTING, capturedInfo.captured.connectState)
-            assertEquals("192.168.1.100", capturedInfo.captured.connectHostAddress)
+            assertEquals(SyncState.CONNECTING, capturedInfos[0].connectState)
+            assertEquals("192.168.1.100", capturedInfos[0].connectHostAddress)
+            assertEquals(SyncState.CONNECTED, capturedInfos[1].connectState)
         }
 
     @Test
@@ -132,7 +136,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveDisconnected(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertEquals(SyncState.INCOMPATIBLE, capturedInfo.captured.connectState)
         }
@@ -153,7 +157,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveDisconnected(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertEquals(SyncState.INCOMPATIBLE, capturedInfo.captured.connectState)
         }
@@ -172,7 +176,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveDisconnected(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
@@ -191,7 +195,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveDisconnected(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             coVerify { deps.telnetHelper.switchHost(emptyList(), any(), any()) }
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
@@ -215,7 +219,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertEquals(SyncState.CONNECTED, capturedInfo.captured.connectState)
             verify { deps.ratingPromptManager.trackSignificantAction() }
@@ -245,7 +249,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfos)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             coVerify { deps.secureStore.deleteCryptPublicKey(syncRuntimeInfo.appInstanceId) }
         }
@@ -266,7 +270,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertEquals(SyncState.INCOMPATIBLE, capturedInfo.captured.connectState)
         }
@@ -287,7 +291,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertEquals(SyncState.UNVERIFIED, capturedInfo.captured.connectState)
         }
@@ -304,12 +308,13 @@ class SyncResolverTest {
                 )
 
             deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
@@ -329,7 +334,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
@@ -351,7 +356,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.CONNECTED, capturedInfo.captured.connectState)
         }
@@ -371,7 +376,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.INCOMPATIBLE, capturedInfo.captured.connectState)
         }
@@ -391,7 +396,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.INCOMPATIBLE, capturedInfo.captured.connectState)
         }
@@ -411,7 +416,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
@@ -436,7 +441,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
@@ -464,7 +469,7 @@ class SyncResolverTest {
             val capturedInfos = mutableListOf<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfos)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             coVerify { deps.secureStore.deleteCryptPublicKey(any()) }
         }
@@ -485,7 +490,7 @@ class SyncResolverTest {
             val capturedInfos = mutableListOf<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfos)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             coVerify { deps.secureStore.deleteCryptPublicKey(any()) }
         }
@@ -506,7 +511,7 @@ class SyncResolverTest {
             val capturedInfos = mutableListOf<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfos)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             coVerify { deps.secureStore.deleteCryptPublicKey(any()) }
         }
@@ -525,7 +530,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
@@ -553,7 +558,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.CONNECTED, capturedInfo.captured.connectState)
             verify { deps.ratingPromptManager.trackSignificantAction() }
@@ -577,7 +582,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.UNVERIFIED, capturedInfo.captured.connectState)
         }
@@ -596,7 +601,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.UNVERIFIED, capturedInfo.captured.connectState)
         }
@@ -615,7 +620,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.INCOMPATIBLE, capturedInfo.captured.connectState)
         }
@@ -634,7 +639,7 @@ class SyncResolverTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
@@ -652,11 +657,12 @@ class SyncResolverTest {
 
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            resolver.emitEvent(SyncEvent.ResolveConnecting(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
 
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
@@ -750,7 +756,7 @@ class SyncResolverTest {
     // ========== F. Event dispatch and callback ==========
 
     @Test
-    fun resolveConnection_disconnected_dispatchesToResolveDisconnected() =
+    fun resolve_disconnected_callsSwitchHost() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -763,13 +769,13 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveConnection(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             coVerify { deps.telnetHelper.switchHost(any(), any(), any()) }
         }
 
     @Test
-    fun resolveConnection_incompatible_dispatchesToResolveDisconnected() =
+    fun resolve_incompatible_callsSwitchHost() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -782,13 +788,13 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveConnection(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             coVerify { deps.telnetHelper.switchHost(any(), any(), any()) }
         }
 
     @Test
-    fun resolveConnection_connecting_dispatchesToResolveConnecting() =
+    fun resolve_connecting_callsAuthenticateNotSwitchHost() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -802,14 +808,14 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ResolveConnection(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             // resolveConnecting path is taken, which calls telnet (not switchHost)
             coVerify(exactly = 0) { deps.telnetHelper.switchHost(any(), any(), any()) }
         }
 
     @Test
-    fun forceResolveConnection_callsRefreshThenResolve() =
+    fun forceResolve_callsRefreshThenResolve() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -820,7 +826,7 @@ class SyncResolverTest {
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(any()) } returns "test-app-1"
 
             val callback = createTestCallback()
-            resolver.emitEvent(SyncEvent.ForceResolveConnection(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.ForceResolve(syncRuntimeInfo, callback))
 
             verify { deps.pasteBonjourService.refreshTarget(any(), any()) }
             coVerify { deps.telnetHelper.switchHost(any(), any(), any()) }
@@ -856,7 +862,7 @@ class SyncResolverTest {
                     onComplete = { onCompleteCalled = true },
                 )
 
-            resolver.emitEvent(SyncEvent.ResolveDisconnected(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertTrue(onCompleteCalled)
         }
@@ -872,6 +878,9 @@ class SyncResolverTest {
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns
                 Pair(hostInfo, VersionRelation.EQUAL_TO)
+            coEvery { deps.secureStore.existCryptPublicKey(any()) } returns true
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
+                SuccessResult(VersionRelation.EQUAL_TO)
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(any()) } returns "test-app-1"
 
             var capturedRelation: VersionRelation? = null
@@ -881,7 +890,7 @@ class SyncResolverTest {
                     onComplete = {},
                 )
 
-            resolver.emitEvent(SyncEvent.ResolveDisconnected(syncRuntimeInfo, callback))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertEquals(VersionRelation.EQUAL_TO, capturedRelation)
         }


### PR DESCRIPTION
Closes #4103

## Summary
- Unify 4 resolve event types (`ResolveDisconnected`, `ResolveConnecting`, `ResolveConnection`, `ForceResolveConnection`) into 2 (`Resolve`, `ForceResolve`)
- Replace scattered resolve methods with phase-based flow: `resolve → discoverAndConnect → authenticate → tryTokenCacheOrUnverified / verifyConnection`
- Complete the full discover → authenticate flow in a single resolve pass, eliminating the intermediate CONNECTING event round-trip
- Skip unnecessary DB writes during UNVERIFIED polling when state doesn't change
- Simplify `GeneralSyncHandler`: all states emit unified `Resolve`; CONNECTING transition handled inline by resolver

## Compatibility
- External protocol unchanged: VERSION=3, all HTTP endpoints, DB schema identical
- 100% compatible with old devices — purely internal refactoring

## Test plan
- [x] All 209 desktop tests pass
- [x] `SyncResolverTest` updated for unified resolve behavior
- [x] `GeneralSyncHandlerTest` updated for new event types
- [x] `GeneralSyncManagerTest` passes without changes
- [ ] Manual test: pair a new device via QR scan
- [ ] Manual test: pair a new device via manual token entry
- [ ] Manual test: disconnect/reconnect cycle
- [ ] Manual test: verify old version device can still connect