### PR TITLE
:hammer: Extract shared AppSourceIcon composable

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/AppSourceIcon.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/AppSourceIcon.kt
@@ -29,54 +29,47 @@ import com.crosspaste.ui.theme.AppUISize.large2X
 import org.koin.compose.koinInject
 
 @Composable
-fun PasteDataScope.AppSourceIcon(
+fun AppSourceIcon(
+    source: String,
+    appInstanceId: String,
     modifier: Modifier = Modifier,
     size: Dp = large2X,
     defaultIcon: @Composable () -> Unit = {},
 ) {
-    val source = pasteData.source
+    val iconStyle = koinInject<IconStyle>()
+    val appSourceLoader = koinInject<ImageLoader>(qualifier = ImageLoaderQualifiers.APP_SOURCE)
+    val platformContext = koinInject<PlatformContext>()
+    val density = LocalDensity.current
+
+    val visualScale =
+        remember(source, appInstanceId) {
+            if (iconStyle.isMacStyleIcon(source, appInstanceId)) {
+                val paddingRatio = 0.075f
+                val contentRatio = 1f - (paddingRatio * 2)
+                1f / contentRatio
+            } else {
+                1f
+            }
+        }
+
+    val sizePx = with(density) { size.roundToPx() }
+
+    val model =
+        remember(source, appInstanceId, platformContext, sizePx) {
+            ImageRequest
+                .Builder(platformContext)
+                .data(AppSourceItem(source, appInstanceId))
+                .size(sizePx)
+                .precision(Precision.INEXACT)
+                .scale(Scale.FILL)
+                .crossfade(true)
+                .build()
+        }
 
     Box(
         modifier = modifier.size(size),
         contentAlignment = Alignment.Center,
     ) {
-        if (source == null) {
-            defaultIcon()
-            return@Box
-        }
-
-        val iconStyle = koinInject<IconStyle>()
-        val appSourceLoader = koinInject<ImageLoader>(qualifier = ImageLoaderQualifiers.APP_SOURCE)
-        val platformContext = koinInject<PlatformContext>()
-        val density = LocalDensity.current
-
-        val appInstanceId = pasteData.appInstanceId
-
-        val visualScale =
-            remember(source, appInstanceId) {
-                if (iconStyle.isMacStyleIcon(source, appInstanceId)) {
-                    val paddingRatio = 0.075f
-                    val contentRatio = 1f - (paddingRatio * 2)
-                    1f / contentRatio
-                } else {
-                    1f
-                }
-            }
-
-        val sizePx = with(density) { size.roundToPx() }
-
-        val model =
-            remember(source, appInstanceId, platformContext, sizePx) {
-                ImageRequest
-                    .Builder(platformContext)
-                    .data(AppSourceItem(source, appInstanceId))
-                    .size(sizePx)
-                    .precision(Precision.INEXACT)
-                    .scale(Scale.FILL)
-                    .crossfade(true)
-                    .build()
-            }
-
         SubcomposeAsyncImage(
             modifier =
                 Modifier
@@ -99,5 +92,30 @@ fun PasteDataScope.AppSourceIcon(
                 }
             }
         }
+    }
+}
+
+@Composable
+fun PasteDataScope.AppSourceIcon(
+    modifier: Modifier = Modifier,
+    size: Dp = large2X,
+    defaultIcon: @Composable () -> Unit = {},
+) {
+    val source = pasteData.source
+    if (source == null) {
+        Box(
+            modifier = modifier.size(size),
+            contentAlignment = Alignment.Center,
+        ) {
+            defaultIcon()
+        }
+    } else {
+        AppSourceIcon(
+            source = source,
+            appInstanceId = pasteData.appInstanceId,
+            modifier = modifier,
+            size = size,
+            defaultIcon = defaultIcon,
+        )
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/sourcecontrol/SourceControlContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/sourcecontrol/SourceControlContentView.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -23,29 +22,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
-import coil3.ImageLoader
-import coil3.PlatformContext
-import coil3.compose.AsyncImagePainter
-import coil3.compose.SubcomposeAsyncImage
-import coil3.compose.SubcomposeAsyncImageContent
-import coil3.request.ImageRequest
-import coil3.request.crossfade
-import coil3.size.Precision
-import coil3.size.Scale
 import com.crosspaste.app.AppInfo
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.i18n.GlobalCopywriter
-import com.crosspaste.image.coil.AppSourceItem
-import com.crosspaste.image.coil.ImageLoaderQualifiers
 import com.crosspaste.paste.DesktopSourceExclusionService
-import com.crosspaste.ui.base.IconStyle
+import com.crosspaste.ui.base.AppSourceIcon
 import com.crosspaste.ui.settings.SettingSectionCard
-import com.crosspaste.ui.theme.AppUISize.large2X
 import com.crosspaste.ui.theme.AppUISize.medium
 import com.crosspaste.ui.theme.AppUISize.tiny
 import com.crosspaste.ui.theme.AppUISize.xxxLarge
@@ -145,6 +129,7 @@ private fun SourceControlItem(
     isEnabled: Boolean,
     onToggle: (Boolean) -> Unit,
 ) {
+    val appInfo = koinInject<AppInfo>()
     Row(
         modifier =
             Modifier
@@ -153,7 +138,11 @@ private fun SourceControlItem(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(medium),
     ) {
-        SourceAppIcon(source = source, size = xxxLarge)
+        AppSourceIcon(
+            source = source,
+            appInstanceId = appInfo.appInstanceId,
+            size = xxxLarge,
+        )
         Text(
             text = source,
             style = MaterialTheme.typography.bodyLarge,
@@ -164,76 +153,5 @@ private fun SourceControlItem(
             checked = isEnabled,
             onCheckedChange = onToggle,
         )
-    }
-}
-
-@Composable
-private fun SourceAppIcon(
-    source: String,
-    size: Dp = large2X,
-) {
-    val appInfo = koinInject<AppInfo>()
-    val iconStyle = koinInject<IconStyle>()
-    val appSourceLoader = koinInject<ImageLoader>(qualifier = ImageLoaderQualifiers.APP_SOURCE)
-    val platformContext = koinInject<PlatformContext>()
-    val density = LocalDensity.current
-
-    val appInstanceId = appInfo.appInstanceId
-
-    var visualScale by remember(source) { mutableStateOf(1f) }
-
-    LaunchedEffect(source) {
-        visualScale =
-            withContext(ioDispatcher) {
-                if (iconStyle.isMacStyleIcon(source, appInstanceId)) {
-                    val paddingRatio = 0.075f
-                    val contentRatio = 1f - (paddingRatio * 2)
-                    1f / contentRatio
-                } else {
-                    1f
-                }
-            }
-    }
-
-    val sizePx = with(density) { size.roundToPx() }
-
-    val model =
-        remember(source, appInstanceId, platformContext, sizePx) {
-            ImageRequest
-                .Builder(platformContext)
-                .data(AppSourceItem(source, appInstanceId))
-                .size(sizePx)
-                .precision(Precision.INEXACT)
-                .scale(Scale.FILL)
-                .crossfade(true)
-                .build()
-        }
-
-    Box(
-        modifier = Modifier.size(size),
-        contentAlignment = Alignment.Center,
-    ) {
-        SubcomposeAsyncImage(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .scale(visualScale),
-            model = model,
-            imageLoader = appSourceLoader,
-            contentDescription = source,
-            contentScale = ContentScale.Fit,
-        ) {
-            val state by painter.state.collectAsState()
-            when (state) {
-                is AsyncImagePainter.State.Loading,
-                is AsyncImagePainter.State.Error,
-                -> {
-                    // Empty placeholder when icon not available
-                }
-                else -> {
-                    SubcomposeAsyncImageContent()
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Closes #4196

## Summary

- Added a plain `AppSourceIcon(source, appInstanceId, modifier, size, defaultIcon)` composable in `app/src/commonMain/.../ui/base/AppSourceIcon.kt` that owns the visual-scale, `ImageRequest`, and state-dispatch logic.
- Rewrote `PasteDataScope.AppSourceIcon` as a thin wrapper that pulls `source`/`appInstanceId` from the scope and delegates (with a `defaultIcon` fast-path for null `source`).
- Deleted the near-duplicate `SourceAppIcon` in `SourceControlContentView.kt`; the call site now uses the top-level `AppSourceIcon(source, appInfo.appInstanceId, size = xxxLarge)`.
- `SideAppSourceIcon` is intentionally not merged — its request pipeline differs (crop transformation, `sideTitleHeight`-driven size).

## Behavior notes

The old `SourceAppIcon` did `LaunchedEffect + withContext(ioDispatcher)` around
`IconStyle.isMacStyleIcon`, while `PasteDataScope.AppSourceIcon` used a
synchronous `remember`. The shared composable follows the synchronous path —
`isMacStyleIcon` is cached behind a Caffeine `LoadingCache`, so subsequent calls
are O(1), and this yields one fewer recomposition plus correct visual scale on
the first frame.

## Test plan

- [ ] Open Settings → Source Control and confirm each source row renders its icon.
- [ ] Confirm paste rows in the main list still render their app source icons correctly (no regression in `PasteDataScope.AppSourceIcon`).
- [ ] Confirm a paste with `source = null` still shows the fallback default icon.