### PR TITLE
:bug: Skip sync for remote clipboard data to prevent duplication

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -118,7 +118,12 @@ class PasteReleaseService(
                 currentPaste.setPasteId(id)
                 taskSubmitter.submit {
                     addRenderingTask(id, pasteType)
-                    addSyncTask(id, maxFileSize, pasteData.appInstanceId)
+                    // Skip syncing for remote clipboard data (e.g., Apple Universal Clipboard / Handoff).
+                    // These items are already from another device, so re-syncing them would cause
+                    // unnecessary duplication or sync loops.
+                    if (!pasteData.remote) {
+                        addSyncTask(id, maxFileSize, pasteData.appInstanceId)
+                    }
 
                     if (pasteType.isFile() || pasteType.isImage()) {
                         if ((firstItem as PasteFiles).isRefFiles()) {


### PR DESCRIPTION
Closes #4147

## Summary
- Skip sync task for remote clipboard data (e.g., Apple Universal Clipboard / Handoff)
- Remote items are already from another device, so re-syncing them causes unnecessary duplication or sync loops
- Only the `addSyncTask` call is guarded by `pasteData.remote` check; rendering and other tasks remain unaffected

## Test plan
- [ ] Copy text on iPhone with Handoff enabled, verify it appears on Mac but is NOT re-synced to other CrossPaste devices
- [ ] Copy text locally on Mac, verify it IS synced to other CrossPaste devices as before
- [ ] Verify no regression in normal paste sync workflow