### PR TITLE
:hammer: Refactor addSyncTask to accept targetAppInstanceIds as Set<String> (#4181)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
@@ -101,7 +101,10 @@ class PasteCollector(
             }
         }
 
-    suspend fun completeCollect(id: Long) {
+    suspend fun completeCollect(
+        id: Long,
+        targetAppInstanceIds: Set<String> = emptySet(),
+    ) {
         logSuspendExecutionTime(logger, "completeCollect") {
             val activeIndices = preCollectors.indices.filter { preCollectors[it].isNotEmpty() }
             if (activeIndices.isEmpty() || (existError && activeIndices.all { updateErrors[it] != null })) {
@@ -121,7 +124,7 @@ class PasteCollector(
                                 }
                             }
                     }
-                    pasteReleaseService.releaseLocalPasteData(id, pasteItems)
+                    pasteReleaseService.releaseLocalPasteData(id, pasteItems, targetAppInstanceIds)
                 }.onFailure { e ->
                     logger.error(e) { "Failed to complete paste $id" }
                     markDeletePasteData(id)

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -65,6 +65,7 @@ class PasteReleaseService(
     suspend fun releaseLocalPasteData(
         id: Long,
         pasteItems: List<PasteItem>,
+        targetAppInstanceIds: Set<String>,
     ) = withContext(ioDispatcher) {
         pasteDao.getLoadingPasteData(id)?.let { pasteData ->
             var pasteAppearItems = pasteItems
@@ -122,7 +123,7 @@ class PasteReleaseService(
                     // These items are already from another device, so re-syncing them would cause
                     // unnecessary duplication or sync loops.
                     if (!pasteData.remote) {
-                        addSyncTask(id, maxFileSize, pasteData.appInstanceId)
+                        addSyncTask(id, maxFileSize, pasteData.appInstanceId, targetAppInstanceIds)
                     }
 
                     if (pasteType.isFile() || pasteType.isImage()) {

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
@@ -14,6 +14,7 @@ interface TransferableConsumer {
         source: String?,
         remote: Boolean,
         dragAndDrop: Boolean = false,
+        targetAppInstanceIds: Set<String> = emptySet(),
     ): Result<Unit>
 
     fun getPlugin(identity: String): PasteTypePlugin?

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
@@ -317,7 +317,7 @@ class DesktopPasteMenuService(
                                     id = pasteData.id,
                                     fileSize = pasteData.size,
                                     appInstanceId = appInfo.appInstanceId,
-                                    targetAppInstanceId = syncRuntimeInfo.appInstanceId,
+                                    targetAppInstanceIds = setOf(syncRuntimeInfo.appInstanceId),
                                 )
                             }
                         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
@@ -39,6 +39,7 @@ class DesktopTransferableConsumer(
         source: String?,
         remote: Boolean,
         dragAndDrop: Boolean,
+        targetAppInstanceIds: Set<String>,
     ): Result<Unit> {
         return runCatching {
             logSuspendExecutionTime(logger, "consume") {
@@ -50,12 +51,18 @@ class DesktopTransferableConsumer(
                 }
 
                 val pasteCollector =
-                    PasteCollector(dataFlavorMap.size, appInfo, pasteDao, pasteReleaseService, dragAndDrop)
+                    PasteCollector(
+                        dataFlavorMap.size,
+                        appInfo,
+                        pasteDao,
+                        pasteReleaseService,
+                        dragAndDrop,
+                    )
 
                 preCollect(dataFlavorMap, pasteTransferable, pasteCollector)
                 pasteCollector.createPrePasteData(source, remote = remote)?.also { id ->
                     updatePasteData(id, dataFlavorMap, pasteTransferable, pasteCollector)
-                    pasteCollector.completeCollect(id)
+                    pasteCollector.completeCollect(id, targetAppInstanceIds)
                 }
             }
         }.onFailure { e ->

--- a/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
@@ -76,15 +76,14 @@ class DesktopTaskBuilder(
         id: Long,
         fileSize: Long,
         appInstanceId: String,
-        targetAppInstanceId: String?,
+        targetAppInstanceIds: Set<String>,
     ): TaskBuilder {
         if (appControl.isFileSizeSyncEnabled(fileSize)) {
-            val targetIds = targetAppInstanceId?.let { setOf(it) } ?: setOf()
             taskIds.add(
                 taskDao.createTaskBlock(
                     id,
                     TaskType.SYNC_PASTE_TASK,
-                    SyncExtraInfo(appInstanceId, targetIds),
+                    SyncExtraInfo(appInstanceId, targetAppInstanceIds),
                 ),
             )
         }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
@@ -157,7 +157,7 @@ class PasteCollectorTest {
 
             collector.completeCollect(1L)
 
-            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any()) }
+            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any(), any()) }
         }
 
     @Test
@@ -188,7 +188,7 @@ class PasteCollectorTest {
             collector.completeCollect(1L)
 
             // Should still release since not all active indices errored
-            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any()) }
+            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any(), any()) }
         }
 
     @Test
@@ -198,7 +198,8 @@ class PasteCollectorTest {
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 
-            coEvery { pasteReleaseService.releaseLocalPasteData(any(), any()) } throws RuntimeException("release error")
+            coEvery { pasteReleaseService.releaseLocalPasteData(any(), any(), any()) } throws
+                RuntimeException("release error")
 
             collector.completeCollect(1L)
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/task/TaskSubmitter.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/task/TaskSubmitter.kt
@@ -25,7 +25,7 @@ interface TaskBuilder {
         id: Long,
         fileSize: Long,
         appInstanceId: String,
-        targetAppInstanceId: String? = null,
+        targetAppInstanceIds: Set<String> = emptySet(),
     ): TaskBuilder
 
     fun addRelaySyncTask(


### PR DESCRIPTION
Closes #4181

## Summary
- Refactor `addSyncTask` parameter from `targetAppInstanceId: String?` to `targetAppInstanceIds: Set<String>`, eliminating internal wrapping
- Thread `targetAppInstanceIds` through `TransferableConsumer.consume()` → `PasteCollector.completeCollect()` → `PasteReleaseService.releaseLocalPasteData()` pipeline
- Update `DesktopPasteMenuService` to pass `setOf(syncRuntimeInfo.appInstanceId)` directly

## Test plan
- [ ] Verify clipboard sync to all devices works (empty set = broadcast)
- [ ] Verify targeted sync to a specific device works via paste menu
- [ ] Verify remote paste data is not re-synced