### PR TITLE
:hammer: Refactor searchPasteData pasteType to pasteTypeList for multi-type filtering

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
@@ -44,7 +44,7 @@ class GeneralPasteSearchViewModel(
                     .searchPasteDataFlow(
                         searchTerms = params.searchTerms,
                         sort = params.sort,
-                        pasteType = params.pasteType,
+                        pasteTypeList = params.pasteTypeList,
                         tag = params.tag,
                         limit = params.limit,
                     ).map { pasteDataList ->

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/PasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/PasteSearchViewModel.kt
@@ -30,7 +30,7 @@ abstract class PasteSearchViewModel : ViewModel() {
     private val _searchBaseParams =
         MutableStateFlow(
             SearchBaseParams(
-                pasteType = null,
+                pasteTypeList = listOf(),
                 sort = true,
                 tag = null,
                 limit = QUERY_BATCH_SIZE,
@@ -61,7 +61,7 @@ abstract class PasteSearchViewModel : ViewModel() {
 
             SearchParams(
                 searchTerms = searchTerms,
-                pasteType = searchBaseParams.pasteType,
+                pasteTypeList = searchBaseParams.pasteTypeList,
                 sort = searchBaseParams.sort,
                 tag = searchBaseParams.tag,
                 limit = searchBaseParams.limit,
@@ -89,11 +89,11 @@ abstract class PasteSearchViewModel : ViewModel() {
             )
     }
 
-    fun updatePasteType(pasteType: Int?) {
+    fun updatePasteType(pasteTypeList: List<Int>) {
         pendingLoadJob?.cancel()
         _searchBaseParams.value =
             _searchBaseParams.value.copy(
-                pasteType = pasteType,
+                pasteTypeList = pasteTypeList,
                 limit = QUERY_BATCH_SIZE,
             )
         _loadAll.value = false
@@ -148,7 +148,7 @@ abstract class PasteSearchViewModel : ViewModel() {
         pendingLoadJob?.cancel()
         _searchBaseParams.value =
             _searchBaseParams.value.copy(
-                pasteType = null,
+                pasteTypeList = listOf(),
                 sort = true,
                 tag = null,
                 limit = QUERY_BATCH_SIZE,

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/SearchParams.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/SearchParams.kt
@@ -1,7 +1,7 @@
 package com.crosspaste.ui.model
 
 data class SearchBaseParams(
-    val pasteType: Int?,
+    val pasteTypeList: List<Int>,
     val sort: Boolean,
     val tag: Long?,
     val limit: Int,
@@ -9,7 +9,7 @@ data class SearchBaseParams(
 
 data class SearchParams(
     val searchTerms: List<String>,
-    val pasteType: Int?,
+    val pasteTypeList: List<Int>,
     val sort: Boolean,
     val tag: Long?,
     val limit: Int,

--- a/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpToolProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/mcp/McpToolProvider.kt
@@ -131,7 +131,7 @@ class McpToolProvider(
             val results =
                 pasteDao.searchPasteData(
                     searchTerms = searchTerms,
-                    pasteType = pasteType?.type,
+                    pasteTypeList = listOfNotNull(pasteType?.type),
                     sort = true,
                     tag = tagId,
                     limit = limit,

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
@@ -130,7 +130,7 @@ fun SidePasteboardContentView() {
     LaunchedEffect(
         inputSearch,
         searchBaseParams.sort,
-        searchBaseParams.pasteType,
+        searchBaseParams.pasteTypeList,
     ) {
         if (searchWindowInfo.show) {
             pasteSelectionViewModel.initSelectIndex()

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/search/SearchTrailingIcon.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/search/SearchTrailingIcon.kt
@@ -71,7 +71,7 @@ fun SearchTrailingIcon() {
 
     var showTypes by remember { mutableStateOf(false) }
 
-    var currentType = searchBaseParams.pasteType?.let { PasteType.fromType(it) }
+    var currentType = searchBaseParams.pasteTypeList.singleOrNull()?.let { PasteType.fromType(it) }
 
     val textStyle =
         MaterialTheme.typography.labelLarge.copy(
@@ -172,13 +172,13 @@ fun SearchTrailingIcon() {
                                 .clip(tiny2XRoundedCornerShape)
                                 .background(MaterialTheme.colorScheme.surfaceBright),
                     ) {
-                        if (searchBaseParams.pasteType != null) {
+                        if (searchBaseParams.pasteTypeList.isNotEmpty()) {
                             MenuItemView(
                                 text = copywriter.getText("all_types"),
                                 textStyle = textStyle,
                                 paddingValues = paddingValues,
                             ) {
-                                pasteSearchViewModel.updatePasteType(null)
+                                pasteSearchViewModel.updatePasteType(listOf())
                                 currentType = null
                                 showTypes = false
                             }
@@ -193,7 +193,7 @@ fun SearchTrailingIcon() {
                                     paddingValues = paddingValues,
                                     background = MaterialTheme.colorScheme.surfaceBright,
                                 ) {
-                                    pasteSearchViewModel.updatePasteType(pasteType.type)
+                                    pasteSearchViewModel.updatePasteType(listOf(pasteType.type))
                                     currentType = pasteType
                                     showTypes = false
                                 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
@@ -285,7 +285,7 @@ class PasteDaoTest {
 
         val textResults = pasteDao.searchPasteData(
             searchTerms = listOf(),
-            pasteType = PasteType.TEXT_TYPE.type,
+            pasteTypeList = listOf(PasteType.TEXT_TYPE.type),
             limit = 100,
         )
         assertEquals(1, textResults.size)

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/model/PasteSearchViewModelTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/model/PasteSearchViewModelTest.kt
@@ -50,7 +50,7 @@ class PasteSearchViewModelTest {
     fun `initial search base params have default values`() {
         val vm = TestSearchViewModel()
         val params = vm.searchBaseParams.value
-        assertNull(params.pasteType)
+        assertTrue(params.pasteTypeList.isEmpty())
         assertTrue(params.sort)
         assertNull(params.tag)
         assertEquals(PasteSearchViewModel.QUERY_BATCH_SIZE, params.limit)
@@ -88,19 +88,22 @@ class PasteSearchViewModelTest {
     @Test
     fun `updatePasteType sets paste type and resets limit`() {
         val vm = TestSearchViewModel()
-        vm.updatePasteType(3)
-        assertEquals(3, vm.searchBaseParams.value.pasteType)
+        vm.updatePasteType(listOf(3))
+        assertEquals(listOf(3), vm.searchBaseParams.value.pasteTypeList)
         assertEquals(PasteSearchViewModel.QUERY_BATCH_SIZE, vm.searchBaseParams.value.limit)
     }
 
     @Test
-    fun `updatePasteType with null clears filter`() {
+    fun `updatePasteType with empty list clears filter`() {
         val vm = TestSearchViewModel()
-        vm.updatePasteType(3)
-        assertEquals(3, vm.searchBaseParams.value.pasteType)
+        vm.updatePasteType(listOf(3))
+        assertEquals(listOf(3), vm.searchBaseParams.value.pasteTypeList)
 
-        vm.updatePasteType(null)
-        assertNull(vm.searchBaseParams.value.pasteType)
+        vm.updatePasteType(listOf())
+        assertTrue(
+            vm.searchBaseParams.value.pasteTypeList
+                .isEmpty(),
+        )
     }
 
     @Test
@@ -148,14 +151,14 @@ class PasteSearchViewModelTest {
         // Change everything
         vm.updateInputSearch("test")
         vm.switchSort()
-        vm.updatePasteType(2)
+        vm.updatePasteType(listOf(2))
         vm.updateTag(99L)
 
         vm.resetSearch()
 
         assertEquals("", vm.inputSearch.value)
         val params = vm.searchBaseParams.value
-        assertNull(params.pasteType)
+        assertTrue(params.pasteTypeList.isEmpty())
         assertTrue(params.sort)
         assertEquals(PasteSearchViewModel.QUERY_BATCH_SIZE, params.limit)
     }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/HistoryCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/HistoryCommand.kt
@@ -45,7 +45,7 @@ class HistoryCommand : CliktCommand(name = "history") {
         runWithDao {
             val pasteDao = getDao<PasteDao>()
             val pasteTagDao = getDao<PasteTagDao>()
-            val pasteType = resolveTypeFilter(type)
+            val pasteTypeList = listOfNotNull(resolveTypeFilter(type))
 
             val tagId: Long? =
                 tag?.let { name ->
@@ -58,7 +58,7 @@ class HistoryCommand : CliktCommand(name = "history") {
             val results =
                 pasteDao.searchPasteData(
                     searchTerms = listOf(),
-                    pasteType = pasteType,
+                    pasteTypeList = pasteTypeList,
                     tag = tagId,
                     limit = limit,
                 )

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/SearchCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/SearchCommand.kt
@@ -32,7 +32,7 @@ class SearchCommand : CliktCommand(name = "search") {
             val pasteTagDao = getDao<PasteTagDao>()
             val searchContentService = getDao<SearchContentService>()
             val searchTerms = searchContentService.createSearchTerms(query)
-            val pasteType = resolveTypeFilter(type)
+            val pasteTypeList = listOfNotNull(resolveTypeFilter(type))
 
             val tagId: Long? =
                 tag?.let { name ->
@@ -45,7 +45,7 @@ class SearchCommand : CliktCommand(name = "search") {
             val results =
                 pasteDao.searchPasteData(
                     searchTerms = searchTerms,
-                    pasteType = pasteType,
+                    pasteTypeList = pasteTypeList,
                     tag = tagId,
                     limit = limit,
                 )

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SearchPasteData.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SearchPasteData.kt
@@ -5,10 +5,17 @@ import kotlinx.coroutines.flow.Flow
 
 interface SearchPasteData {
 
+    /**
+     * Search paste data with optional type filtering.
+     *
+     * [pasteTypeList] accepts multiple paste types for OR-matching (SQL `IN` clause),
+     * allowing mobile clients to query several types in a single request.
+     * An empty list means no type filter (returns all types).
+     */
     suspend fun searchPasteData(
         searchTerms: List<String>,
         local: Boolean? = null,
-        pasteType: Int? = null,
+        pasteTypeList: List<Int> = listOf(),
         sort: Boolean = true,
         tag: Long? = null,
         limit: Int,
@@ -17,7 +24,7 @@ interface SearchPasteData {
     fun searchPasteDataFlow(
         searchTerms: List<String>,
         local: Boolean? = null,
-        pasteType: Int? = null,
+        pasteTypeList: List<Int> = listOf(),
         sort: Boolean = true,
         tag: Long? = null,
         limit: Int,

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
@@ -7,6 +7,7 @@ import com.crosspaste.app.AppInfo
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteExportParam
 import com.crosspaste.paste.PasteState
+import com.crosspaste.paste.PasteType.Companion.INVALID_TYPE
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.clear
 import com.crosspaste.paste.item.PasteItem
@@ -334,12 +335,17 @@ class SqlPasteDao(
     private fun createSearchPasteQuery(
         searchTerms: List<String>,
         local: Boolean? = null,
-        pasteType: Int? = null,
+        pasteTypeList: List<Int> = listOf(),
         sort: Boolean = true,
         tagId: Long? = null,
         limit: Int,
     ): Query<PasteData> {
         val appInstanceId: String? = local?.let { appInfo.appInstanceId }
+        // filterByPasteType=true (list empty) → skip type filter, return all types.
+        // filterByPasteType=false (list non-empty) → apply IN clause for OR-matching multiple types.
+        // A dummy value is used when the list is empty because SQLDelight's IN clause requires a non-empty collection.
+        val filterByPasteType = pasteTypeList.isEmpty()
+        val pasteTypeLongList = pasteTypeList.ifEmpty { listOf(INVALID_TYPE.type) }.map { it.toLong() }
 
         return if (searchTerms.isNotEmpty()) {
             val searchQuery = "pasteSearchContent:(${searchTerms.joinToString(" AND ") { "$it*" }})"
@@ -348,7 +354,8 @@ class SqlPasteDao(
             pasteDatabaseQueries.complexSearch(
                 local = local == true,
                 appInstanceId = appInstanceId,
-                pasteType = pasteType?.toLong(),
+                filterByPasteType = filterByPasteType,
+                pasteType = pasteTypeLongList,
                 searchQuery = searchQuery,
                 sort = sort,
                 tagId = tagId,
@@ -361,7 +368,8 @@ class SqlPasteDao(
             pasteDatabaseQueries.simpleSearch(
                 local = local == true,
                 appInstanceId = appInstanceId,
-                pasteType = pasteType?.toLong(),
+                filterByPasteType = filterByPasteType,
+                pasteType = pasteTypeLongList,
                 sort = sort,
                 tagId = tagId,
                 number = limit.toLong(),
@@ -373,7 +381,7 @@ class SqlPasteDao(
     override suspend fun searchPasteData(
         searchTerms: List<String>,
         local: Boolean?,
-        pasteType: Int?,
+        pasteTypeList: List<Int>,
         sort: Boolean,
         tag: Long?,
         limit: Int,
@@ -381,30 +389,30 @@ class SqlPasteDao(
         withContext(ioDispatcher) {
             logExecutionTime(logger, "searchPasteData") {
                 logger.info { "Performing search for: $searchTerms" }
-                createSearchPasteQuery(searchTerms, local, pasteType, sort, tag, limit).executeAsList()
+                createSearchPasteQuery(searchTerms, local, pasteTypeList, sort, tag, limit).executeAsList()
             }
         }
 
     override fun searchPasteDataFlow(
         searchTerms: List<String>,
         local: Boolean?,
-        pasteType: Int?,
+        pasteTypeList: List<Int>,
         sort: Boolean,
         tag: Long?,
         limit: Int,
     ): Flow<List<PasteData>> =
         logExecutionTime(logger, "searchPasteData") {
             logger.info { "Performing search for: $searchTerms" }
-            createSearchPasteQuery(searchTerms, local, pasteType, sort, tag, limit)
+            createSearchPasteQuery(searchTerms, local, pasteTypeList, sort, tag, limit)
                 .asFlow()
                 .map { it.executeAsList() }
                 .catch { e ->
                     logger.error(e) {
                         "Error executing search query: ${e.message}\n" +
                             "searchTerms=$searchTerms local=$local " +
-                            "pasteType=$pasteType sort=$sort"
+                            "pasteTypeList=$pasteTypeList sort=$sort"
                     }
-                    emit(searchPasteData(listOf(), local, pasteType, sort, tag, limit))
+                    emit(searchPasteData(listOf(), local, pasteTypeList, sort, tag, limit))
                 }.flowOn(ioDispatcher)
         }
 

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
@@ -157,6 +157,9 @@ WHERE hash = :hash AND
         WHERE PasteTagEntity.pasteId = PasteDataEntity.id
     );
 
+-- pasteType filter: filterByPasteType=TRUE means no type filter (return all types);
+-- filterByPasteType=FALSE applies the IN clause to match any of the given types.
+-- This supports mobile clients that need to query multiple paste types in one request.
 simpleSearch:
 SELECT * FROM PasteDataEntity
 WHERE
@@ -168,10 +171,7 @@ WHERE
         END
             ELSE TRUE
         END AND
-        CASE WHEN :pasteType IS NOT NULL
-          THEN pasteType = :pasteType
-          ELSE TRUE
-        END AND
+        (:filterByPasteType OR (pasteType IN ?)) AND
         CASE WHEN :tagId IS NOT NULL
             THEN EXISTS (
                 SELECT 1 FROM PasteTagEntity
@@ -197,10 +197,7 @@ SELECT PasteDataEntity.*
             END
             ELSE TRUE
         END AND
-        CASE WHEN :pasteType IS NOT NULL
-            THEN pasteType = :pasteType
-            ELSE TRUE
-        END AND
+        (:filterByPasteType OR (pasteType IN ?)) AND
         CASE WHEN :tagId IS NOT NULL
             THEN EXISTS (
                 SELECT 1 FROM PasteTagEntity


### PR DESCRIPTION
Closes #4121

## Summary
- Refactor `pasteType: Int?` → `pasteTypeList: List<Int>` across the search API, enabling OR-matching of multiple paste types in a single query via SQL `IN` clause
- An empty list means no type filter (returns all types), preserving backward compatibility
- Supports mobile clients that need to query several paste types in one request

## Changes
- **SQL**: Replace `CASE WHEN :pasteType IS NOT NULL THEN pasteType = :pasteType ELSE TRUE END` with `(:filterByPasteType OR (pasteType IN ?))` in both `simpleSearch` and `complexSearch`
- **Interface/DAO**: `SearchPasteData`, `SqlPasteDao` — parameter renamed with list semantics
- **ViewModel**: `SearchParams`, `PasteSearchViewModel` — `pasteType: Int?` → `pasteTypeList: List<Int>`
- **UI**: `SearchTrailingIcon`, `SidePasteboardContentView` — updated callers
- **CLI**: `SearchCommand`, `HistoryCommand` — use `listOfNotNull()` to wrap single type
- **MCP**: `McpToolProvider` — use `listOfNotNull()` to wrap single type
- **Tests**: `PasteDaoTest`, `PasteSearchViewModelTest` — updated assertions

## Test plan
- [ ] Verify search with no type filter returns all paste types
- [ ] Verify search with a single type filter works correctly
- [ ] Verify search with multiple types returns matching items
- [ ] Verify CLI `--type` flag still works for single type filtering
- [ ] Verify UI type dropdown selection and "All Types" reset work