### PR TITLE
:zap: Improve device reconnection with fast-then-slow telnet probe strategy (#4107)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
@@ -15,18 +15,24 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.milliseconds
 
 class TelnetHelper(
     private val pasteClient: PasteClient,
     private val syncApi: SyncApi,
 ) {
 
+    companion object {
+        const val FAST_TIMEOUT = 500L
+        const val SLOW_TIMEOUT = 2000L
+    }
+
     private val logger = KotlinLogging.logger {}
 
     suspend fun switchHost(
         hostInfoList: List<HostInfo>,
         port: Int,
-        timeout: Long = 500L,
+        timeout: Long = FAST_TIMEOUT,
     ): Pair<HostInfo, VersionRelation>? {
         if (hostInfoList.isEmpty()) return null
 
@@ -51,7 +57,7 @@ class TelnetHelper(
         }
 
         return try {
-            withTimeout(timeout) { result.await() }
+            withTimeout(timeout.milliseconds) { result.await() }
         } catch (_: TimeoutCancellationException) {
             null
         } finally {
@@ -62,7 +68,7 @@ class TelnetHelper(
     suspend fun telnet(
         hostAddress: String,
         port: Int,
-        timeout: Long = 500L,
+        timeout: Long = FAST_TIMEOUT,
     ): VersionRelation? =
         runCatching {
             val hostAndPort = HostAndPort(hostAddress, port)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -182,10 +182,14 @@ class SyncResolver(
     /**
      * Phase 1: Discover a reachable host and attempt full connection
      * in one pass (telnet + heartbeat without an event round-trip).
+     *
+     * Uses a fast-then-slow strategy: if a previously connected address
+     * exists, try it first with a short timeout. On failure, fall back
+     * to probing the full address list with a longer timeout.
      */
     private suspend fun SyncRuntimeInfo.discoverAndConnect(callback: ResolveCallback) {
         val result =
-            telnetHelper.switchHost(hostInfoList, port) ?: run {
+            discoverReachableHost() ?: run {
                 logger.info { "$appInstanceId no reachable host, hostInfoList: $hostInfoList" }
                 updateConnectState(SyncState.DISCONNECTED)
                 return
@@ -327,6 +331,28 @@ class SyncResolver(
         logger.info { "Force resolve $appInstanceId" }
         refreshSyncInfo(appInstanceId, hostInfoList)
         resolve(callback)
+    }
+
+    /**
+     * Fast-then-slow host discovery: try the last known address first
+     * with a short timeout, then fall back to probing all addresses
+     * with a longer timeout.
+     */
+    private suspend fun SyncRuntimeInfo.discoverReachableHost(): Pair<HostInfo, VersionRelation>? {
+        // Fast path: try the previously connected address first
+        connectHostAddress?.let { lastHost ->
+            val lastHostInfo = hostInfoList.firstOrNull { it.hostAddress == lastHost }
+            if (lastHostInfo != null) {
+                logger.info { "$appInstanceId fast probe $lastHost:$port" }
+                telnetHelper.telnet(lastHost, port, TelnetHelper.FAST_TIMEOUT)?.let { version ->
+                    return@discoverReachableHost Pair(lastHostInfo, version)
+                }
+                logger.info { "$appInstanceId fast probe failed, falling back to full list" }
+            }
+        }
+
+        // Slow path: try all addresses in parallel with a longer timeout
+        return telnetHelper.switchHost(hostInfoList, port, TelnetHelper.SLOW_TIMEOUT)
     }
 
     // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #4107

## Summary
- Add two-phase host discovery in `SyncResolver.discoverAndConnect()`: try the last known `connectHostAddress` first with 500ms timeout, then fall back to probing all addresses with 2000ms timeout
- Extract `FAST_TIMEOUT` (500ms) and `SLOW_TIMEOUT` (2000ms) constants in `TelnetHelper` to replace hardcoded values

## Test plan
- [x] Existing `SyncResolverTest` tests pass
- [ ] Verify normal reconnection completes within 500ms (fast path)
- [ ] Verify reconnection after IP change succeeds via slow path (2000ms)
- [ ] Verify first-time connection (no `connectHostAddress`) uses slow path directly