### PR TITLE
:bug: Add RemoveHtmlImagePlugin and paste process pipeline to Chrome extension (#4173)

### DIFF
--- a/web/src/shared/paste/paste-collector.ts
+++ b/web/src/shared/paste/paste-collector.ts
@@ -2,6 +2,8 @@ import { PasteTypeInt } from "@/shared/models/paste-item";
 import type { PasteItem } from "@/shared/models/paste-item";
 import type { PasteCollection } from "@/shared/models/paste-data";
 import { detectPasteType, parseColor } from "./paste-type-detector";
+import type { PasteProcessPlugin, TypedItem } from "./plugin/paste-process-plugin";
+import { RemoveHtmlImagePlugin } from "./plugin/remove-html-image-plugin";
 
 /**
  * Priority map matching desktop's PasteType.kt.
@@ -43,7 +45,6 @@ interface CollectedPaste {
   fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }>;
 }
 
-type TypedItem = { pasteType: number; item: PasteItem };
 type HashFn = (s: string) => string;
 type HashBytesFn = (bytes: Uint8Array) => string;
 
@@ -191,6 +192,10 @@ function collectTextToColorItem(text: string, existing: TypedItem[], hashText: H
   };
 }
 
+const pasteProcessPlugins: PasteProcessPlugin[] = [
+  new RemoveHtmlImagePlugin(),
+];
+
 /**
  * Collect all clipboard formats into PasteItems, sort by priority,
  * and split into pasteAppearItem + pasteCollection.
@@ -223,17 +228,21 @@ export function collectPasteItems(
 
   if (items.length === 0) return null;
 
-  if (result.text) {
-    const colorItem = collectTextToColorItem(result.text, items, hashText);
-    if (colorItem) items.push(colorItem);
+  let processedItems: TypedItem[] = items;
+  for (const plugin of pasteProcessPlugins) {
+    processedItems = plugin.process(processedItems);
   }
 
-  // Sort by priority descending (matching desktop SortPlugin)
-  items.sort((a, b) => (PRIORITY[b.pasteType] ?? 0) - (PRIORITY[a.pasteType] ?? 0));
+  if (result.text) {
+    const colorItem = collectTextToColorItem(result.text, processedItems, hashText);
+    if (colorItem) processedItems.push(colorItem);
+  }
 
-  const appearItem = items[0];
-  const collectionItems = items.slice(1).map((i) => i.item);
-  const totalSize = items.reduce((sum, i) => sum + i.item.size, 0);
+  processedItems.sort((a, b) => (PRIORITY[b.pasteType] ?? 0) - (PRIORITY[a.pasteType] ?? 0));
+
+  const appearItem = processedItems[0];
+  const collectionItems = processedItems.slice(1).map((i) => i.item);
+  const totalSize = processedItems.reduce((sum, i) => sum + i.item.size, 0);
 
   return {
     pasteAppearItem: appearItem.item,

--- a/web/src/shared/paste/plugin/paste-process-plugin.ts
+++ b/web/src/shared/paste/plugin/paste-process-plugin.ts
@@ -1,0 +1,10 @@
+import type { PasteItem } from "@/shared/models/paste-item";
+
+export interface TypedItem {
+  pasteType: number;
+  item: PasteItem;
+}
+
+export interface PasteProcessPlugin {
+  process(items: TypedItem[]): TypedItem[];
+}

--- a/web/src/shared/paste/plugin/remove-html-image-plugin.ts
+++ b/web/src/shared/paste/plugin/remove-html-image-plugin.ts
@@ -1,0 +1,23 @@
+import { PasteTypeInt } from "@/shared/models/paste-item";
+import type { PasteProcessPlugin, TypedItem } from "./paste-process-plugin";
+
+function isSingleImgInBody(html: string): boolean {
+  const imgCount = (html.match(/<img[\s>]/gi) || []).length;
+  if (imgCount !== 1) return false;
+  const textContent = html.replace(/<[^>]*>/g, "").trim();
+  return textContent.length === 0;
+}
+
+export class RemoveHtmlImagePlugin implements PasteProcessPlugin {
+  process(items: TypedItem[]): TypedItem[] {
+    const hasImage = items.some((i) => i.pasteType === PasteTypeInt.IMAGE);
+    if (!hasImage) return items;
+    const htmlItem = items.find((i) => i.pasteType === PasteTypeInt.HTML);
+    if (!htmlItem) return items;
+    const html = (htmlItem.item as { html: string }).html;
+    if (isSingleImgInBody(html)) {
+      return items.filter((i) => i !== htmlItem);
+    }
+    return items;
+  }
+}


### PR DESCRIPTION
Closes #4173

## Summary
- Add `PasteProcessPlugin` interface and plugin pipeline to Chrome extension's paste collector, mirroring the desktop's extensible architecture
- Implement `RemoveHtmlImagePlugin` that detects when HTML clipboard content is just a single `<img>` tag wrapper and removes the redundant HTML item, so images are correctly recognized as image paste type
- Uses regex-based HTML detection (instead of `DOMParser`) since the code runs in a Service Worker environment where DOM APIs are unavailable

## Test plan
- [ ] Copy an image from a browser page → should be recognized as an image paste item (not HTML)
- [ ] Copy rich HTML content containing text and images → should still be recognized as HTML
- [ ] Copy plain text → no change in behavior