### PR TITLE
Fix Chrome extension sync ordering and write synced clipboard

### DIFF
--- a/web/manifest.json
+++ b/web/manifest.json
@@ -3,7 +3,7 @@
   "name": "CrossPaste",
   "description": "Clipboard sync with CrossPaste desktop",
   "version": "0.1.0",
-  "permissions": ["storage", "sidePanel", "alarms", "offscreen", "clipboardRead", "clipboardWrite"],
+  "permissions": ["storage", "sidePanel", "alarms", "offscreen", "clipboardRead", "clipboardWrite", "downloads"],
   "host_permissions": ["http://*/*"],
   "side_panel": {
     "default_path": "src/sidepanel/index.html"

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -13,6 +13,7 @@ import { WsManager } from "@/shared/ws/ws-manager";
 import { createWsMessageHandler } from "@/shared/ws/ws-message-handler";
 import { WsMessageType, simpleEnvelope } from "@/shared/ws/ws-types";
 import type { WsEnvelope } from "@/shared/ws/ws-types";
+import { ingestPaste } from "@/shared/paste/paste-ingestion";
 
 // ─── Per-device runtime status ──────────────────────────────────────────
 
@@ -97,19 +98,6 @@ async function storeFileBlobs(collected: { hash: string; fileBlobs: Array<{ name
   }
 }
 
-/** Persist paste data, deduplicate old entries, and evict over limit. */
-async function persistPasteData(pasteData: PasteData, hash: string): Promise<boolean> {
-  const newId = await PasteStore.createPasteData(pasteData);
-  if (newId === null) return false;
-
-  const deleted = await PasteStore.markDeleteSameHash(newId, hash);
-  for (const h of deleted) await BlobStore.deleteForPaste(h);
-  const evicted = await PasteStore.evictOverLimit();
-  for (const h of evicted) await BlobStore.deleteForPaste(h);
-
-  broadcastToSidePanel({ type: "PASTE_UPDATED" });
-  return true;
-}
 
 /** Push paste data to all trusted WebSocket-connected devices. */
 async function pushPasteToDevices(pasteData: PasteData): Promise<void> {
@@ -155,6 +143,7 @@ async function pollClipboard(): Promise<void> {
 
     const lastHash = await getLastHash();
     if (collected.hash === lastHash) return;
+
     await setLastHash(collected.hash);
 
     await storeFileBlobs(collected);
@@ -174,7 +163,7 @@ async function pollClipboard(): Promise<void> {
       receivedAt: Date.now(),
     };
 
-    if (await persistPasteData(pasteData, collected.hash)) {
+    if ((await ingestPaste(pasteData, broadcastToSidePanel)) !== null) {
       await pushPasteToDevices(pasteData);
     }
   } catch {
@@ -241,14 +230,7 @@ async function syncAllDevices(): Promise<void> {
         targetAppInstanceId: device.targetAppInstanceId,
       });
       if (data) {
-        const newId = await PasteStore.createPasteData(data);
-        if (newId !== null) {
-          const deleted = await PasteStore.markDeleteSameHash(newId, data.hash);
-          for (const h of deleted) await BlobStore.deleteForPaste(h);
-          const evicted = await PasteStore.evictOverLimit();
-          for (const h of evicted) await BlobStore.deleteForPaste(h);
-          broadcastToSidePanel({ type: "PASTE_UPDATED" });
-          // Update last hash so polling doesn't re-capture synced content
+        if ((await ingestPaste(data, broadcastToSidePanel)) !== null) {
           await setLastHash(data.hash);
         }
       }
@@ -360,7 +342,6 @@ async function initializeWebSocket(): Promise<void> {
       }
     },
     broadcastToSidePanel,
-    getLastHash,
     setLastHash,
     onRemoteRemoveDevice: async (targetId) => {
       wsManager?.disconnectDevice(targetId);
@@ -591,6 +572,20 @@ async function handleDeletePaste(pasteId: number): Promise<unknown> {
   return { success: hash !== null };
 }
 
+async function handleDownloadFile(hash: string, fileName: string): Promise<unknown> {
+  const data = await BlobStore.get(hash, fileName);
+  if (!data) return { success: false, error: "File not found" };
+
+  const blob = new Blob([data]);
+  const url = URL.createObjectURL(blob);
+  try {
+    await chrome.downloads.download({ url, filename: fileName, saveAs: true });
+    return { success: true };
+  } finally {
+    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  }
+}
+
 async function handleMessage(
   message: Record<string, unknown>,
 ): Promise<unknown> {
@@ -609,6 +604,7 @@ async function handleMessage(
     case "COPY_ITEM": return { success: true };
     case "LOCAL_COPY": return handleLocalCopy(message.pasteId as number);
     case "DELETE_PASTE": return handleDeletePaste(message.pasteId as number);
+    case "DOWNLOAD_FILE": return handleDownloadFile(message.hash as string, message.fileName as string);
     case "GET_WS_STATUS": return { statuses: wsManager?.getConnectionStates() ?? {} };
     default: return { error: "Unknown message type" };
   }

--- a/web/src/components/paste-grid/PasteCard.tsx
+++ b/web/src/components/paste-grid/PasteCard.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { Copy, Trash2 } from "lucide-react";
+import { Copy, Trash2, Download } from "lucide-react";
 import type { PasteData } from "@/shared/models/paste-data";
 import { PasteType, PASTE_TYPE_FROM_INT, PASTE_TYPE_I18N_KEYS } from "@/shared/models/paste-item";
 import { useI18n } from "@/shared/i18n/use-i18n";
@@ -218,12 +218,39 @@ export function PasteCard({ data, onClick, onDelete }: Props) {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
+  const isFileType = data.pasteType === 3; // PasteTypeInt.FILE
+
   const handleCopy = useCallback(async () => {
     try {
       await copyPasteData(data);
       NotificationManager.success("Copied");
     } catch {
       NotificationManager.error("Copy failed");
+    }
+  }, [data]);
+
+  const handleDownload = useCallback(async () => {
+    const item = data.pasteAppearItem ?? data.pasteCollection.pasteItems[0];
+    if (!item || (item.type !== "files" && item.type !== "images")) return;
+    const fileItem = item as FilesPasteItem | ImagesPasteItem;
+    const hash = fileItem.hash;
+    if (!hash || !fileItem.relativePathList?.length) return;
+
+    for (const fileName of fileItem.relativePathList) {
+      try {
+        const result = await chrome.runtime.sendMessage({
+          type: "DOWNLOAD_FILE",
+          hash,
+          fileName,
+        }) as { success: boolean; error?: string };
+        if (result.success) {
+          NotificationManager.success(`Downloading ${fileName}`);
+        } else {
+          NotificationManager.error(result.error ?? "Download failed");
+        }
+      } catch {
+        NotificationManager.error("Download failed");
+      }
     }
   }, [data]);
 
@@ -281,6 +308,15 @@ export function PasteCard({ data, onClick, onDelete }: Props) {
             <Copy size={16} className="text-m3-on-surface-variant" />
             <span>{t("copy")}</span>
           </button>
+          {isFileType && (
+            <button
+              onClick={() => { setContextMenu(null); handleDownload(); }}
+              className="flex items-center gap-3 w-full px-4 py-2.5 text-sm text-m3-on-surface hover:bg-m3-surface-container transition-colors"
+            >
+              <Download size={16} className="text-m3-on-surface-variant" />
+              <span>{t("download")}</span>
+            </button>
+          )}
           {onDelete && (
             <button
               onClick={() => { setContextMenu(null); onDelete(); }}

--- a/web/src/offscreen/offscreen.ts
+++ b/web/src/offscreen/offscreen.ts
@@ -123,9 +123,45 @@ function readClipboard(): Promise<ClipboardResult> {
   });
 }
 
+async function writeClipboard(data: {
+  text?: string;
+  html?: string;
+  imageDataUrl?: string;
+}): Promise<boolean> {
+  try {
+    const blobs: Record<string, Blob> = {};
+
+    if (data.imageDataUrl) {
+      const res = await fetch(data.imageDataUrl);
+      const blob = await res.blob();
+      blobs["image/png"] = blob;
+    }
+
+    if (data.html) {
+      blobs["text/html"] = new Blob([data.html], { type: "text/html" });
+    }
+
+    if (data.text) {
+      blobs["text/plain"] = new Blob([data.text], { type: "text/plain" });
+    }
+
+    if (Object.keys(blobs).length === 0) return false;
+
+    await navigator.clipboard.write([new ClipboardItem(blobs)]);
+    return true;
+  } catch (e) {
+    console.error("[Offscreen] writeClipboard failed:", e);
+    return false;
+  }
+}
+
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message.type === "READ_CLIPBOARD") {
     readClipboard().then(sendResponse);
-    return true; // async response
+    return true;
+  }
+  if (message.type === "WRITE_CLIPBOARD") {
+    writeClipboard(message.data).then(sendResponse);
+    return true;
   }
 });

--- a/web/src/shared/clipboard/clipboard-sync-writer.ts
+++ b/web/src/shared/clipboard/clipboard-sync-writer.ts
@@ -1,0 +1,81 @@
+import type { PasteData } from "@/shared/models/paste-data";
+import { PasteType, PasteTypeInt } from "@/shared/models/paste-item";
+import type {
+  TextPasteItem,
+  UrlPasteItem,
+  HtmlPasteItem,
+  ImagesPasteItem,
+  ColorPasteItem,
+} from "@/shared/models/paste-item";
+import { BlobStore } from "@/shared/storage/blob-store";
+import { argbToHex } from "@/shared/utils/color";
+
+/**
+ * Write a remotely-synced paste to the system clipboard via the offscreen document.
+ * Used by the service worker when receiving paste_push from desktop.
+ *
+ * Supports text, URL, HTML, color, and image types.
+ * File type is skipped (Chrome cannot write file references to clipboard).
+ *
+ * Returns true if clipboard was written successfully.
+ */
+export async function writeRemotePasteToClipboard(pasteData: PasteData): Promise<boolean> {
+  const pasteType = pasteData.pasteType;
+
+  // File and RTF types cannot be written to system clipboard
+  if (pasteType === PasteTypeInt.FILE || pasteType === PasteTypeInt.RTF) {
+    return false;
+  }
+
+  const item = pasteData.pasteAppearItem ?? pasteData.pasteCollection.pasteItems[0];
+  if (!item) return false;
+
+  const writeData: { text?: string; html?: string; imageDataUrl?: string } = {};
+
+  switch (item.type) {
+    case PasteType.TEXT:
+      writeData.text = (item as TextPasteItem).text;
+      break;
+    case PasteType.URL:
+      writeData.text = (item as UrlPasteItem).url;
+      break;
+    case PasteType.COLOR:
+      writeData.text = argbToHex((item as ColorPasteItem).color);
+      break;
+    case PasteType.HTML: {
+      const htmlItem = item as HtmlPasteItem;
+      writeData.html = htmlItem.html;
+      break;
+    }
+    case PasteType.IMAGE: {
+      const imgItem = item as ImagesPasteItem;
+      if (imgItem.dataUrl) {
+        writeData.imageDataUrl = imgItem.dataUrl;
+      } else if (imgItem.hash && imgItem.relativePathList?.length > 0) {
+        const blob = await BlobStore.get(imgItem.hash, imgItem.relativePathList[0]);
+        if (blob) {
+          const bytes = new Uint8Array(blob);
+          let binary = "";
+          for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+          writeData.imageDataUrl = `data:image/png;base64,${btoa(binary)}`;
+        }
+      }
+      break;
+    }
+    default:
+      return false;
+  }
+
+  if (!writeData.text && !writeData.html && !writeData.imageDataUrl) return false;
+
+  try {
+    const result = await chrome.runtime.sendMessage({
+      type: "WRITE_CLIPBOARD",
+      data: writeData,
+    });
+    return result === true;
+  } catch (e) {
+    console.error("[ClipboardSyncWriter] Failed to write clipboard:", e);
+    return false;
+  }
+}

--- a/web/src/shared/paste/paste-ingestion.ts
+++ b/web/src/shared/paste/paste-ingestion.ts
@@ -1,0 +1,26 @@
+import { PasteStore } from "@/shared/storage/paste-store";
+import { BlobStore } from "@/shared/storage/blob-store";
+import type { PasteData } from "@/shared/models/paste-data";
+
+/**
+ * Unified paste ingestion: store, deduplicate, evict, and broadcast.
+ * Both clipboard polling and WebSocket paste_push flow through here.
+ *
+ * Returns the new internal ID if stored, or null if rejected.
+ */
+export async function ingestPaste(
+  pasteData: PasteData,
+  broadcastToSidePanel: (message: unknown) => void,
+): Promise<number | null> {
+  const newId = await PasteStore.createPasteData(pasteData);
+  if (newId === null) return null;
+
+  const deleted = await PasteStore.markDeleteSameHash(newId, pasteData.hash);
+  for (const h of deleted) await BlobStore.deleteForPaste(h);
+
+  const evicted = await PasteStore.evictOverLimit();
+  for (const h of evicted) await BlobStore.deleteForPaste(h);
+
+  broadcastToSidePanel({ type: "PASTE_UPDATED" });
+  return newId;
+}

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -2,8 +2,9 @@ import { type WsEnvelope, WsMessageType, simpleEnvelope } from "./ws-types";
 import { parsePasteData, type PasteData } from "@/shared/models/paste-data";
 import { PasteType } from "@/shared/models/paste-item";
 import type { FilesPasteItem, ImagesPasteItem } from "@/shared/models/paste-item";
-import { PasteStore } from "@/shared/storage/paste-store";
 import { BlobStore } from "@/shared/storage/blob-store";
+import { ingestPaste } from "@/shared/paste/paste-ingestion";
+import { writeRemotePasteToClipboard } from "@/shared/clipboard/clipboard-sync-writer";
 
 /** Payload of a FILE_PULL_REQUEST message (matches Kotlin WsPullFileRequest). */
 interface WsPullFileRequest {
@@ -22,8 +23,7 @@ export interface WsMessageHandlerDeps {
   updateDeviceStatus: (targetAppInstanceId: string, status: "synced" | "error") => void;
   /** Broadcast a message to the side panel UI. */
   broadcastToSidePanel: (message: unknown) => void;
-  /** Get/set the clipboard last hash to prevent re-capture of synced content. */
-  getLastHash: () => Promise<string>;
+  /** Set the clipboard last hash after writing to clipboard, so poll skips it. */
   setLastHash: (hash: string) => Promise<void>;
   /** Handle remote removal: remove device from storage and disconnect WebSocket. */
   onRemoteRemoveDevice: (targetAppInstanceId: string) => Promise<void>;
@@ -70,7 +70,6 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
 
   async function handlePastePush(appInstanceId: string, envelope: WsEnvelope): Promise<void> {
     try {
-      // Decode payload — no encryption support yet (encrypted=false)
       const jsonString = new TextDecoder().decode(envelope.payload);
       const pasteData = parsePasteData(jsonString);
       if (!pasteData) {
@@ -78,25 +77,19 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
         return;
       }
 
-      const newId = await PasteStore.createPasteData(pasteData);
+      const newId = await ingestPaste(pasteData, deps.broadcastToSidePanel);
       if (newId !== null) {
-        const deleted = await PasteStore.markDeleteSameHash(newId, pasteData.hash);
-        for (const h of deleted) await BlobStore.deleteForPaste(h);
-        const evicted = await PasteStore.evictOverLimit();
-        for (const h of evicted) await BlobStore.deleteForPaste(h);
-
-        deps.broadcastToSidePanel({ type: "PASTE_UPDATED" });
-        // Prevent clipboard poller from re-capturing this synced content
-        await deps.setLastHash(pasteData.hash);
-
-        // Pull file content from desktop if this paste has files
         await pullFilesIfNeeded(appInstanceId, pasteData);
+
+        const written = await writeRemotePasteToClipboard(pasteData);
+        if (written) {
+          await deps.setLastHash(pasteData.hash);
+        }
       }
 
       deps.updateDeviceStatus(appInstanceId, "synced");
-      console.log(`[WsHandler] paste_push from ${appInstanceId} processed`);
     } catch (e) {
-      console.error(`[WsHandler] paste_push from ${appInstanceId} failed:`, e);
+      console.error(`[WS-PASTE-PUSH] Failed from ${appInstanceId}:`, e);
     }
   }
 


### PR DESCRIPTION
Closes #4171

## Summary
- **Fix sync ordering bug**: `setLastHash` was called on every `paste_push` receive, polluting the clipboard poller's hash state. Now only called after actually writing to system clipboard.
- **Unified `ingestPaste()`**: Extract common store→dedup→evict→broadcast logic into a single entry point used by both clipboard polling and WebSocket paste_push.
- **Write synced clipboard**: Synced text/HTML/image from desktop is written to the system clipboard via offscreen document, so users can paste directly without opening the side panel.
- **File download**: File-type pastes get a "Download" option in the context menu, using `chrome.downloads` API.

## Test plan
- [ ] Sync text from desktop → Chrome extension → verify text is on system clipboard, can paste directly
- [ ] Sync image from desktop → Chrome extension → verify image is on system clipboard
- [ ] Sync text A, then image → verify image stays as latest (no ordering flip)
- [ ] Sync file from desktop → right-click in side panel → verify "Download" button appears and works
- [ ] Copy text in Chrome → verify it still syncs to desktop (clipboard poll still works)
- [ ] Verify clipboard poll doesn't re-send synced content back to desktop