### PR TITLE
:hammer: Namespace source icons by appInstanceId

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/image/IconKey.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/image/IconKey.kt
@@ -1,0 +1,6 @@
+package com.crosspaste.image
+
+data class IconKey(
+    val source: String,
+    val appInstanceId: String?,
+)

--- a/app/src/commonMain/kotlin/com/crosspaste/image/coil/AppSourceFetcher.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/image/coil/AppSourceFetcher.kt
@@ -7,7 +7,6 @@ import coil3.fetch.FetchResult
 import coil3.fetch.Fetcher
 import coil3.fetch.SourceFetchResult
 import coil3.request.Options
-import com.crosspaste.app.AppFileType
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
@@ -25,10 +24,9 @@ class AppSourceFetcher(
 
     override suspend fun fetch(): FetchResult? =
         withContext(ioDispatcher) {
-            data.source?.let {
+            data.source?.let { source ->
                 runCatching {
-                    val path = userDataPathProvider.resolve("$it.png", AppFileType.ICON)
-                    if (fileUtils.existFile(path)) {
+                    userDataPathProvider.findIconPath(data.appInstanceId, source)?.let { path ->
                         SourceFetchResult(
                             source =
                                 ImageSource(
@@ -38,8 +36,6 @@ class AppSourceFetcher(
                             mimeType = "image/png",
                             dataSource = DataSource.MEMORY_CACHE,
                         )
-                    } else {
-                        null
                     }
                 }.onFailure { e ->
                     logger.error(e) { "Error while fetching app source" }

--- a/app/src/commonMain/kotlin/com/crosspaste/image/coil/ImageItems.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/image/coil/ImageItems.kt
@@ -19,6 +19,7 @@ class GenerateImageKeyer : Keyer<GenerateImageItem> {
 
 data class AppSourceItem(
     val source: String?,
+    val appInstanceId: String? = null,
 )
 
 data class UrlItem(
@@ -30,7 +31,7 @@ class AppSourceKeyer : Keyer<AppSourceItem> {
     override fun key(
         data: AppSourceItem,
         options: Options,
-    ): String = data.source ?: ""
+    ): String = "${data.appInstanceId ?: ""}/${data.source ?: ""}"
 }
 
 class UrlKeyer : Keyer<UrlItem> {

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
@@ -1,6 +1,5 @@
 package com.crosspaste.net.routing
 
-import com.crosspaste.app.AppFileType
 import com.crosspaste.app.AppInfo
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.dto.pull.PullFileRequest
@@ -93,12 +92,12 @@ fun Routing.pullRouting(
             return@get
         }
 
-        val iconPath = userDataPathProvider.resolve("$source.png", AppFileType.ICON)
-        if (!fileUtils.existFile(iconPath)) {
-            logger.error { "icon not found: $source" }
-            failResponse(call, StandardErrorCode.NOT_FOUND_ICON.toErrorCode())
-            return@get
-        }
+        val iconPath =
+            userDataPathProvider.findIconPath(appInfo.appInstanceId, source) ?: run {
+                logger.error { "icon not found: $source" }
+                failResponse(call, StandardErrorCode.NOT_FOUND_ICON.toErrorCode())
+                return@get
+            }
 
         val producer: suspend ByteWriteChannel.() -> Unit = {
             fileUtils.readFile(iconPath, this)

--- a/app/src/commonMain/kotlin/com/crosspaste/task/PullIconTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/PullIconTaskExecutor.kt
@@ -1,6 +1,5 @@
 package com.crosspaste.task
 
-import com.crosspaste.app.AppFileType
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.db.task.BaseExtraInfo
 import com.crosspaste.db.task.PasteTask
@@ -56,28 +55,28 @@ class PullIconTaskExecutor(
                     runCatching {
                         val appInstanceId = pasteData.appInstanceId
 
-                        val iconPath = userDataPathProvider.resolve("$source.png", AppFileType.ICON)
-                        if (!fileUtils.existFile(iconPath)) {
-                            syncManager.getSyncHandlers()[appInstanceId]?.let {
-                                val port = it.currentSyncRuntimeInfo.port
-                                it.getConnectHostAddress()?.let { host ->
-                                    pullIcon(source, iconPath, host, port, baseExtraInfo)
-                                } ?: run {
-                                    createFailurePasteTaskResult(
-                                        baseExtraInfo = baseExtraInfo,
-                                        errorCodeSupplier = StandardErrorCode.CANT_GET_SYNC_ADDRESS,
-                                        errorMessage = "Failed to get connect host address by $appInstanceId",
-                                    )
-                                }
+                        if (userDataPathProvider.findIconPath(appInstanceId, source) != null) {
+                            return@withLock SuccessPasteTaskResult()
+                        }
+
+                        syncManager.getSyncHandlers()[appInstanceId]?.let { handler ->
+                            val iconPath = userDataPathProvider.resolveIconPath(appInstanceId, source)
+                            val port = handler.currentSyncRuntimeInfo.port
+                            handler.getConnectHostAddress()?.let { host ->
+                                pullIcon(source, iconPath, host, port, baseExtraInfo)
                             } ?: run {
                                 createFailurePasteTaskResult(
                                     baseExtraInfo = baseExtraInfo,
-                                    errorCodeSupplier = StandardErrorCode.PULL_ICON_TASK_FAIL,
-                                    errorMessage = "Failed to sync paste to $appInstanceId",
+                                    errorCodeSupplier = StandardErrorCode.CANT_GET_SYNC_ADDRESS,
+                                    errorMessage = "Failed to get connect host address by $appInstanceId",
                                 )
                             }
-                        } else {
-                            SuccessPasteTaskResult()
+                        } ?: run {
+                            createFailurePasteTaskResult(
+                                baseExtraInfo = baseExtraInfo,
+                                errorCodeSupplier = StandardErrorCode.PULL_ICON_TASK_FAIL,
+                                errorMessage = "Failed to sync paste to $appInstanceId",
+                            )
                         }
                     }.getOrElse {
                         createFailurePasteTaskResult(

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/AppSourceIcon.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/AppSourceIcon.kt
@@ -50,9 +50,11 @@ fun PasteDataScope.AppSourceIcon(
         val platformContext = koinInject<PlatformContext>()
         val density = LocalDensity.current
 
+        val appInstanceId = pasteData.appInstanceId
+
         val visualScale =
-            remember(source) {
-                if (iconStyle.isMacStyleIcon(source)) {
+            remember(source, appInstanceId) {
+                if (iconStyle.isMacStyleIcon(source, appInstanceId)) {
                     val paddingRatio = 0.075f
                     val contentRatio = 1f - (paddingRatio * 2)
                     1f / contentRatio
@@ -64,10 +66,10 @@ fun PasteDataScope.AppSourceIcon(
         val sizePx = with(density) { size.roundToPx() }
 
         val model =
-            remember(source, platformContext, sizePx) {
+            remember(source, appInstanceId, platformContext, sizePx) {
                 ImageRequest
                     .Builder(platformContext)
-                    .data(AppSourceItem(source))
+                    .data(AppSourceItem(source, appInstanceId))
                     .size(sizePx)
                     .precision(Precision.INEXACT)
                     .scale(Scale.FILL)

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/IconStyle.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/IconStyle.kt
@@ -2,7 +2,13 @@ package com.crosspaste.ui.base
 
 interface IconStyle {
 
-    fun isMacStyleIcon(source: String): Boolean
+    fun isMacStyleIcon(
+        source: String,
+        appInstanceId: String? = null,
+    ): Boolean
 
-    fun refreshStyle(source: String)
+    fun refreshStyle(
+        source: String,
+        appInstanceId: String? = null,
+    )
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
@@ -63,7 +63,7 @@ fun desktopUiModule(): Module =
         single<AppWindowManager> { get<DesktopAppWindowManager>() }
         single<DesktopAppSize> { DesktopAppSize(get()) }
         single<DesktopAppWindowManager> {
-            getDesktopAppWindowManager(get(), lazy { get() }, lazy { get() }, get(), get())
+            getDesktopAppWindowManager(get(), get(), lazy { get() }, lazy { get() }, get(), get())
         }
         single<DesktopIconColorExtractor> { DesktopIconColorExtractor(get()) }
         single<DesktopScreenProvider> { DesktopScreenProvider(get(), get(), get(), get(), get(), get()) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 fun getDesktopAppWindowManager(
+    appInfo: AppInfo,
     appSize: DesktopAppSize,
     lazyShortcutKeys: Lazy<ShortcutKeys>,
     lazyShortcutKeysAction: Lazy<ShortcutKeysAction>,
@@ -28,18 +29,21 @@ fun getDesktopAppWindowManager(
 ): DesktopAppWindowManager =
     if (platform.isMacos()) {
         MacAppWindowManager(
+            appInfo,
             appSize,
             lazyShortcutKeys,
             userDataPathProvider,
         )
     } else if (platform.isWindows()) {
         WinAppWindowManager(
+            appInfo,
             appSize,
             lazyShortcutKeys,
             userDataPathProvider,
         )
     } else if (platform.isLinux()) {
         LinuxAppWindowManager(
+            appInfo,
             appSize,
             lazyShortcutKeys,
             lazyShortcutKeysAction,

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 class LinuxAppWindowManager(
+    private val appInfo: AppInfo,
     appSize: DesktopAppSize,
     private val lazyShortcutKeys: Lazy<ShortcutKeys>,
     private val lazyShortcutKeysAction: Lazy<ShortcutKeysAction>,
@@ -96,9 +97,11 @@ class LinuxAppWindowManager(
         window: Window,
         className: String,
     ) {
-        val iconPath = userDataPathProvider.resolve("$className.png", AppFileType.ICON)
-        if (!iconPath.toFile().exists()) {
-            X11Api.saveAppIcon(window, iconPath.toNioPath())
+        runCatching {
+            val iconPath = userDataPathProvider.resolveIconPath(appInfo.appInstanceId, className)
+            if (!iconPath.toFile().exists()) {
+                X11Api.saveAppIcon(window, iconPath.toNioPath())
+            }
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/MacAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/MacAppWindowManager.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 class MacAppWindowManager(
+    private val appInfo: AppInfo,
     appSize: DesktopAppSize,
     lazyShortcutKeys: Lazy<ShortcutKeys>,
     private val userDataPathProvider: UserDataPathProvider,
@@ -72,9 +73,11 @@ class MacAppWindowManager(
         bundleIdentifier: String,
         localizedName: String,
     ) {
-        val appImagePath = userDataPathProvider.resolve("$localizedName.png", AppFileType.ICON)
-        if (!appImagePath.toFile().exists()) {
-            MacAppUtils.saveAppIcon(bundleIdentifier, appImagePath.toString())
+        runCatching {
+            val appImagePath = userDataPathProvider.resolveIconPath(appInfo.appInstanceId, localizedName)
+            if (!appImagePath.toFile().exists()) {
+                MacAppUtils.saveAppIcon(bundleIdentifier, appImagePath.toString())
+            }
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/WinAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/WinAppWindowManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class WinAppWindowManager(
+    appInfo: AppInfo,
     appSize: DesktopAppSize,
     private val lazyShortcutKeys: Lazy<ShortcutKeys>,
     userDataPathProvider: UserDataPathProvider,
@@ -51,7 +52,7 @@ class WinAppWindowManager(
             return _cachedBubbleHWND
         }
 
-    private val winAppInfoCaches = WinAppInfoCaches(userDataPathProvider, ioScope)
+    private val winAppInfoCaches = WinAppInfoCaches(appInfo, userDataPathProvider, ioScope)
 
     private val windowFocusRecorder = WindowFocusRecorder(this)
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopIconColorExtractor.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopIconColorExtractor.kt
@@ -24,11 +24,6 @@ class DesktopIconColorExtractor(
 
     private val logger = KotlinLogging.logger {}
 
-    private data class IconKey(
-        val source: String,
-        val appInstanceId: String?,
-    )
-
     private val colorCache: MutableMap<IconKey, Box<Color>> = ConcurrentMap()
 
     private val mutex = StripedMutex()

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopIconColorExtractor.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopIconColorExtractor.kt
@@ -1,7 +1,6 @@
 package com.crosspaste.image
 
 import androidx.compose.ui.graphics.Color
-import com.crosspaste.app.AppFileType
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.Box
 import com.crosspaste.utils.ColorConversion.hsvToRgb
@@ -25,33 +24,42 @@ class DesktopIconColorExtractor(
 
     private val logger = KotlinLogging.logger {}
 
-    private val colorCache: MutableMap<String, Box<Color>> = ConcurrentMap()
+    private data class IconKey(
+        val source: String,
+        val appInstanceId: String?,
+    )
+
+    private val colorCache: MutableMap<IconKey, Box<Color>> = ConcurrentMap()
 
     private val mutex = StripedMutex()
 
-    /**
-     * Get background color from icon path (with cache)
-     */
-    suspend fun getBackgroundColor(source: String): Color? =
-        mutex.withLock(source) {
-            colorCache[source]?.let { cached ->
+    suspend fun getBackgroundColor(
+        source: String,
+        appInstanceId: String? = null,
+    ): Color? {
+        val cacheKey = IconKey(source, appInstanceId)
+        return mutex.withLock(cacheKey) {
+            colorCache[cacheKey]?.let { cached ->
                 return@withLock cached.getOrNull()
             }
 
             withContext(ioDispatcher) {
                 val color =
                     runCatching {
-                        val path = userDataPathProvider.resolve("$source.png", AppFileType.ICON)
+                        val path =
+                            userDataPathProvider.findIconPath(appInstanceId, source)
+                                ?: return@runCatching null
                         val bytes = path.toNioPath().readBytes()
                         extractColorFromBytes(bytes)
                     }.getOrNull()
 
                 logger.debug { "$source - ${color?.toHexString()}" }
 
-                colorCache[source] = Box.of(color)
+                colorCache[cacheKey] = Box.of(color)
                 color
             }
         }
+    }
 
     /**
      * Extract dominant color from image byte array

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WinAppInfo.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WinAppInfo.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.platform.windows
 
-import com.crosspaste.app.AppFileType
+import com.crosspaste.app.AppInfo
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.getFileUtils
 import com.github.benmanes.caffeine.cache.Caffeine
@@ -26,6 +26,7 @@ class WinAppInfo(
 }
 
 class WinAppInfoCaches(
+    private val appInfo: AppInfo,
     private val userDataPathProvider: UserDataPathProvider,
     private val scope: CoroutineScope,
 ) {
@@ -74,9 +75,11 @@ class WinAppInfoCaches(
         exeFilePath: Path,
         appName: String,
     ) {
-        val iconPath = userDataPathProvider.resolve("$appName.png", AppFileType.ICON)
-        if (!fileUtils.existFile(iconPath)) {
-            WindowsIconUtils.extractAndSaveIcon(exeFilePath, iconPath)
+        runCatching {
+            val iconPath = userDataPathProvider.resolveIconPath(appInfo.appInstanceId, appName)
+            if (!fileUtils.existFile(iconPath)) {
+                WindowsIconUtils.extractAndSaveIcon(exeFilePath, iconPath)
+            }
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopIconStyle.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopIconStyle.kt
@@ -3,41 +3,46 @@ package com.crosspaste.ui.base
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.graphics.toPixelMap
-import com.crosspaste.app.AppFileType
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.getCoilUtils
-import com.crosspaste.utils.getFileUtils
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.LoadingCache
 
 class DesktopIconStyle(
-    userDataPathProvider: UserDataPathProvider,
+    private val userDataPathProvider: UserDataPathProvider,
 ) : IconStyle {
 
     private val coilUtils = getCoilUtils()
-    private val fileUtils = getFileUtils()
 
-    private val iconStyleCache: LoadingCache<String, Boolean> =
+    private data class IconKey(
+        val source: String,
+        val appInstanceId: String?,
+    )
+
+    private val iconStyleCache: LoadingCache<IconKey, Boolean> =
         Caffeine
             .newBuilder()
             .maximumSize(1000)
             .build { key ->
-                val iconPath = userDataPathProvider.resolve("$key.png", AppFileType.ICON)
-                if (fileUtils.existFile(iconPath)) {
+                userDataPathProvider.findIconPath(key.appInstanceId, key.source)?.let { iconPath ->
                     val imageBitmap =
                         coilUtils
                             .createBitmap(iconPath)
                             .asComposeImageBitmap()
                     checkMacStyleIcon(imageBitmap)
-                } else {
-                    false
-                }
+                } ?: false
             }
 
-    override fun isMacStyleIcon(source: String): Boolean = iconStyleCache.get(source)
+    override fun isMacStyleIcon(
+        source: String,
+        appInstanceId: String?,
+    ): Boolean = iconStyleCache.get(IconKey(source, appInstanceId))
 
-    override fun refreshStyle(source: String) {
-        iconStyleCache.refresh(source)
+    override fun refreshStyle(
+        source: String,
+        appInstanceId: String?,
+    ) {
+        iconStyleCache.refresh(IconKey(source, appInstanceId))
     }
 
     private fun checkMacStyleIcon(imageBitmap: ImageBitmap): Boolean {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopIconStyle.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopIconStyle.kt
@@ -3,6 +3,7 @@ package com.crosspaste.ui.base
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.graphics.toPixelMap
+import com.crosspaste.image.IconKey
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.getCoilUtils
 import com.github.benmanes.caffeine.cache.Caffeine
@@ -13,11 +14,6 @@ class DesktopIconStyle(
 ) : IconStyle {
 
     private val coilUtils = getCoilUtils()
-
-    private data class IconKey(
-        val source: String,
-        val appInstanceId: String?,
-    )
 
     private val iconStyleCache: LoadingCache<IconKey, Boolean> =
         Caffeine

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/SideAppSourceIcon.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/SideAppSourceIcon.kt
@@ -46,7 +46,7 @@ fun PasteDataScope.SideAppSourceIcon(
     val sizePx = with(density) { appSizeValue.sideTitleHeight.roundToPx() }
 
     val model =
-        remember(pasteData.source, sizePx, platform, syncPlatform) {
+        remember(pasteData.source, pasteData.appInstanceId, sizePx, platform, syncPlatform) {
             val transformation = create(platform, syncPlatform)
 
             val requestSizePx = transformation?.requestSize(sizePx) ?: sizePx
@@ -55,7 +55,7 @@ fun PasteDataScope.SideAppSourceIcon(
 
             ImageRequest
                 .Builder(platformContext)
-                .data(AppSourceItem(pasteData.source))
+                .data(AppSourceItem(pasteData.source, pasteData.appInstanceId))
                 .transformations(transformations)
                 .size(requestSizePx)
                 .precision(Precision.INEXACT)

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/sourcecontrol/SourceControlContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/sourcecontrol/SourceControlContentView.kt
@@ -35,6 +35,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.size.Precision
 import coil3.size.Scale
+import com.crosspaste.app.AppInfo
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.db.paste.PasteDao
@@ -171,17 +172,20 @@ private fun SourceAppIcon(
     source: String,
     size: Dp = large2X,
 ) {
+    val appInfo = koinInject<AppInfo>()
     val iconStyle = koinInject<IconStyle>()
     val appSourceLoader = koinInject<ImageLoader>(qualifier = ImageLoaderQualifiers.APP_SOURCE)
     val platformContext = koinInject<PlatformContext>()
     val density = LocalDensity.current
+
+    val appInstanceId = appInfo.appInstanceId
 
     var visualScale by remember(source) { mutableStateOf(1f) }
 
     LaunchedEffect(source) {
         visualScale =
             withContext(ioDispatcher) {
-                if (iconStyle.isMacStyleIcon(source)) {
+                if (iconStyle.isMacStyleIcon(source, appInstanceId)) {
                     val paddingRatio = 0.075f
                     val contentRatio = 1f - (paddingRatio * 2)
                     1f / contentRatio
@@ -194,10 +198,10 @@ private fun SourceAppIcon(
     val sizePx = with(density) { size.roundToPx() }
 
     val model =
-        remember(source, platformContext, sizePx) {
+        remember(source, appInstanceId, platformContext, sizePx) {
             ImageRequest
                 .Builder(platformContext)
-                .data(AppSourceItem(source))
+                .data(AppSourceItem(source, appInstanceId))
                 .size(sizePx)
                 .precision(Precision.INEXACT)
                 .scale(Scale.FILL)

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SidePasteTitleView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SidePasteTitleView.kt
@@ -117,7 +117,9 @@ fun PasteDataScope.SidePasteTitleView() {
 
     LaunchedEffect(isCurrentThemeDark, pasteData.source) {
         pasteData.source?.let {
-            desktopIconColorExtractor.getBackgroundColor(it)?.let { color -> background = color }
+            desktopIconColorExtractor.getBackgroundColor(it, pasteData.appInstanceId)?.let { color ->
+                background = color
+            }
         }
     }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/image/coil/ImageItemsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/image/coil/ImageItemsTest.kt
@@ -20,13 +20,14 @@ class ImageItemsTest {
     @Test
     fun `AppSourceKeyer uses source as key`() {
         val keyer = AppSourceKeyer()
-        assertEquals("com.example.app", keyer.key(AppSourceItem("com.example.app"), io.mockk.mockk()))
+        assertEquals("/com.example.app", keyer.key(AppSourceItem("com.example.app"), io.mockk.mockk()))
+        assertEquals("inst-1/com.example.app", keyer.key(AppSourceItem("com.example.app", "inst-1"), io.mockk.mockk()))
     }
 
     @Test
     fun `AppSourceKeyer returns empty string for null source`() {
         val keyer = AppSourceKeyer()
-        assertEquals("", keyer.key(AppSourceItem(null), io.mockk.mockk()))
+        assertEquals("/", keyer.key(AppSourceItem(null), io.mockk.mockk()))
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/crosspaste/path/UserDataPathProvider.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/path/UserDataPathProvider.kt
@@ -147,6 +147,38 @@ class UserDataPathProvider(
         }
     }
 
+    fun resolveIconPath(
+        appInstanceId: String,
+        source: String,
+    ): Path {
+        require(isSafeIconComponent(appInstanceId)) { "Invalid appInstanceId: $appInstanceId" }
+        require(isSafeIconComponent(source)) { "Invalid source: $source" }
+        val iconDir = resolve(appFileType = AppFileType.ICON)
+        val instanceDir = iconDir.resolve(appInstanceId)
+        autoCreateDir(instanceDir)
+        return instanceDir.resolve("$source.png")
+    }
+
+    fun findIconPath(
+        appInstanceId: String?,
+        source: String,
+    ): Path? {
+        if (!isSafeIconComponent(source)) return null
+        val iconDir = resolve(appFileType = AppFileType.ICON)
+        if (appInstanceId != null && isSafeIconComponent(appInstanceId)) {
+            val instancePath = iconDir.resolve(appInstanceId).resolve("$source.png")
+            if (fileUtils.existFile(instancePath)) return instancePath
+        }
+        val fallbackPath = iconDir.resolve("$source.png")
+        return if (fileUtils.existFile(fallbackPath)) fallbackPath else null
+    }
+
+    private fun isSafeIconComponent(value: String): Boolean =
+        value.isNotEmpty() &&
+            !value.contains('/') &&
+            !value.contains('\\') &&
+            !value.contains("..")
+
     fun getUserDataPath(): Path =
         if (configManager.getCurrentConfig().useDefaultStoragePath) {
             platformUserDataPathProvider.getUserDefaultStoragePath()


### PR DESCRIPTION
Closes #4190

## Summary
- Store source icons under `icons/{appInstanceId}/{source}.png` so the same app name on different devices no longer collides
- Reads fall back to the old `icons/{source}.png` path so existing data keeps working
- Centralize path-traversal validation in `UserDataPathProvider` and replace fragile string cache keys with `IconKey` data classes

## Changes
**Save (write to per-instance dir)**
- `MacAppWindowManager`, `WinAppInfoCaches`, `LinuxAppWindowManager` use `resolveIconPath(appInfo.appInstanceId, source)`
- `PullIconTaskExecutor` saves remote icons to `icons/{remoteAppInstanceId}/`

**Serve & display (read with fallback)**
- `/pull/icon/{source}` serves from local instance dir, falls back to flat
- `AppSourceFetcher`, `DesktopIconStyle`, `DesktopIconColorExtractor` use `findIconPath(appInstanceId, source)` with fallback

**API surface**
- `AppSourceItem` gains optional `appInstanceId`
- `IconStyle.isMacStyleIcon`/`refreshStyle` gain optional `appInstanceId`
- `getDesktopAppWindowManager` factory threads `AppInfo` through to the platform managers

**Robustness**
- `resolveIconPath`/`findIconPath` reject `/`, `\`, `..`, empty inputs (throw on write, return null on read)
- Local save sites wrap in `runCatching` so a malicious app name (e.g. macOS `localizedName` with `/`) skips the save instead of crashing the listener
- `PullIconTaskExecutor` keeps the idempotent fast path: succeed when the icon is already on disk even if the remote handler is gone
- Cache keys in `DesktopIconStyle` and `DesktopIconColorExtractor` switched from string concat/split to a private `IconKey` data class

## Test plan
- [x] `./gradlew ktlintFormat` clean
- [x] `./gradlew :app:compileKotlinDesktop :shared:compileKotlinDesktop :core:compileKotlinDesktop` succeeds
- [x] `./gradlew app:desktopTest` — 1007 tests pass (including updated `ImageItemsTest` for the new keyer format)
- [ ] Manual: copy from an app, verify icon appears in paste history and is written under `icons/{appInstanceId}/`
- [ ] Manual: sync paste from another device, verify remote icon is pulled into `icons/{remoteAppInstanceId}/` and displayed
- [ ] Manual: verify pre-existing icons under flat `icons/{source}.png` still display via fallback