### PR TITLE
:hammer: Refactor targetAppInstanceIds to nullable Set<String>? for explicit no-sync semantics (#4187)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
@@ -103,7 +103,7 @@ class PasteCollector(
 
     suspend fun completeCollect(
         id: Long,
-        targetAppInstanceIds: Set<String> = emptySet(),
+        targetAppInstanceIds: Set<String>? = null,
     ) {
         logSuspendExecutionTime(logger, "completeCollect") {
             val activeIndices = preCollectors.indices.filter { preCollectors[it].isNotEmpty() }

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -65,7 +65,7 @@ class PasteReleaseService(
     suspend fun releaseLocalPasteData(
         id: Long,
         pasteItems: List<PasteItem>,
-        targetAppInstanceIds: Set<String>,
+        targetAppInstanceIds: Set<String>?,
     ) = withContext(ioDispatcher) {
         pasteDao.getLoadingPasteData(id)?.let { pasteData ->
             var pasteAppearItems = pasteItems

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
@@ -14,7 +14,7 @@ interface TransferableConsumer {
         source: String?,
         remote: Boolean,
         dragAndDrop: Boolean = false,
-        targetAppInstanceIds: Set<String> = emptySet(),
+        targetAppInstanceIds: Set<String>? = null,
     ): Result<Unit>
 
     fun getPlugin(identity: String): PasteTypePlugin?

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -123,10 +123,7 @@ class SyncPasteTaskExecutor(
                 handler.currentSyncRuntimeInfo.allowSend &&
                     handler.currentVersionRelation == VersionRelation.EQUAL_TO &&
                     (
-                        syncExtraInfo.targetAppInstanceIds.isEmpty() ||
-                            syncExtraInfo.targetAppInstanceIds.contains(
-                                key,
-                            )
+                        syncExtraInfo.targetAppInstanceIds?.contains(key) != false
                     ) &&
                     (syncExtraInfo.syncFails.isEmpty() || syncExtraInfo.syncFails.contains(key))
             }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
@@ -39,7 +39,7 @@ class DesktopTransferableConsumer(
         source: String?,
         remote: Boolean,
         dragAndDrop: Boolean,
-        targetAppInstanceIds: Set<String>,
+        targetAppInstanceIds: Set<String>?,
     ): Result<Unit> {
         return runCatching {
             logSuspendExecutionTime(logger, "consume") {

--- a/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
@@ -76,7 +76,7 @@ class DesktopTaskBuilder(
         id: Long,
         fileSize: Long,
         appInstanceId: String,
-        targetAppInstanceIds: Set<String>,
+        targetAppInstanceIds: Set<String>?,
     ): TaskBuilder {
         if (appControl.isFileSizeSyncEnabled(fileSize)) {
             taskIds.add(

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/task/SyncExtraInfo.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/task/SyncExtraInfo.kt
@@ -9,7 +9,7 @@ class SyncExtraInfo(
     @SerialName("appInstanceId")
     val appInstanceId: String,
     @SerialName("targetAppInstanceIds")
-    val targetAppInstanceIds: Set<String> = emptySet(),
+    val targetAppInstanceIds: Set<String>? = null,
 ) : PasteTaskExtraInfo {
 
     @SerialName("executionHistories")

--- a/shared/src/commonMain/kotlin/com/crosspaste/task/TaskSubmitter.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/task/TaskSubmitter.kt
@@ -25,7 +25,7 @@ interface TaskBuilder {
         id: Long,
         fileSize: Long,
         appInstanceId: String,
-        targetAppInstanceIds: Set<String> = emptySet(),
+        targetAppInstanceIds: Set<String>? = null,
     ): TaskBuilder
 
     fun addRelaySyncTask(


### PR DESCRIPTION
Closes #4187

## Summary

- Change `targetAppInstanceIds` type from `Set<String>` to `Set<String>?` across the sync pipeline
- `null` = sync to all devices (default), `emptySet()` = no sync, non-empty set = sync to specified targets
- Update eligibility check in `SyncPasteTaskExecutor` to use `?.contains(key) != false`

## Test plan

- [ ] Verify default sync behavior (no `targetAppInstanceIds` passed) still syncs to all devices
- [ ] Verify passing `emptySet()` skips sync entirely
- [ ] Verify passing specific IDs only syncs to those targets
- [ ] Verify relay sync tasks still work correctly (uses default `null`)