### PR TITLE
:bug: Restore ESC key binding for hide_window and display it in shortcuts UI (#4183)

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/listener/MacKeyboardKeys.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/listener/MacKeyboardKeys.kt
@@ -9,7 +9,7 @@ object MacKeyboardKeys : KeyboardKeys {
         KeyboardKeyDefine("⏎", NativeKeyEvent.VC_ENTER, 0x34) { it.keyCode == NativeKeyEvent.VC_ENTER }
 
     override val ESC: KeyboardKeyDefine =
-        KeyboardKeyDefine("⎋", NativeKeyEvent.VC_ESCAPE, 0x35) { it.keyCode == NativeKeyEvent.VC_ESCAPE }
+        KeyboardKeyDefine("Esc", NativeKeyEvent.VC_ESCAPE, 0x35) { it.keyCode == NativeKeyEvent.VC_ESCAPE }
 
     override val DELETE: KeyboardKeyDefine =
         KeyboardKeyDefine("Delete", NativeKeyEvent.VC_DELETE, 0x75) { it.keyCode == NativeKeyEvent.VC_DELETE }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/ShortcutKeysContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/ShortcutKeysContentView.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import com.crosspaste.app.DesktopAppLaunchState
 import com.crosspaste.i18n.GlobalCopywriter
+import com.crosspaste.listener.DesktopShortcutKeys.Companion.HIDE_WINDOW
 import com.crosspaste.listener.DesktopShortcutKeys.Companion.PASTE_LOCAL_LAST
 import com.crosspaste.listener.DesktopShortcutKeys.Companion.PASTE_PLAIN_TEXT
 import com.crosspaste.listener.DesktopShortcutKeys.Companion.PASTE_PRIMARY_TYPE
@@ -87,6 +88,8 @@ fun ShortcutKeysContentView() {
                 ShortcutKeyRow(SHOW_MAIN)
                 HorizontalDivider()
                 ShortcutKeyRow(SHOW_SEARCH)
+                HorizontalDivider()
+                ShortcutKeyRow(HIDE_WINDOW)
             }
         }
 

--- a/app/src/desktopMain/resources/shortcut_keys/Linux.properties
+++ b/app/src/desktopMain/resources/shortcut_keys/Linux.properties
@@ -5,6 +5,6 @@ paste_local_last=
 paste_remote_last=
 show_main=42+3675+51
 show_search=42+3675+57
-hide_window=
+hide_window=1
 toggle_pasteboard_monitoring=
 toggle_encrypt=

--- a/app/src/desktopMain/resources/shortcut_keys/Macos.properties
+++ b/app/src/desktopMain/resources/shortcut_keys/Macos.properties
@@ -5,6 +5,6 @@ paste_local_last=
 paste_remote_last=
 show_main=42+3675+51
 show_search=42+3675+57
-hide_window=
+hide_window=1
 toggle_pasteboard_monitoring=
 toggle_encrypt=

--- a/app/src/desktopMain/resources/shortcut_keys/Windows.properties
+++ b/app/src/desktopMain/resources/shortcut_keys/Windows.properties
@@ -5,6 +5,6 @@ paste_local_last=
 paste_remote_last=
 show_main=42+3675+51
 show_search=42+3675+57
-hide_window=
+hide_window=1
 toggle_pasteboard_monitoring=
 toggle_encrypt=


### PR DESCRIPTION
Closes #4183

## Summary
- Restore `hide_window=1` (ESC key) as default shortcut on all platforms (macOS, Linux, Windows), which was removed in PR #4126
- Add `HIDE_WINDOW` to the "Toggle Window" section in the shortcut keys settings UI so users can see and configure it

## Test plan
- [ ] Launch the app, open a window, press ESC — window should hide
- [ ] Open Settings → Shortcut Keys → verify "hide_window" appears under "Toggle Window" section showing the ESC key
- [ ] Verify the shortcut is configurable via the settings dialog