### PR TITLE
:hammer: Log failures when saving app icons in window managers

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
@@ -102,6 +102,8 @@ class LinuxAppWindowManager(
             if (!iconPath.toFile().exists()) {
                 X11Api.saveAppIcon(window, iconPath.toNioPath())
             }
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to save app icon for $className" }
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/MacAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/MacAppWindowManager.kt
@@ -78,6 +78,8 @@ class MacAppWindowManager(
             if (!appImagePath.toFile().exists()) {
                 MacAppUtils.saveAppIcon(bundleIdentifier, appImagePath.toString())
             }
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to save app icon for $localizedName ($bundleIdentifier)" }
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WinAppInfo.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WinAppInfo.kt
@@ -6,6 +6,7 @@ import com.crosspaste.utils.getFileUtils
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.LoadingCache
 import com.sun.jna.platform.win32.WinDef.HWND
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import okio.Path
@@ -30,6 +31,8 @@ class WinAppInfoCaches(
     private val userDataPathProvider: UserDataPathProvider,
     private val scope: CoroutineScope,
 ) {
+
+    private val logger = KotlinLogging.logger {}
 
     private val fileUtils = getFileUtils()
 
@@ -80,6 +83,8 @@ class WinAppInfoCaches(
             if (!fileUtils.existFile(iconPath)) {
                 WindowsIconUtils.extractAndSaveIcon(exeFilePath, iconPath)
             }
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to save app icon for $appName" }
         }
     }
 


### PR DESCRIPTION
Closes #4200

## Summary

- Added `.onFailure { logger.warn(...) }` to the `runCatching` blocks in `LinuxAppWindowManager.saveAppImage`, `MacAppWindowManager.saveImagePathByApp`, and `WinAppInfoCaches.saveAppImage` so icon-save failures (e.g., `resolveIconPath` validation, native icon extraction) are no longer silent.
- Introduced a `KotlinLogging` logger on `WinAppInfoCaches` (it had none previously).

## Test plan

- [ ] Trigger an icon save with an invalid `appInstanceId` / app name and confirm a warning appears in the log on each platform.
- [ ] Confirm the normal happy-path icon save still works and does not log.