### PR TITLE
:sparkles: Notify Chrome extension on skipped oversize paste, fix WS whole-file pull

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
@@ -59,5 +59,6 @@ object WsMessageType {
     const val NOTIFY_REMOVE = "notify_remove"
     const val FILE_PULL_REQUEST = "file_pull_request"
     const val FILE_PULL_RESPONSE = "file_pull_response"
+    const val PASTE_REJECTED_OVERSIZE = "paste_rejected_oversize"
     const val ERROR = "error"
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
@@ -207,7 +207,7 @@ class FilePullService(
             val targetPath = targetPaths[index]
 
             runCatching {
-                val request =
+                val request: WsPullFileRequest =
                     WsPullFileRequest.WholeFileRequest(
                         hash = hash,
                         fileName = requestFileName,

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -8,6 +8,7 @@ import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.SyncExtraInfo
 import com.crosspaste.db.task.TaskType
+import com.crosspaste.dto.notice.OversizePasteNotice
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.VersionRelation
 import com.crosspaste.net.clientapi.ClientApiResult
@@ -207,14 +208,19 @@ class SyncPasteTaskExecutor(
         // Extension devices have file size limits — skip file-type pastes that exceed them
         if (syncRuntimeInfo.platform.isExtension() && pasteData.isFileType()) {
             val pasteFiles = pasteData.getPasteItem(PasteFiles::class)
-            if (pasteFiles == null || !isWithinExtensionFileLimit(pasteFiles)) {
+            val oversizeNotice =
+                if (pasteFiles == null) null else detectExtensionOversize(pasteFiles)
+            if (pasteFiles == null || oversizeNotice != null) {
                 logger.info {
                     "Skipping file-type paste sync to extension $handlerKey: " +
                         if (pasteFiles == null) {
                             "unable to resolve PasteFiles for size check"
                         } else {
-                            "file size exceeds extension limit (total=${pasteFiles.size})"
+                            "file size exceeds extension limit (reason=${oversizeNotice?.reason})"
                         }
+                }
+                if (oversizeNotice != null) {
+                    notifyExtensionOversize(targetAppInstanceId, oversizeNotice)
                 }
                 return SuccessResult()
             }
@@ -277,10 +283,48 @@ class SyncPasteTaskExecutor(
             logger.warn(e) { "WebSocket paste send failed for $targetAppInstanceId, falling back to HTTP" }
         }.getOrNull()
 
-    private fun isWithinExtensionFileLimit(pasteFiles: PasteFiles): Boolean {
-        if (pasteFiles.size > EXTENSION_MAX_TOTAL_FILE_SIZE) return false
-        return pasteFiles.fileInfoTreeMap.values.all { fileInfoTree ->
-            fileInfoTree.size <= EXTENSION_MAX_FILE_SIZE
+    /**
+     * Returns a notice describing why [pasteFiles] exceeds the Chrome extension
+     * per-file / total-size limits, or null if it's within bounds.
+     */
+    private fun detectExtensionOversize(pasteFiles: PasteFiles): OversizePasteNotice? {
+        val oversizeFile =
+            pasteFiles.fileInfoTreeMap.entries.firstOrNull { (_, info) ->
+                info.size > EXTENSION_MAX_FILE_SIZE
+            }
+        if (oversizeFile != null) {
+            return OversizePasteNotice(
+                reason = OversizePasteNotice.Reason.FILE_TOO_LARGE,
+                fileName = oversizeFile.key,
+                actualSize = oversizeFile.value.size,
+                sizeLimitBytes = EXTENSION_MAX_FILE_SIZE,
+            )
+        }
+        if (pasteFiles.size > EXTENSION_MAX_TOTAL_FILE_SIZE) {
+            return OversizePasteNotice(
+                reason = OversizePasteNotice.Reason.TOTAL_TOO_LARGE,
+                fileName = null,
+                actualSize = pasteFiles.size,
+                sizeLimitBytes = EXTENSION_MAX_TOTAL_FILE_SIZE,
+            )
+        }
+        return null
+    }
+
+    private suspend fun notifyExtensionOversize(
+        targetAppInstanceId: String,
+        notice: OversizePasteNotice,
+    ) {
+        runCatching {
+            val payload = getJsonUtils().JSON.encodeToString(notice).encodeToByteArray()
+            val envelope =
+                WsEnvelope(
+                    type = WsMessageType.PASTE_REJECTED_OVERSIZE,
+                    payload = payload,
+                )
+            wsSessionManager.send(targetAppInstanceId, envelope)
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to send PASTE_REJECTED_OVERSIZE to $targetAppInstanceId" }
         }
     }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
@@ -6,6 +6,7 @@ import com.crosspaste.dto.paste.SyncPasteCollection
 import com.crosspaste.dto.paste.SyncPasteData
 import com.crosspaste.dto.paste.SyncPasteLabel
 import com.crosspaste.dto.pull.PullFileRequest
+import com.crosspaste.dto.pull.WsPullFileRequest
 import com.crosspaste.dto.secure.PairingRequest
 import com.crosspaste.dto.secure.PairingResponse
 import com.crosspaste.dto.secure.TrustRequest
@@ -42,6 +43,48 @@ class DtoSerializationTest {
         val decoded = json.decodeFromString<PullFileRequest>(encoded)
         assertEquals(42L, decoded.id)
         assertEquals(7, decoded.chunkIndex)
+    }
+
+    // --- WsPullFileRequest ---
+    // The sealed class uses @JsonClassDiscriminator("mode"); the discriminator is only emitted
+    // when encoding via the parent-type serializer. If the Desktop side encodes a concrete
+    // subtype directly, Chrome rejects the request with "only supports whole-file mode".
+
+    @Test
+    fun `WsPullFileRequest WholeFileRequest encodes mode discriminator via parent type`() {
+        val request: WsPullFileRequest =
+            WsPullFileRequest.WholeFileRequest(hash = "abc", fileName = "image.png")
+        val encoded = json.encodeToString(request)
+        assertTrue(
+            encoded.contains("\"mode\":\"whole\""),
+            "Expected discriminator 'mode:whole' in payload, got: $encoded",
+        )
+    }
+
+    @Test
+    fun `WsPullFileRequest ChunkRequest encodes mode discriminator via parent type`() {
+        val request: WsPullFileRequest = WsPullFileRequest.ChunkRequest(id = 1L, chunkIndex = 0)
+        val encoded = json.encodeToString(request)
+        assertTrue(
+            encoded.contains("\"mode\":\"chunk\""),
+            "Expected discriminator 'mode:chunk' in payload, got: $encoded",
+        )
+    }
+
+    @Test
+    fun `WsPullFileRequest roundtrip preserves subtype`() {
+        val whole: WsPullFileRequest =
+            WsPullFileRequest.WholeFileRequest(hash = "h", fileName = "f.png")
+        val decodedWhole = json.decodeFromString<WsPullFileRequest>(json.encodeToString(whole))
+        assertTrue(decodedWhole is WsPullFileRequest.WholeFileRequest)
+        assertEquals("h", (decodedWhole as WsPullFileRequest.WholeFileRequest).hash)
+        assertEquals("f.png", decodedWhole.fileName)
+
+        val chunk: WsPullFileRequest = WsPullFileRequest.ChunkRequest(id = 5L, chunkIndex = 2)
+        val decodedChunk = json.decodeFromString<WsPullFileRequest>(json.encodeToString(chunk))
+        assertTrue(decodedChunk is WsPullFileRequest.ChunkRequest)
+        assertEquals(5L, (decodedChunk as WsPullFileRequest.ChunkRequest).id)
+        assertEquals(2, decodedChunk.chunkIndex)
     }
 
     // --- EndpointInfo ---

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/notice/OversizePasteNotice.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/notice/OversizePasteNotice.kt
@@ -1,0 +1,26 @@
+package com.crosspaste.dto.notice
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Notice sent to a receiver (typically the Chrome extension) when the sender
+ * has rejected a paste because it exceeds the receiver's size limits.
+ *
+ * The receiver can surface this as a user-visible notification rather than
+ * silently dropping the paste.
+ */
+@Serializable
+data class OversizePasteNotice(
+    val reason: Reason,
+    /** File name of the offending file; null when [reason] is [Reason.TOTAL_TOO_LARGE]. */
+    val fileName: String? = null,
+    /** Actual size in bytes of the offending unit (single file or total paste). */
+    val actualSize: Long,
+    /** Limit in bytes that was exceeded. */
+    val sizeLimitBytes: Long,
+) {
+    enum class Reason {
+        FILE_TOO_LARGE,
+        TOTAL_TOO_LARGE,
+    }
+}

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/pull/WsPullFileRequest.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/pull/WsPullFileRequest.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.dto.pull
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
@@ -11,6 +12,7 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  * **Whole-file mode** (Desktop ↔ Chrome extension): [WholeFileRequest] with `fileName`
  *   plus `id` (Desktop-side lookup) or `hash` (Chrome-side lookup).
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 @JsonClassDiscriminator("mode")
 sealed class WsPullFileRequest {

--- a/core/src/jsMain/kotlin/com/crosspaste/web/CrossPasteApi.kt
+++ b/core/src/jsMain/kotlin/com/crosspaste/web/CrossPasteApi.kt
@@ -119,7 +119,7 @@ object CrossPasteCrypto {
             val privateKey = serializer.decodeSignPrivateKey(signPrivateKeyDer)
 
             val timestamp =
-                kotlinx.datetime.Clock.System
+                kotlin.time.Clock.System
                     .now()
                     .toEpochMilliseconds()
 

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -10,7 +10,11 @@ import type { PasteData } from "@/shared/models/paste-data";
 import { APP_VERSION } from "@/shared/app/version.generated";
 import { collectPasteItems } from "@/shared/paste/paste-collector";
 import { WsManager } from "@/shared/ws/ws-manager";
-import { createWsMessageHandler } from "@/shared/ws/ws-message-handler";
+import {
+  createWsMessageHandler,
+  type OversizePasteNotice,
+} from "@/shared/ws/ws-message-handler";
+import { buildTranslatorFromStorage } from "@/shared/i18n/i18n-core";
 import { WsMessageType, simpleEnvelope } from "@/shared/ws/ws-types";
 import type { WsEnvelope } from "@/shared/ws/ws-types";
 import { ingestPaste } from "@/shared/paste/paste-ingestion";
@@ -489,6 +493,7 @@ async function initializeWebSocket(): Promise<void> {
     },
     broadcastToSidePanel,
     setLastHash,
+    showOversizePasteNotice,
     onRemoteRemoveDevice: async (targetId) => {
       wsManager?.disconnectDevice(targetId);
       await DeviceStore.remove(targetId);
@@ -572,6 +577,31 @@ function broadcastToSidePanel(message: unknown): void {
   chrome.runtime.sendMessage(message).catch(() => {
     // Side panel not open — ignore
   });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+async function showOversizePasteNotice(
+  sourceAppInstanceId: string,
+  notice: OversizePasteNotice,
+): Promise<void> {
+  const device = await DeviceStore.get(sourceAppInstanceId);
+  const deviceName =
+    device?.noteName || device?.syncInfo.endpointInfo.deviceName || "Remote device";
+  const t = await buildTranslatorFromStorage();
+  const limit = formatBytes(notice.sizeLimitBytes);
+  const actual = formatBytes(notice.actualSize);
+  const title = t("paste_not_synced_title", deviceName);
+  const message =
+    notice.reason === "FILE_TOO_LARGE"
+      ? t("paste_oversize_file", notice.fileName ?? "", actual, limit)
+      : t("paste_oversize_total", actual, limit);
+
+  broadcastToSidePanel({ type: "OVERSIZE_NOTICE", title, message });
 }
 
 // ─── Message handling ───────────────────────────────────────────────────

--- a/web/src/shared/hooks/use-oversize-notice.ts
+++ b/web/src/shared/hooks/use-oversize-notice.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { NotificationManager } from "@/shared/notification/notification-manager";
+
+interface OversizeNoticeMessage {
+  type: "OVERSIZE_NOTICE";
+  title: string;
+  message: string;
+}
+
+/**
+ * Listen for PASTE_REJECTED_OVERSIZE events relayed by the service worker
+ * and show a persistent in-panel notification (dismissed manually).
+ */
+export function useOversizeNoticeListener(): void {
+  useEffect(() => {
+    const listener = (message: { type: string } & Partial<OversizeNoticeMessage>) => {
+      if (message.type !== "OVERSIZE_NOTICE") return;
+      if (!message.title) return;
+      NotificationManager.warning(message.title, message.message, null);
+    };
+    chrome.runtime.onMessage.addListener(listener);
+    return () => chrome.runtime.onMessage.removeListener(listener);
+  }, []);
+}

--- a/web/src/shared/i18n/extension-messages.ts
+++ b/web/src/shared/i18n/extension-messages.ts
@@ -34,6 +34,9 @@ export const extensionMessages: Record<string, Record<string, string>> = {
       "Find your device's IP and port in the desktop app: Settings → Network Settings",
     devices_guide_step2:
       "Click \"Add Device\" below and enter the connection info",
+    paste_not_synced_title: "CrossPaste: paste from %s not synced",
+    paste_oversize_file: "\"%s\" (%s) exceeds the %s per-file limit",
+    paste_oversize_total: "Total size %s exceeds the %s limit",
   },
   de: {
     clipboard: "Zwischenablage",
@@ -66,6 +69,9 @@ export const extensionMessages: Record<string, Record<string, string>> = {
       "IP-Adresse und Port des Geräts finden: Desktop-App → Einstellungen → Netzwerkeinstellungen",
     devices_guide_step2:
       'Klicken Sie unten auf „Gerät hinzufügen" und geben Sie die Verbindungsdaten ein',
+    paste_not_synced_title: "CrossPaste: Einfügung von %s nicht synchronisiert",
+    paste_oversize_file: "„%s\" (%s) überschreitet das Limit von %s pro Datei",
+    paste_oversize_total: "Gesamtgröße %s überschreitet das Limit von %s",
   },
   es: {
     clipboard: "Portapapeles",
@@ -98,6 +104,9 @@ export const extensionMessages: Record<string, Record<string, string>> = {
       "Encuentre la IP y el puerto del dispositivo en la app de escritorio: Ajustes → Configuración de red",
     devices_guide_step2:
       "Haga clic en \"Agregar dispositivo\" abajo e ingrese la información de conexión",
+    paste_not_synced_title: "CrossPaste: pegado de %s no sincronizado",
+    paste_oversize_file: "\"%s\" (%s) supera el límite de %s por archivo",
+    paste_oversize_total: "El tamaño total %s supera el límite de %s",
   },
   fr: {
     clipboard: "Presse-papiers",
@@ -130,6 +139,9 @@ export const extensionMessages: Record<string, Record<string, string>> = {
       "Trouvez l'IP et le port de l'appareil dans l'application de bureau : Paramètres → Paramètres réseau",
     devices_guide_step2:
       "Cliquez sur « Ajouter un appareil » ci-dessous et entrez les informations de connexion",
+    paste_not_synced_title: "CrossPaste : collage depuis %s non synchronisé",
+    paste_oversize_file: "« %s » (%s) dépasse la limite de %s par fichier",
+    paste_oversize_total: "La taille totale %s dépasse la limite de %s",
   },
   ja: {
     clipboard: "クリップボード",
@@ -161,6 +173,9 @@ export const extensionMessages: Record<string, Record<string, string>> = {
       "デスクトップアプリでデバイスの IP とポートを確認：設定 → ネットワーク設定",
     devices_guide_step2:
       "下の「デバイスを追加」をクリックし、接続情報を入力してください",
+    paste_not_synced_title: "CrossPaste: %s からのペーストは同期されませんでした",
+    paste_oversize_file: "「%s」(%s) が1ファイルあたりの上限 %s を超えています",
+    paste_oversize_total: "合計サイズ %s が上限 %s を超えています",
   },
   ko: {
     clipboard: "클립보드",
@@ -191,6 +206,9 @@ export const extensionMessages: Record<string, Record<string, string>> = {
       "데스크톱 앱에서 기기의 IP와 포트를 확인하세요: 설정 → 네트워크 설정",
     devices_guide_step2:
       "아래의 \"기기 추가\"를 클릭하고 연결 정보를 입력하세요",
+    paste_not_synced_title: "CrossPaste: %s 의 붙여넣기가 동기화되지 않았습니다",
+    paste_oversize_file: "\"%s\"(%s)이(가) 파일당 한도 %s 을(를) 초과합니다",
+    paste_oversize_total: "총 크기 %s 이(가) 한도 %s 을(를) 초과합니다",
   },
   zh: {
     clipboard: "剪贴板",
@@ -220,6 +238,9 @@ export const extensionMessages: Record<string, Record<string, string>> = {
       "在桌面端查找设备的 IP 和端口：设置 → 网络设置",
     devices_guide_step2:
       "点击下方「添加设备」按钮，输入连接信息",
+    paste_not_synced_title: "CrossPaste：来自 %s 的剪贴板未同步",
+    paste_oversize_file: "文件「%s」大小为 %s，超过单文件上限 %s",
+    paste_oversize_total: "总大小 %s 超过 %s 上限",
   },
   zh_hant: {
     clipboard: "剪貼簿",
@@ -249,5 +270,8 @@ export const extensionMessages: Record<string, Record<string, string>> = {
       "在桌面端查看裝置的 IP 和連接埠：設定 → 網路設定",
     devices_guide_step2:
       "點擊下方「新增裝置」按鈕，輸入連線資訊",
+    paste_not_synced_title: "CrossPaste：來自 %s 的剪貼簿未同步",
+    paste_oversize_file: "檔案「%s」大小為 %s，超過單檔上限 %s",
+    paste_oversize_total: "總大小 %s 超過 %s 上限",
   },
 };

--- a/web/src/shared/i18n/i18n-core.ts
+++ b/web/src/shared/i18n/i18n-core.ts
@@ -1,0 +1,50 @@
+import { translations } from "./translations.generated";
+import { extensionMessages } from "./extension-messages";
+
+/** Storage key where the user-selected UI language is persisted. */
+export const LANGUAGE_STORAGE_KEY = "ui_language";
+
+export type TranslateFn = (key: string, ...args: (string | number)[]) => string;
+
+/** Map a browser/navigator locale to a supported translation key. */
+export function detectLanguage(): string {
+  const locale = navigator.language?.toLowerCase().replace("-", "_") ?? "en";
+  if (locale in translations) return locale;
+  const base = locale.split("_")[0];
+  if (base === "zh") {
+    if (locale.includes("tw") || locale.includes("hk") || locale.includes("hant")) {
+      return "zh_hant";
+    }
+    return "zh";
+  }
+  if (base in translations) return base;
+  return "en";
+}
+
+/** Build a standalone translator for [lang] (falls back to English keys). */
+export function buildTranslator(lang: string): TranslateFn {
+  const messages: Record<string, string> = {
+    ...translations.en,
+    ...extensionMessages.en,
+    ...translations[lang],
+    ...extensionMessages[lang],
+  };
+  return function t(key: string, ...args: (string | number)[]): string {
+    let text = messages[key] ?? key;
+    for (const arg of args) {
+      text = text.replace("%s", String(arg));
+    }
+    return text;
+  };
+}
+
+/**
+ * Build a translator using the language persisted by the side panel UI,
+ * falling back to browser detection. Safe to call from service-workers
+ * (no React / DOM dependencies beyond `chrome.storage`).
+ */
+export async function buildTranslatorFromStorage(): Promise<TranslateFn> {
+  const stored = await chrome.storage.local.get(LANGUAGE_STORAGE_KEY);
+  const lang = (stored[LANGUAGE_STORAGE_KEY] as string) || detectLanguage();
+  return buildTranslator(lang);
+}

--- a/web/src/shared/i18n/use-i18n.ts
+++ b/web/src/shared/i18n/use-i18n.ts
@@ -9,39 +9,17 @@ import {
   type ReactNode,
 } from "react";
 import { translations } from "./translations.generated";
-import { extensionMessages } from "./extension-messages";
+import {
+  buildTranslator,
+  detectLanguage,
+  LANGUAGE_STORAGE_KEY,
+  type TranslateFn,
+} from "./i18n-core";
 
 // ─── Language detection ─────────────────────────────────────────────────
 
-const STORAGE_KEY = "ui_language";
-
 /** All supported language codes, sorted for UI display */
 export const SUPPORTED_LANGUAGES = Object.keys(translations).sort();
-
-/**
- * Detect the user's language from the browser/Chrome settings
- * and map to our supported language codes.
- */
-function detectLanguage(): string {
-  const locale = navigator.language?.toLowerCase().replace("-", "_") ?? "en";
-
-  if (locale in translations) return locale;
-
-  const base = locale.split("_")[0];
-  if (base === "zh") {
-    if (
-      locale.includes("tw") ||
-      locale.includes("hk") ||
-      locale.includes("hant")
-    ) {
-      return "zh_hant";
-    }
-    return "zh";
-  }
-
-  if (base in translations) return base;
-  return "en";
-}
 
 /** Get the native display name for a language code */
 export function getLanguageName(code: string): string {
@@ -49,8 +27,6 @@ export function getLanguageName(code: string): string {
 }
 
 // ─── Context ────────────────────────────────────────────────────────────
-
-type TranslateFn = (key: string, ...args: (string | number)[]) => string;
 
 interface I18nContextValue {
   t: TranslateFn;
@@ -62,38 +38,21 @@ const I18nContext = createContext<I18nContextValue | null>(null);
 
 // ─── Provider ───────────────────────────────────────────────────────────
 
-function buildTranslator(lang: string): TranslateFn {
-  const messages: Record<string, string> = {
-    ...translations.en,
-    ...extensionMessages.en,
-    ...translations[lang],
-    ...extensionMessages[lang],
-  };
-
-  return function t(key: string, ...args: (string | number)[]): string {
-    let text = messages[key] ?? key;
-    for (const arg of args) {
-      text = text.replace("%s", String(arg));
-    }
-    return text;
-  };
-}
-
 export function I18nProvider({ children }: { children: ReactNode }) {
   const [language, setLanguageState] = useState<string | null>(null);
 
   // Load persisted language on mount
   useEffect(() => {
-    chrome.storage.local.get(STORAGE_KEY).then((result) => {
+    chrome.storage.local.get(LANGUAGE_STORAGE_KEY).then((result) => {
       setLanguageState(
-        (result[STORAGE_KEY] as string) ?? detectLanguage(),
+        (result[LANGUAGE_STORAGE_KEY] as string) ?? detectLanguage(),
       );
     });
   }, []);
 
   const setLanguage = useCallback((lang: string) => {
     setLanguageState(lang);
-    chrome.storage.local.set({ [STORAGE_KEY]: lang });
+    chrome.storage.local.set({ [LANGUAGE_STORAGE_KEY]: lang });
   }, []);
 
   const t = useMemo(() => {

--- a/web/src/shared/notification/notification-manager.ts
+++ b/web/src/shared/notification/notification-manager.ts
@@ -40,7 +40,7 @@ export const NotificationManager = {
     lastContentTime = now;
 
     const msg: Message = { id: nextId++, title, message, type, duration };
-    messages = [...messages, msg];
+    messages = [msg, ...messages];
     notify();
 
     if (duration !== null) {

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -22,6 +22,14 @@ interface WsWholeFileRequest {
 
 type WsPullFileRequest = WsChunkRequest | WsWholeFileRequest;
 
+/** Payload of a PASTE_REJECTED_OVERSIZE message (matches Kotlin OversizePasteNotice). */
+export interface OversizePasteNotice {
+  reason: "FILE_TOO_LARGE" | "TOTAL_TOO_LARGE";
+  fileName?: string | null;
+  actualSize: number;
+  sizeLimitBytes: number;
+}
+
 export interface WsMessageHandlerDeps {
   /** Send an envelope back to the device that sent the message. */
   sendToDevice: (targetAppInstanceId: string, envelope: WsEnvelope) => Promise<void>;
@@ -35,6 +43,11 @@ export interface WsMessageHandlerDeps {
   setLastHash: (hash: string) => Promise<void>;
   /** Handle remote removal: remove device from storage and disconnect WebSocket. */
   onRemoteRemoveDevice: (targetAppInstanceId: string) => Promise<void>;
+  /** Surface an oversize-paste rejection from [sourceAppInstanceId] to the user. */
+  showOversizePasteNotice: (
+    sourceAppInstanceId: string,
+    notice: OversizePasteNotice,
+  ) => Promise<void>;
 }
 
 /**
@@ -68,6 +81,10 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
 
         case WsMessageType.FILE_PULL_REQUEST:
           await handleFilePullRequest(appInstanceId, envelope);
+          break;
+
+        case WsMessageType.PASTE_REJECTED_OVERSIZE:
+          await handlePasteRejectedOversize(appInstanceId, envelope);
           break;
 
         default:
@@ -232,6 +249,20 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
         BlobStore.notifyChange(hash);
         deps.broadcastToSidePanel({ type: "BLOBS_READY", hash });
       }
+    }
+  }
+
+  async function handlePasteRejectedOversize(
+    appInstanceId: string,
+    envelope: WsEnvelope,
+  ): Promise<void> {
+    try {
+      const notice = JSON.parse(
+        new TextDecoder().decode(envelope.payload),
+      ) as OversizePasteNotice;
+      await deps.showOversizePasteNotice(appInstanceId, notice);
+    } catch (e) {
+      console.error(`[WsHandler] Failed to handle PASTE_REJECTED_OVERSIZE from ${appInstanceId}:`, e);
     }
   }
 

--- a/web/src/shared/ws/ws-types.ts
+++ b/web/src/shared/ws/ws-types.ts
@@ -12,6 +12,7 @@ export const WsMessageType = {
   NOTIFY_REMOVE: "notify_remove",
   FILE_PULL_REQUEST: "file_pull_request",
   FILE_PULL_RESPONSE: "file_pull_response",
+  PASTE_REJECTED_OVERSIZE: "paste_rejected_oversize",
   ERROR: "error",
 } as const;
 

--- a/web/src/sidepanel/App.tsx
+++ b/web/src/sidepanel/App.tsx
@@ -6,6 +6,7 @@ import { PasteGrid } from "@/components/paste-grid/PasteGrid";
 import { SettingsView } from "@/components/settings/SettingsView";
 import { useConnection } from "@/shared/hooks/use-connection";
 import { useDesktopStatus } from "@/shared/hooks/use-desktop-status";
+import { useOversizeNoticeListener } from "@/shared/hooks/use-oversize-notice";
 import { useI18n, I18nProvider } from "@/shared/i18n/use-i18n";
 import { ThemeProvider } from "@/shared/theme/use-theme";
 import { NotificationHost } from "@/components/notification/NotificationHost";
@@ -43,6 +44,7 @@ export default function App() {
   const { devices, connect, pair, rePair, removeDevice, updateNote } = useConnection();
   const [activeTab, setActiveTab] = usePersistedTab();
   const desktopConnected = useDesktopStatus();
+  useOversizeNoticeListener();
 
   return (
     <ThemeProvider>


### PR DESCRIPTION
Closes #4228

## Summary

- **Oversize paste notification**: Desktop now sends a `PASTE_REJECTED_OVERSIZE` WS message to the Chrome extension before skipping a file/image paste that exceeds the 1MB per-file or 32MB total limit. The extension surfaces it as a persistent in-panel notification the user must dismiss manually. i18n covers all 8 supported languages.
- **Fix WS whole-file pull regression** (introduced by #4180): `FilePullService` encoded `WsPullFileRequest.WholeFileRequest` through the concrete-subtype serializer, so kotlinx.serialization dropped the `@JsonClassDiscriminator("mode")` field and Chrome rejected the request with `"only supports whole-file mode"`. Fixed by annotating the variable with the sealed-parent type, plus regression tests.
- **i18n plumbing**: extracted `buildTranslator` / `detectLanguage` into a React-free `i18n-core.ts` so service-workers can translate with the user's stored language preference.
- **Notification ordering**: `NotificationManager` now prepends new items so the latest appears on top.
- **Compiler warning cleanup**: `@OptIn(ExperimentalSerializationApi::class)` on `WsPullFileRequest`; migrate `kotlinx.datetime.Clock` to stable `kotlin.time.Clock` in `CrossPasteApi.kt`.

## Test plan

- [x] `./gradlew app:desktopTest --tests DtoSerializationTest` — 15 passing (including 3 new `WsPullFileRequest` roundtrip/discriminator tests)
- [x] `./gradlew app:compileKotlinDesktop core:compileKotlinJs` — no warnings
- [x] `npx tsc --noEmit` (web) — clean
- [x] `npm test` (web) — 79/79 passing
- [ ] Manual: copy a >1MB image on Desktop while Chrome extension is paired → in-panel amber banner appears in side panel with "paste from `<device>` not synced" + file size detail, does not auto-dismiss
- [ ] Manual: copy a ≤1MB image on Desktop → Chrome receives it normally via WS whole-file pull