### PR TITLE
:hammer: Improve AppSourceIcon accessibility and remember key efficiency

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/AppSourceIcon.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/AppSourceIcon.kt
@@ -46,7 +46,7 @@ fun AppSourceIcon(
     val requestSizePx = transformer.requestSize(sizePx)
 
     val model =
-        remember(source, appInstanceId, platformContext, requestSizePx, transformer) {
+        remember(source, appInstanceId, requestSizePx) {
             ImageRequest
                 .Builder(platformContext)
                 .data(AppSourceItem(source, appInstanceId))
@@ -66,7 +66,7 @@ fun AppSourceIcon(
             modifier = Modifier.fillMaxSize(),
             model = model,
             imageLoader = appSourceLoader,
-            contentDescription = "App Source Icon",
+            contentDescription = source,
             contentScale = ContentScale.Fit,
         ) {
             val state by painter.state.collectAsState()

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/SideAppSourceIcon.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/SideAppSourceIcon.kt
@@ -39,7 +39,7 @@ fun PasteDataScope.SideAppSourceIcon(
     val requestSizePx = transformer.requestSize(sizePx)
 
     val model =
-        remember(pasteData.source, pasteData.appInstanceId, requestSizePx, transformer) {
+        remember(pasteData.source, pasteData.appInstanceId, requestSizePx) {
             ImageRequest
                 .Builder(platformContext)
                 .data(AppSourceItem(pasteData.source, pasteData.appInstanceId))
@@ -54,7 +54,7 @@ fun PasteDataScope.SideAppSourceIcon(
         modifier = modifier,
         model = model,
         imageLoader = appSourceLoader,
-        contentDescription = "Paste Icon",
+        contentDescription = pasteData.source,
         content = {
             val state by this.painter.state.collectAsState()
             when (state) {


### PR DESCRIPTION
Closes #4204

## Summary

- Pass the actual `source` (or `pasteData.source`) as `contentDescription` in both `AppSourceIcon` and `SideAppSourceIcon`, replacing the hardcoded, inconsistent strings (`"App Source Icon"` / `"Paste Icon"`). This improves accessibility and debugging.
- Remove the Koin singletons `platformContext` and `transformer` from the `remember` keys — their references never change during composition, so including them only added needless reference comparisons per recomposition.

## Test plan

- [x] `./gradlew ktlintFormat`
- [ ] Visual verification: open the app and confirm source icons still render correctly in both the detail view and the side panel