### PR TITLE
:hammer: Code quality improvements for Chrome extension and WebSocket file pull

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessageHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessageHandler.kt
@@ -143,7 +143,7 @@ class WsMessageHandler(
             return
         }
 
-        runCatching {
+        withErrorResponse(appInstanceId, requestId, "FILE_PULL_REQUEST") {
             val request = json.decodeFromString<WsPullFileRequest>(envelope.payload.decodeToString())
             logger.debug { "FILE_PULL_REQUEST from $appInstanceId: $request" }
 
@@ -151,30 +151,26 @@ class WsMessageHandler(
                 syncRoutingApi.getSyncHandler(appInstanceId) ?: run {
                     logger.error { "FILE_PULL_REQUEST: no sync handler for $appInstanceId" }
                     sendErrorResponse(appInstanceId, requestId, "No sync handler")
-                    return
+                    return@withErrorResponse
                 }
 
             if (!syncHandler.currentSyncRuntimeInfo.allowSend) {
                 logger.debug { "FILE_PULL_REQUEST from $appInstanceId: not allow send" }
                 sendErrorResponse(appInstanceId, requestId, "Not allowed to send")
-                return
+                return@withErrorResponse
             }
 
-            if (request.isChunkMode()) {
-                serveFileChunk(appInstanceId, requestId, request)
-            } else {
-                serveWholeFile(appInstanceId, requestId, request)
+            when (request) {
+                is WsPullFileRequest.ChunkRequest -> serveFileChunk(appInstanceId, requestId, request)
+                is WsPullFileRequest.WholeFileRequest -> serveWholeFile(appInstanceId, requestId, request)
             }
-        }.onFailure { e ->
-            logger.error(e) { "FILE_PULL_REQUEST from $appInstanceId failed" }
-            runCatching { sendErrorResponse(appInstanceId, requestId, "Internal error: ${e.message}") }
         }
     }
 
     private suspend fun serveFileChunk(
         appInstanceId: String,
         requestId: String,
-        request: WsPullFileRequest,
+        request: WsPullFileRequest.ChunkRequest,
     ) {
         val filesIndex =
             cacheManager.getFilesIndex(request.id) ?: run {
@@ -211,13 +207,8 @@ class WsMessageHandler(
     private suspend fun serveWholeFile(
         appInstanceId: String,
         requestId: String,
-        request: WsPullFileRequest,
+        request: WsPullFileRequest.WholeFileRequest,
     ) {
-        if (request.fileName.isEmpty()) {
-            sendErrorResponse(appInstanceId, requestId, "Missing fileName in whole-file request")
-            return
-        }
-
         val pasteData =
             pasteDao.getNoDeletePasteData(request.id) ?: run {
                 logger.error { "FILE_PULL_REQUEST whole-file: paste not found for id=${request.id}" }
@@ -285,6 +276,24 @@ class WsMessageHandler(
         }
         if (!wsPendingRequests.complete(requestId, envelope)) {
             logger.warn { "FILE_PULL_RESPONSE: no pending request for requestId=$requestId" }
+        }
+    }
+
+    private suspend inline fun withErrorResponse(
+        appInstanceId: String,
+        requestId: String,
+        label: String,
+        block: () -> Unit,
+    ) {
+        try {
+            block()
+        } catch (e: Exception) {
+            logger.error(e) { "$label from $appInstanceId failed" }
+            try {
+                sendErrorResponse(appInstanceId, requestId, "Internal error: ${e.message}")
+            } catch (sendError: Exception) {
+                logger.error(sendError) { "$label: failed to send error response to $appInstanceId" }
+            }
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsPendingRequests.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsPendingRequests.kt
@@ -65,7 +65,7 @@ class WsPendingRequests {
         requestId: String,
         response: WsEnvelope,
     ): Boolean {
-        val deferred = pending[requestId]
+        val deferred = pending.remove(requestId)
         if (deferred != null) {
             deferred.complete(response)
             return true

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
@@ -126,6 +126,29 @@ class FilePullService(
         }
     }
 
+    private fun resolveLocalPaths(
+        appInstanceId: String,
+        createTime: Long,
+        pasteId: Long,
+        pasteFiles: PasteFiles,
+        filesIndexBuilder: FilesIndexBuilder?,
+        resolveConflicts: Boolean,
+    ): Map<String, String> {
+        val dateString =
+            dateUtils.getYMD(
+                dateUtils.epochMillisecondsToLocalDateTime(createTime),
+            )
+        return userDataPathProvider.resolve(
+            appInstanceId,
+            dateString,
+            pasteId,
+            pasteFiles,
+            true,
+            filesIndexBuilder,
+            resolveConflicts = resolveConflicts,
+        )
+    }
+
     /**
      * Pull files from a Chrome extension via WebSocket using whole-file mode.
      * Chrome files are always ≤ 1MB, so no chunking is needed.
@@ -137,23 +160,8 @@ class FilePullService(
         createTime: Long,
         pasteFiles: PasteFiles,
     ): FilePullResult {
-        val dateString =
-            dateUtils.getYMD(
-                dateUtils.epochMillisecondsToLocalDateTime(createTime),
-            )
-
-        // Resolve target paths and create empty placeholder files.
-        // Pass null for filesIndexBuilder — we don't need chunk indexing in whole-file mode.
         val renameMap =
-            userDataPathProvider.resolve(
-                appInstanceId,
-                dateString,
-                pasteId,
-                pasteFiles,
-                true,
-                null,
-                resolveConflicts = true,
-            )
+            resolveLocalPaths(appInstanceId, createTime, pasteId, pasteFiles, null, true)
 
         // Build a map from original file name → actual disk path (accounting for renames)
         val filePaths = pasteFiles.getFilePaths(userDataPathProvider)
@@ -200,7 +208,7 @@ class FilePullService(
 
             runCatching {
                 val request =
-                    WsPullFileRequest(
+                    WsPullFileRequest.WholeFileRequest(
                         hash = hash,
                         fileName = requestFileName,
                     )
@@ -257,22 +265,10 @@ class FilePullService(
         pullChunks: IntArray,
         syncHandler: SyncHandler,
     ): FilePullResult {
-        val dateString =
-            dateUtils.getYMD(
-                dateUtils.epochMillisecondsToLocalDateTime(createTime),
-            )
         val isRetry = pullChunks.isNotEmpty()
         val filesIndexBuilder = FilesIndexBuilder(CHUNK_SIZE)
         val renameMap =
-            userDataPathProvider.resolve(
-                appInstanceId,
-                dateString,
-                pasteId,
-                pasteFiles,
-                true,
-                filesIndexBuilder,
-                resolveConflicts = !isRetry,
-            )
+            resolveLocalPaths(appInstanceId, createTime, pasteId, pasteFiles, filesIndexBuilder, !isRetry)
         val filesIndex = filesIndexBuilder.build()
 
         if (filesIndex.getChunkCount() == 0) {

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/pull/WsPullFileRequest.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/pull/WsPullFileRequest.kt
@@ -1,29 +1,32 @@
 package com.crosspaste.dto.pull
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 
 /**
- * WebSocket file pull request supporting two modes:
+ * WebSocket file pull request — two modes expressed as a sealed hierarchy.
  *
- * **Chunk mode** (pulling from Desktop): `id` + `chunkIndex` ≥ 0
- * Uses the same chunk system as HTTP pull — each chunk ≤ 1MB.
- *
- * **Whole-file mode** (pulling from Chrome extension): `hash` + `fileName`
- * Requests an entire file by paste hash and name. Chrome files are always ≤ 1MB.
+ * **Chunk mode** (Desktop ↔ Desktop): [ChunkRequest] with `id` + `chunkIndex`.
+ * **Whole-file mode** (Desktop ↔ Chrome extension): [WholeFileRequest] with `fileName`
+ *   plus `id` (Desktop-side lookup) or `hash` (Chrome-side lookup).
  */
 @Serializable
-data class WsPullFileRequest(
-    val id: Long = 0,
-    val chunkIndex: Int = -1,
-    val hash: String = "",
-    val fileName: String = "",
-) {
-    fun isChunkMode(): Boolean = chunkIndex >= 0
+@JsonClassDiscriminator("mode")
+sealed class WsPullFileRequest {
 
-    override fun toString(): String =
-        if (isChunkMode()) {
-            "WsPullFileRequest(chunk: id=$id, chunkIndex=$chunkIndex)"
-        } else {
-            "WsPullFileRequest(file: hash=$hash, fileName=$fileName)"
-        }
+    @Serializable
+    @SerialName("chunk")
+    data class ChunkRequest(
+        val id: Long,
+        val chunkIndex: Int,
+    ) : WsPullFileRequest()
+
+    @Serializable
+    @SerialName("whole")
+    data class WholeFileRequest(
+        val id: Long = 0,
+        val hash: String = "",
+        val fileName: String,
+    ) : WsPullFileRequest()
 }

--- a/web/src/shared/hooks/use-blob-data.ts
+++ b/web/src/shared/hooks/use-blob-data.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect } from "react";
+import { BlobStore } from "@/shared/storage/blob-store";
+
+let bridgeInitialized = false;
+
+function initChromeMessageBridge() {
+  if (bridgeInitialized) return;
+  bridgeInitialized = true;
+  chrome.runtime.onMessage.addListener((message: Record<string, unknown>) => {
+    if (message.type === "BLOBS_READY" && typeof message.hash === "string") {
+      BlobStore.notifyChange(message.hash);
+    }
+  });
+}
+
+export function useBlobData(
+  hash: string | undefined,
+  fileName: string | undefined,
+): ArrayBuffer | undefined {
+  const [data, setData] = useState<ArrayBuffer | undefined>(undefined);
+
+  useEffect(() => {
+    initChromeMessageBridge();
+  }, []);
+
+  useEffect(() => {
+    if (!hash || !fileName) return;
+
+    let cancelled = false;
+
+    const load = () => {
+      BlobStore.get(hash, fileName).then((result) => {
+        if (!cancelled && result) setData(result);
+      });
+    };
+
+    load();
+
+    const unsubscribe = BlobStore.subscribe(hash, load);
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [hash, fileName]);
+
+  return data;
+}

--- a/web/src/shared/hooks/use-image-url.ts
+++ b/web/src/shared/hooks/use-image-url.ts
@@ -1,86 +1,15 @@
-import { useState, useEffect, useRef } from "react";
-import { BlobStore } from "@/shared/storage/blob-store";
 import type { ImagesPasteItem } from "@/shared/models/paste-item";
-
-function mimeFromExt(fileName: string): string | undefined {
-  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
-  const mimeMap: Record<string, string> = {
-    png: "image/png",
-    jpg: "image/jpeg",
-    jpeg: "image/jpeg",
-    gif: "image/gif",
-    webp: "image/webp",
-    svg: "image/svg+xml",
-    bmp: "image/bmp",
-    ico: "image/x-icon",
-    tiff: "image/tiff",
-    tif: "image/tiff",
-  };
-  return mimeMap[ext];
-}
+import { useBlobData } from "./use-blob-data";
+import { useObjectUrl } from "./use-object-url";
 
 export function useImageUrl(
   hash: string | undefined,
   fileName: string | undefined,
   dataUrl: string | undefined,
 ): string | undefined {
-  const [url, setUrl] = useState<string | undefined>(dataUrl);
-  const [blobVersion, setBlobVersion] = useState(0);
-
-  useEffect(() => {
-    if (!hash) return;
-    const listener = (message: Record<string, unknown>) => {
-      if (message.type === "BLOBS_READY" && message.hash === hash) {
-        setBlobVersion((v) => v + 1);
-      }
-    };
-    chrome.runtime.onMessage.addListener(listener);
-    return () => chrome.runtime.onMessage.removeListener(listener);
-  }, [hash]);
-
-  const loadedHashRef = useRef<string | undefined>(undefined);
-  const objectUrlRef = useRef<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (dataUrl) {
-      setUrl(dataUrl);
-      return;
-    }
-    if (!hash || !fileName) return;
-
-    if (loadedHashRef.current === hash && objectUrlRef.current) {
-      return;
-    }
-
-    let cancelled = false;
-
-    BlobStore.get(hash, fileName).then((data) => {
-      if (cancelled || !data) return;
-      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
-      const mime = mimeFromExt(fileName);
-      const blob = mime ? new Blob([data], { type: mime }) : new Blob([data]);
-      objectUrlRef.current = URL.createObjectURL(blob);
-      loadedHashRef.current = hash;
-      setUrl(objectUrlRef.current);
-    });
-
-    return () => {
-      cancelled = true;
-      if (objectUrlRef.current) {
-        URL.revokeObjectURL(objectUrlRef.current);
-        objectUrlRef.current = undefined;
-        loadedHashRef.current = undefined;
-      }
-    };
-  }, [hash, fileName, dataUrl, blobVersion]);
-
-  useEffect(() => {
-    return () => {
-      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
-    };
-  }, []);
-
-  return url;
+  const blobData = useBlobData(dataUrl ? undefined : hash, dataUrl ? undefined : fileName);
+  const objectUrl = useObjectUrl(blobData, fileName);
+  return dataUrl ?? objectUrl;
 }
 
 export function useImageItemUrl(item: ImagesPasteItem): string | undefined {

--- a/web/src/shared/hooks/use-object-url.ts
+++ b/web/src/shared/hooks/use-object-url.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useRef } from "react";
+
+const MIME_MAP: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+  tiff: "image/tiff",
+  tif: "image/tiff",
+};
+
+function mimeFromExt(fileName: string): string | undefined {
+  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+  return MIME_MAP[ext];
+}
+
+export function useObjectUrl(
+  data: ArrayBuffer | undefined,
+  fileName: string | undefined,
+): string | undefined {
+  const [url, setUrl] = useState<string | undefined>(undefined);
+  const objectUrlRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!data || !fileName) {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = undefined;
+      }
+      setUrl(undefined);
+      return;
+    }
+
+    if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    const mime = mimeFromExt(fileName);
+    const blob = mime ? new Blob([data], { type: mime }) : new Blob([data]);
+    objectUrlRef.current = URL.createObjectURL(blob);
+    setUrl(objectUrlRef.current);
+
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = undefined;
+      }
+    };
+  }, [data, fileName]);
+
+  return url;
+}

--- a/web/src/shared/paste/__tests__/remove-html-image-plugin.test.ts
+++ b/web/src/shared/paste/__tests__/remove-html-image-plugin.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { isSingleImgInBody } from "../plugin/remove-html-image-plugin";
+import { RemoveHtmlImagePlugin } from "../plugin/remove-html-image-plugin";
+import { PasteTypeInt } from "@/shared/models/paste-item";
+import type { TypedItem, PasteProcessContext } from "../plugin/paste-process-plugin";
+
+// ─── isSingleImgInBody ───────────────────────────────────────────────
+
+describe("isSingleImgInBody", () => {
+  it("returns true for a bare <img> tag", () => {
+    expect(isSingleImgInBody('<img src="x.png">')).toBe(true);
+  });
+
+  it("returns true for <img> wrapped in tags with no text", () => {
+    expect(isSingleImgInBody("<html><body><img src='x.png'></body></html>")).toBe(true);
+    expect(isSingleImgInBody("<div><p><img src='x.png' /></p></div>")).toBe(true);
+  });
+
+  it("returns false when there is visible text alongside <img>", () => {
+    expect(isSingleImgInBody("<div>Hello<img src='x.png'></div>")).toBe(false);
+    expect(isSingleImgInBody("<img src='x.png'>caption")).toBe(false);
+  });
+
+  it("returns false when there are multiple <img> tags", () => {
+    expect(isSingleImgInBody("<img src='a.png'><img src='b.png'>")).toBe(false);
+  });
+
+  it("returns false when there are zero <img> tags", () => {
+    expect(isSingleImgInBody("<div>no images here</div>")).toBe(false);
+    expect(isSingleImgInBody("")).toBe(false);
+  });
+
+  it("ignores <img> inside HTML comments", () => {
+    expect(isSingleImgInBody("<!-- <img src='x.png'> -->")).toBe(false);
+    expect(isSingleImgInBody("<!-- <img src='a'> --><img src='b'>")).toBe(true);
+  });
+
+  it("ignores text inside HTML comments", () => {
+    expect(isSingleImgInBody("<!-- some text --><img src='x.png'>")).toBe(true);
+  });
+
+  it("handles self-closing <img /> tags", () => {
+    expect(isSingleImgInBody("<img />")).toBe(true);
+    expect(isSingleImgInBody("<img/>")).toBe(true);
+  });
+
+  it("is case-insensitive for tag name", () => {
+    expect(isSingleImgInBody("<IMG src='x.png'>")).toBe(true);
+    expect(isSingleImgInBody("<Img src='x.png'>")).toBe(true);
+  });
+
+  it("treats whitespace-only text as empty", () => {
+    expect(isSingleImgInBody("  <img src='x.png'>  ")).toBe(true);
+    expect(isSingleImgInBody("\n\t<img src='x.png'>\n")).toBe(true);
+  });
+});
+
+// ─── RemoveHtmlImagePlugin.process ───────────────────────────────────
+
+describe("RemoveHtmlImagePlugin", () => {
+  const plugin = new RemoveHtmlImagePlugin();
+  const ctx: PasteProcessContext = {};
+
+  function htmlItem(html: string): TypedItem {
+    return { pasteType: PasteTypeInt.HTML, item: { html } };
+  }
+
+  const imageItem: TypedItem = {
+    pasteType: PasteTypeInt.IMAGE,
+    item: { dataUrl: "data:image/png;base64,AA==" },
+  };
+
+  it("removes HTML item when it is a single-img wrapper and IMAGE is present", () => {
+    const items = [htmlItem("<div><img src='x.png'></div>"), imageItem];
+    const result = plugin.process(items, ctx);
+    expect(result).toEqual([imageItem]);
+  });
+
+  it("keeps HTML item when it contains text alongside <img>", () => {
+    const items = [htmlItem("<div>Hello<img src='x.png'></div>"), imageItem];
+    const result = plugin.process(items, ctx);
+    expect(result).toEqual(items);
+  });
+
+  it("keeps HTML item when no IMAGE item is present", () => {
+    const items = [htmlItem("<img src='x.png'>")];
+    const result = plugin.process(items, ctx);
+    expect(result).toEqual(items);
+  });
+
+  it("does not remove HTML when <img> is inside a comment", () => {
+    const items = [htmlItem("<!-- <img src='x.png'> -->"), imageItem];
+    const result = plugin.process(items, ctx);
+    expect(result).toEqual(items);
+  });
+});

--- a/web/src/shared/paste/paste-collector.ts
+++ b/web/src/shared/paste/paste-collector.ts
@@ -1,23 +1,11 @@
 import { PasteTypeInt } from "@/shared/models/paste-item";
 import type { PasteItem } from "@/shared/models/paste-item";
 import type { PasteCollection } from "@/shared/models/paste-data";
-import { detectPasteType, parseColor } from "./paste-type-detector";
+import { detectPasteType } from "./paste-type-detector";
 import type { PasteProcessPlugin, TypedItem } from "./plugin/paste-process-plugin";
 import { RemoveHtmlImagePlugin } from "./plugin/remove-html-image-plugin";
-
-/**
- * Priority map matching desktop's PasteType.kt.
- * Higher value = higher priority = becomes pasteAppearItem.
- */
-const PRIORITY: Record<number, number> = {
-  [PasteTypeInt.TEXT]: 0,
-  [PasteTypeInt.URL]: 1,
-  [PasteTypeInt.IMAGE]: 2,
-  [PasteTypeInt.RTF]: 3,
-  [PasteTypeInt.HTML]: 4,
-  [PasteTypeInt.COLOR]: 5,
-  [PasteTypeInt.FILE]: 6,
-};
+import { SortPlugin } from "./plugin/sort-plugin";
+import { TextToColorPlugin } from "./plugin/text-to-color-plugin";
 
 interface ClipboardFileInfo {
   name: string;
@@ -174,26 +162,10 @@ function collectTextItem(text: string, hashText: HashFn): TypedItem {
   return { pasteType: detected.pasteType, item: detected.pasteItem };
 }
 
-function collectTextToColorItem(text: string, existing: TypedItem[], hashText: HashFn): TypedItem | null {
-  if (existing.some((i) => i.pasteType === PasteTypeInt.COLOR)) return null;
-  const trimmed = text.trim();
-  if (trimmed.includes("\n")) return null;
-  const colorValue = parseColor(trimmed);
-  if (colorValue === null) return null;
-  return {
-    pasteType: PasteTypeInt.COLOR,
-    item: {
-      type: "color",
-      identifiers: ["text/plain"],
-      hash: hashText(trimmed),
-      size: new TextEncoder().encode(trimmed).length,
-      color: colorValue,
-    },
-  };
-}
-
 const pasteProcessPlugins: PasteProcessPlugin[] = [
   new RemoveHtmlImagePlugin(),
+  new TextToColorPlugin(),
+  new SortPlugin(),
 ];
 
 /**
@@ -228,17 +200,11 @@ export function collectPasteItems(
 
   if (items.length === 0) return null;
 
+  const context = { hashText };
   let processedItems: TypedItem[] = items;
   for (const plugin of pasteProcessPlugins) {
-    processedItems = plugin.process(processedItems);
+    processedItems = plugin.process(processedItems, context);
   }
-
-  if (result.text) {
-    const colorItem = collectTextToColorItem(result.text, processedItems, hashText);
-    if (colorItem) processedItems.push(colorItem);
-  }
-
-  processedItems.sort((a, b) => (PRIORITY[b.pasteType] ?? 0) - (PRIORITY[a.pasteType] ?? 0));
 
   const appearItem = processedItems[0];
   const collectionItems = processedItems.slice(1).map((i) => i.item);

--- a/web/src/shared/paste/plugin/paste-process-plugin.ts
+++ b/web/src/shared/paste/plugin/paste-process-plugin.ts
@@ -5,6 +5,10 @@ export interface TypedItem {
   item: PasteItem;
 }
 
+export interface PasteProcessContext {
+  hashText: (s: string) => string;
+}
+
 export interface PasteProcessPlugin {
-  process(items: TypedItem[]): TypedItem[];
+  process(items: TypedItem[], context: PasteProcessContext): TypedItem[];
 }

--- a/web/src/shared/paste/plugin/remove-html-image-plugin.ts
+++ b/web/src/shared/paste/plugin/remove-html-image-plugin.ts
@@ -1,15 +1,20 @@
 import { PasteTypeInt } from "@/shared/models/paste-item";
-import type { PasteProcessPlugin, TypedItem } from "./paste-process-plugin";
+import type { PasteProcessContext, PasteProcessPlugin, TypedItem } from "./paste-process-plugin";
 
-function isSingleImgInBody(html: string): boolean {
-  const imgCount = (html.match(/<img[\s>]/gi) || []).length;
+function stripComments(html: string): string {
+  return html.replace(/<!--[\s\S]*?-->/g, "");
+}
+
+export function isSingleImgInBody(html: string): boolean {
+  const stripped = stripComments(html);
+  const imgCount = (stripped.match(/<img[\s/>]/gi) || []).length;
   if (imgCount !== 1) return false;
-  const textContent = html.replace(/<[^>]*>/g, "").trim();
+  const textContent = stripped.replace(/<[^>]*>/g, "").trim();
   return textContent.length === 0;
 }
 
 export class RemoveHtmlImagePlugin implements PasteProcessPlugin {
-  process(items: TypedItem[]): TypedItem[] {
+  process(items: TypedItem[], _context: PasteProcessContext): TypedItem[] {
     const hasImage = items.some((i) => i.pasteType === PasteTypeInt.IMAGE);
     if (!hasImage) return items;
     const htmlItem = items.find((i) => i.pasteType === PasteTypeInt.HTML);

--- a/web/src/shared/paste/plugin/sort-plugin.ts
+++ b/web/src/shared/paste/plugin/sort-plugin.ts
@@ -1,0 +1,18 @@
+import { PasteTypeInt } from "@/shared/models/paste-item";
+import type { PasteProcessContext, PasteProcessPlugin, TypedItem } from "./paste-process-plugin";
+
+const PRIORITY: Record<number, number> = {
+  [PasteTypeInt.TEXT]: 0,
+  [PasteTypeInt.URL]: 1,
+  [PasteTypeInt.IMAGE]: 2,
+  [PasteTypeInt.RTF]: 3,
+  [PasteTypeInt.HTML]: 4,
+  [PasteTypeInt.COLOR]: 5,
+  [PasteTypeInt.FILE]: 6,
+};
+
+export class SortPlugin implements PasteProcessPlugin {
+  process(items: TypedItem[], _context: PasteProcessContext): TypedItem[] {
+    return [...items].sort((a, b) => (PRIORITY[b.pasteType] ?? 0) - (PRIORITY[a.pasteType] ?? 0));
+  }
+}

--- a/web/src/shared/paste/plugin/text-to-color-plugin.ts
+++ b/web/src/shared/paste/plugin/text-to-color-plugin.ts
@@ -1,0 +1,33 @@
+import { PasteTypeInt } from "@/shared/models/paste-item";
+import { parseColor } from "@/shared/paste/paste-type-detector";
+import type { PasteProcessContext, PasteProcessPlugin, TypedItem } from "./paste-process-plugin";
+
+export class TextToColorPlugin implements PasteProcessPlugin {
+  process(items: TypedItem[], context: PasteProcessContext): TypedItem[] {
+    if (items.some((i) => i.pasteType === PasteTypeInt.COLOR)) return items;
+
+    const textItem = items.find((i) => i.pasteType === PasteTypeInt.TEXT || i.pasteType === PasteTypeInt.URL);
+    if (!textItem) return items;
+
+    const text = (textItem.item as { text?: string }).text ?? "";
+    const trimmed = text.trim();
+    if (trimmed.includes("\n")) return items;
+
+    const colorValue = parseColor(trimmed);
+    if (colorValue === null) return items;
+
+    return [
+      ...items,
+      {
+        pasteType: PasteTypeInt.COLOR,
+        item: {
+          type: "color",
+          identifiers: (textItem.item as { identifiers: string[] }).identifiers,
+          hash: context.hashText(trimmed),
+          size: new TextEncoder().encode(trimmed).length,
+          color: colorValue,
+        },
+      },
+    ];
+  }
+}

--- a/web/src/shared/storage/blob-store.ts
+++ b/web/src/shared/storage/blob-store.ts
@@ -1,7 +1,6 @@
-// TODO: When a second consumer needs blob-change notifications (e.g. file preview, audio),
-// add an onChange(hash, callback) subscription API here so hooks subscribe directly to
-// BlobStore instead of each listening to chrome.runtime.onMessage independently.
 import { openDB, type IDBPDatabase } from "idb";
+
+const changeListeners = new Map<string, Set<() => void>>();
 
 const DB_NAME = "crosspaste-blobs";
 const STORE_NAME = "blobs";
@@ -83,5 +82,21 @@ export const BlobStore = {
   async clear(): Promise<void> {
     const db = await getDb();
     await db.clear(STORE_NAME);
+  },
+
+  subscribe(hash: string, cb: () => void): () => void {
+    if (!changeListeners.has(hash)) changeListeners.set(hash, new Set());
+    changeListeners.get(hash)!.add(cb);
+    return () => {
+      const set = changeListeners.get(hash);
+      if (set) {
+        set.delete(cb);
+        if (set.size === 0) changeListeners.delete(hash);
+      }
+    };
+  },
+
+  notifyChange(hash: string): void {
+    changeListeners.get(hash)?.forEach((cb) => cb());
   },
 };

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -6,13 +6,21 @@ import { BlobStore } from "@/shared/storage/blob-store";
 import { ingestPaste } from "@/shared/paste/paste-ingestion";
 import { writeRemotePasteToClipboard } from "@/shared/clipboard/clipboard-sync-writer";
 
-/** Payload of a FILE_PULL_REQUEST message (matches Kotlin WsPullFileRequest). */
-interface WsPullFileRequest {
+/** Payload of a FILE_PULL_REQUEST message (matches Kotlin WsPullFileRequest sealed class). */
+interface WsChunkRequest {
+  mode: "chunk";
   id: number;
   chunkIndex: number;
-  hash: string;
+}
+
+interface WsWholeFileRequest {
+  mode: "whole";
+  id?: number;
+  hash?: string;
   fileName: string;
 }
+
+type WsPullFileRequest = WsChunkRequest | WsWholeFileRequest;
 
 export interface WsMessageHandlerDeps {
   /** Send an envelope back to the device that sent the message. */
@@ -112,7 +120,11 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
       const request: WsPullFileRequest = JSON.parse(new TextDecoder().decode(envelope.payload));
       console.log(`[WsHandler] FILE_PULL_REQUEST from ${appInstanceId}:`, request);
 
-      // Whole-file mode: retrieve blob by hash + fileName
+      if (request.mode !== "whole") {
+        await sendErrorResponse(appInstanceId, requestId, "Chrome extension only supports whole-file mode");
+        return;
+      }
+
       if (!request.hash || !request.fileName) {
         await sendErrorResponse(appInstanceId, requestId, "Missing hash or fileName");
         return;
@@ -183,9 +195,9 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
 
         try {
           const bareFileName = fileName.includes("/") ? fileName.split("/").pop() || fileName : fileName;
-          const request = {
+          const request: WsWholeFileRequest = {
+            mode: "whole",
             id: pasteData.id,
-            chunkIndex: -1,
             hash,
             fileName: bareFileName,
           };
@@ -217,6 +229,7 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
       }
 
       if (pulledAny) {
+        BlobStore.notifyChange(hash);
         deps.broadcastToSidePanel({ type: "BLOBS_READY", hash });
       }
     }


### PR DESCRIPTION
Closes #4179

## Summary

- **`WsPullFileRequest` → sealed class hierarchy** with `ChunkRequest`/`WholeFileRequest` subtypes using `@JsonClassDiscriminator("mode")`, eliminating `isChunkMode()` boolean dispatch and invalid field combinations
- **`WsMessageHandler.withErrorResponse`** — extract nested `runCatching` into reusable inline helper with proper error logging
- **`WsPendingRequests.complete`** — use `remove()` instead of `get()` for atomic cleanup
- **`FilePullService.resolveLocalPaths`** — extract duplicated path resolution logic
- **`RemoveHtmlImagePlugin`** — strip HTML comments before regex matching; support `<img/>` self-closing; add 14 unit tests
- **Paste plugin pipeline refactor** — extract `SortPlugin`, `TextToColorPlugin` from inline logic; add `PasteProcessContext` interface
- **`useImageUrl` decomposition** — split into composable `useBlobData` + `useObjectUrl` hooks
- **`BlobStore.subscribe/notifyChange`** — replace broadcast-based blob notifications with direct subscription API
- **`ws-message-handler.ts`** — typed request interfaces matching Kotlin sealed class discriminator

## Test plan

- [x] 14 new unit tests for `RemoveHtmlImagePlugin` (all passing)
- [ ] Verify Kotlin compilation succeeds (`./gradlew app:compileKotlinDesktop`)
- [ ] Verify Chrome extension paste + file sync still works end-to-end
- [ ] Verify Desktop ↔ Desktop chunk-mode file pull still works