### PR TITLE
:sparkles: Add WebSocket-based file pulling for Chrome Extension (#4167)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
@@ -57,5 +57,7 @@ object WsMessageType {
     const val SYNC_INFO = "sync_info"
     const val NOTIFY_EXIT = "notify_exit"
     const val NOTIFY_REMOVE = "notify_remove"
+    const val FILE_PULL_REQUEST = "file_pull_request"
+    const val FILE_PULL_RESPONSE = "file_pull_response"
     const val ERROR = "error"
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessageHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessageHandler.kt
@@ -1,10 +1,17 @@
 package com.crosspaste.net.ws
 
 import com.crosspaste.app.AppControl
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.dto.pull.WsPullFileRequest
 import com.crosspaste.net.routing.SyncRoutingApi
+import com.crosspaste.paste.CacheManager
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteboardService
+import com.crosspaste.paste.item.PasteFiles
+import com.crosspaste.paste.item.getFilePaths
+import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.secure.SecureStore
+import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -14,16 +21,23 @@ import kotlinx.coroutines.launch
 
 class WsMessageHandler(
     private val lazyAppControl: Lazy<AppControl>,
+    private val lazyCacheManager: Lazy<CacheManager>,
+    private val lazyPasteDao: Lazy<PasteDao>,
     private val lazyPasteboardService: Lazy<PasteboardService>,
     private val lazySyncRoutingApi: Lazy<SyncRoutingApi>,
     private val secureStore: SecureStore,
+    private val userDataPathProvider: UserDataPathProvider,
+    private val wsPendingRequests: WsPendingRequests,
     private val wsSessionManager: WsSessionManager,
     private val scope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
 ) {
     private val appControl: AppControl get() = lazyAppControl.value
+    private val cacheManager: CacheManager get() = lazyCacheManager.value
+    private val pasteDao: PasteDao get() = lazyPasteDao.value
     private val pasteboardService: PasteboardService get() = lazyPasteboardService.value
     private val syncRoutingApi: SyncRoutingApi get() = lazySyncRoutingApi.value
     private val logger = KotlinLogging.logger {}
+    private val fileUtils = getFileUtils()
     private val json = getJsonUtils().JSON
 
     suspend fun handleMessage(
@@ -57,6 +71,18 @@ class WsMessageHandler(
             WsMessageType.NOTIFY_REMOVE -> {
                 logger.info { "WS notify remove from $appInstanceId" }
                 syncRoutingApi.removeSyncHandler(appInstanceId)
+            }
+
+            WsMessageType.FILE_PULL_REQUEST -> {
+                handleFilePullRequest(appInstanceId, envelope)
+            }
+
+            WsMessageType.FILE_PULL_RESPONSE -> {
+                handleFilePullResponse(envelope)
+            }
+
+            WsMessageType.ERROR -> {
+                handleErrorResponse(appInstanceId, envelope)
             }
 
             else -> {
@@ -105,5 +131,174 @@ class WsMessageHandler(
         }.onFailure { e ->
             logger.error(e) { "WS paste_push from $appInstanceId failed" }
         }
+    }
+
+    private suspend fun handleFilePullRequest(
+        appInstanceId: String,
+        envelope: WsEnvelope,
+    ) {
+        val requestId = envelope.requestId
+        if (requestId == null) {
+            logger.warn { "FILE_PULL_REQUEST from $appInstanceId missing requestId" }
+            return
+        }
+
+        runCatching {
+            val request = json.decodeFromString<WsPullFileRequest>(envelope.payload.decodeToString())
+            logger.debug { "FILE_PULL_REQUEST from $appInstanceId: $request" }
+
+            val syncHandler =
+                syncRoutingApi.getSyncHandler(appInstanceId) ?: run {
+                    logger.error { "FILE_PULL_REQUEST: no sync handler for $appInstanceId" }
+                    sendErrorResponse(appInstanceId, requestId, "No sync handler")
+                    return
+                }
+
+            if (!syncHandler.currentSyncRuntimeInfo.allowSend) {
+                logger.debug { "FILE_PULL_REQUEST from $appInstanceId: not allow send" }
+                sendErrorResponse(appInstanceId, requestId, "Not allowed to send")
+                return
+            }
+
+            if (request.isChunkMode()) {
+                serveFileChunk(appInstanceId, requestId, request)
+            } else {
+                serveWholeFile(appInstanceId, requestId, request)
+            }
+        }.onFailure { e ->
+            logger.error(e) { "FILE_PULL_REQUEST from $appInstanceId failed" }
+            runCatching { sendErrorResponse(appInstanceId, requestId, "Internal error: ${e.message}") }
+        }
+    }
+
+    private suspend fun serveFileChunk(
+        appInstanceId: String,
+        requestId: String,
+        request: WsPullFileRequest,
+    ) {
+        val filesIndex =
+            cacheManager.getFilesIndex(request.id) ?: run {
+                logger.error { "FILE_PULL_REQUEST: filesIndex not found for id=${request.id}" }
+                sendErrorResponse(appInstanceId, requestId, "FilesIndex not found")
+                return
+            }
+
+        val chunk =
+            filesIndex.getChunk(request.chunkIndex) ?: run {
+                logger.error { "FILE_PULL_REQUEST: chunk index out of range: ${request.chunkIndex}" }
+                sendErrorResponse(appInstanceId, requestId, "Chunk index out of range")
+                return
+            }
+
+        // Read the chunk's file segments into a byte array
+        val bytes = fileUtils.readFilesChunkToByteArray(chunk)
+
+        val response =
+            WsEnvelope(
+                type = WsMessageType.FILE_PULL_RESPONSE,
+                payload = bytes,
+                requestId = requestId,
+            )
+        wsSessionManager.send(appInstanceId, response)
+        logger.debug { "Served file chunk ${request.chunkIndex} (${bytes.size} bytes) to $appInstanceId" }
+    }
+
+    /**
+     * Serve a single file by paste ID + fileName (whole-file mode).
+     * Used when Chrome extension pulls files from Desktop.
+     * Files are guaranteed ≤ 1MB by SyncPasteTaskExecutor's extension filter.
+     */
+    private suspend fun serveWholeFile(
+        appInstanceId: String,
+        requestId: String,
+        request: WsPullFileRequest,
+    ) {
+        if (request.fileName.isEmpty()) {
+            sendErrorResponse(appInstanceId, requestId, "Missing fileName in whole-file request")
+            return
+        }
+
+        val pasteData =
+            pasteDao.getNoDeletePasteData(request.id) ?: run {
+                logger.error { "FILE_PULL_REQUEST whole-file: paste not found for id=${request.id}" }
+                sendErrorResponse(appInstanceId, requestId, "Paste not found")
+                return
+            }
+
+        // Find the file across all PasteFiles items in this paste
+        val allFileItems = pasteData.getPasteAppearItems().filterIsInstance<PasteFiles>()
+        var targetPath: okio.Path? = null
+
+        for (pasteFiles in allFileItems) {
+            val filePaths = pasteFiles.getFilePaths(userDataPathProvider)
+            for (filePath in filePaths) {
+                if (filePath.name == request.fileName) {
+                    targetPath = filePath
+                    break
+                }
+            }
+            if (targetPath != null) break
+        }
+
+        if (targetPath == null) {
+            logger.error { "FILE_PULL_REQUEST whole-file: file '${request.fileName}' not found in paste ${request.id}" }
+            sendErrorResponse(appInstanceId, requestId, "File not found: ${request.fileName}")
+            return
+        }
+
+        if (!fileUtils.existFile(targetPath)) {
+            logger.error { "FILE_PULL_REQUEST whole-file: file does not exist on disk: $targetPath" }
+            sendErrorResponse(appInstanceId, requestId, "File not found on disk")
+            return
+        }
+
+        val bytes = fileUtils.fileSystem.read(targetPath) { readByteArray() }
+
+        val response =
+            WsEnvelope(
+                type = WsMessageType.FILE_PULL_RESPONSE,
+                payload = bytes,
+                requestId = requestId,
+            )
+        wsSessionManager.send(appInstanceId, response)
+        logger.debug { "Served whole file '${request.fileName}' (${bytes.size} bytes) to $appInstanceId" }
+    }
+
+    private fun handleErrorResponse(
+        appInstanceId: String,
+        envelope: WsEnvelope,
+    ) {
+        val requestId = envelope.requestId
+        if (requestId != null && wsPendingRequests.complete(requestId, envelope)) {
+            logger.debug { "Error response from $appInstanceId routed to pending request $requestId" }
+        } else {
+            val msg = if (envelope.payload.isNotEmpty()) envelope.payload.decodeToString() else "(no detail)"
+            logger.warn { "WS error from $appInstanceId (requestId=$requestId): $msg" }
+        }
+    }
+
+    private fun handleFilePullResponse(envelope: WsEnvelope) {
+        val requestId = envelope.requestId
+        if (requestId == null) {
+            logger.warn { "FILE_PULL_RESPONSE missing requestId" }
+            return
+        }
+        if (!wsPendingRequests.complete(requestId, envelope)) {
+            logger.warn { "FILE_PULL_RESPONSE: no pending request for requestId=$requestId" }
+        }
+    }
+
+    private suspend fun sendErrorResponse(
+        appInstanceId: String,
+        requestId: String,
+        message: String,
+    ) {
+        val errorEnvelope =
+            WsEnvelope(
+                type = WsMessageType.ERROR,
+                payload = message.encodeToByteArray(),
+                requestId = requestId,
+            )
+        wsSessionManager.send(appInstanceId, errorEnvelope)
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsPendingRequests.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsPendingRequests.kt
@@ -1,0 +1,76 @@
+package com.crosspaste.net.ws
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.util.collections.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeout
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Manages in-flight WebSocket request-response correlations.
+ *
+ * A requester calls [request] which generates a unique [requestId],
+ * sends the envelope, and suspends until a matching response arrives
+ * via [complete] or the timeout elapses.
+ */
+class WsPendingRequests {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val pending: MutableMap<String, CompletableDeferred<WsEnvelope>> = ConcurrentMap()
+
+    companion object {
+        const val DEFAULT_TIMEOUT_MS = 30_000L
+    }
+
+    /**
+     * Send a request envelope and wait for the correlated response.
+     *
+     * The [envelope] must NOT already have a requestId set — one will be generated.
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    suspend fun request(
+        wsSessionManager: WsSessionManager,
+        appInstanceId: String,
+        envelope: WsEnvelope,
+        timeoutMs: Long = DEFAULT_TIMEOUT_MS,
+    ): WsEnvelope {
+        val requestId = Uuid.random().toString()
+        val deferred = CompletableDeferred<WsEnvelope>()
+        pending[requestId] = deferred
+
+        val requestEnvelope =
+            envelope.copy(requestId = requestId)
+
+        try {
+            val sent = wsSessionManager.send(appInstanceId, requestEnvelope)
+            if (!sent) {
+                throw IllegalStateException("WebSocket send failed for $appInstanceId")
+            }
+            return withTimeout(timeoutMs) {
+                deferred.await()
+            }
+        } finally {
+            pending.remove(requestId)
+        }
+    }
+
+    /**
+     * Complete a pending request with a response envelope.
+     *
+     * @return true if a matching pending request was found and completed.
+     */
+    fun complete(
+        requestId: String,
+        response: WsEnvelope,
+    ): Boolean {
+        val deferred = pending[requestId]
+        if (deferred != null) {
+            deferred.complete(response)
+            return true
+        }
+        logger.debug { "No pending request for requestId=$requestId" }
+        return false
+    }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
@@ -1,14 +1,20 @@
 package com.crosspaste.sync
 
 import com.crosspaste.dto.pull.PullFileRequest
+import com.crosspaste.dto.pull.WsPullFileRequest
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.clientapi.ClientApiResult
 import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.PullClientApi
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.createFailureResult
+import com.crosspaste.net.ws.WsEnvelope
+import com.crosspaste.net.ws.WsMessageType
+import com.crosspaste.net.ws.WsPendingRequests
+import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.paste.PasteSyncProcessManager
 import com.crosspaste.paste.item.PasteFiles
+import com.crosspaste.paste.item.getFilePaths
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FilesIndexBuilder
 import com.crosspaste.utils.DateUtils
@@ -17,6 +23,7 @@ import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import com.crosspaste.utils.getDateUtils
 import com.crosspaste.utils.getFileUtils
+import com.crosspaste.utils.getJsonUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.URLBuilder
 import io.ktor.utils.io.ByteReadChannel
@@ -59,6 +66,8 @@ class FilePullService(
     private val userDataPathProvider: UserDataPathProvider,
     private val pasteSyncProcessManager: PasteSyncProcessManager<Long>,
     private val syncManager: SyncManager,
+    private val wsPendingRequests: WsPendingRequests,
+    private val wsSessionManager: WsSessionManager,
 ) {
 
     companion object {
@@ -70,6 +79,8 @@ class FilePullService(
         private val dateUtils: DateUtils = getDateUtils()
 
         private val fileUtils: FileUtils = getFileUtils()
+
+        private val json = getJsonUtils().JSON
     }
 
     /**
@@ -91,6 +102,155 @@ class FilePullService(
         remotePasteId: Long,
         pasteFiles: PasteFiles,
         pullChunks: IntArray,
+    ): FilePullResult {
+        val syncHandler =
+            syncManager.getSyncHandlers()[appInstanceId]
+                ?: return FilePullResult.NoSyncHandler(appInstanceId)
+
+        // Extension devices (e.g. Chrome) have no HTTP server — use WebSocket whole-file pull
+        if (syncHandler.getSyncPlatform().isExtension()) {
+            return pullFilesViaWs(appInstanceId, pasteId, createTime, pasteFiles)
+        }
+
+        return pullFilesViaHttp(
+            appInstanceId,
+            pasteId,
+            createTime,
+            remotePasteId,
+            pasteFiles,
+            pullChunks,
+            syncHandler,
+        )
+    }
+
+    /**
+     * Pull files from a Chrome extension via WebSocket using whole-file mode.
+     * Chrome files are always ≤ 1MB, so no chunking is needed.
+     * Files are requested by paste hash + file name.
+     */
+    private suspend fun pullFilesViaWs(
+        appInstanceId: String,
+        pasteId: Long,
+        createTime: Long,
+        pasteFiles: PasteFiles,
+    ): FilePullResult {
+        val dateString =
+            dateUtils.getYMD(
+                dateUtils.epochMillisecondsToLocalDateTime(createTime),
+            )
+
+        // Resolve target paths and create empty placeholder files.
+        // Pass null for filesIndexBuilder — we don't need chunk indexing in whole-file mode.
+        val renameMap =
+            userDataPathProvider.resolve(
+                appInstanceId,
+                dateString,
+                pasteId,
+                pasteFiles,
+                true,
+                null,
+                resolveConflicts = true,
+            )
+
+        // Build a map from original file name → actual disk path (accounting for renames)
+        val filePaths = pasteFiles.getFilePaths(userDataPathProvider)
+        if (filePaths.isEmpty()) {
+            logger.warn { "No files to pull via WS for pasteId $pasteId" }
+            return FilePullResult.Empty
+        }
+
+        // filePaths are aligned with relativePathList and use original names.
+        // If a rename happened, the actual file on disk has the renamed name in the same parent dir.
+        val targetPaths =
+            pasteFiles.relativePathList.zip(filePaths).map { (originalName, originalPath) ->
+                val renamedName = renameMap[originalName]
+                if (renamedName != null) {
+                    originalPath.parent!! / renamedName
+                } else {
+                    originalPath
+                }
+            }
+
+        val hash = (pasteFiles as? com.crosspaste.paste.item.PasteItem)?.hash ?: ""
+        if (hash.isEmpty()) {
+            logger.error { "Cannot pull files via WS: paste hash is empty for pasteId $pasteId" }
+            return FilePullResult.Failure(
+                mapOf(
+                    0 to
+                        createFailureResult(
+                            StandardErrorCode.PULL_FILE_TASK_FAIL,
+                            "Paste hash is empty",
+                        ) as FailureResult,
+                ),
+                intArrayOf(),
+            )
+        }
+
+        val failedFiles = mutableMapOf<Int, FailureResult>()
+
+        // Request each file individually by hash + fileName
+        pasteFiles.relativePathList.forEachIndexed { index, relativePath ->
+            val requestFileName = relativePath // Chrome stores by original name
+            val targetPath = targetPaths[index]
+
+            runCatching {
+                val request =
+                    WsPullFileRequest(
+                        hash = hash,
+                        fileName = requestFileName,
+                    )
+
+                val requestEnvelope =
+                    WsEnvelope(
+                        type = WsMessageType.FILE_PULL_REQUEST,
+                        payload = json.encodeToString(request).encodeToByteArray(),
+                    )
+
+                val response =
+                    wsPendingRequests.request(
+                        wsSessionManager,
+                        appInstanceId,
+                        requestEnvelope,
+                    )
+
+                if (response.type == WsMessageType.ERROR) {
+                    val errorMsg = response.payload.decodeToString()
+                    throw IllegalStateException("File pull error: $errorMsg")
+                }
+
+                // Write the received bytes directly to the target file path
+                fileUtils.writeFile(targetPath) { sink ->
+                    sink.write(response.payload)
+                }
+
+                logger.debug { "WS file pull success: $requestFileName → $targetPath (${response.payload.size} bytes)" }
+            }.onFailure { e ->
+                logger.error(e) { "WS file pull failed for $requestFileName from $appInstanceId" }
+                failedFiles[index] =
+                    createFailureResult(
+                        StandardErrorCode.PULL_FILE_CHUNK_TASK_FAIL,
+                        "WS file pull failed: ${e.message}",
+                    ) as FailureResult
+            }
+        }
+
+        return if (failedFiles.isEmpty()) {
+            FilePullResult.Success(renameMap)
+        } else {
+            // For WS whole-file mode, pullChunks is not meaningful (no chunk system),
+            // but return an empty array to satisfy the Failure contract.
+            FilePullResult.Failure(failedFiles, intArrayOf())
+        }
+    }
+
+    private suspend fun pullFilesViaHttp(
+        appInstanceId: String,
+        pasteId: Long,
+        createTime: Long,
+        remotePasteId: Long,
+        pasteFiles: PasteFiles,
+        pullChunks: IntArray,
+        syncHandler: SyncHandler,
     ): FilePullResult {
         val dateString =
             dateUtils.getYMD(
@@ -125,10 +285,6 @@ class FilePullService(
                 }
                 pullChunks
             }
-
-        val syncHandler =
-            syncManager.getSyncHandlers()[appInstanceId]
-                ?: return FilePullResult.NoSyncHandler(appInstanceId)
 
         val host =
             syncHandler.getConnectHostAddress()

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
@@ -27,6 +27,7 @@ import com.crosspaste.utils.getJsonUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.URLBuilder
 import io.ktor.utils.io.ByteReadChannel
+import okio.Path.Companion.toPath
 
 sealed class FilePullResult {
     data class Success(
@@ -188,9 +189,11 @@ class FilePullService(
 
         val failedFiles = mutableMapOf<Int, FailureResult>()
 
-        // Request each file individually by hash + fileName
+        // Request each file individually by hash + fileName.
+        // relativePathList may contain bind-transformed paths like "appInstanceId/date/id/file.png",
+        // but Chrome's BlobStore stores by the original file name only (e.g. "file.png").
         pasteFiles.relativePathList.forEachIndexed { index, relativePath ->
-            val requestFileName = relativePath // Chrome stores by original name
+            val requestFileName = relativePath.toPath().name
             val targetPath = targetPaths[index]
 
             runCatching {

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -21,6 +21,7 @@ import com.crosspaste.net.ws.WsMessageType
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteType
+import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.SyncHandler
 import com.crosspaste.sync.SyncManager
@@ -191,6 +192,14 @@ class SyncPasteTaskExecutor(
             ),
         )
 
+    companion object {
+        /** Chrome extension per-file size limit (1MB). */
+        const val EXTENSION_MAX_FILE_SIZE: Long = 1L * 1024 * 1024
+
+        /** Chrome extension total files size limit (32MB). */
+        const val EXTENSION_MAX_TOTAL_FILE_SIZE: Long = 32L * 1024 * 1024
+    }
+
     private suspend fun syncPasteToTarget(
         handlerKey: String,
         handler: SyncHandler,
@@ -206,6 +215,18 @@ class SyncPasteTaskExecutor(
                 StandardErrorCode.SYNC_NOT_ALLOW_SEND_BY_APP,
                 "Failed to send paste to $handlerKey",
             )
+        }
+
+        // Extension devices have file size limits — skip file-type pastes that exceed them
+        if (syncRuntimeInfo.platform.isExtension() && pasteData.isFileType()) {
+            val pasteFiles = pasteData.getPasteItem(PasteFiles::class)
+            if (pasteFiles != null && !isWithinExtensionFileLimit(pasteFiles)) {
+                logger.info {
+                    "Skipping file-type paste sync to extension $handlerKey: " +
+                        "file size exceeds extension limit (total=${pasteFiles.size})"
+                }
+                return SuccessResult() // Don't retry — this is intentional
+            }
         }
 
         // Prefer WebSocket if available — lower latency, no new connection
@@ -251,6 +272,13 @@ class SyncPasteTaskExecutor(
         }.onFailure { e ->
             logger.warn(e) { "WebSocket paste send failed for $targetAppInstanceId, falling back to HTTP" }
         }.getOrNull()
+
+    private fun isWithinExtensionFileLimit(pasteFiles: PasteFiles): Boolean {
+        if (pasteFiles.size > EXTENSION_MAX_TOTAL_FILE_SIZE) return false
+        return pasteFiles.fileInfoTreeMap.values.all { fileInfoTree ->
+            fileInfoTree.size <= EXTENSION_MAX_FILE_SIZE
+        }
+    }
 
     private fun processResults(
         results: Map<String, ClientApiResult>,

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -135,13 +135,18 @@ class SyncPasteTaskExecutor(
                 handler.getConnectHostInfo()?.let { connectHostInfo ->
                     syncManager.getSyncHandlers().filter { (key, handler) ->
                         if (key != syncExtraInfo.appInstanceId) {
-                            val address = handler.getConnectHostAddress()
-                            if (address != null && !connectHostInfo.filter(address)) {
+                            val isEligible =
                                 handler.currentSyncRuntimeInfo.allowSend &&
                                     handler.currentVersionRelation == VersionRelation.EQUAL_TO &&
                                     (syncExtraInfo.syncFails.isEmpty() || syncExtraInfo.syncFails.contains(key))
-                            } else {
+                            if (!isEligible) {
                                 false
+                            } else if (handler.currentSyncRuntimeInfo.platform.isExtension()) {
+                                // Extension devices use WebSocket — no host address to filter
+                                true
+                            } else {
+                                val address = handler.getConnectHostAddress()
+                                address != null && !connectHostInfo.filter(address)
                             }
                         } else {
                             false
@@ -158,30 +163,17 @@ class SyncPasteTaskExecutor(
     ): Deferred<Pair<String, ClientApiResult>> =
         ioScope.async {
             runCatching {
-                handler.getConnectHostAddress()?.let {
-                    val result = syncPasteToTarget(handlerKey, handler, pasteData, it)
+                val result = syncPasteToTarget(handlerKey, handler, pasteData)
 
-                    if (result is SuccessResult) {
-                        appControl.completeSendOperation()
-                    }
-
-                    Pair(handlerKey, result)
-                } ?: run {
-                    createNoHostAddressResult(handlerKey)
+                if (result is SuccessResult) {
+                    appControl.completeSendOperation()
                 }
+
+                Pair(handlerKey, result)
             }.getOrElse {
                 createExceptionResult(handlerKey)
             }
         }
-
-    private fun createNoHostAddressResult(handlerKey: String): Pair<String, ClientApiResult> =
-        Pair(
-            handlerKey,
-            createFailureResult(
-                StandardErrorCode.CANT_GET_SYNC_ADDRESS,
-                "Failed to get connect host address by $handlerKey",
-            ),
-        )
 
     private fun createExceptionResult(handlerKey: String): Pair<String, ClientApiResult> =
         Pair(
@@ -204,7 +196,6 @@ class SyncPasteTaskExecutor(
         handlerKey: String,
         handler: SyncHandler,
         pasteData: PasteData,
-        hostAddress: String,
     ): ClientApiResult {
         val syncRuntimeInfo = handler.currentSyncRuntimeInfo
         val port = syncRuntimeInfo.port
@@ -229,20 +220,33 @@ class SyncPasteTaskExecutor(
             }
         }
 
-        // Prefer WebSocket if available — lower latency, no new connection
-        if (wsSessionManager.isConnected(targetAppInstanceId)) {
-            val wsSendResult = trySendViaWebSocket(targetAppInstanceId, pasteData)
-            if (wsSendResult != null) return wsSendResult
+        // 1. Extension targets always use WebSocket
+        if (syncRuntimeInfo.platform.isExtension()) {
+            return trySendViaWebSocket(targetAppInstanceId, pasteData)
+                ?: createFailureResult(
+                    StandardErrorCode.SYNC_PASTE_ERROR,
+                    "WebSocket send failed for extension $handlerKey",
+                )
         }
 
-        // Fallback to HTTP
-        val hostAndPort = HostAndPort(hostAddress, port)
-        return pasteClientApi.sendPaste(
-            pasteData,
-            targetAppInstanceId,
-        ) {
-            buildUrl(hostAndPort)
+        // 2. Regular devices prefer HTTP (supports concurrent chunk transfer for large files)
+        val hostAddress = handler.getConnectHostAddress()
+        if (hostAddress != null) {
+            val hostAndPort = HostAndPort(hostAddress, port)
+            return pasteClientApi.sendPaste(
+                pasteData,
+                targetAppInstanceId,
+            ) {
+                buildUrl(hostAndPort)
+            }
         }
+
+        // 3. No host address — fall back to WebSocket
+        return trySendViaWebSocket(targetAppInstanceId, pasteData)
+            ?: createFailureResult(
+                StandardErrorCode.CANT_GET_SYNC_ADDRESS,
+                "Failed to get connect host address by $handlerKey and WebSocket unavailable",
+            )
     }
 
     private suspend fun trySendViaWebSocket(

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -30,6 +30,7 @@ import com.crosspaste.net.exception.ExceptionHandler
 import com.crosspaste.net.routing.SyncRoutingApi
 import com.crosspaste.net.ws.WsClientConnector
 import com.crosspaste.net.ws.WsMessageHandler
+import com.crosspaste.net.ws.WsPendingRequests
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.sync.GeneralNearbyDeviceManager
 import com.crosspaste.sync.GeneralSyncManager
@@ -90,12 +91,19 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
         single<WsSessionManager> {
             WsSessionManager()
         }
+        single<WsPendingRequests> {
+            WsPendingRequests()
+        }
         single<WsMessageHandler> {
             WsMessageHandler(
                 lazyAppControl = lazy { get() },
+                lazyCacheManager = lazy { get() },
+                lazyPasteDao = lazy { get() },
                 lazyPasteboardService = lazy { get() },
                 lazySyncRoutingApi = lazy { get() },
                 secureStore = get(),
+                userDataPathProvider = get(),
+                wsPendingRequests = get(),
                 wsSessionManager = get(),
             )
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
@@ -99,7 +99,7 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
         single<DesktopPasteTagMenuService> {
             DesktopPasteTagMenuService(get(), get())
         }
-        single<FilePullService> { FilePullService(get(), get(), get(), get()) }
+        single<FilePullService> { FilePullService(get(), get(), get(), get(), get(), get()) }
         single<PastePullService> { PastePullService(get(), get(), get(), get()) }
         single<PasteReleaseService> {
             PasteReleaseService(

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsModuleDependencyTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsModuleDependencyTest.kt
@@ -4,6 +4,7 @@ import com.crosspaste.app.AppControl
 import com.crosspaste.app.AppInfo
 import com.crosspaste.app.RatingPromptManager
 import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.net.NetworkInterfaceService
 import com.crosspaste.net.PasteBonjourService
@@ -12,7 +13,9 @@ import com.crosspaste.net.SyncInfoFactory
 import com.crosspaste.net.TelnetHelper
 import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.routing.SyncRoutingApi
+import com.crosspaste.paste.CacheManager
 import com.crosspaste.paste.PasteboardService
+import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.platform.Platform
 import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureStore
@@ -80,15 +83,25 @@ class WsModuleDependencyTest : KoinTest {
                 single<TokenCacheApi> { mockk(relaxed = true) }
 
                 // The actual components under test — mirrors DesktopNetworkModule wiring
+                single<CacheManager> { mockk(relaxed = true) }
+                single<PasteDao> { mockk(relaxed = true) }
+                single<UserDataPathProvider> { mockk(relaxed = true) }
                 single<WsSessionManager> {
                     WsSessionManager()
+                }
+                single<WsPendingRequests> {
+                    WsPendingRequests()
                 }
                 single<WsMessageHandler> {
                     WsMessageHandler(
                         lazyAppControl = lazy { get() },
+                        lazyCacheManager = lazy { get() },
+                        lazyPasteDao = lazy { get() },
                         lazyPasteboardService = lazy { get() },
                         lazySyncRoutingApi = lazy { get() },
                         secureStore = get(),
+                        userDataPathProvider = get(),
+                        wsPendingRequests = get(),
                         wsSessionManager = get(),
                     )
                 }

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/pull/WsPullFileRequest.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/pull/WsPullFileRequest.kt
@@ -1,0 +1,29 @@
+package com.crosspaste.dto.pull
+
+import kotlinx.serialization.Serializable
+
+/**
+ * WebSocket file pull request supporting two modes:
+ *
+ * **Chunk mode** (pulling from Desktop): `id` + `chunkIndex` ≥ 0
+ * Uses the same chunk system as HTTP pull — each chunk ≤ 1MB.
+ *
+ * **Whole-file mode** (pulling from Chrome extension): `hash` + `fileName`
+ * Requests an entire file by paste hash and name. Chrome files are always ≤ 1MB.
+ */
+@Serializable
+data class WsPullFileRequest(
+    val id: Long = 0,
+    val chunkIndex: Int = -1,
+    val hash: String = "",
+    val fileName: String = "",
+) {
+    fun isChunkMode(): Boolean = chunkIndex >= 0
+
+    override fun toString(): String =
+        if (isChunkMode()) {
+            "WsPullFileRequest(chunk: id=$id, chunkIndex=$chunkIndex)"
+        } else {
+            "WsPullFileRequest(file: hash=$hash, fileName=$fileName)"
+        }
+}

--- a/shared/src/commonMain/kotlin/com/crosspaste/utils/FileUtils.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/utils/FileUtils.kt
@@ -353,6 +353,19 @@ interface FileUtils {
         byteWriteChannel: ByteWriteChannel,
     )
 
+    fun readFilesChunkToByteArray(filesChunk: FilesChunk): ByteArray {
+        val buffer = okio.Buffer()
+        for (fileChunk in filesChunk.fileChunks) {
+            fileSystem.source(fileChunk.path).buffer().use { source ->
+                source.skip(fileChunk.offset)
+                val bytes = ByteArray(fileChunk.size.toInt())
+                source.readFully(bytes)
+                buffer.write(bytes)
+            }
+        }
+        return buffer.readByteArray()
+    }
+
     fun resolveNonConflictFileName(
         dir: Path,
         fileName: String,

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -323,6 +323,10 @@ async function initializeWebSocket(): Promise<void> {
     sendToDevice: async (targetId, envelope) => {
       await wsManager?.send(targetId, envelope);
     },
+    sendRequest: async (targetId, envelope) => {
+      if (!wsManager) throw new Error("WsManager not initialized");
+      return wsManager.sendRequest(targetId, envelope);
+    },
     updateDeviceStatus: (targetId, status) => {
       if (deviceStatuses.get(targetId) !== status) {
         deviceStatuses.set(targetId, status);

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -92,13 +92,23 @@ async function pollClipboard(): Promise<void> {
 
     await setLastHash(collected.hash);
 
-    // Store file blobs separately
+    // Store file blobs separately, grouped by hash.
+    // Most blobs use collected.hash, but image blobs may have their own hash
+    // so Desktop can look them up by the PasteFiles item hash.
     if (collected.fileBlobs.length > 0) {
-      const blobFiles = collected.fileBlobs.map((f) => ({
-        name: f.name,
-        data: dataUrlToArrayBuffer(f.dataUrl),
-      }));
-      await BlobStore.putAll(collected.hash, blobFiles);
+      const byHash = new Map<string, Array<{ name: string; data: ArrayBuffer }>>();
+      for (const f of collected.fileBlobs) {
+        const h = f.hash ?? collected.hash;
+        let group = byHash.get(h);
+        if (!group) {
+          group = [];
+          byHash.set(h, group);
+        }
+        group.push({ name: f.name, data: dataUrlToArrayBuffer(f.dataUrl) });
+      }
+      for (const [h, files] of byHash) {
+        await BlobStore.putAll(h, files);
+      }
     }
 
     const appInstanceId = await getAppInstanceId();

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -83,7 +83,12 @@ async function pollClipboard(): Promise<void> {
     await ensureOffscreen();
 
     const response = await chrome.runtime.sendMessage({ type: "READ_CLIPBOARD" });
-    const collected = collectPasteItems(response, CrossPasteHash.hashText);
+    const collected = collectPasteItems(
+      response,
+      CrossPasteHash.hashText,
+      (bytes: Uint8Array) =>
+        CrossPasteHash.hashBytes(new Int8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength)),
+    );
     if (!collected) return;
 
     // Deduplicate by appear item hash

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -6,6 +6,7 @@ import { SyncApi } from "@/shared/api/sync";
 import { PullApi } from "@/shared/api/pull";
 import { CrossPasteHash, CrossPasteJson } from "@/shared/core";
 import type { SyncInfo } from "@/shared/models/sync-info";
+import type { PasteData } from "@/shared/models/paste-data";
 import { APP_VERSION } from "@/shared/app/version.generated";
 import { collectPasteItems } from "@/shared/paste/paste-collector";
 import { WsManager } from "@/shared/ws/ws-manager";
@@ -78,6 +79,67 @@ function dataUrlToArrayBuffer(dataUrl: string): ArrayBuffer {
   return bytes.buffer;
 }
 
+/** Store file blobs grouped by their hash. */
+async function storeFileBlobs(collected: { hash: string; fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }> }): Promise<void> {
+  if (collected.fileBlobs.length === 0) return;
+  const byHash = new Map<string, Array<{ name: string; data: ArrayBuffer }>>();
+  for (const f of collected.fileBlobs) {
+    const h = f.hash ?? collected.hash;
+    let group = byHash.get(h);
+    if (!group) {
+      group = [];
+      byHash.set(h, group);
+    }
+    group.push({ name: f.name, data: dataUrlToArrayBuffer(f.dataUrl) });
+  }
+  for (const [h, files] of byHash) {
+    await BlobStore.putAll(h, files);
+  }
+}
+
+/** Persist paste data, deduplicate old entries, and evict over limit. */
+async function persistPasteData(pasteData: PasteData, hash: string): Promise<boolean> {
+  const newId = await PasteStore.createPasteData(pasteData);
+  if (newId === null) return false;
+
+  const deleted = await PasteStore.markDeleteSameHash(newId, hash);
+  for (const h of deleted) await BlobStore.deleteForPaste(h);
+  const evicted = await PasteStore.evictOverLimit();
+  for (const h of evicted) await BlobStore.deleteForPaste(h);
+
+  broadcastToSidePanel({ type: "PASTE_UPDATED" });
+  return true;
+}
+
+/** Push paste data to all trusted WebSocket-connected devices. */
+async function pushPasteToDevices(pasteData: PasteData): Promise<void> {
+  if (!wsManager) return;
+
+  let normalizedPayload: Uint8Array;
+  try {
+    const normalized = CrossPasteJson.parsePasteData(JSON.stringify(pasteData));
+    normalizedPayload = new TextEncoder().encode(normalized);
+  } catch (e) {
+    console.error("[WS] Failed to normalize pasteData for push:", e);
+    return;
+  }
+
+  const envelope: WsEnvelope = {
+    type: WsMessageType.PASTE_PUSH,
+    payload: normalizedPayload,
+    encrypted: false,
+  };
+  const devices = await DeviceStore.getAll();
+  for (const device of devices) {
+    if (!device.trusted) continue;
+    if (wsManager.isConnected(device.targetAppInstanceId)) {
+      wsManager.send(device.targetAppInstanceId, envelope).catch(() => {
+        // WS send failed, desktop will poll on its own
+      });
+    }
+  }
+}
+
 async function pollClipboard(): Promise<void> {
   try {
     await ensureOffscreen();
@@ -91,30 +153,11 @@ async function pollClipboard(): Promise<void> {
     );
     if (!collected) return;
 
-    // Deduplicate by appear item hash
     const lastHash = await getLastHash();
     if (collected.hash === lastHash) return;
-
     await setLastHash(collected.hash);
 
-    // Store file blobs separately, grouped by hash.
-    // Most blobs use collected.hash, but image blobs may have their own hash
-    // so Desktop can look them up by the PasteFiles item hash.
-    if (collected.fileBlobs.length > 0) {
-      const byHash = new Map<string, Array<{ name: string; data: ArrayBuffer }>>();
-      for (const f of collected.fileBlobs) {
-        const h = f.hash ?? collected.hash;
-        let group = byHash.get(h);
-        if (!group) {
-          group = [];
-          byHash.set(h, group);
-        }
-        group.push({ name: f.name, data: dataUrlToArrayBuffer(f.dataUrl) });
-      }
-      for (const [h, files] of byHash) {
-        await BlobStore.putAll(h, files);
-      }
-    }
+    await storeFileBlobs(collected);
 
     const appInstanceId = await getAppInstanceId();
     const pasteData = {
@@ -131,40 +174,8 @@ async function pollClipboard(): Promise<void> {
       receivedAt: Date.now(),
     };
 
-    const newId = await PasteStore.createPasteData(pasteData);
-    if (newId !== null) {
-      const deleted = await PasteStore.markDeleteSameHash(newId, collected.hash);
-      for (const h of deleted) await BlobStore.deleteForPaste(h);
-      const evicted = await PasteStore.evictOverLimit();
-      for (const h of evicted) await BlobStore.deleteForPaste(h);
-      broadcastToSidePanel({ type: "PASTE_UPDATED" });
-
-      // Push via WebSocket to all connected devices
-      if (wsManager) {
-        let normalizedPayload: Uint8Array;
-        try {
-          // Round-trip through Kotlin serializer to ensure wire format compatibility
-          const normalized = CrossPasteJson.parsePasteData(JSON.stringify(pasteData));
-          normalizedPayload = new TextEncoder().encode(normalized);
-        } catch (e) {
-          console.error("[WS] Failed to normalize pasteData for push:", e);
-          return;
-        }
-        const envelope: WsEnvelope = {
-          type: WsMessageType.PASTE_PUSH,
-          payload: normalizedPayload,
-          encrypted: false,
-        };
-        const devices = await DeviceStore.getAll();
-        for (const device of devices) {
-          if (!device.trusted) continue;
-          if (wsManager.isConnected(device.targetAppInstanceId)) {
-            wsManager.send(device.targetAppInstanceId, envelope).catch(() => {
-              // WS send failed, desktop will poll on its own
-            });
-          }
-        }
-      }
+    if (await persistPasteData(pasteData, collected.hash)) {
+      await pushPasteToDevices(pasteData);
     }
   } catch {
     offscreenReady = false;

--- a/web/src/shared/paste/paste-collector.ts
+++ b/web/src/shared/paste/paste-collector.ts
@@ -63,6 +63,17 @@ function collectFileItems(
     if (f.dataUrl) fileBlobs.push({ name: f.name, dataUrl: f.dataUrl });
   }
 
+  // Build fileInfoTreeMap so Desktop can resolve file paths and create placeholders.
+  // Format matches Kotlin's SingleFileInfoTree: { type: "file", size, hash }
+  const fileInfoTreeMap: Record<string, unknown> = {};
+  for (const f of files) {
+    fileInfoTreeMap[f.name] = {
+      type: "file",
+      size: f.size,
+      hash: f.dataUrl ? hashText(f.dataUrl) : hashText(`${f.name}:${f.size}`),
+    };
+  }
+
   return {
     items: [{
       pasteType: PasteTypeInt.FILE,
@@ -73,7 +84,7 @@ function collectFileItems(
         size: totalSize,
         count: files.length,
         relativePathList: files.map((f) => f.name),
-        fileInfoTreeMap: {},
+        fileInfoTreeMap,
       },
     }],
     fileBlobs,
@@ -83,16 +94,19 @@ function collectFileItems(
 function collectImageItem(imageDataUrl: string, hashText: HashFn): TypedItem {
   const base64Part = imageDataUrl.split(",")[1] ?? "";
   const imgSize = Math.round((base64Part.length * 3) / 4);
+  const imgHash = hashText(imageDataUrl);
   return {
     pasteType: PasteTypeInt.IMAGE,
     item: {
       type: "images",
       identifiers: ["image/png"],
-      hash: hashText(imageDataUrl),
+      hash: imgHash,
       size: imgSize,
       count: 1,
       relativePathList: ["clipboard-image.png"],
-      fileInfoTreeMap: {},
+      fileInfoTreeMap: {
+        "clipboard-image.png": { type: "file", size: imgSize, hash: imgHash },
+      },
       dataUrl: imageDataUrl,
     },
   };

--- a/web/src/shared/paste/paste-collector.ts
+++ b/web/src/shared/paste/paste-collector.ts
@@ -39,8 +39,8 @@ interface CollectedPaste {
   pasteType: number;
   size: number;
   hash: string;
-  /** Files that need blob storage (name → dataUrl) */
-  fileBlobs: Array<{ name: string; dataUrl: string }>;
+  /** Files that need blob storage (name → dataUrl, optional per-item hash) */
+  fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }>;
 }
 
 type TypedItem = { pasteType: number; item: PasteItem };
@@ -51,8 +51,8 @@ const MAX_FILE_SIZE = 32 * 1024 * 1024; // 32MB
 function collectFileItems(
   files: ClipboardFileInfo[],
   hashText: HashFn,
-): { items: TypedItem[]; fileBlobs: Array<{ name: string; dataUrl: string }> } {
-  const fileBlobs: Array<{ name: string; dataUrl: string }> = [];
+): { items: TypedItem[]; fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }> } {
+  const fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }> = [];
   if (files.length === 0) return { items: [], fileBlobs };
 
   const totalSize = files.reduce((sum, f) => sum + f.size, 0);
@@ -161,14 +161,21 @@ export function collectPasteItems(
   hashText: HashFn,
 ): CollectedPaste | null {
   const items: TypedItem[] = [];
-  let fileBlobs: Array<{ name: string; dataUrl: string }> = [];
+  let fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }> = [];
 
   if (result.files && result.files.length > 0) {
     const collected = collectFileItems(result.files, hashText);
     items.push(...collected.items);
     fileBlobs = collected.fileBlobs;
   }
-  if (result.imageDataUrl) items.push(collectImageItem(result.imageDataUrl, hashText));
+  if (result.imageDataUrl) {
+    const imageItem = collectImageItem(result.imageDataUrl, hashText);
+    items.push(imageItem);
+    // Store image data in BlobStore so it can be served via FILE_PULL_REQUEST.
+    // Use the image item's own hash (not the appear item's hash) so Desktop
+    // can look it up by the PasteFiles hash it receives in the paste data.
+    fileBlobs.push({ name: "clipboard-image.png", dataUrl: result.imageDataUrl, hash: imageItem.item.hash });
+  }
   if (result.html) items.push(collectHtmlItem(result.html, result.htmlBackgroundColor, hashText));
   if (result.rtf) items.push(collectRtfItem(result.rtf, hashText));
   if (result.text && result.text.length > 0) items.push(collectTextItem(result.text, hashText));

--- a/web/src/shared/paste/paste-collector.ts
+++ b/web/src/shared/paste/paste-collector.ts
@@ -45,12 +45,37 @@ interface CollectedPaste {
 
 type TypedItem = { pasteType: number; item: PasteItem };
 type HashFn = (s: string) => string;
+type HashBytesFn = (bytes: Uint8Array) => string;
+
+/** Decode a data URL's base64 payload to raw bytes. */
+function dataUrlToBytes(dataUrl: string): Uint8Array {
+  const base64 = dataUrl.split(",")[1] ?? "";
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/** Hash file content — uses raw-byte hash if available, otherwise falls back to string hash. */
+function hashFileContent(
+  dataUrl: string,
+  hashText: HashFn,
+  hashBytes?: HashBytesFn,
+): string {
+  if (hashBytes) {
+    return hashBytes(dataUrlToBytes(dataUrl));
+  }
+  return hashText(dataUrl);
+}
 
 const MAX_FILE_SIZE = 32 * 1024 * 1024; // 32MB
 
 function collectFileItems(
   files: ClipboardFileInfo[],
   hashText: HashFn,
+  hashBytes?: HashBytesFn,
 ): { items: TypedItem[]; fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }> } {
   const fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }> = [];
   if (files.length === 0) return { items: [], fileBlobs };
@@ -65,12 +90,13 @@ function collectFileItems(
 
   // Build fileInfoTreeMap so Desktop can resolve file paths and create placeholders.
   // Format matches Kotlin's SingleFileInfoTree: { type: "file", size, hash }
+  // Hash raw file bytes (matching Desktop's getFileHash) when hashBytes is available.
   const fileInfoTreeMap: Record<string, unknown> = {};
   for (const f of files) {
     fileInfoTreeMap[f.name] = {
       type: "file",
       size: f.size,
-      hash: f.dataUrl ? hashText(f.dataUrl) : hashText(`${f.name}:${f.size}`),
+      hash: f.dataUrl ? hashFileContent(f.dataUrl, hashText, hashBytes) : hashText(`${f.name}:${f.size}`),
     };
   }
 
@@ -91,10 +117,10 @@ function collectFileItems(
   };
 }
 
-function collectImageItem(imageDataUrl: string, hashText: HashFn): TypedItem {
+function collectImageItem(imageDataUrl: string, hashText: HashFn, hashBytes?: HashBytesFn): TypedItem {
   const base64Part = imageDataUrl.split(",")[1] ?? "";
   const imgSize = Math.round((base64Part.length * 3) / 4);
-  const imgHash = hashText(imageDataUrl);
+  const imgHash = hashFileContent(imageDataUrl, hashText, hashBytes);
   return {
     pasteType: PasteTypeInt.IMAGE,
     item: {
@@ -173,17 +199,18 @@ function collectTextToColorItem(text: string, existing: TypedItem[], hashText: H
 export function collectPasteItems(
   result: ClipboardResult,
   hashText: HashFn,
+  hashBytes?: HashBytesFn,
 ): CollectedPaste | null {
   const items: TypedItem[] = [];
   let fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }> = [];
 
   if (result.files && result.files.length > 0) {
-    const collected = collectFileItems(result.files, hashText);
+    const collected = collectFileItems(result.files, hashText, hashBytes);
     items.push(...collected.items);
     fileBlobs = collected.fileBlobs;
   }
   if (result.imageDataUrl) {
-    const imageItem = collectImageItem(result.imageDataUrl, hashText);
+    const imageItem = collectImageItem(result.imageDataUrl, hashText, hashBytes);
     items.push(imageItem);
     // Store image data in BlobStore so it can be served via FILE_PULL_REQUEST.
     // Use the image item's own hash (not the appear item's hash) so Desktop

--- a/web/src/shared/ws/ws-client.ts
+++ b/web/src/shared/ws/ws-client.ts
@@ -8,6 +8,7 @@ import {
 
 const HEARTBEAT_INTERVAL_MS = 20_000;
 const HEARTBEAT_ACK_TIMEOUT_MS = 10_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
 export type WsClientState = "idle" | "connecting" | "connected" | "closed";
 
@@ -16,6 +17,12 @@ export interface WsClientConfig {
   port: number;
   appInstanceId: string;
   targetAppInstanceId: string;
+}
+
+interface PendingRequest {
+  resolve: (envelope: WsEnvelope) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 /**
@@ -43,6 +50,9 @@ export class WsClient {
     reject: (e: Error) => void;
   }> = [];
   private isSending = false;
+
+  // Request-response tracking
+  private pendingRequests: Map<string, PendingRequest> = new Map();
 
   readonly config: WsClientConfig;
 
@@ -136,6 +146,34 @@ export class WsClient {
   }
 
   /**
+   * Send a request envelope and wait for the correlated response.
+   * Generates a requestId, sends the envelope, and resolves when a
+   * response with the same requestId arrives (or rejects on timeout).
+   */
+  sendRequest(
+    envelope: WsEnvelope,
+    timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
+  ): Promise<WsEnvelope> {
+    const requestId = crypto.randomUUID();
+    const requestEnvelope: WsEnvelope = { ...envelope, requestId };
+
+    return new Promise<WsEnvelope>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(requestId);
+        reject(new Error(`Request ${requestId} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pendingRequests.set(requestId, { resolve, reject, timer });
+
+      this.sendEnvelope(requestEnvelope).catch((e) => {
+        this.pendingRequests.delete(requestId);
+        clearTimeout(timer);
+        reject(e);
+      });
+    });
+  }
+
+  /**
    * Close the connection gracefully.
    */
   close(): void {
@@ -191,6 +229,17 @@ export class WsClient {
     if (envelope.type === WsMessageType.HEARTBEAT_ACK) {
       this.clearHeartbeatAckTimer();
       return;
+    }
+
+    // Check if this is a response to a pending request
+    if (envelope.requestId) {
+      const pending = this.pendingRequests.get(envelope.requestId);
+      if (pending) {
+        this.pendingRequests.delete(envelope.requestId);
+        clearTimeout(pending.timer);
+        pending.resolve(envelope);
+        return;
+      }
     }
 
     this.onMessage?.(envelope);
@@ -278,5 +327,11 @@ export class WsClient {
     }
     this.sendQueue = [];
     this.isSending = false;
+    // Reject any pending requests
+    for (const [, pending] of this.pendingRequests) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("Connection closed"));
+    }
+    this.pendingRequests.clear();
   }
 }

--- a/web/src/shared/ws/ws-manager.ts
+++ b/web/src/shared/ws/ws-manager.ts
@@ -158,6 +158,18 @@ export class WsManager {
   }
 
   /**
+   * Send a request to a connected device and wait for a correlated response.
+   * Throws if the device is not connected or the request times out.
+   */
+  async sendRequest(targetAppInstanceId: string, envelope: WsEnvelope): Promise<WsEnvelope> {
+    const conn = this.sessions.get(targetAppInstanceId);
+    if (!conn?.client.isActive) {
+      throw new Error(`Device ${targetAppInstanceId} not connected`);
+    }
+    return conn.client.sendRequest(envelope);
+  }
+
+  /**
    * Get connection status for all known devices.
    */
   getConnectionStates(): Record<string, WsConnectionStatus> {

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -1,11 +1,23 @@
 import { type WsEnvelope, WsMessageType, simpleEnvelope } from "./ws-types";
-import { parsePasteData } from "@/shared/models/paste-data";
+import { parsePasteData, type PasteData } from "@/shared/models/paste-data";
+import { PasteType } from "@/shared/models/paste-item";
+import type { FilesPasteItem, ImagesPasteItem } from "@/shared/models/paste-item";
 import { PasteStore } from "@/shared/storage/paste-store";
 import { BlobStore } from "@/shared/storage/blob-store";
+
+/** Payload of a FILE_PULL_REQUEST message (matches Kotlin WsPullFileRequest). */
+interface WsPullFileRequest {
+  id: number;
+  chunkIndex: number;
+  hash: string;
+  fileName: string;
+}
 
 export interface WsMessageHandlerDeps {
   /** Send an envelope back to the device that sent the message. */
   sendToDevice: (targetAppInstanceId: string, envelope: WsEnvelope) => Promise<void>;
+  /** Send a request and wait for the correlated response. */
+  sendRequest: (targetAppInstanceId: string, envelope: WsEnvelope) => Promise<WsEnvelope>;
   /** Update device status (synced/error). */
   updateDeviceStatus: (targetAppInstanceId: string, status: "synced" | "error") => void;
   /** Broadcast a message to the side panel UI. */
@@ -46,6 +58,10 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
           await deps.onRemoteRemoveDevice(appInstanceId);
           break;
 
+        case WsMessageType.FILE_PULL_REQUEST:
+          await handleFilePullRequest(appInstanceId, envelope);
+          break;
+
         default:
           console.warn(`[WsHandler] Unknown message type: ${envelope.type} from ${appInstanceId}`);
       }
@@ -72,6 +88,9 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
         deps.broadcastToSidePanel({ type: "PASTE_UPDATED" });
         // Prevent clipboard poller from re-capturing this synced content
         await deps.setLastHash(pasteData.hash);
+
+        // Pull file content from desktop if this paste has files
+        await pullFilesIfNeeded(appInstanceId, pasteData);
       }
 
       deps.updateDeviceStatus(appInstanceId, "synced");
@@ -79,5 +98,137 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
     } catch (e) {
       console.error(`[WsHandler] paste_push from ${appInstanceId} failed:`, e);
     }
+  }
+
+  /**
+   * Handle FILE_PULL_REQUEST from Desktop.
+   * Desktop wants to pull a file from Chrome's BlobStore.
+   * Supports whole-file mode only (hash + fileName).
+   */
+  async function handleFilePullRequest(
+    appInstanceId: string,
+    envelope: WsEnvelope,
+  ): Promise<void> {
+    const requestId = envelope.requestId;
+    if (!requestId) {
+      console.warn(`[WsHandler] FILE_PULL_REQUEST from ${appInstanceId} missing requestId`);
+      return;
+    }
+
+    try {
+      const request: WsPullFileRequest = JSON.parse(new TextDecoder().decode(envelope.payload));
+      console.log(`[WsHandler] FILE_PULL_REQUEST from ${appInstanceId}:`, request);
+
+      // Whole-file mode: retrieve blob by hash + fileName
+      if (!request.hash || !request.fileName) {
+        await sendErrorResponse(appInstanceId, requestId, "Missing hash or fileName");
+        return;
+      }
+
+      const data = await BlobStore.get(request.hash, request.fileName);
+      if (!data) {
+        await sendErrorResponse(
+          appInstanceId,
+          requestId,
+          `Blob not found: ${request.hash}/${request.fileName}`,
+        );
+        return;
+      }
+
+      const response: WsEnvelope = {
+        type: WsMessageType.FILE_PULL_RESPONSE,
+        payload: new Uint8Array(data),
+        encrypted: false,
+        requestId,
+      };
+      await deps.sendToDevice(appInstanceId, response);
+      console.log(
+        `[WsHandler] Served file ${request.fileName} (${data.byteLength} bytes) to ${appInstanceId}`,
+      );
+    } catch (e) {
+      console.error(`[WsHandler] FILE_PULL_REQUEST from ${appInstanceId} failed:`, e);
+      try {
+        await sendErrorResponse(appInstanceId, requestId, `Internal error: ${String(e)}`);
+      } catch {
+        // Best effort
+      }
+    }
+  }
+
+  /**
+   * After receiving a paste_push with file/image items from desktop,
+   * pull the actual file content via WebSocket FILE_PULL_REQUEST.
+   */
+  async function pullFilesIfNeeded(
+    appInstanceId: string,
+    pasteData: PasteData,
+  ): Promise<void> {
+    const allItems = [pasteData.pasteAppearItem, ...pasteData.pasteCollection.pasteItems].filter(
+      Boolean,
+    );
+    const fileItems = allItems.filter(
+      (item): item is FilesPasteItem | ImagesPasteItem =>
+        item !== null && (item.type === PasteType.FILE || item.type === PasteType.IMAGE),
+    );
+
+    if (fileItems.length === 0) return;
+
+    for (const item of fileItems) {
+      if (!item.relativePathList || item.relativePathList.length === 0) continue;
+      const hash = item.hash;
+      if (!hash) continue;
+
+      for (const fileName of item.relativePathList) {
+        // Skip if we already have this blob
+        const existing = await BlobStore.get(hash, fileName);
+        if (existing) continue;
+
+        try {
+          const request = {
+            id: pasteData.id,
+            chunkIndex: -1,
+            hash,
+            fileName,
+          };
+
+          const requestEnvelope: WsEnvelope = {
+            type: WsMessageType.FILE_PULL_REQUEST,
+            payload: new TextEncoder().encode(JSON.stringify(request)),
+            encrypted: false,
+          };
+
+          const response = await deps.sendRequest(appInstanceId, requestEnvelope);
+
+          if (response.type === WsMessageType.ERROR) {
+            const errorMsg = new TextDecoder().decode(response.payload);
+            console.warn(`[WsHandler] File pull error for ${fileName}: ${errorMsg}`);
+            continue;
+          }
+
+          if (response.payload.length > 0) {
+            await BlobStore.put(hash, fileName, response.payload.slice().buffer as ArrayBuffer);
+            console.log(
+              `[WsHandler] Pulled file ${fileName} (${response.payload.length} bytes) from ${appInstanceId}`,
+            );
+          }
+        } catch (e) {
+          console.error(`[WsHandler] Failed to pull file ${fileName} from ${appInstanceId}:`, e);
+        }
+      }
+    }
+  }
+
+  async function sendErrorResponse(
+    appInstanceId: string,
+    requestId: string,
+    message: string,
+  ): Promise<void> {
+    const errorEnvelope: WsEnvelope = {
+      type: WsMessageType.ERROR,
+      payload: new TextEncoder().encode(message),
+      encrypted: false,
+      requestId,
+    };
+    await deps.sendToDevice(appInstanceId, errorEnvelope);
   }
 }

--- a/web/src/shared/ws/ws-types.ts
+++ b/web/src/shared/ws/ws-types.ts
@@ -10,6 +10,8 @@ export const WsMessageType = {
   SYNC_INFO: "sync_info",
   NOTIFY_EXIT: "notify_exit",
   NOTIFY_REMOVE: "notify_remove",
+  FILE_PULL_REQUEST: "file_pull_request",
+  FILE_PULL_RESPONSE: "file_pull_response",
   ERROR: "error",
 } as const;
 


### PR DESCRIPTION
Closes #4167

## Summary

- Add `FILE_PULL_REQUEST` / `FILE_PULL_RESPONSE` WebSocket message types with `requestId`-based request-response correlation
- Desktop pulls files from Chrome Extension via whole-file mode (`hash + fileName` → BlobStore lookup)
- Chrome Extension pulls files from Desktop via whole-file mode (`pasteId + fileName` → disk read)
- `SyncPasteTaskExecutor` skips file-type paste sync to Chrome Extension when any file >1MB or total >32MB
- Chrome auto-pulls file content after receiving `paste_push` with file items

## Key files

**Kotlin (Desktop):**
- `WsPendingRequests.kt` — new request-response correlation utility using `CompletableDeferred` + timeout
- `WsPullFileRequest.kt` — new DTO supporting chunk mode and whole-file mode
- `WsMessageHandler.kt` — handles `FILE_PULL_REQUEST` (serves files) and `FILE_PULL_RESPONSE` (routes to pending requests)
- `FilePullService.kt` — detects extension peers, uses WS whole-file pull instead of HTTP
- `SyncPasteTaskExecutor.kt` — filters oversized files for extension targets

**TypeScript (Chrome Extension):**
- `ws-client.ts` — adds `sendRequest()` with requestId tracking and timeout
- `ws-message-handler.ts` — handles `FILE_PULL_REQUEST` (serves blobs from IndexedDB), auto-pulls files after `paste_push`
- `ws-manager.ts` — exposes `sendRequest()` to message handler

## Test plan

- [ ] Build passes: `./gradlew build`
- [ ] Existing tests pass: `./gradlew app:desktopTest`
- [ ] Manual: pair Chrome Extension ↔ Desktop, copy small file on Chrome → Desktop receives file via WS
- [ ] Manual: copy small file on Desktop → Chrome receives file via WS
- [ ] Manual: copy file >1MB on Desktop → Chrome does NOT receive this paste