### PR TITLE
Polish WsSessionManager: TOCTOU fix, ping mutex removal, namedScope cleanup

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
@@ -82,7 +82,7 @@ fun Routing.wsRouting(
             }
         } finally {
             logger.info { "WebSocket disconnected: $appInstanceId" }
-            wsSessionManager.notifySessionClosed(appInstanceId)
+            wsSessionManager.notifySessionClosed(appInstanceId, wsSession)
         }
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
@@ -74,7 +74,7 @@ class WsClientConnector(
                     }
                 } finally {
                     logger.info { "WebSocket client disconnected from $targetAppInstanceId" }
-                    wsSessionManager.notifySessionClosed(targetAppInstanceId)
+                    wsSessionManager.notifySessionClosed(targetAppInstanceId, wsSession)
                 }
             }
             true

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
@@ -13,7 +13,10 @@ import kotlinx.coroutines.withTimeoutOrNull
  *
  * Wire protocol: each logical message is sent as 1 Text frame (JSON header)
  * followed by 0 or 1 Binary frames (payload). A [Mutex] guarantees atomicity
- * so concurrent senders cannot interleave their frame pairs.
+ * for these data-frame pairs so concurrent senders cannot interleave them.
+ * Control frames (ping) are single frames and bypass the mutex — RFC 6455
+ * permits control frames to be injected between data frames, and Ktor handles
+ * pong replies internally so they are invisible to the application stream.
  */
 class WsSession(
     private val session: WebSocketSession,
@@ -35,11 +38,9 @@ class WsSession(
     }
 
     suspend fun ping(): Boolean =
-        sendMutex.withLock {
-            withTimeoutOrNull(PING_TIMEOUT_MS) {
-                runCatching { session.send(Frame.Ping(PING_PAYLOAD)) }.isSuccess
-            } ?: false
-        }
+        withTimeoutOrNull(PING_TIMEOUT_MS) {
+            runCatching { session.send(Frame.Ping(PING_PAYLOAD)) }.isSuccess
+        } ?: false
 
     suspend fun close(reason: String = "Normal closure") {
         session.close(CloseReason(CloseReason.Codes.NORMAL, reason))

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
@@ -7,7 +7,7 @@ class WsSessionManager {
 
     private val logger = KotlinLogging.logger {}
 
-    private val sessions: MutableMap<String, WsSession> = ConcurrentMap()
+    private val sessions: ConcurrentMap<String, WsSession> = ConcurrentMap()
 
     private var onSessionClosed: ((String) -> Unit)? = null
 
@@ -35,8 +35,11 @@ class WsSessionManager {
         }
     }
 
-    fun notifySessionClosed(appInstanceId: String) {
-        if (sessions.remove(appInstanceId) != null) {
+    fun notifySessionClosed(
+        appInstanceId: String,
+        session: WsSession,
+    ) {
+        if (sessions.remove(appInstanceId, session)) {
             logger.info { "Unregistered WebSocket session for $appInstanceId" }
             onSessionClosed?.invoke(appInstanceId)
         }
@@ -49,12 +52,12 @@ class WsSessionManager {
     suspend fun probe(appInstanceId: String): Boolean {
         val session = sessions[appInstanceId] ?: return false
         if (!session.isActive) {
-            notifySessionClosed(appInstanceId)
+            notifySessionClosed(appInstanceId, session)
             return false
         }
         val success = session.ping()
         if (!success) {
-            notifySessionClosed(appInstanceId)
+            notifySessionClosed(appInstanceId, session)
         }
         return success
     }
@@ -85,7 +88,7 @@ class WsSessionManager {
             true
         }.onFailure { e ->
             logger.warn(e) { "WebSocket send failed for $appInstanceId" }
-            notifySessionClosed(appInstanceId)
+            notifySessionClosed(appInstanceId, session)
         }.getOrDefault(false)
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/CoroutineScopes.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/CoroutineScopes.kt
@@ -18,8 +18,5 @@ fun loggingExceptionHandler(name: String): CoroutineExceptionHandler =
 fun namedScope(
     dispatcher: CoroutineDispatcher,
     name: String,
-    job: CompletableJob? = SupervisorJob(),
-): CoroutineScope =
-    job?.let {
-        CoroutineScope(dispatcher + it + loggingExceptionHandler(name))
-    } ?: CoroutineScope(dispatcher + loggingExceptionHandler(name))
+    job: CompletableJob = SupervisorJob(),
+): CoroutineScope = CoroutineScope(dispatcher + job + loggingExceptionHandler(name))

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
@@ -32,9 +32,10 @@ class WsSessionManagerTest {
             val mgr = WsSessionManager()
             val fired = mutableListOf<String>()
             mgr.setOnSessionClosed { fired.add(it) }
-            mgr.registerSession("A", fakeSession())
+            val session = fakeSession()
+            mgr.registerSession("A", session)
 
-            mgr.notifySessionClosed("A")
+            mgr.notifySessionClosed("A", session)
 
             assertEquals(listOf("A"), fired)
         }
@@ -46,7 +47,7 @@ class WsSessionManagerTest {
             val fired = mutableListOf<String>()
             mgr.setOnSessionClosed { fired.add(it) }
 
-            mgr.notifySessionClosed("missing")
+            mgr.notifySessionClosed("missing", fakeSession())
 
             assertEquals(emptyList(), fired)
         }
@@ -57,13 +58,31 @@ class WsSessionManagerTest {
             val mgr = WsSessionManager()
             val fired = mutableListOf<String>()
             mgr.setOnSessionClosed { fired.add(it) }
-            mgr.registerSession("A", fakeSession())
+            val session = fakeSession()
+            mgr.registerSession("A", session)
 
-            mgr.notifySessionClosed("A")
-            mgr.notifySessionClosed("A")
+            mgr.notifySessionClosed("A", session)
+            mgr.notifySessionClosed("A", session)
 
             assertEquals(listOf("A"), fired)
             assertFalse(mgr.isConnected("A"))
+        }
+
+    @Test
+    fun notifySessionClosed_replacedSession_doesNotRemoveNewEntry() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionClosed { fired.add(it) }
+            val oldSession = fakeSession()
+            val newSession = fakeSession()
+            mgr.registerSession("A", oldSession)
+            mgr.registerSession("A", newSession)
+
+            mgr.notifySessionClosed("A", oldSession)
+
+            assertEquals(emptyList(), fired)
+            assertTrue(mgr.isConnected("A"))
         }
 
     @Test


### PR DESCRIPTION
Closes #4224

## Summary

Three independent code-review fixes in the WebSocket / coroutine plumbing.

### 1. TOCTOU race in `WsSessionManager.notifySessionClosed`

`notifySessionClosed(appInstanceId)` removed the entry by key alone. If another thread had already replaced the session via `registerSession`, the new (legitimate) session was evicted and `onSessionClosed` fired spuriously. The same race exists in the `finally` blocks of `WsRouting` and `WsClientConnector`, where the old session's disconnect cleanup races with a new connection's registration.

**Fix:** signature is now `notifySessionClosed(appInstanceId, session)` and uses `ConcurrentMap.remove(key, value)` (atomic identity-CAS via `ConcurrentHashMap.remove(key, value)`). The entry is removed only if it still points to the observed instance. The `sessions` field is typed as `ConcurrentMap` to make the atomic API call unambiguous. All four call sites (`probe` ×2, `send`, and both `finally` blocks) pass the captured session reference.

### 2. `WsSession.ping()` holds `sendMutex` during 3s timeout

The mutex's documented purpose is to keep `sendEnvelope`'s text+binary frame pair from interleaving with another sender's pair. A `Frame.Ping` is a single control frame and per RFC 6455 §5.4 may be injected between data frames; Ktor handles pong replies internally and they never reach the application stream. Holding the mutex for the full 3-second ping timeout created head-of-line blocking against `sendEnvelope`.

**Fix:** drop the mutex from `ping()`; keep `withTimeoutOrNull` for the bounded send. Class docstring updated to clarify the mutex applies only to data-frame pairs.

### 3. `namedScope` nullable `CompletableJob?` parameter

All ~36 call sites use the default; the one customizing the job (`DefaultServerModule`) passes a non-null `SupervisorJob`. The `job?.let { ... } ?: ...` branch was dead complexity.

**Fix:** parameter is now `CompletableJob = SupervisorJob()`, body collapses to a single expression.

## Test plan

- [x] `./gradlew app:desktopTest --tests "com.crosspaste.net.ws.*"` — 14 tests pass, including the existing `WsSessionTest` suite added on main.
- [x] New regression test `notifySessionClosed_replacedSession_doesNotRemoveNewEntry` — registers an old session, replaces it with a new one, then calls `notifySessionClosed` with the old reference and verifies the new session remains and the callback does not fire.
- [x] Existing `notifySessionClosed_*` tests updated for the new signature; all pass.
- [x] `./gradlew ktlintFormat` clean.
- [x] `./gradlew app:compileKotlinDesktop` clean (only pre-existing warnings unrelated to this change).