### PR TITLE
:bug: Fix incorrect MCP SSE endpoint URL in configuration command

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/mcp/McpContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/mcp/McpContentView.kt
@@ -57,7 +57,7 @@ fun McpContentView() {
             DesktopMcpServer.DEFAULT_PORT
         }
 
-    val mcpCommand = "claude mcp add crosspaste --transport sse http://localhost:$displayPort/sse"
+    val mcpCommand = "claude mcp add crosspaste --transport sse http://localhost:$displayPort/"
 
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Closes #4145

## Summary
- Fix the MCP configuration command URL from `http://localhost:PORT/sse` to `http://localhost:PORT/`
- After upgrading MCP Kotlin SDK to v0.10.0, the server uses Streamable HTTP transport on the root `/` endpoint instead of the legacy `/sse` path
- Reported by user in #4144

## Test plan
- [ ] Enable MCP Server in CrossPaste settings
- [ ] Copy the configuration command from the UI
- [ ] Run the command in terminal and verify it connects successfully