### PR TITLE
Add missing enableRemoteShowPairingCode field to CliReadOnlyAppConfig

### DIFF
--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CliAdapters.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CliAdapters.kt
@@ -54,6 +54,7 @@ data class CliReadOnlyAppConfig(
     override val enableSyncImage: Boolean = true,
     override val enableSyncFile: Boolean = true,
     override val enableSyncColor: Boolean = true,
+    override val enableRemoteShowPairingCode: Boolean = true,
 ) : AppConfig {
     override fun copy(
         key: String,


### PR DESCRIPTION
Closes #4117

## Summary
- Add missing `enableRemoteShowPairingCode` property to `CliReadOnlyAppConfig` to satisfy the `AppConfig` interface contract.

## Test plan
- [ ] Verify CLI module compiles successfully