### PR TITLE
:bug: Fix robustness issues in Chrome extension and native messaging integration

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
@@ -14,6 +14,7 @@ import com.crosspaste.net.ws.WsPendingRequests
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.paste.PasteSyncProcessManager
 import com.crosspaste.paste.item.PasteFiles
+import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.paste.item.getFilePaths
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FilesIndexBuilder
@@ -24,6 +25,7 @@ import com.crosspaste.utils.buildUrl
 import com.crosspaste.utils.getDateUtils
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.getJsonUtils
+import com.crosspaste.utils.noOptionParent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.URLBuilder
 import io.ktor.utils.io.ByteReadChannel
@@ -109,19 +111,19 @@ class FilePullService(
                 ?: return FilePullResult.NoSyncHandler(appInstanceId)
 
         // Extension devices (e.g. Chrome) have no HTTP server — use WebSocket whole-file pull
-        if (syncHandler.getSyncPlatform().isExtension()) {
-            return pullFilesViaWs(appInstanceId, pasteId, createTime, pasteFiles)
+        return if (syncHandler.getSyncPlatform().isExtension()) {
+            pullFilesViaWs(appInstanceId, pasteId, createTime, pasteFiles)
+        } else {
+            pullFilesViaHttp(
+                appInstanceId,
+                pasteId,
+                createTime,
+                remotePasteId,
+                pasteFiles,
+                pullChunks,
+                syncHandler,
+            )
         }
-
-        return pullFilesViaHttp(
-            appInstanceId,
-            pasteId,
-            createTime,
-            remotePasteId,
-            pasteFiles,
-            pullChunks,
-            syncHandler,
-        )
     }
 
     /**
@@ -166,13 +168,13 @@ class FilePullService(
             pasteFiles.relativePathList.zip(filePaths).map { (originalName, originalPath) ->
                 val renamedName = renameMap[originalName]
                 if (renamedName != null) {
-                    originalPath.parent!! / renamedName
+                    originalPath.noOptionParent / renamedName
                 } else {
                     originalPath
                 }
             }
 
-        val hash = (pasteFiles as? com.crosspaste.paste.item.PasteItem)?.hash ?: ""
+        val hash = (pasteFiles as? PasteItem)?.hash ?: ""
         if (hash.isEmpty()) {
             logger.error { "Cannot pull files via WS: paste hash is empty for pasteId $pasteId" }
             return FilePullResult.Failure(
@@ -181,7 +183,7 @@ class FilePullService(
                         createFailureResult(
                             StandardErrorCode.PULL_FILE_TASK_FAIL,
                             "Paste hash is empty",
-                        ) as FailureResult,
+                        ),
                 ),
                 intArrayOf(),
             )

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -211,12 +211,16 @@ class SyncPasteTaskExecutor(
         // Extension devices have file size limits — skip file-type pastes that exceed them
         if (syncRuntimeInfo.platform.isExtension() && pasteData.isFileType()) {
             val pasteFiles = pasteData.getPasteItem(PasteFiles::class)
-            if (pasteFiles != null && !isWithinExtensionFileLimit(pasteFiles)) {
+            if (pasteFiles == null || !isWithinExtensionFileLimit(pasteFiles)) {
                 logger.info {
                     "Skipping file-type paste sync to extension $handlerKey: " +
-                        "file size exceeds extension limit (total=${pasteFiles.size})"
+                        if (pasteFiles == null) {
+                            "unable to resolve PasteFiles for size check"
+                        } else {
+                            "file size exceeds extension limit (total=${pasteFiles.size})"
+                        }
                 }
-                return SuccessResult() // Don't retry — this is intentional
+                return SuccessResult()
             }
         }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -20,6 +20,7 @@ import com.crosspaste.app.AppStartUpService
 import com.crosspaste.app.AppUpdateService
 import com.crosspaste.app.DesktopAppSize
 import com.crosspaste.app.DesktopAppWindowManager
+import com.crosspaste.app.DesktopPidFileService
 import com.crosspaste.app.ExitMode
 import com.crosspaste.app.NativeMessagingHostService
 import com.crosspaste.clean.CleanScheduler
@@ -159,6 +160,7 @@ class CrossPaste {
                     koin.get<PasteBonjourService>()
                     koin.get<CleanScheduler>().start()
                     koin.get<AppStartUpService>().followConfig()
+                    koin.get<DesktopPidFileService>().start()
                     koin.get<NativeMessagingHostService>().register()
                     koin.get<AppUpdateService>().start()
                     koin.get<GuidePasteDataService>().initData()

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
@@ -24,6 +24,7 @@ import com.crosspaste.app.DesktopAppRestartService
 import com.crosspaste.app.DesktopAppStartUpService
 import com.crosspaste.app.DesktopAppUpdateService
 import com.crosspaste.app.DesktopAppUrls
+import com.crosspaste.app.DesktopPidFileService
 import com.crosspaste.app.EndpointInfoFactory
 import com.crosspaste.app.NativeMessagingHostService
 import com.crosspaste.config.CommonConfigManager
@@ -97,7 +98,8 @@ fun desktopAppModule(
         single<AppPathProvider> { appPathProvider }
         single<AppRestartService> { DesktopAppRestartService(get(), get()) }
         single<AppStartUpService> { DesktopAppStartUpService(get(), get(), get(), get()) }
-        single<NativeMessagingHostService> { NativeMessagingHostService(get(), get()) }
+        single<DesktopPidFileService> { DesktopPidFileService(get(), get()) }
+        single<NativeMessagingHostService> { NativeMessagingHostService(get(), get(), get()) }
         single<AppUpdateService> { DesktopAppUpdateService(get(), get(), get(), get(), get()) }
         single<AppUrls> { DesktopAppUrls }
         single<CrossPasteWebService> { CrossPasteWebService(get(), get()) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopPidFileService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopPidFileService.kt
@@ -1,0 +1,28 @@
+package com.crosspaste.app
+
+import com.crosspaste.path.AppPathProvider
+import com.crosspaste.presist.FilePersist
+import io.github.oshai.kotlinlogging.KotlinLogging
+import okio.Path
+
+class DesktopPidFileService(
+    private val appPathProvider: AppPathProvider,
+    private val appExitService: AppExitService,
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    val pidFilePath: Path
+        get() = appPathProvider.pasteUserPath.resolve("crosspaste.pid")
+
+    fun start() {
+        val pid = ProcessHandle.current().pid().toString()
+        FilePersist
+            .createOneFilePersist(pidFilePath)
+            .saveBytes(pid.encodeToByteArray())
+        appExitService.beforeExitList.add {
+            runCatching { pidFilePath.toFile().delete() }
+        }
+        logger.info { "PID file written: $pidFilePath (pid=$pid)" }
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/NativeMessagingHostService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/NativeMessagingHostService.kt
@@ -11,6 +11,7 @@ import java.util.Properties
 
 class NativeMessagingHostService(
     private val appPathProvider: AppPathProvider,
+    private val pidFileService: DesktopPidFileService,
     private val platform: Platform,
 ) {
 
@@ -130,34 +131,39 @@ class NativeMessagingHostService(
         ).map { File(localAppData).resolve(it).toOkioPath() }
     }
 
-    private fun unixBridgeScript(): String =
-        """
-        #!/bin/bash
-        cat > /dev/null &
-        send_message() {
-            local msg="${'$'}1"
-            local len=${'$'}{#msg}
-            printf "\\x$(printf '%02x' ${'$'}((len & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 8) & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 16) & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 24) & 0xFF)))"
-            printf '%s' "${'$'}msg"
-        }
-        is_running() {
-            pgrep -x "CrossPaste" > /dev/null 2>&1 && return 0
-            pgrep -x "crosspaste" > /dev/null 2>&1 && return 0
-            pgrep -f "com.crosspaste" | grep -v ${'$'}${'$'} > /dev/null 2>&1 && return 0
-            return 1
-        }
-        while true; do
-            if ! is_running; then
-                exit 0
-            fi
-            send_message '{"status":"running"}'
-            sleep 5
-        done
-        """.trimIndent()
+    private fun unixBridgeScript(): String {
+        val pidFilePath = pidFileService.pidFilePath.toString()
+        return """
+            #!/bin/bash
+            cat > /dev/null &
+            PID_FILE="$pidFilePath"
+            send_message() {
+                local msg="${'$'}1"
+                local len=${'$'}{#msg}
+                printf "\\x$(printf '%02x' ${'$'}((len & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 8) & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 16) & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 24) & 0xFF)))"
+                printf '%s' "${'$'}msg"
+            }
+            is_running() {
+                [ -f "${'$'}PID_FILE" ] || return 1
+                local pid
+                pid=${'$'}(cat "${'$'}PID_FILE" 2>/dev/null) || return 1
+                kill -0 "${'$'}pid" 2>/dev/null
+            }
+            while true; do
+                if ! is_running; then
+                    exit 0
+                fi
+                send_message '{"status":"running"}'
+                sleep 5
+            done
+            """.trimIndent()
+    }
 
-    private fun windowsBridgeScript(): String =
-        """
-        @echo off
-        powershell -NoProfile -Command "${'$'}stdin=[Console]::OpenStandardInput(); ${'$'}null=[System.Threading.Tasks.Task]::Run({${'$'}buf=New-Object byte[] 4096; while(${'$'}stdin.Read(${'$'}buf,0,4096) -gt 0){}}); ${'$'}stdout=[Console]::OpenStandardOutput(); ${'$'}msg=[System.Text.Encoding]::UTF8.GetBytes('{\"status\":\"running\"}'); ${'$'}lenBytes=[System.BitConverter]::GetBytes(${'$'}msg.Length); while(${'$'}true){ if(-not(Get-Process -Name CrossPaste -ErrorAction SilentlyContinue)){exit}; ${'$'}stdout.Write(${'$'}lenBytes,0,4); ${'$'}stdout.Write(${'$'}msg,0,${'$'}msg.Length); ${'$'}stdout.Flush(); Start-Sleep -Seconds 5 }"
-        """.trimIndent()
+    private fun windowsBridgeScript(): String {
+        val pidFilePath = pidFileService.pidFilePath.toString().replace("/", "\\")
+        return """
+            @echo off
+            powershell -NoProfile -Command "${'$'}stdin=[Console]::OpenStandardInput(); ${'$'}null=[System.Threading.Tasks.Task]::Run({${'$'}buf=New-Object byte[] 4096; while(${'$'}stdin.Read(${'$'}buf,0,4096) -gt 0){}}); ${'$'}stdout=[Console]::OpenStandardOutput(); ${'$'}msg=[System.Text.Encoding]::UTF8.GetBytes('{\"status\":\"running\"}'); ${'$'}lenBytes=[System.BitConverter]::GetBytes(${'$'}msg.Length); ${'$'}pidFile='$pidFilePath'; while(${'$'}true){ if(-not(Test-Path ${'$'}pidFile)){exit}; ${'$'}pid=[int](Get-Content ${'$'}pidFile -ErrorAction SilentlyContinue); if(-not(Get-Process -Id ${'$'}pid -ErrorAction SilentlyContinue)){exit}; ${'$'}stdout.Write(${'$'}lenBytes,0,4); ${'$'}stdout.Write(${'$'}msg,0,${'$'}msg.Length); ${'$'}stdout.Flush(); Start-Sleep -Seconds 5 }"
+            """.trimIndent()
+    }
 }

--- a/web/src/background/native-host.ts
+++ b/web/src/background/native-host.ts
@@ -1,5 +1,6 @@
 const NATIVE_HOST_NAME = "com.crosspaste.desktop";
-const RECONNECT_INTERVAL_MS = 10_000;
+const RECONNECT_BASE_MS = 10_000;
+const RECONNECT_MAX_MS = 60_000;
 
 type NativeHostCallbacks = {
   onDesktopConnected: () => void;
@@ -11,6 +12,7 @@ let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let callbacks: NativeHostCallbacks | null = null;
 let desktopConnected = false;
 let initialResolve: ((connected: boolean) => void) | null = null;
+let reconnectDelay = RECONNECT_BASE_MS;
 
 export function isDesktopConnected(): boolean {
   return desktopConnected;
@@ -31,6 +33,7 @@ function attemptConnect(): void {
     port.onMessage.addListener((_msg: unknown) => {
       if (!desktopConnected) {
         desktopConnected = true;
+        reconnectDelay = RECONNECT_BASE_MS;
         if (initialResolve) {
           initialResolve(true);
           initialResolve = null;
@@ -61,8 +64,10 @@ function attemptConnect(): void {
 
 function scheduleReconnect(): void {
   if (reconnectTimer) clearTimeout(reconnectTimer);
+  const delay = reconnectDelay;
+  reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX_MS);
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
     attemptConnect();
-  }, RECONNECT_INTERVAL_MS);
+  }, delay);
 }

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -167,7 +167,8 @@ async function pollClipboard(): Promise<void> {
     if ((await ingestPaste(pasteData, broadcastToSidePanel)) !== null) {
       await pushPasteToDevices(pasteData);
     }
-  } catch {
+  } catch (e) {
+    console.error("[pollClipboard] error:", e);
     offscreenReady = false;
   }
 }
@@ -206,10 +207,14 @@ function pauseForDesktop(): void {
 function resumeFromDesktop(): void {
   console.log("[NativeMessaging] Desktop app disconnected, resuming extension");
   startClipboardPolling();
-  DeviceStore.getAll().then((devices) => {
+  DeviceStore.getAll().then(async (devices) => {
     if (devices.some((d) => d.trusted)) {
       startSyncAlarms();
-      wsManager?.connectAllDevices();
+      if (!wsManager) {
+        await initializeWebSocket();
+      } else {
+        await wsManager.connectAllDevices();
+      }
     }
   });
   broadcastToSidePanel({ type: "DESKTOP_STATUS_CHANGED", connected: false });
@@ -624,10 +629,22 @@ async function handleDownloadFile(hash: string, fileName: string): Promise<unkno
   const blob = new Blob([data]);
   const url = URL.createObjectURL(blob);
   try {
-    await chrome.downloads.download({ url, filename: fileName, saveAs: true });
+    const downloadId = await chrome.downloads.download({ url, filename: fileName, saveAs: true });
+
+    const listener = (delta: chrome.downloads.DownloadDelta) => {
+      if (delta.id !== downloadId) return;
+      const state = delta.state?.current;
+      if (state === "complete" || state === "interrupted") {
+        chrome.downloads.onChanged.removeListener(listener);
+        URL.revokeObjectURL(url);
+      }
+    };
+    chrome.downloads.onChanged.addListener(listener);
+
     return { success: true };
-  } finally {
-    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  } catch (e) {
+    URL.revokeObjectURL(url);
+    return { success: false, error: String(e) };
   }
 }
 

--- a/web/src/shared/hooks/use-image-url.ts
+++ b/web/src/shared/hooks/use-image-url.ts
@@ -66,6 +66,11 @@ export function useImageUrl(
 
     return () => {
       cancelled = true;
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = undefined;
+        loadedHashRef.current = undefined;
+      }
     };
   }, [hash, fileName, dataUrl, blobVersion]);
 


### PR DESCRIPTION
Closes #4177

## Summary

- **SyncPasteTaskExecutor**: Treat null `PasteFiles` as unverifiable size → skip sync to extension instead of silently bypassing the check
- **native-host.ts**: Add exponential backoff for reconnection (10s → 20s → 40s → 60s cap), reset on successful connection
- **service-worker.ts `resumeFromDesktop`**: Initialize `wsManager` via `initializeWebSocket()` if not yet created, instead of silently no-op
- **service-worker.ts `handleDownloadFile`**: Replace fixed 60s timeout with `chrome.downloads.onChanged` listener to revoke URL on completion/interruption
- **use-image-url.ts**: Revoke object URLs eagerly on effect cleanup (hash change), not only on unmount
- **NativeMessagingHostService**: Replace fragile `pgrep -x` with PID file approach — new `DesktopPidFileService` writes `crosspaste.pid` on startup, deletes on exit
- **service-worker.ts `pollClipboard`**: Log errors instead of swallowing them silently

## Test plan

- [ ] Verify native messaging bridge detects desktop app running/stopped via PID file
- [ ] Confirm reconnection backoff increases when desktop is unavailable (check console logs)
- [ ] Test `resumeFromDesktop` when `wsManager` was never initialized (no trusted devices at startup, then desktop disconnects)
- [ ] Download a large file from paste list — verify URL is not revoked prematurely
- [ ] Cancel a download — verify URL is revoked immediately
- [ ] Scroll through paste list with many images — verify no object URL memory leak
- [ ] Sync a file-type paste to extension when `PasteFiles` is null — verify it's skipped with log message