### PR TITLE
:sparkles: Active WebSocket probe for Chrome Extension liveness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ output*/
 /code-review/
 /ai/
 /.claude/skills/ui-ux-pro-max/
+/docs/superpowers/
 web/dist/

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
@@ -33,7 +33,16 @@ class WsSession(
         }
     }
 
+    suspend fun ping(): Boolean =
+        sendMutex.withLock {
+            runCatching { session.send(Frame.Ping(PING_PAYLOAD)) }.isSuccess
+        }
+
     suspend fun close(reason: String = "Normal closure") {
         session.close(CloseReason(CloseReason.Codes.NORMAL, reason))
+    }
+
+    companion object {
+        private val PING_PAYLOAD = "cp".encodeToByteArray()
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
@@ -5,6 +5,7 @@ import io.ktor.websocket.*
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Unified wrapper around Ktor WebSocket sessions (server or client).
@@ -35,7 +36,9 @@ class WsSession(
 
     suspend fun ping(): Boolean =
         sendMutex.withLock {
-            runCatching { session.send(Frame.Ping(PING_PAYLOAD)) }.isSuccess
+            withTimeoutOrNull(PING_TIMEOUT_MS) {
+                runCatching { session.send(Frame.Ping(PING_PAYLOAD)) }.isSuccess
+            } ?: false
         }
 
     suspend fun close(reason: String = "Normal closure") {
@@ -44,5 +47,6 @@ class WsSession(
 
     companion object {
         private val PING_PAYLOAD = "cp".encodeToByteArray()
+        private const val PING_TIMEOUT_MS = 3_000L
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
@@ -36,8 +36,10 @@ class WsSessionManager {
     }
 
     fun notifySessionClosed(appInstanceId: String) {
-        unregisterSession(appInstanceId)
-        onSessionClosed?.invoke(appInstanceId)
+        if (sessions.remove(appInstanceId) != null) {
+            logger.info { "Unregistered WebSocket session for $appInstanceId" }
+            onSessionClosed?.invoke(appInstanceId)
+        }
     }
 
     fun getSession(appInstanceId: String): WsSession? = sessions[appInstanceId]

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
@@ -46,6 +46,19 @@ class WsSessionManager {
 
     fun isConnected(appInstanceId: String): Boolean = sessions[appInstanceId]?.isActive == true
 
+    suspend fun probe(appInstanceId: String): Boolean {
+        val session = sessions[appInstanceId] ?: return false
+        if (!session.isActive) {
+            notifySessionClosed(appInstanceId)
+            return false
+        }
+        val success = session.ping()
+        if (!success) {
+            notifySessionClosed(appInstanceId)
+        }
+        return success
+    }
+
     suspend fun closeSession(appInstanceId: String) {
         sessions.remove(appInstanceId)?.let { session ->
             runCatching { session.close("Device removed") }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -31,7 +31,7 @@ class GeneralSyncHandler(
 
     override var versionRelation: StateFlow<VersionRelation> = _versionRelation
 
-    private val syncPollingManager = SyncPollingManager(syncHandlerScope)
+    internal val syncPollingManager = SyncPollingManager(syncHandlerScope)
 
     private val job: Job
 
@@ -55,14 +55,22 @@ class GeneralSyncHandler(
 
         job =
             syncPollingManager.startPollingResolve {
-                emitEvent(SyncEvent.Resolve(currentSyncRuntimeInfo, createCallback()))
+                emitEvent(SyncEvent.Resolve(currentSyncRuntimeInfo, createPollingCallback()))
             }
     }
 
     private fun createCallback(onComplete: () -> Unit = {}): ResolveCallback =
         ResolveCallback(
             updateVersionRelation = ::updateVersionRelation,
+            markPollFailure = {},
             onComplete = onComplete,
+        )
+
+    internal fun createPollingCallback(): ResolveCallback =
+        ResolveCallback(
+            updateVersionRelation = ::updateVersionRelation,
+            markPollFailure = { syncPollingManager.fail() },
+            onComplete = {},
         )
 
     override fun updateSyncRuntimeInfo(syncRuntimeInfo: SyncRuntimeInfo) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -31,6 +31,7 @@ class GeneralSyncHandler(
 
     override var versionRelation: StateFlow<VersionRelation> = _versionRelation
 
+    // @VisibleForTesting
     internal val syncPollingManager = SyncPollingManager(syncHandlerScope)
 
     private val job: Job
@@ -66,6 +67,7 @@ class GeneralSyncHandler(
             onComplete = onComplete,
         )
 
+    // @VisibleForTesting
     internal fun createPollingCallback(): ResolveCallback =
         ResolveCallback(
             updateVersionRelation = ::updateVersionRelation,

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/ResolveCallback.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/ResolveCallback.kt
@@ -4,5 +4,6 @@ import com.crosspaste.net.VersionRelation
 
 data class ResolveCallback(
     val updateVersionRelation: (VersionRelation) -> Unit,
-    val onComplete: () -> Unit,
+    val markPollFailure: suspend () -> Unit = {},
+    val onComplete: () -> Unit = {},
 )

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncPollingManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncPollingManager.kt
@@ -34,6 +34,7 @@ class SyncPollingManager(
 
     private val stateMutex = Mutex()
 
+    // @VisibleForTesting
     internal val currentFailCount: Int
         get() = failTimeRef.value
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncPollingManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncPollingManager.kt
@@ -34,6 +34,9 @@ class SyncPollingManager(
 
     private val stateMutex = Mutex()
 
+    internal val currentFailCount: Int
+        get() = failTimeRef.value
+
     suspend fun reset() {
         stateMutex.withLock {
             failTimeRef.value = 0

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -199,17 +199,32 @@ class SyncResolver(
     /**
      * Resolve extension devices (e.g. Chrome Extension).
      * Extensions are client-only — they have no server, no host, no port.
-     * Connection liveness is determined solely by WebSocket session state.
+     * Liveness is verified by sending an in-band Frame.Ping; send failure
+     * means the underlying socket is dead.
      */
     private suspend fun SyncRuntimeInfo.resolveExtension(callback: ResolveCallback) {
-        val wsConnected = wsSessionManager.isConnected(appInstanceId)
-        if (wsConnected && connectState == SyncState.DISCONNECTED) {
-            logger.info { "Extension $appInstanceId WebSocket active, marking CONNECTED" }
-            callback.updateVersionRelation(VersionRelation.EQUAL_TO)
-            updateConnectState(SyncState.CONNECTED)
-        } else if (!wsConnected && connectState == SyncState.CONNECTED) {
-            logger.info { "Extension $appInstanceId WebSocket gone, marking DISCONNECTED" }
-            updateConnectState(SyncState.DISCONNECTED)
+        when (connectState) {
+            SyncState.CONNECTED -> {
+                if (!wsSessionManager.probe(appInstanceId)) {
+                    logger.info { "Extension $appInstanceId probe failed, marking DISCONNECTED" }
+                    updateConnectState(SyncState.DISCONNECTED)
+                }
+                // probe success → stay CONNECTED
+            }
+            SyncState.DISCONNECTED -> {
+                if (wsSessionManager.isConnected(appInstanceId)) {
+                    logger.info { "Extension $appInstanceId WebSocket back, marking CONNECTED" }
+                    callback.updateVersionRelation(VersionRelation.EQUAL_TO)
+                    updateConnectState(SyncState.CONNECTED)
+                } else {
+                    // WS still gone; only scheduled polling will actually escalate backoff
+                    // (force-resolve / first-value paths pass a no-op markPollFailure).
+                    callback.markPollFailure()
+                }
+            }
+            else -> {
+                logger.warn { "Extension $appInstanceId in unexpected state=$connectState" }
+            }
         }
     }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
@@ -1,0 +1,69 @@
+package com.crosspaste.net.ws
+
+import io.ktor.websocket.WebSocketSession
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class WsSessionManagerTest {
+
+    private fun fakeSession(): WsSession {
+        val inner: WebSocketSession = mockk(relaxed = true)
+        return WsSession(inner, "remote")
+    }
+
+    @Test
+    fun notifySessionClosed_presentSession_invokesCallbackOnce() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionClosed { fired.add(it) }
+            mgr.registerSession("A", fakeSession())
+
+            mgr.notifySessionClosed("A")
+
+            assertEquals(listOf("A"), fired)
+        }
+
+    @Test
+    fun notifySessionClosed_absentSession_doesNotInvokeCallback() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionClosed { fired.add(it) }
+
+            mgr.notifySessionClosed("missing")
+
+            assertEquals(emptyList(), fired)
+        }
+
+    @Test
+    fun notifySessionClosed_calledTwice_invokesCallbackOnce() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionClosed { fired.add(it) }
+            mgr.registerSession("A", fakeSession())
+
+            mgr.notifySessionClosed("A")
+            mgr.notifySessionClosed("A")
+
+            assertEquals(listOf("A"), fired)
+            assertFalse(mgr.isConnected("A"))
+        }
+
+    @Test
+    fun unregisterSession_doesNotInvokeCallback() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionClosed { fired.add(it) }
+            mgr.registerSession("A", fakeSession())
+
+            mgr.unregisterSession("A")
+
+            assertEquals(emptyList(), fired)
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
@@ -1,16 +1,28 @@
 package com.crosspaste.net.ws
 
+import io.ktor.websocket.Frame
 import io.ktor.websocket.WebSocketSession
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
+import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class WsSessionManagerTest {
 
-    private fun fakeSession(): WsSession {
-        val inner: WebSocketSession = mockk(relaxed = true)
+    private fun fakeSession(active: Boolean = true): WsSession {
+        val job = Job().apply { if (!active) cancel() }
+        val inner: WebSocketSession =
+            mockk(relaxed = true) {
+                every { coroutineContext } returns job
+            }
         return WsSession(inner, "remote")
     }
 
@@ -65,5 +77,64 @@ class WsSessionManagerTest {
             mgr.unregisterSession("A")
 
             assertEquals(emptyList(), fired)
+        }
+
+    @Test
+    fun probe_unknownAppInstanceId_returnsFalse() =
+        runTest {
+            val mgr = WsSessionManager()
+
+            assertFalse(mgr.probe("missing"))
+        }
+
+    @Test
+    fun probe_sessionNotActive_firesCallbackAndReturnsFalse() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionClosed { fired.add(it) }
+            mgr.registerSession("A", fakeSession(active = false))
+
+            assertFalse(mgr.probe("A"))
+            assertEquals(listOf("A"), fired)
+            assertFalse(mgr.isConnected("A"))
+        }
+
+    @Test
+    fun probe_pingFails_firesCallbackAndReturnsFalse() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionClosed { fired.add(it) }
+            val activeJob = Job()
+            val inner: WebSocketSession =
+                mockk(relaxed = true) {
+                    every { coroutineContext } returns activeJob
+                }
+            coEvery { inner.send(any<Frame.Ping>()) } throws IOException("closed")
+            mgr.registerSession("A", WsSession(inner, "remote"))
+
+            assertFalse(mgr.probe("A"))
+            assertEquals(listOf("A"), fired)
+            assertFalse(mgr.isConnected("A"))
+        }
+
+    @Test
+    fun probe_pingSucceeds_returnsTrueAndSessionStillRegistered() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionClosed { fired.add(it) }
+            val activeJob = Job()
+            val inner: WebSocketSession =
+                mockk(relaxed = true) {
+                    every { coroutineContext } returns activeJob
+                }
+            coEvery { inner.send(any<Frame.Ping>()) } just Runs
+            mgr.registerSession("A", WsSession(inner, "remote"))
+
+            assertTrue(mgr.probe("A"))
+            assertEquals(emptyList(), fired)
+            assertTrue(mgr.isConnected("A"))
         }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionTest.kt
@@ -53,4 +53,17 @@ class WsSessionTest {
 
             assertFalse(wsSession.ping())
         }
+
+    @Test
+    fun ping_sendHangsLongerThanTimeout_returnsFalse() =
+        runTest {
+            val inner = mockSession()
+            coEvery { inner.send(any<Frame.Ping>()) } coAnswers {
+                kotlinx.coroutines.delay(10_000L)
+            }
+
+            val wsSession = WsSession(inner, "remote-id")
+
+            assertFalse(wsSession.ping())
+        }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionTest.kt
@@ -1,0 +1,56 @@
+package com.crosspaste.net.ws
+
+import io.ktor.websocket.Frame
+import io.ktor.websocket.WebSocketSession
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WsSessionTest {
+
+    private fun mockSession(
+        @Suppress("UNUSED_PARAMETER") active: Boolean = true,
+    ): WebSocketSession = mockk(relaxed = true)
+
+    @Test
+    fun ping_sendSucceeds_returnsTrue() =
+        runTest {
+            val inner = mockSession()
+            coEvery { inner.send(any<Frame.Ping>()) } just Runs
+
+            val wsSession = WsSession(inner, "remote-id")
+
+            assertTrue(wsSession.ping())
+            coVerify(exactly = 1) { inner.send(any<Frame.Ping>()) }
+        }
+
+    @Test
+    fun ping_sendThrowsIOException_returnsFalse() =
+        runTest {
+            val inner = mockSession()
+            coEvery { inner.send(any<Frame.Ping>()) } throws IOException("broken pipe")
+
+            val wsSession = WsSession(inner, "remote-id")
+
+            assertFalse(wsSession.ping())
+        }
+
+    @Test
+    fun ping_sendThrowsCancellation_returnsFalse() =
+        runTest {
+            val inner = mockSession(active = false)
+            coEvery { inner.send(any<Frame.Ping>()) } throws
+                kotlinx.coroutines.CancellationException("session gone")
+
+            val wsSession = WsSession(inner, "remote-id")
+
+            assertFalse(wsSession.ping())
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
@@ -402,4 +402,63 @@ class GeneralSyncHandlerTest {
             assertNull(address)
             childScope.cancel()
         }
+
+    // ========== X. callback wiring (polling vs force) ==========
+
+    // NOTE on approach: the plan's original design had the test capture a polling-origin
+    // Resolve event via `advanceTimeBy(61_000L)` to trigger SyncPollingManager's 60s tick.
+    // However, `SyncPollingManager.waitForNextExecution` reads wall-clock time via
+    // `DateUtils.nowEpochMilliseconds()` (Clock.System.now()), not the virtual TestScheduler
+    // clock. Under `runTest`, `advanceTimeBy` advances virtual time but not wall-clock, so the
+    // polling loop spins indefinitely (`delay(1000)` returns under virtual time but the
+    // `while` check never sees wall-clock pass `nextExecutionTime`). That hangs `runTest`.
+    //
+    // To verify the wiring without refactoring the time source, we expose
+    // `createPollingCallback` as an `internal` member on GeneralSyncHandler and invoke it
+    // directly — it is the same factory the polling loop uses (`init { job = startPollingResolve { emitEvent(Resolve(..., createPollingCallback())) } }`).
+
+    @Test
+    fun pollingCallback_markPollFailure_incrementsFailCount() =
+        runTest {
+            val emitter = TestEmitter()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo()
+
+            val handler = GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
+            advanceTimeBy(SMALL_ADVANCE_MS)
+
+            // Directly obtain the polling-origin callback the polling loop would use
+            val pollingCallback = handler.createPollingCallback()
+
+            val before = handler.syncPollingManager.currentFailCount
+            pollingCallback.markPollFailure()
+            val after = handler.syncPollingManager.currentFailCount
+
+            assertEquals(before + 1, after)
+            childScope.cancel()
+        }
+
+    @Test
+    fun forceResolveCallback_markPollFailure_isNoOp() =
+        runTest {
+            val emitter = TestEmitter()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo()
+
+            val handler = GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
+            advanceTimeBy(SMALL_ADVANCE_MS)
+
+            handler.forceResolve()
+            advanceTimeBy(SMALL_ADVANCE_MS)
+
+            val forceEvent =
+                emitter.events.filterIsInstance<SyncEvent.ForceResolve>().first()
+
+            val before = handler.syncPollingManager.currentFailCount
+            forceEvent.callback.markPollFailure()
+            val after = handler.syncPollingManager.currentFailCount
+
+            assertEquals(before, after)
+            childScope.cancel()
+        }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -916,6 +916,132 @@ class SyncResolverTest {
             assertEquals(VersionRelation.EQUAL_TO, capturedRelation)
         }
 
+    // ========== F. resolveExtension ==========
+
+    @Test
+    fun resolveExtension_connected_probeSucceeds_staysConnected() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createExtensionSyncRuntimeInfo(connectState = SyncState.CONNECTED)
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.probe(syncRuntimeInfo.appInstanceId) } returns true
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun resolveExtension_connected_probeFails_setsDisconnected() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createExtensionSyncRuntimeInfo(connectState = SyncState.CONNECTED)
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.probe(syncRuntimeInfo.appInstanceId) } returns false
+
+            val captured = slot<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(captured)) } returns
+                syncRuntimeInfo.appInstanceId
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(SyncState.DISCONNECTED, captured.captured.connectState)
+        }
+
+    @Test
+    fun resolveExtension_disconnected_wsConnected_setsConnected() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createExtensionSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
+
+            deps.stubDbRead(syncRuntimeInfo)
+            every { deps.wsSessionManager.isConnected(syncRuntimeInfo.appInstanceId) } returns true
+
+            val captured = slot<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(captured)) } returns
+                syncRuntimeInfo.appInstanceId
+
+            var capturedRelation: VersionRelation? = null
+            val callback =
+                ResolveCallback(
+                    updateVersionRelation = { capturedRelation = it },
+                )
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
+
+            assertEquals(SyncState.CONNECTED, captured.captured.connectState)
+            assertEquals(VersionRelation.EQUAL_TO, capturedRelation)
+        }
+
+    @Test
+    fun resolveExtension_disconnected_wsNotConnected_invokesMarkPollFailure() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createExtensionSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
+
+            deps.stubDbRead(syncRuntimeInfo)
+            every { deps.wsSessionManager.isConnected(syncRuntimeInfo.appInstanceId) } returns false
+
+            var failureCalls = 0
+            val callback =
+                ResolveCallback(
+                    updateVersionRelation = {},
+                    markPollFailure = { failureCalls++ },
+                )
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
+
+            assertEquals(1, failureCalls)
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun resolveExtension_unexpectedState_noOp() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createExtensionSyncRuntimeInfo(connectState = SyncState.UNVERIFIED)
+
+            deps.stubDbRead(syncRuntimeInfo)
+
+            var failureCalls = 0
+            val callback =
+                ResolveCallback(
+                    updateVersionRelation = {},
+                    markPollFailure = { failureCalls++ },
+                )
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
+
+            assertEquals(0, failureCalls)
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+            coVerify(exactly = 0) { deps.wsSessionManager.probe(any()) }
+        }
+
+    private fun extensionPlatform(): Platform =
+        mockk(relaxed = true) {
+            every { isExtension() } returns true
+            every { isChromeExtension() } returns true
+            every { name } returns "ChromeExtension"
+            every { version } returns "1.0.0"
+        }
+
+    private fun createExtensionSyncRuntimeInfo(
+        appInstanceId: String = "chrome-ext-1",
+        connectState: Int = SyncState.CONNECTED,
+    ): SyncRuntimeInfo =
+        createSyncRuntimeInfo(
+            appInstanceId = appInstanceId,
+            platform = extensionPlatform(),
+            connectState = connectState,
+        )
+
     private fun createTestCallback(): ResolveCallback =
         ResolveCallback(
             updateVersionRelation = {},

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -1025,12 +1025,12 @@ class SyncResolverTest {
         }
 
     private fun extensionPlatform(): Platform =
-        mockk(relaxed = true) {
-            every { isExtension() } returns true
-            every { isChromeExtension() } returns true
-            every { name } returns "ChromeExtension"
-            every { version } returns "1.0.0"
-        }
+        Platform(
+            name = Platform.CHROME_EXTENSION,
+            arch = "any",
+            bitMode = 64,
+            version = "1.0.0",
+        )
 
     private fun createExtensionSyncRuntimeInfo(
         appInstanceId: String = "chrome-ext-1",


### PR DESCRIPTION
Closes #4221.

## Summary

Chrome Extension devices connect to the desktop over WebSocket only — no HTTP server to heartbeat against. Offline detection previously relied entirely on Ktor's server-side WS ping/pong (30s + 15s = ~45s lag) and a 60s polling loop that merely read `wsSessionManager.isConnected()`, a stale bit until Ktor itself judged the session dead. Zombie connections (proxies, Chrome background-tab throttling, abrupt network loss without TCP FIN) could keep a device "online" indefinitely.

Now the desktop actively probes each CONNECTED Extension device every polling tick by sending `Frame.Ping` under the session's existing `sendMutex` (3s timeout). Send failure → session closed, device marked DISCONNECTED. Polling backoff reuses `SyncPollingManager.fail()` / `reset()` with the existing 1.5s → 2.5s → … → 60s cap. **Backoff escalates only from scheduled polling** — user-initiated refresh and force-resolve pass a no-op `markPollFailure` so user clicks don't worsen the cadence.

## Changes

| Layer | Change |
|---|---|
| `WsSession.ping()` | New in-band Frame.Ping under `sendMutex`, wrapped in `withTimeoutOrNull(3s)` to avoid blocking on TCP-half-open. |
| `WsSessionManager.probe()` | New: missing / inactive / ping-fails → `notifySessionClosed` + false. |
| `WsSessionManager.notifySessionClosed` | Guarded: callback fires only when `sessions.remove` actually removed an entry. |
| `ResolveCallback.markPollFailure` | New optional field (default no-op). |
| `GeneralSyncHandler` | Split `createCallback` (no-op) from `createPollingCallback` (wires `syncPollingManager.fail()`). Polling loop uses the latter; every other origin uses the former. |
| `SyncResolver.resolveExtension` | Rewrite: CONNECTED → `probe()`; DISCONNECTED → check `isConnected` or `markPollFailure`; other states → warn+no-op. |

## What doesn't change

- No protocol change, no storage format change, no wire version bump.
- Non-Extension (HTTP) device polling, heartbeat, backoff: untouched.
- Ktor server-side WS ping config (`pingPeriodMillis=30_000, timeoutMillis=15_000`): untouched — kept as belt-and-suspenders fallback.
- UI: existing `DeviceActionButton` refresh button for DISCONNECTED/CONNECTING already wires through `forceResolve`, which now hits the new `resolveExtension` path.

## Test Plan

- [x] `./gradlew app:desktopTest` — 1010 passed, 0 failed, 29 skipped.
- [x] `./gradlew :app:ktlintCheck` — clean.
- [x] Unit coverage:
  - `WsSessionTest` (4): ping succeeds / IOException / Cancellation / timeout-hang.
  - `WsSessionManagerTest` (8): `notifySessionClosed` × 4 (present / absent / duplicate / unregister-no-callback); `probe` × 4 (missing / inactive / ping-fails / ping-ok).
  - `SyncResolverTest` (5 new Extension cases): CONNECTED + probe-ok / CONNECTED + probe-fails / DISCONNECTED + WS-back / DISCONNECTED + WS-gone → markPollFailure / unexpected state → no-op.
  - `GeneralSyncHandlerTest` (2 new): polling callback escalates `failCount`; force-resolve callback is no-op.
- [ ] Manual smoke (follow-up in staging): pair a Chrome Extension, confirm CONNECTED → kill Chrome → observe DISCONNECTED within ~1 polling tick → reopen Chrome → confirm CONNECTED again. Validate refresh button does not escalate backoff.

## Design & plan

- Design: `docs/superpowers/specs/2026-04-20-chrome-ws-liveness-probe-design.md`
- Plan: `docs/superpowers/plans/2026-04-20-chrome-ws-liveness-probe.md`

## Follow-ups (out of scope here, worth tracking)

- Inject a clock into `SyncPollingManager` so the backoff timeline can be unit-tested via `TestScheduler` instead of wall-clock. Would also retire a few `internal` visibility bumps this PR introduced for testability.
- Integration test for the reconnect loop (probe fails → `notifySessionClosed` cascades → next poll → Chrome reconnects → CONNECTED).
- Concurrent probe-vs-Ktor-finally race test (idempotency of `notifySessionClosed` is atomic via `ConcurrentMap.remove`, but an explicit test would document the contract).