### PR TITLE
:zap: Skip icon pull when local icon file already exists

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/task/PullIconTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/PullIconTaskExecutor.kt
@@ -54,9 +54,13 @@ class PullIconTaskExecutor(
                 mutex.withLock(source) {
                     runCatching {
                         val appInstanceId = pasteData.appInstanceId
+                        val iconPath = userDataPathProvider.resolveIconPath(appInstanceId, source)
+
+                        if (fileUtils.existFile(iconPath)) {
+                            return@withLock SuccessPasteTaskResult()
+                        }
 
                         syncManager.getSyncHandlers()[appInstanceId]?.let { handler ->
-                            val iconPath = userDataPathProvider.resolveIconPath(appInstanceId, source)
                             val port = handler.currentSyncRuntimeInfo.port
                             handler.getConnectHostAddress()?.let { host ->
                                 pullIcon(source, iconPath, host, port, baseExtraInfo)


### PR DESCRIPTION
Closes #4194

## Summary

- Resolve the icon path before entering the sync handler lookup in `PullIconTaskExecutor`.
- Short-circuit with `SuccessPasteTaskResult` when the icon file already exists on disk, skipping the remote pull.

## Test plan

- [ ] Trigger a paste that references an already-cached source icon and confirm no remote pull is performed.
- [ ] Trigger a paste referencing a new source icon and confirm the remote pull still runs and writes the file.