### PR TITLE
:hammer: Enforce namespaced icon paths in sync endpoints

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
@@ -93,11 +93,13 @@ fun Routing.pullRouting(
         }
 
         val iconPath =
-            userDataPathProvider.findIconPath(appInfo.appInstanceId, source) ?: run {
-                logger.error { "icon not found: $source" }
-                failResponse(call, StandardErrorCode.NOT_FOUND_ICON.toErrorCode())
-                return@get
-            }
+            userDataPathProvider.resolveIconPath(appInfo.appInstanceId, source)
+
+        if (!fileUtils.existFile(iconPath)) {
+            logger.error { "icon not found: $source" }
+            failResponse(call, StandardErrorCode.NOT_FOUND_ICON.toErrorCode())
+            return@get
+        }
 
         val producer: suspend ByteWriteChannel.() -> Unit = {
             fileUtils.readFile(iconPath, this)

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -1,7 +1,6 @@
 package com.crosspaste.paste
 
 import com.crosspaste.Database
-import com.crosspaste.app.AppFileType
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.paste.item.PasteFiles
@@ -147,7 +146,7 @@ class PasteReleaseService(
             val isFileType = pasteData.isFileType()
             val existIconFile: Boolean? =
                 pasteData.source?.let {
-                    fileUtils.existFile(userDataPathProvider.resolve("$it.png", AppFileType.ICON))
+                    fileUtils.existFile(userDataPathProvider.resolveIconPath(pasteData.appInstanceId, it))
                 }
 
             val pasteState =

--- a/app/src/commonMain/kotlin/com/crosspaste/task/PullIconTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/PullIconTaskExecutor.kt
@@ -55,10 +55,6 @@ class PullIconTaskExecutor(
                     runCatching {
                         val appInstanceId = pasteData.appInstanceId
 
-                        if (userDataPathProvider.findIconPath(appInstanceId, source) != null) {
-                            return@withLock SuccessPasteTaskResult()
-                        }
-
                         syncManager.getSyncHandlers()[appInstanceId]?.let { handler ->
                             val iconPath = userDataPathProvider.resolveIconPath(appInstanceId, source)
                             val port = handler.currentSyncRuntimeInfo.port


### PR DESCRIPTION
Closes #4192

Follow-up to #4191 to finish the migration to namespaced icon storage.

## Summary
- **Bug fix** `PasteReleaseService.releaseRemotePasteData` now probes `resolveIconPath(appInstanceId, source)` — the flat-path probe always missed after namespacing, scheduling a redundant `PullIconTask` for every remote paste.
- **Breaking migration** `/pull/icon/{source}` drops the flat-path fallback. Stale flat icons on the server return 404 until they are re-captured into the per-instance dir.
- **Breaking migration** `PullIconTaskExecutor` removes the `findIconPath` fast path. Every scheduled task now fetches from the remote.

UI read paths (`AppSourceFetcher`, `DesktopIconStyle`, `DesktopIconColorExtractor`) keep the `findIconPath` fallback, so user-visible rendering is unaffected.

## Test plan
- [ ] Sync clipboard items with `source` between two devices; confirm icon pulled exactly once per source (no redundant task churn in logs).
- [ ] Delete an icon from the namespaced dir on the sender and request it from a receiver; confirm 404 from `/pull/icon`.
- [ ] Restart the app with an existing icon on disk and trigger a remote paste for the same source; confirm pull is no longer short-circuited.