### PR TITLE
:hammer: Refactor getCrossPasteWebUrl to use remote locale config from meta.json (#4123)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/CrossPasteWebService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/CrossPasteWebService.kt
@@ -1,0 +1,68 @@
+package com.crosspaste.app
+
+import com.crosspaste.net.ResourcesClient
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class WebLocale(
+    val code: String,
+    val label: String,
+    val path: String,
+)
+
+@Serializable
+data class WebMeta(
+    val locales: List<WebLocale>,
+)
+
+class CrossPasteWebService(
+    private val appUrls: AppUrls,
+    private val resourcesClient: ResourcesClient,
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+        }
+
+    @Volatile
+    private var localePathMap: Map<String, String> = emptyMap()
+
+    suspend fun refresh() {
+        runCatching {
+            val metaUrl = "${appUrls.homeUrl}/api/meta.json"
+            resourcesClient
+                .request(metaUrl)
+                .getOrNull()
+                ?.let { response ->
+                    val text = response.getBodyAsText()
+                    val meta = json.decodeFromString<WebMeta>(text)
+                    localePathMap = meta.locales.associate { it.code to it.path }
+                    logger.info { "Web locale config loaded: ${localePathMap.keys}" }
+                }
+        }.onFailure { e ->
+            logger.warn { "Failed to fetch web locale config: ${e.message}" }
+        }
+    }
+
+    fun getWebUrl(
+        language: String,
+        path: String = "",
+    ): String {
+        val localePath = resolveLocalePath(language)
+        return "${appUrls.homeUrl}$localePath$path"
+    }
+
+    private fun resolveLocalePath(language: String): String {
+        val map = localePathMap
+        if (map.isNotEmpty()) {
+            return map[language] ?: map["en"] ?: "/en/"
+        }
+        // Fallback before meta.json loads
+        return if (language == "zh") "/" else "/en/"
+    }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ResourcesClient.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ResourcesClient.kt
@@ -2,6 +2,7 @@ package com.crosspaste.net
 
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentLength
@@ -27,6 +28,8 @@ class ClientResponse(
 ) {
 
     suspend fun getBody(): ByteReadChannel = response.bodyAsChannel()
+
+    suspend fun getBodyAsText(): String = response.bodyAsText()
 
     fun getContentLength(): Long = response.contentLength() ?: -1L
 

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/UISupport.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/UISupport.kt
@@ -1,9 +1,12 @@
 package com.crosspaste.ui.base
 
+import com.crosspaste.app.CrossPasteWebService
 import com.crosspaste.paste.PasteData
 import okio.Path
 
 interface UISupport {
+
+    val crossPasteWebService: CrossPasteWebService
 
     fun openUrlInBrowser(url: String)
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
@@ -14,6 +14,7 @@ import com.crosspaste.app.AppRestartService
 import com.crosspaste.app.AppStartUpService
 import com.crosspaste.app.AppUpdateService
 import com.crosspaste.app.AppUrls
+import com.crosspaste.app.CrossPasteWebService
 import com.crosspaste.app.DesktopAppControl
 import com.crosspaste.app.DesktopAppExitService
 import com.crosspaste.app.DesktopAppInfoFactory
@@ -99,6 +100,7 @@ fun desktopAppModule(
         single<AppStartUpService> { DesktopAppStartUpService(get(), get(), get(), get()) }
         single<AppUpdateService> { DesktopAppUpdateService(get(), get(), get(), get(), get()) }
         single<AppUrls> { DesktopAppUrls }
+        single<CrossPasteWebService> { CrossPasteWebService(get(), get()) }
         single<PromoteService> { DesktopPromoteService(get(), get()) }
         single<CacheManager> { DesktopCacheManager(get(), get()) }
         single<CommonConfigManager> { configManager as CommonConfigManager }

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessModule.kt
@@ -22,7 +22,7 @@ fun headlessUiModule() =
         single<RatingPromptManager> { DesktopRatingPromptManager() }
         single<SoundService> { HeadlessSoundService() }
         single<TokenCacheApi> { TokenCache }
-        single<UISupport> { HeadlessUISupport() }
+        single<UISupport> { HeadlessUISupport(get()) }
     }
 
 fun headlessViewModelModule() = module {}

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessUISupport.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessUISupport.kt
@@ -1,11 +1,14 @@
 package com.crosspaste.headless
 
+import com.crosspaste.app.CrossPasteWebService
 import com.crosspaste.paste.PasteData
 import com.crosspaste.ui.base.UISupport
 import io.github.oshai.kotlinlogging.KotlinLogging
 import okio.Path
 
-class HeadlessUISupport : UISupport {
+class HeadlessUISupport(
+    override val crossPasteWebService: CrossPasteWebService,
+) : UISupport {
 
     private val logger = KotlinLogging.logger {}
 
@@ -13,7 +16,7 @@ class HeadlessUISupport : UISupport {
         logger.info { "Headless mode: cannot open URL in browser: $url" }
     }
 
-    override fun getCrossPasteWebUrl(path: String): String = "https://crosspaste.com/$path"
+    override fun getCrossPasteWebUrl(path: String): String = crossPasteWebService.getWebUrl("en", path)
 
     override fun openEmailClient(email: String?) {
         logger.info { "Headless mode: cannot open email client" }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
@@ -1,9 +1,8 @@
 package com.crosspaste.ui.base
 
 import com.crosspaste.app.AppFileType
-import com.crosspaste.app.AppUrls
+import com.crosspaste.app.CrossPasteWebService
 import com.crosspaste.app.DesktopAppWindowManager
-import com.crosspaste.i18n.DesktopGlobalCopywriter.Companion.ZH
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.notification.MessageType
 import com.crosspaste.notification.NotificationManager
@@ -34,7 +33,7 @@ import java.net.URI
 import javax.swing.JColorChooser
 
 class DesktopUISupport(
-    private val appUrls: AppUrls,
+    override val crossPasteWebService: CrossPasteWebService,
     private val copywriter: GlobalCopywriter,
     private val notificationManager: NotificationManager,
     private val platform: Platform,
@@ -50,6 +49,12 @@ class DesktopUISupport(
 
     private val htmlUtils = getHtmlUtils()
 
+    init {
+        actionScope.launch {
+            crossPasteWebService.refresh()
+        }
+    }
+
     override fun openUrlInBrowser(url: String) {
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
             Desktop.getDesktop().browse(URI(url))
@@ -62,14 +67,7 @@ class DesktopUISupport(
         }
     }
 
-    override fun getCrossPasteWebUrl(path: String): String {
-        val webPath =
-            when (val language = copywriter.language()) {
-                ZH -> path
-                else -> "$language/$path"
-            }
-        return "${appUrls.homeUrl}/$webPath"
-    }
+    override fun getCrossPasteWebUrl(path: String): String = crossPasteWebService.getWebUrl(copywriter.language(), path)
 
     override fun openEmailClient(email: String?) {
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.MAIL)) {


### PR DESCRIPTION
Closes #4123

## Summary
- Add `CrossPasteWebService` in `commonMain` that fetches locale config from `https://crosspaste.com/api/meta.json` at startup and builds locale-aware web URLs
- Add `getBodyAsText()` to `ClientResponse` for multiplatform text response reading
- Replace hardcoded language-to-URL-path mapping in `DesktopUISupport` and `HeadlessUISupport` with data-driven lookup from `CrossPasteWebService`
- Unsupported app languages gracefully fall back to the `en` locale path; before meta.json loads, fallback uses `zh` → `/`, others → `/en/`