### PR TITLE
Fix Chrome extension image preview for synced clipboard images

### DIFF
--- a/web/src/components/paste-grid/ImagePreview.tsx
+++ b/web/src/components/paste-grid/ImagePreview.tsx
@@ -1,10 +1,10 @@
 import type { ImagesPasteItem } from "@/shared/models/paste-item";
 import { formatSize } from "@/shared/utils/format";
-import { useImageUrl } from "@/shared/hooks/use-image-url";
+import { useImageItemUrl } from "@/shared/hooks/use-image-url";
 
 export function ImagePreview({ item }: { item: ImagesPasteItem }) {
   const fileName = item.relativePathList?.[0] ?? "image";
-  const imageUrl = useImageUrl(item.hash, item.relativePathList?.[0], item.dataUrl);
+  const imageUrl = useImageItemUrl(item);
 
   if (imageUrl) {
     return (

--- a/web/src/components/paste-grid/ImagePreview.tsx
+++ b/web/src/components/paste-grid/ImagePreview.tsx
@@ -1,15 +1,16 @@
 import type { ImagesPasteItem } from "@/shared/models/paste-item";
 import { formatSize } from "@/shared/utils/format";
+import { useImageUrl } from "@/shared/hooks/use-image-url";
 
 export function ImagePreview({ item }: { item: ImagesPasteItem }) {
   const fileName = item.relativePathList?.[0] ?? "image";
+  const imageUrl = useImageUrl(item.hash, item.relativePathList?.[0], item.dataUrl);
 
-  // Inline image data — show actual thumbnail
-  if (item.dataUrl) {
+  if (imageUrl) {
     return (
       <div className="flex flex-col gap-2">
         <img
-          src={item.dataUrl}
+          src={imageUrl}
           alt={fileName}
           className="w-full max-h-40 object-contain rounded-lg bg-m3-surface"
         />
@@ -20,7 +21,6 @@ export function ImagePreview({ item }: { item: ImagesPasteItem }) {
     );
   }
 
-  // File-path based image (pulled from desktop) — show metadata only
   return (
     <div className="flex items-center gap-2">
       <svg

--- a/web/src/components/paste-grid/PasteCard.tsx
+++ b/web/src/components/paste-grid/PasteCard.tsx
@@ -19,6 +19,7 @@ import { relativeTime } from "@/shared/utils/date";
 import { isDarkColor } from "@/shared/utils/html-color";
 import { copyPasteData } from "@/shared/clipboard/clipboard-writer";
 import { NotificationManager } from "@/shared/notification/notification-manager";
+import { useImageUrl } from "@/shared/hooks/use-image-url";
 
 const MAX_SIZE = 5 * 1024 * 1024;
 
@@ -93,11 +94,12 @@ function UrlContent({ item }: { item: UrlPasteItem }) {
 }
 
 function ImageContent({ item }: { item: ImagesPasteItem }) {
-  if (item.dataUrl) {
+  const imageUrl = useImageUrl(item.hash, item.relativePathList?.[0], item.dataUrl);
+  if (imageUrl) {
     return (
       <div className="flex-1 overflow-hidden">
         <img
-          src={item.dataUrl}
+          src={imageUrl}
           alt=""
           className="w-full h-full object-cover"
         />

--- a/web/src/components/paste-grid/PasteCard.tsx
+++ b/web/src/components/paste-grid/PasteCard.tsx
@@ -19,7 +19,7 @@ import { relativeTime } from "@/shared/utils/date";
 import { isDarkColor } from "@/shared/utils/html-color";
 import { copyPasteData } from "@/shared/clipboard/clipboard-writer";
 import { NotificationManager } from "@/shared/notification/notification-manager";
-import { useImageUrl } from "@/shared/hooks/use-image-url";
+import { useImageItemUrl } from "@/shared/hooks/use-image-url";
 
 const MAX_SIZE = 5 * 1024 * 1024;
 
@@ -94,7 +94,7 @@ function UrlContent({ item }: { item: UrlPasteItem }) {
 }
 
 function ImageContent({ item }: { item: ImagesPasteItem }) {
-  const imageUrl = useImageUrl(item.hash, item.relativePathList?.[0], item.dataUrl);
+  const imageUrl = useImageItemUrl(item);
   if (imageUrl) {
     return (
       <div className="flex-1 overflow-hidden">

--- a/web/src/components/paste-grid/PasteDetailView.tsx
+++ b/web/src/components/paste-grid/PasteDetailView.tsx
@@ -13,7 +13,7 @@ import type {
   RtfPasteItem,
 } from "@/shared/models/paste-item";
 import { useI18n } from "@/shared/i18n/use-i18n";
-import { useImageUrl } from "@/shared/hooks/use-image-url";
+import { useImageItemUrl } from "@/shared/hooks/use-image-url";
 import { isDarkColor } from "@/shared/utils/html-color";
 import { argbToHex, argbToComponents } from "@/shared/utils/color";
 import { formatSize } from "@/shared/utils/format";
@@ -102,7 +102,7 @@ function FileDetailContent({ item }: { item: FilesPasteItem }) {
 }
 
 function ImageDetailContent({ item }: { item: ImagesPasteItem }) {
-  const imageUrl = useImageUrl(item.hash, item.relativePathList?.[0], item.dataUrl);
+  const imageUrl = useImageItemUrl(item);
   if (imageUrl) {
     return (
       <div className="flex-1 min-h-0 rounded-[14px] bg-m3-surface-container flex items-center justify-center overflow-hidden">

--- a/web/src/components/paste-grid/PasteDetailView.tsx
+++ b/web/src/components/paste-grid/PasteDetailView.tsx
@@ -13,6 +13,7 @@ import type {
   RtfPasteItem,
 } from "@/shared/models/paste-item";
 import { useI18n } from "@/shared/i18n/use-i18n";
+import { useImageUrl } from "@/shared/hooks/use-image-url";
 import { isDarkColor } from "@/shared/utils/html-color";
 import { argbToHex, argbToComponents } from "@/shared/utils/color";
 import { formatSize } from "@/shared/utils/format";
@@ -101,11 +102,12 @@ function FileDetailContent({ item }: { item: FilesPasteItem }) {
 }
 
 function ImageDetailContent({ item }: { item: ImagesPasteItem }) {
-  if (item.dataUrl) {
+  const imageUrl = useImageUrl(item.hash, item.relativePathList?.[0], item.dataUrl);
+  if (imageUrl) {
     return (
       <div className="flex-1 min-h-0 rounded-[14px] bg-m3-surface-container flex items-center justify-center overflow-hidden">
         <img
-          src={item.dataUrl}
+          src={imageUrl}
           alt="clipboard image"
           className="w-full max-h-full object-contain"
         />

--- a/web/src/shared/hooks/use-image-url.ts
+++ b/web/src/shared/hooks/use-image-url.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect } from "react";
+import { BlobStore } from "@/shared/storage/blob-store";
+
+function mimeFromExt(fileName: string): string {
+  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+  switch (ext) {
+    case "png":
+      return "image/png";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    case "svg":
+      return "image/svg+xml";
+    default:
+      return "image/jpeg";
+  }
+}
+
+export function useImageUrl(
+  hash: string | undefined,
+  fileName: string | undefined,
+  dataUrl: string | undefined,
+): string | undefined {
+  const [url, setUrl] = useState<string | undefined>(dataUrl);
+  const [blobVersion, setBlobVersion] = useState(0);
+
+  useEffect(() => {
+    const listener = (message: Record<string, unknown>) => {
+      if (message.type === "BLOBS_READY" && message.hash === hash) {
+        setBlobVersion((v) => v + 1);
+      }
+    };
+    chrome.runtime.onMessage.addListener(listener);
+    return () => chrome.runtime.onMessage.removeListener(listener);
+  }, [hash]);
+
+  useEffect(() => {
+    if (dataUrl) {
+      setUrl(dataUrl);
+      return;
+    }
+    if (!hash || !fileName) return;
+
+    let cancelled = false;
+    let objectUrl: string | undefined;
+
+    BlobStore.get(hash, fileName).then((data) => {
+      if (cancelled || !data) return;
+      const blob = new Blob([data], { type: mimeFromExt(fileName) });
+      objectUrl = URL.createObjectURL(blob);
+      setUrl(objectUrl);
+    });
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [hash, fileName, dataUrl, blobVersion]);
+
+  return url;
+}

--- a/web/src/shared/hooks/use-image-url.ts
+++ b/web/src/shared/hooks/use-image-url.ts
@@ -1,20 +1,22 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { BlobStore } from "@/shared/storage/blob-store";
+import type { ImagesPasteItem } from "@/shared/models/paste-item";
 
-function mimeFromExt(fileName: string): string {
+function mimeFromExt(fileName: string): string | undefined {
   const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
-  switch (ext) {
-    case "png":
-      return "image/png";
-    case "gif":
-      return "image/gif";
-    case "webp":
-      return "image/webp";
-    case "svg":
-      return "image/svg+xml";
-    default:
-      return "image/jpeg";
-  }
+  const mimeMap: Record<string, string> = {
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    webp: "image/webp",
+    svg: "image/svg+xml",
+    bmp: "image/bmp",
+    ico: "image/x-icon",
+    tiff: "image/tiff",
+    tif: "image/tiff",
+  };
+  return mimeMap[ext];
 }
 
 export function useImageUrl(
@@ -26,6 +28,7 @@ export function useImageUrl(
   const [blobVersion, setBlobVersion] = useState(0);
 
   useEffect(() => {
+    if (!hash) return;
     const listener = (message: Record<string, unknown>) => {
       if (message.type === "BLOBS_READY" && message.hash === hash) {
         setBlobVersion((v) => v + 1);
@@ -35,6 +38,9 @@ export function useImageUrl(
     return () => chrome.runtime.onMessage.removeListener(listener);
   }, [hash]);
 
+  const loadedHashRef = useRef<string>();
+  const objectUrlRef = useRef<string>();
+
   useEffect(() => {
     if (dataUrl) {
       setUrl(dataUrl);
@@ -42,21 +48,36 @@ export function useImageUrl(
     }
     if (!hash || !fileName) return;
 
+    if (loadedHashRef.current === hash && objectUrlRef.current) {
+      return;
+    }
+
     let cancelled = false;
-    let objectUrl: string | undefined;
 
     BlobStore.get(hash, fileName).then((data) => {
       if (cancelled || !data) return;
-      const blob = new Blob([data], { type: mimeFromExt(fileName) });
-      objectUrl = URL.createObjectURL(blob);
-      setUrl(objectUrl);
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+      const mime = mimeFromExt(fileName);
+      const blob = mime ? new Blob([data], { type: mime }) : new Blob([data]);
+      objectUrlRef.current = URL.createObjectURL(blob);
+      loadedHashRef.current = hash;
+      setUrl(objectUrlRef.current);
     });
 
     return () => {
       cancelled = true;
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [hash, fileName, dataUrl, blobVersion]);
 
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    };
+  }, []);
+
   return url;
+}
+
+export function useImageItemUrl(item: ImagesPasteItem): string | undefined {
+  return useImageUrl(item.hash, item.relativePathList?.[0], item.dataUrl);
 }

--- a/web/src/shared/hooks/use-image-url.ts
+++ b/web/src/shared/hooks/use-image-url.ts
@@ -38,8 +38,8 @@ export function useImageUrl(
     return () => chrome.runtime.onMessage.removeListener(listener);
   }, [hash]);
 
-  const loadedHashRef = useRef<string>();
-  const objectUrlRef = useRef<string>();
+  const loadedHashRef = useRef<string | undefined>(undefined);
+  const objectUrlRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     if (dataUrl) {

--- a/web/src/shared/storage/blob-store.ts
+++ b/web/src/shared/storage/blob-store.ts
@@ -1,3 +1,6 @@
+// TODO: When a second consumer needs blob-change notifications (e.g. file preview, audio),
+// add an onChange(hash, callback) subscription API here so hooks subscribe directly to
+// BlobStore instead of each listening to chrome.runtime.onMessage independently.
 import { openDB, type IDBPDatabase } from "idb";
 
 const DB_NAME = "crosspaste-blobs";

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -178,13 +178,18 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
       const hash = item.hash;
       if (!hash) continue;
 
+      let pulledAny = false;
+
       for (const fileName of item.relativePathList) {
         // Skip if we already have this blob
         const existing = await BlobStore.get(hash, fileName);
-        if (existing) continue;
+        if (existing) {
+          pulledAny = true;
+          continue;
+        }
 
         try {
-          const bareFileName = fileName.includes("/") ? fileName.split("/").pop()! : fileName;
+          const bareFileName = fileName.includes("/") ? fileName.split("/").pop() || fileName : fileName;
           const request = {
             id: pasteData.id,
             chunkIndex: -1,
@@ -208,6 +213,7 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
 
           if (response.payload.length > 0) {
             await BlobStore.put(hash, fileName, response.payload.slice().buffer as ArrayBuffer);
+            pulledAny = true;
             console.log(
               `[WsHandler] Pulled file ${fileName} (${response.payload.length} bytes) from ${appInstanceId}`,
             );
@@ -217,7 +223,9 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
         }
       }
 
-      deps.broadcastToSidePanel({ type: "BLOBS_READY", hash });
+      if (pulledAny) {
+        deps.broadcastToSidePanel({ type: "BLOBS_READY", hash });
+      }
     }
   }
 

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -184,11 +184,12 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
         if (existing) continue;
 
         try {
+          const bareFileName = fileName.includes("/") ? fileName.split("/").pop()! : fileName;
           const request = {
             id: pasteData.id,
             chunkIndex: -1,
             hash,
-            fileName,
+            fileName: bareFileName,
           };
 
           const requestEnvelope: WsEnvelope = {
@@ -215,6 +216,8 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
           console.error(`[WsHandler] Failed to pull file ${fileName} from ${appInstanceId}:`, e);
         }
       }
+
+      deps.broadcastToSidePanel({ type: "BLOBS_READY", hash });
     }
   }
 


### PR DESCRIPTION
Closes #4169

## Summary
- Fix FILE_PULL_REQUEST sending full relative path (`appInstanceId/date/id/fileName`) as `fileName`, while desktop matches only `filePath.name` (bare filename) — file pull always failed silently
- Add reactive `useImageUrl` hook that loads images from BlobStore and listens for `BLOBS_READY` events after file pull completes
- Update `ImagePreview`, `PasteCard`, and `PasteDetailView` to use the hook for both inline `dataUrl` and BlobStore-backed images

## Test plan
- [ ] Sync an image clipboard from desktop to Chrome extension
- [ ] Verify image preview appears in grid card view immediately after sync
- [ ] Verify image preview appears in detail view
- [ ] Verify locally captured images still display correctly
- [ ] Verify image preview in search results (ImagePreview component)