### PR TITLE
:bug: Reactively read port in CurrentDeviceDialog

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/CurrentDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/CurrentDeviceDialog.kt
@@ -17,7 +17,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Dialog
@@ -49,19 +50,18 @@ fun CurrentDeviceDialog(onDismiss: () -> Unit) {
 
     val appSizeValue = LocalAppSizeValueState.current
 
+    val port by server.portFlow.collectAsState()
+
     val rows =
-        remember(appInfo, platform, copywriter) {
-            val port = server.port()
-            listOf(
-                "device_name" to deviceUtils.getDeviceName(),
-                "user_name" to appInfo.userName,
-                "app_version" to appInfo.displayVersion(),
-                "device_id" to deviceUtils.getDeviceId(),
-                "os" to "${platform.name} ${platform.version}",
-                "arch" to platform.arch,
-                "port" to if (port <= 0) copywriter.getText("unknown") else port.toString(),
-            )
-        }
+        listOf(
+            "device_name" to deviceUtils.getDeviceName(),
+            "user_name" to appInfo.userName,
+            "app_version" to appInfo.displayVersion(),
+            "device_id" to deviceUtils.getDeviceId(),
+            "os" to "${platform.name} ${platform.version}",
+            "arch" to platform.arch,
+            "port" to if (port <= 0) copywriter.getText("unknown") else port.toString(),
+        )
 
     Dialog(
         onDismissRequest = onDismiss,


### PR DESCRIPTION
Closes #4213

## Summary
- Replace `server.port()` (a one-shot read inside `remember`) with `server.portFlow.collectAsState()` so the displayed port stays in sync when the server restarts on a different port
- Drop the `remember(appInfo, platform, copywriter)` wrapper around the `rows` list — `copywriter` was ineffective as a key (singleton identity never changes), so the "unknown" fallback text never recomputed on language switch; building 7 `Pair`s per recomposition is cheap enough to do unconditionally, and this fixes both issues at once

## Test plan
- [ ] Open devices screen, tap "Current Device", switch UI language — confirm labels refresh in-place (e.g. "Device Name" → "设备名称")
- [ ] With the server port set to an invalid value so it shows "unknown", switch language and confirm the fallback word translates