### PR TITLE
:hammer: unify coroutine scopes via namedScope helper

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
@@ -1,8 +1,7 @@
 package com.crosspaste.app
 
 import com.crosspaste.utils.ioDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
+import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,7 +16,7 @@ import kotlin.random.Random
 
 abstract class AppTokenService : AppTokenApi {
 
-    private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val scope = namedScope(ioDispatcher, "AppTokenService")
 
     private val lock = Mutex()
 

--- a/app/src/commonMain/kotlin/com/crosspaste/clean/CleanScheduler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/clean/CleanScheduler.kt
@@ -5,9 +5,8 @@ import com.crosspaste.db.task.TaskDao
 import com.crosspaste.db.task.TaskType
 import com.crosspaste.task.TaskExecutor
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -22,7 +21,7 @@ class CleanScheduler(
 
     private val logger = KotlinLogging.logger {}
 
-    private val coroutineScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val coroutineScope = namedScope(ioDispatcher, "CleanScheduler")
 
     private val cleanInterval = 5.minutes
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -28,6 +28,7 @@ import com.crosspaste.sync.PendingKeyExchangeStore
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
@@ -35,7 +36,6 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 
@@ -91,7 +91,11 @@ open class DefaultServerModule(
                 }
             }
             val pasteRoutingScope =
-                CoroutineScope(ioDispatcher + SupervisorJob(coroutineContext[Job]))
+                namedScope(
+                    ioDispatcher,
+                    "DefaultServerModule.pasteRoutingScope",
+                    SupervisorJob(coroutineContext[Job]),
+                )
             routing {
                 syncRouting(
                     appInfo,

--- a/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
@@ -3,18 +3,16 @@ package com.crosspaste.net
 import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
-import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.statement.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration.Companion.milliseconds
 
 class TelnetHelper(
@@ -36,32 +34,29 @@ class TelnetHelper(
     ): Pair<HostInfo, VersionRelation>? {
         if (hostInfoList.isEmpty()) return null
 
-        val result = CompletableDeferred<Pair<HostInfo, VersionRelation>?>()
-        val mutex = Mutex()
-        val scope = CoroutineScope(ioDispatcher)
+        return withTimeoutOrNull(timeout.milliseconds) {
+            supervisorScope {
+                val result = CompletableDeferred<Pair<HostInfo, VersionRelation>?>()
+                val mutex = Mutex()
 
-        hostInfoList.forEach { hostInfo ->
-            scope.launch(CoroutineName("SwitchHost")) {
-                runCatching {
-                    telnet(hostInfo.hostAddress, port, timeout)?.let {
-                        mutex.withLock {
-                            if (!result.isCompleted) {
-                                result.complete(Pair(hostInfo, it))
+                hostInfoList.forEach { hostInfo ->
+                    launch(CoroutineName("SwitchHost")) {
+                        runCatching {
+                            telnet(hostInfo.hostAddress, port, timeout)?.let {
+                                mutex.withLock {
+                                    if (!result.isCompleted) {
+                                        result.complete(Pair(hostInfo, it))
+                                    }
+                                }
                             }
+                        }.onFailure { e ->
+                            logger.debug(e) { "switchHost telnet failed for ${hostInfo.hostAddress}:$port" }
                         }
                     }
-                }.onFailure { e ->
-                    logger.debug(e) { "switchHost telnet failed for ${hostInfo.hostAddress}:$port" }
                 }
-            }
-        }
 
-        return try {
-            withTimeout(timeout.milliseconds) { result.await() }
-        } catch (_: TimeoutCancellationException) {
-            null
-        } finally {
-            scope.cancel()
+                result.await().also { coroutineContext.cancelChildren() }
+            }
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/ClientApiResult.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/ClientApiResult.kt
@@ -7,8 +7,10 @@ import com.crosspaste.exception.standardErrorCodeMap
 import com.crosspaste.net.exception.ExceptionHandler
 import io.github.oshai.kotlinlogging.KLogger
 import io.ktor.client.call.*
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.statement.*
 import kotlinx.serialization.Serializable
+import kotlin.coroutines.cancellation.CancellationException
 
 interface ClientApiResult
 
@@ -30,6 +32,8 @@ object ConnectionRefused : ClientApiResult
 object EncryptFail : ClientApiResult
 
 object DecryptFail : ClientApiResult
+
+object RequestTimeout : ClientApiResult
 
 object UnknownError : ClientApiResult
 
@@ -71,6 +75,11 @@ suspend inline fun <T> request(
         } else {
             SuccessResult(transformData(response))
         }
+    } catch (e: HttpRequestTimeoutException) {
+        logger.warn(e) { "request timeout" }
+        RequestTimeout
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         logger.error(e) { "request error" }
         if (exceptionHandler.isConnectionRefused(e)) {

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
@@ -3,12 +3,11 @@ package com.crosspaste.net.ws
 import com.crosspaste.app.AppInfo
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.websocket.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 class WsClientConnector(
@@ -19,7 +18,7 @@ class WsClientConnector(
 ) {
     private val logger = KotlinLogging.logger {}
     private val json = getJsonUtils().JSON
-    private val connectScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val connectScope = namedScope(ioDispatcher, "WsClientConnector")
 
     /**
      * Attempt to open a WebSocket connection to a remote peer.

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessageHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessageHandler.kt
@@ -14,9 +14,9 @@ import com.crosspaste.secure.SecureStore
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 class WsMessageHandler(
@@ -29,7 +29,7 @@ class WsMessageHandler(
     private val userDataPathProvider: UserDataPathProvider,
     private val wsPendingRequests: WsPendingRequests,
     private val wsSessionManager: WsSessionManager,
-    private val scope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    private val scope: CoroutineScope = namedScope(ioDispatcher, "WsMessageHandler"),
 ) {
     private val appControl: AppControl get() = lazyAppControl.value
     private val cacheManager: CacheManager get() = lazyCacheManager.value

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/DefaultPasteSyncProcessManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/DefaultPasteSyncProcessManager.kt
@@ -5,7 +5,9 @@ import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.utils.createPlatformLock
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.mainDispatcher
-import kotlinx.coroutines.CoroutineScope
+import com.crosspaste.utils.namedScope
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +21,9 @@ import kotlin.time.Duration.Companion.seconds
 
 class DefaultPasteSyncProcessManager : PasteSyncProcessManager<Long> {
 
-    private val ioScope = CoroutineScope(ioDispatcher)
+    private val logger = KotlinLogging.logger {}
+
+    private val ioScope = namedScope(ioDispatcher, "DefaultPasteSyncProcessManager")
 
     private val semaphore = Semaphore(10)
 
@@ -48,23 +52,30 @@ class DefaultPasteSyncProcessManager : PasteSyncProcessManager<Long> {
         pasteDataId: Long,
         tasks: List<suspend () -> Pair<Int, ClientApiResult>>,
     ): List<Pair<Int, ClientApiResult>> {
+        if (tasks.isEmpty()) return emptyList()
         val process = getProcess(pasteDataId, tasks.size)
         return ioScope
             .async {
                 tasks
                     .map { task ->
                         async {
-                            semaphore.withPermit {
-                                withTimeout(60.seconds) {
-                                    val result = task()
-                                    if (result.second is SuccessResult) {
-                                        process.success(result.first)
+                            try {
+                                semaphore.withPermit {
+                                    withTimeout(60.seconds) {
+                                        val result = task()
+                                        if (result.second is SuccessResult) {
+                                            process.success(result.first)
+                                        }
+                                        result
                                     }
-                                    result
                                 }
+                            } catch (e: TimeoutCancellationException) {
+                                logger.warn(e) { "runTask timed out for pasteDataId=$pasteDataId" }
+                                null
                             }
                         }
                     }.awaitAll()
+                    .filterNotNull()
             }.await()
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteExportService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteExportService.kt
@@ -14,9 +14,8 @@ import com.crosspaste.utils.getCodecsUtils
 import com.crosspaste.utils.getCompressUtils
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -36,7 +35,7 @@ class PasteExportService(
 
     private val fileUtils = getFileUtils()
 
-    private val ioCoroutineDispatcher = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val ioCoroutineDispatcher = namedScope(ioDispatcher, "PasteExportService")
 
     private val mutex = Mutex()
 

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
@@ -16,10 +16,9 @@ import com.crosspaste.utils.getCodecsUtils
 import com.crosspaste.utils.getCompressUtils
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import com.crosspaste.utils.noOptionParent
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -40,7 +39,7 @@ class PasteImportService(
 
     private val fileUtils = getFileUtils()
 
-    private val ioCoroutineDispatcher = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val ioCoroutineDispatcher = namedScope(ioDispatcher, "PasteImportService")
 
     private val mutex = Mutex()
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
@@ -6,9 +6,9 @@ import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -22,7 +22,7 @@ class GeneralNearbyDeviceManager(
     configManager: CommonConfigManager,
     private val ratingPromptManager: RatingPromptManager,
     private val syncManager: SyncManager,
-    override val nearbyDeviceScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    override val nearbyDeviceScope: CoroutineScope = namedScope(ioDispatcher, "GeneralNearbyDeviceManager"),
 ) : NearbyDeviceManager {
 
     private val logger = KotlinLogging.logger {}

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -5,10 +5,10 @@ import com.crosspaste.db.sync.SyncRuntimeInfo.Companion.hostInfoListEqual
 import com.crosspaste.db.sync.SyncState
 import com.crosspaste.net.VersionRelation
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,7 +20,7 @@ import kotlin.time.Duration.Companion.seconds
 class GeneralSyncHandler(
     syncRuntimeInfo: SyncRuntimeInfo,
     private val emitEvent: suspend (SyncEvent) -> Unit,
-    private val syncHandlerScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    private val syncHandlerScope: CoroutineScope = namedScope(ioDispatcher, "GeneralSyncHandler"),
 ) : SyncHandler {
 
     private val _syncRuntimeInfo: MutableStateFlow<SyncRuntimeInfo> = MutableStateFlow(syncRuntimeInfo)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -9,13 +9,13 @@ import com.crosspaste.net.filter
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.mainDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.*
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
@@ -32,7 +32,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class GeneralSyncManager(
-    override val realTimeSyncScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    override val realTimeSyncScope: CoroutineScope = namedScope(ioDispatcher, "GeneralSyncManager"),
     private val syncResolver: SyncResolverApi,
     private val syncRuntimeInfoDao: SyncRuntimeInfoDao,
     private val wsSessionManager: WsSessionManager,

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingNearbyDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingNearbyDeviceManager.kt
@@ -6,14 +6,14 @@ import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.platform.Platform
 import com.crosspaste.platform.Platform.Companion.LINUX
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class MarketingNearbyDeviceManager : NearbyDeviceManager {
 
-    override val nearbyDeviceScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    override val nearbyDeviceScope: CoroutineScope = namedScope(ioDispatcher, "MarketingNearbyDeviceManager")
 
     override val searching: MutableStateFlow<Boolean> = MutableStateFlow(false)
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
@@ -7,9 +7,8 @@ import com.crosspaste.platform.Platform
 import com.crosspaste.platform.Platform.Companion.MACOS
 import com.crosspaste.platform.Platform.Companion.WINDOWS
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.ktor.util.collections.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -70,7 +69,7 @@ class MarketingSyncManager : SyncManager {
 
     private var internalSyncHandlers: MutableMap<String, SyncHandler> = ConcurrentMap()
 
-    override val realTimeSyncScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    override val realTimeSyncScope = namedScope(ioDispatcher, "MarketingSyncManager")
 
     override fun createSyncHandler(syncRuntimeInfo: SyncRuntimeInfo): SyncHandler =
         MarketingSyncHandler(syncRuntimeInfo)

--- a/app/src/commonMain/kotlin/com/crosspaste/task/DelayedDeletePasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/DelayedDeletePasteTaskExecutor.kt
@@ -7,15 +7,15 @@ import com.crosspaste.db.task.TaskType
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.TaskUtils
 import com.crosspaste.utils.cpuDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class DelayedDeletePasteTaskExecutor(
     private val pasteDao: PasteDao,
-    private val scope: CoroutineScope = CoroutineScope(cpuDispatcher + SupervisorJob()),
+    private val scope: CoroutineScope = namedScope(cpuDispatcher, "DelayedDeletePasteTaskExecutor"),
 ) : SingleTypeTaskExecutor {
 
     private val logger = KotlinLogging.logger {}

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -30,10 +30,9 @@ import com.crosspaste.utils.TaskUtils
 import com.crosspaste.utils.buildUrl
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlin.collections.filter
 
@@ -52,7 +51,7 @@ class SyncPasteTaskExecutor(
 
     private val jsonUtils = getJsonUtils()
 
-    private val ioScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val ioScope = namedScope(ioDispatcher, "SyncPasteTaskExecutor")
 
     override val taskType: Int = TaskType.SYNC_PASTE_TASK
 

--- a/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
@@ -4,10 +4,10 @@ import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskDao
 import com.crosspaste.utils.TaskUtils
 import com.crosspaste.utils.cpuDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
@@ -17,7 +17,7 @@ class TaskExecutor(
     singleTypeTaskExecutors: List<SingleTypeTaskExecutor>,
     private val taskDao: TaskDao,
     maxConcurrentTasks: Int = 10,
-    private val scope: CoroutineScope = CoroutineScope(cpuDispatcher + SupervisorJob()),
+    private val scope: CoroutineScope = namedScope(cpuDispatcher, "TaskExecutor"),
 ) {
     private val logger = KotlinLogging.logger {}
 

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/FontManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/FontManager.kt
@@ -8,8 +8,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.text.font.FontFamily
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.utils.ioDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
+import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,7 +36,7 @@ abstract class FontManager(
             )
     }
 
-    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val scope = namedScope(ioDispatcher, "FontManager")
 
     private val _selectableFonts = MutableStateFlow(listOf(defaultFontInfo))
 

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/settings/StorageStatisticsScope.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/settings/StorageStatisticsScope.kt
@@ -6,12 +6,12 @@ import androidx.compose.runtime.setValue
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 
 class StorageStatisticsScope(
     val pasteDao: PasteDao,
-    val scope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    val scope: CoroutineScope = namedScope(ioDispatcher, "StorageStatisticsScope"),
 ) {
 
     val fileUtils = getFileUtils()

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/CoroutineScopes.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/CoroutineScopes.kt
@@ -1,0 +1,25 @@
+package com.crosspaste.utils
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+
+private val logger = KotlinLogging.logger {}
+
+// Prevents Kotlin/Native abort() from uncaught exceptions in sibling coroutines (e.g. Ktor HttpTimeout killer).
+fun loggingExceptionHandler(name: String): CoroutineExceptionHandler =
+    CoroutineExceptionHandler { _, throwable ->
+        logger.error(throwable) { "Unhandled exception in $name" }
+    }
+
+fun namedScope(
+    dispatcher: CoroutineDispatcher,
+    name: String,
+    job: CompletableJob? = SupervisorJob(),
+): CoroutineScope =
+    job?.let {
+        CoroutineScope(dispatcher + it + loggingExceptionHandler(name))
+    } ?: CoroutineScope(dispatcher + loggingExceptionHandler(name))

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/GlobalCoroutineScope.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/GlobalCoroutineScope.kt
@@ -1,13 +1,10 @@
 package com.crosspaste.utils
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-
 object GlobalCoroutineScope {
 
-    val mainCoroutineDispatcher = CoroutineScope(SupervisorJob() + mainDispatcher)
+    val mainCoroutineDispatcher = namedScope(mainDispatcher, "GlobalCoroutineScope.main")
 
-    val ioCoroutineDispatcher = CoroutineScope(SupervisorJob() + ioDispatcher)
+    val ioCoroutineDispatcher = namedScope(ioDispatcher, "GlobalCoroutineScope.io")
 
-    val cpuCoroutineDispatcher = CoroutineScope(SupervisorJob() + cpuDispatcher)
+    val cpuCoroutineDispatcher = namedScope(cpuDispatcher, "GlobalCoroutineScope.cpu")
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUpdateService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUpdateService.kt
@@ -5,13 +5,12 @@ import com.crosspaste.notification.MessageType
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.ui.base.UISupport
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import dev.hydraulic.conveyor.control.SoftwareUpdateController
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.z4kn4fein.semver.Version
 import io.ktor.utils.io.jvm.javaio.toInputStream
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,7 +33,7 @@ class DesktopAppUpdateService(
 
     private val controller: SoftwareUpdateController? = SoftwareUpdateController.getInstance()
 
-    private val coroutineScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val coroutineScope = namedScope(ioDispatcher, "DesktopAppUpdateService")
 
     private val _currentVersion: MutableStateFlow<Version> =
         MutableStateFlow(

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
@@ -10,10 +10,9 @@ import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.platform.Platform
 import com.crosspaste.utils.GlobalCoroutineScope.mainCoroutineDispatcher
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -87,7 +86,7 @@ abstract class DesktopAppWindowManager(
 
     val bubbleWindowTitle: String = BUBBLE_WINDOW_TITLE
 
-    protected val ioScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    protected val ioScope = namedScope(ioDispatcher, "DesktopAppWindowManager")
 
     private val _mainWindowInfo =
         MutableStateFlow(

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessPasteboardService.kt
@@ -6,10 +6,10 @@ import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 
 class HeadlessPasteboardService(
@@ -23,7 +23,7 @@ class HeadlessPasteboardService(
 
     override val remotePasteboardChannel: Channel<suspend () -> Result<Unit?>> = Channel(Channel.CONFLATED)
 
-    override val serviceScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    override val serviceScope: CoroutineScope = namedScope(ioDispatcher, "HeadlessPasteboardService")
 
     override fun start() {
         logger.info { "Headless pasteboard service started (no clipboard monitoring)" }

--- a/app/src/desktopMain/kotlin/com/crosspaste/log/DesktopCrossPasteLogger.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/log/DesktopCrossPasteLogger.kt
@@ -10,8 +10,8 @@ import ch.qos.logback.core.util.FileSize
 import ch.qos.logback.core.util.StatusPrinter2
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory
 class DesktopCrossPasteLogger(
     override val logPath: String,
     configManager: DesktopConfigManager,
-    loggerLevelScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    loggerLevelScope: CoroutineScope = namedScope(ioDispatcher, "DesktopCrossPasteLogger"),
 ) : CrossPasteLogger {
 
     private val context = LoggerFactory.getILoggerFactory() as LoggerContext

--- a/app/src/desktopMain/kotlin/com/crosspaste/module/ModuleDownloadManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/module/ModuleDownloadManager.kt
@@ -6,13 +6,13 @@ import com.crosspaste.net.ResourcesClient
 import com.crosspaste.utils.getDateUtils
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.*
 import io.ktor.util.collections.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 class ModuleDownloadManager(
     private val moduleManager: ModuleManager,
     private val resourcesClient: ResourcesClient,
-    private val downloadScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    private val downloadScope: CoroutineScope = namedScope(ioDispatcher, "ModuleDownloadManager"),
 ) {
 
     companion object Companion {

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkInterfaceService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkInterfaceService.kt
@@ -3,9 +3,9 @@ package com.crosspaste.net
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.stateIn
 
 class DesktopNetworkInterfaceService(
     private val configManager: DesktopConfigManager,
-    networkRefreshScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    networkRefreshScope: CoroutineScope = namedScope(ioDispatcher, "DesktopNetworkInterfaceService"),
 ) : AbstractNetworkInterfaceService() {
 
     private val jsonUtils = getJsonUtils()

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
@@ -9,10 +9,10 @@ import com.crosspaste.utils.DesktopControlUtils.ensureMinExecutionTime
 import com.crosspaste.utils.TxtRecordUtils
 import com.crosspaste.utils.getDateUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
@@ -32,7 +32,7 @@ class DesktopPasteBonjourService(
     private val endpointInfoFactory: EndpointInfoFactory,
     private val nearbyDeviceManager: NearbyDeviceManager,
     private val networkInterfaceService: NetworkInterfaceService,
-    private val scope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    private val scope: CoroutineScope = namedScope(ioDispatcher, "DesktopPasteBonjourService"),
 ) : PasteBonjourService {
 
     companion object {

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/AbstractPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/AbstractPasteboardService.kt
@@ -6,8 +6,7 @@ import com.crosspaste.notification.NotificationManager
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.sound.SoundService
 import com.crosspaste.utils.ioDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
+import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.onFailure
 import java.awt.datatransfer.Clipboard
@@ -38,7 +37,7 @@ abstract class AbstractPasteboardService :
 
     override val remotePasteboardChannel: Channel<suspend () -> Result<Unit?>> = Channel(Channel.CONFLATED)
 
-    override val serviceScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    override val serviceScope = namedScope(ioDispatcher, "AbstractPasteboardService")
 
     fun isValidContents(contents: Transferable?): Boolean =
         contents != null && contents.transferDataFlavors.isNotEmpty()

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
@@ -36,12 +36,11 @@ import com.crosspaste.ui.paste.PasteDataScope
 import com.crosspaste.ui.theme.AppUIColors
 import com.crosspaste.ui.theme.AppUISize.small
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import com.dzirbel.contextmenu.ContextMenuDivider
 import com.dzirbel.contextmenu.ContextMenuGroup
 import com.dzirbel.contextmenu.MaterialContextMenuItem
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -71,7 +70,7 @@ class DesktopPasteMenuService(
 
     private val desktopAppWindowManager = appWindowManager as DesktopAppWindowManager
 
-    private val menuScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val menuScope = namedScope(ioDispatcher, "DesktopPasteMenuService")
 
     private val _pendingCutPasteId = MutableStateFlow<Long?>(null)
     val pendingCutPasteId: StateFlow<Long?> = _pendingCutPasteId.asStateFlow()

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
@@ -13,6 +13,7 @@ import com.crosspaste.sound.SoundService
 import com.crosspaste.utils.DesktopControlUtils
 import com.crosspaste.utils.cpuDispatcher
 import com.crosspaste.utils.getControlUtils
+import com.crosspaste.utils.namedScope
 import com.sun.jna.Pointer
 import com.sun.jna.platform.win32.Kernel32
 import com.sun.jna.platform.win32.WinDef.HWND
@@ -22,9 +23,7 @@ import com.sun.jna.platform.win32.WinUser.MSG
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.awt.Toolkit
 import java.awt.datatransfer.Clipboard
@@ -62,7 +61,7 @@ class WindowsPasteboardService(
 
     override val systemClipboard: Clipboard = Toolkit.getDefaultToolkit().systemClipboard
 
-    private val serviceConsumerScope = CoroutineScope(cpuDispatcher + SupervisorJob())
+    private val serviceConsumerScope = namedScope(cpuDispatcher, "WindowsPasteboardService")
 
     private var job: Job? = null
     private var viewer: HWND? = null

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowFocusRecorder.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowFocusRecorder.kt
@@ -4,14 +4,13 @@ import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.platform.windows.api.User32
 import com.crosspaste.platform.windows.api.User32.Companion.INSTANCE
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import com.sun.jna.Native
 import com.sun.jna.platform.win32.WinDef
 import com.sun.jna.platform.win32.WinDef.HWND
 import com.sun.jna.platform.win32.WinNT
 import com.sun.jna.platform.win32.WinUser
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -29,7 +28,7 @@ class WindowFocusRecorder(
 
     val lastWinAppInfo: StateFlow<WinAppInfo?> = _lastWinAppInfo
 
-    private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val scope = namedScope(ioDispatcher, "WindowFocusRecorder")
 
     fun start() {
         if (hookHandle != null) return

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowsLazyClipboard.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowsLazyClipboard.kt
@@ -2,6 +2,7 @@ package com.crosspaste.platform.windows
 
 import com.crosspaste.platform.windows.api.Kernel32
 import com.crosspaste.platform.windows.api.User32
+import com.crosspaste.utils.namedScope
 import com.sun.jna.Function
 import com.sun.jna.Memory
 import com.sun.jna.Pointer
@@ -11,11 +12,9 @@ import com.sun.jna.platform.win32.WinDef.WPARAM
 import com.sun.jna.platform.win32.WinUser
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
@@ -35,7 +34,7 @@ class WindowsLazyClipboard : AutoCloseable {
     private val getMessageW = Function.getFunction("user32", "GetMessageW", Function.ALT_CONVENTION)
 
     private val windowDispatcher = newSingleThreadContext("WindowsLazyClipboard")
-    private val scope = CoroutineScope(windowDispatcher + SupervisorJob())
+    private val scope = namedScope(windowDispatcher, "WindowsLazyClipboard")
 
     private var hwnd: HWND? = null
     private var messageLoopJob: Job? = null

--- a/app/src/desktopMain/kotlin/com/crosspaste/sound/DesktopSoundService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/sound/DesktopSoundService.kt
@@ -4,10 +4,9 @@ import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.utils.DesktopResourceUtils
 import com.crosspaste.utils.cpuDispatcher
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -24,7 +23,7 @@ class DesktopSoundService(
 
     private val logger = KotlinLogging.logger {}
 
-    private val scope = CoroutineScope(cpuDispatcher + SupervisorJob())
+    private val scope = namedScope(cpuDispatcher, "DesktopSoundService")
 
     companion object {
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/DesktopUISupport.kt
@@ -20,9 +20,9 @@ import com.crosspaste.utils.extension
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.getHtmlUtils
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import okio.Path
 import java.awt.Color
@@ -40,7 +40,7 @@ class DesktopUISupport(
     private val updatePasteItemHelper: UpdatePasteItemHelper,
     private val userDataPathProvider: UserDataPathProvider,
     private val appWindowManager: DesktopAppWindowManager,
-    private val actionScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob()),
+    private val actionScope: CoroutineScope = namedScope(ioDispatcher, "DesktopUISupport"),
 ) : UISupport {
 
     private val logger = KotlinLogging.logger {}

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/theme/DesktopThemeDetector.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/theme/DesktopThemeDetector.kt
@@ -3,8 +3,8 @@ package com.crosspaste.ui.theme
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.ui.theme.ThemeState.Companion.createThemeState
 import com.crosspaste.utils.mainDispatcher
+import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.stateIn
 
 class DesktopThemeDetector(
     private val configManager: CommonConfigManager,
-    scope: CoroutineScope = CoroutineScope(SupervisorJob() + mainDispatcher),
+    scope: CoroutineScope = namedScope(mainDispatcher, "DesktopThemeDetector"),
 ) : ThemeDetector {
 
     private data class ThemeConfig(

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/tray/MacTrayView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/tray/MacTrayView.kt
@@ -21,10 +21,10 @@ import com.crosspaste.platform.macos.api.MenuCallback
 import com.crosspaste.ui.LocalExitApplication
 import com.crosspaste.ui.base.MenuHelper
 import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -83,7 +83,7 @@ class NativeTrayManager(
 ) {
     private val lib = MacosApi.INSTANCE
 
-    private val menuScope: CoroutineScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val menuScope: CoroutineScope = namedScope(ioDispatcher, "MacTrayView.NativeTrayManager")
 
     private var menuCallbacks = mutableMapOf<Int, () -> Unit>()
 


### PR DESCRIPTION
Closes #4215

## Summary

- Add `CoroutineScopes.namedScope` / `loggingExceptionHandler` so every background scope has an identifying name and logs uncaught exceptions.
- Migrate ~35 call sites from `CoroutineScope(dispatcher + SupervisorJob())` to `namedScope(...)`.
- `TelnetHelper.switchHost`: rewrite as `withTimeoutOrNull { supervisorScope { ... } }`.
- `ClientApiResult.request {}`: map `HttpRequestTimeoutException` to a new `RequestTimeout` result; rethrow `CancellationException` instead of swallowing it.
- `DefaultPasteSyncProcessManager`:
  - `ioScope` upgraded from plain `Job` to `SupervisorJob` — prevents the singleton scope from being poisoned by a single uncaught exception.
  - Each inner `async` catches its own `TimeoutCancellationException` locally — one chunk's timeout no longer cascades to cancel sibling chunks.

## Test plan
- [x] `./gradlew ktlintFormat` — clean
- [x] `./gradlew :app:compileKotlinDesktop` — clean
- [x] `./gradlew :app:desktopTest --tests "com.crosspaste.paste.DefaultPasteSyncProcessManagerTest"` — 16/16 pass
- [ ] Full `./gradlew :app:desktopTest` on CI
- [ ] Manual smoke: run app, sync a paste to another device, observe normal operation