### PR TITLE
:art: Shrink OfflineToggle switch scale for header fit

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -262,7 +262,7 @@ private fun OfflineToggle(
         horizontalArrangement = Arrangement.spacedBy(tiny2X),
     ) {
         Switch(
-            modifier = Modifier.scale(0.8f),
+            modifier = Modifier.scale(0.7f),
             checked = checked,
             onCheckedChange = onCheckedChange,
         )


### PR DESCRIPTION
Closes #4211

## Summary
- Shrink the Material3 Switch inside `OfflineToggle` from `Modifier.scale(0.8f)` to `Modifier.scale(0.7f)` so it feels better balanced next to the "My Devices" section-header label

## Test plan
- [ ] Open devices screen with at least one disconnected device
- [ ] Confirm the Switch in the "My Devices" header is visually balanced with the "Show Offline (N)" label