### PR TITLE
:hammer: Deduplicate icon path validation in PullRouting

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
@@ -86,14 +86,14 @@ fun Routing.pullRouting(
                 return@get
             }
 
-        if (source.contains('/') || source.contains('\\') || source.contains("..")) {
-            logger.warn { "icon source contains invalid characters: $source" }
-            failResponse(call, StandardErrorCode.NOT_FOUND_SOURCE.toErrorCode())
-            return@get
-        }
-
         val iconPath =
-            userDataPathProvider.resolveIconPath(appInfo.appInstanceId, source)
+            runCatching {
+                userDataPathProvider.resolveIconPath(appInfo.appInstanceId, source)
+            }.getOrElse {
+                logger.warn { "icon source contains invalid characters: $source" }
+                failResponse(call, StandardErrorCode.NOT_FOUND_SOURCE.toErrorCode())
+                return@get
+            }
 
         if (!fileUtils.existFile(iconPath)) {
             logger.error { "icon not found: $source" }


### PR DESCRIPTION
Closes #4198

## Summary

- Removed the manual `/`, `\`, `..` check from `/pull/icon/{source}` — `UserDataPathProvider.resolveIconPath` already runs the same validation via `isSafeIconComponent` (which also covers the empty-string case).
- Wrapped `resolveIconPath` in `runCatching` so validation failures map to a clean 404 (`NOT_FOUND_SOURCE`) instead of bubbling up as an unhandled 500.

## Test plan

- [ ] Request `/pull/icon/foo%2Fbar` (contains `/`) and confirm 404 response.
- [ ] Request `/pull/icon/..` (contains `..`) and confirm 404 response.
- [ ] Request `/pull/icon/nonexistent` and confirm 404 (`NOT_FOUND_ICON`).
- [ ] Request a valid source with an existing icon and confirm the icon is served.