### PR TITLE
Fix ConnectCodeUtils to use KMP-compatible concatToString

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/utils/ConnectCodeUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/ConnectCodeUtils.kt
@@ -53,7 +53,7 @@ object ConnectCodeUtils {
             remaining = remaining ushr 5
         }
 
-        return "${String(chars, 0, 5)}-${String(chars, 5, 5)}"
+        return "${chars.concatToString(0, 5)}-${chars.concatToString(5, 10)}"
     }
 
     /**


### PR DESCRIPTION
Closes #4153

Replace `String(CharArray, Int, Int)` JVM-only constructor with `CharArray.concatToString()` in `ConnectCodeUtils.encode()` for Kotlin Multiplatform compatibility.