### PR TITLE
:hammer: Add identity parameter to loadRepresentation for mobile platform support (#4185)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
@@ -56,6 +56,7 @@ interface TransferableConsumer {
                         plugin.loadRepresentation(
                             pasteId,
                             itemIndex,
+                            identity,
                             flavor,
                             dataFlavorMap,
                             pasteTransferable,

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/type/PasteTypePlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/type/PasteTypePlugin.kt
@@ -20,9 +20,11 @@ interface PasteTypePlugin {
         pasteCollector: PasteCollector,
     )
 
+    // identity: unused on Desktop, required by Android/iOS to resolve platform-specific representations
     fun loadRepresentation(
         pasteId: Long,
         itemIndex: Int,
+        identity: String,
         dataFlavor: PasteDataFlavor,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,
@@ -35,6 +37,7 @@ interface PasteTypePlugin {
                     transferData,
                     pasteId,
                     itemIndex,
+                    identity,
                     dataFlavor,
                     dataFlavorMap,
                     pasteTransferable,
@@ -50,6 +53,7 @@ interface PasteTypePlugin {
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
+        identity: String,
         dataFlavor: PasteDataFlavor,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopColorTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopColorTypePlugin.kt
@@ -24,6 +24,7 @@ class DesktopColorTypePlugin : ColorTypePlugin {
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
+        identity: String,
         dataFlavor: PasteDataFlavor,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopFilesTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopFilesTypePlugin.kt
@@ -63,6 +63,7 @@ class DesktopFilesTypePlugin(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
+        identity: String,
         dataFlavor: PasteDataFlavor,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopHtmlTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopHtmlTypePlugin.kt
@@ -55,6 +55,7 @@ class DesktopHtmlTypePlugin(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
+        identity: String,
         dataFlavor: PasteDataFlavor,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
@@ -76,6 +76,7 @@ class DesktopImageTypePlugin(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
+        identity: String,
         dataFlavor: PasteDataFlavor,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopRtfTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopRtfTypePlugin.kt
@@ -57,6 +57,7 @@ class DesktopRtfTypePlugin : RtfTypePlugin {
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
+        identity: String,
         dataFlavor: PasteDataFlavor,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopTextTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopTextTypePlugin.kt
@@ -41,6 +41,7 @@ class DesktopTextTypePlugin : TextTypePlugin {
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
+        identity: String,
         dataFlavor: PasteDataFlavor,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopUrlTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopUrlTypePlugin.kt
@@ -43,6 +43,7 @@ class DesktopUrlTypePlugin(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
+        identity: String,
         dataFlavor: PasteDataFlavor,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,


### PR DESCRIPTION
Closes #4185

## Summary
- Add `identity: String` parameter to `PasteTypePlugin.loadRepresentation` and `doLoadRepresentation` interfaces
- Thread `identity` through the call chain from `TransferableConsumer.updatePasteData`
- Update all 7 desktop `doLoadRepresentation` implementations to include the new parameter (unused on desktop, required by Android/iOS)

## Test plan
- [x] `./gradlew ktlintFormat` passes
- [x] `./gradlew app:compileKotlinDesktop` compiles successfully
- [x] Verify desktop clipboard operations still work (copy/paste text, files, images, URLs, HTML, RTF, colors)