### PR TITLE
:sparkles: Chrome extension UISupport helpers + install CTA on oversize notice

### DIFF
--- a/web/manifest.json
+++ b/web/manifest.json
@@ -4,7 +4,7 @@
   "description": "Clipboard sync with CrossPaste desktop",
   "version": "0.1.0",
   "permissions": ["storage", "sidePanel", "alarms", "offscreen", "clipboardRead", "clipboardWrite", "downloads", "nativeMessaging"],
-  "host_permissions": ["http://*/*"],
+  "host_permissions": ["http://*/*", "https://crosspaste.com/*"],
   "side_panel": {
     "default_path": "src/sidepanel/index.html"
   },

--- a/web/src/components/notification/NotificationHost.tsx
+++ b/web/src/components/notification/NotificationHost.tsx
@@ -63,27 +63,44 @@ function NotificationCard({
 
   const styles = TYPE_STYLES[msg.type];
   const Icon = TYPE_ICONS[msg.type];
+  const hasBody = Boolean(msg.message) || Boolean(msg.action);
 
   return (
     <div
       className={`
-        flex items-start gap-2.5 px-3 py-2.5 rounded-xl shadow-lg
+        flex gap-2.5 px-3 py-2.5 rounded-xl shadow-lg
         transition-all duration-200 ease-out
+        ${hasBody ? "items-start" : "items-center"}
         ${styles.container}
         ${visible && !exiting ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2"}
         ${exiting ? "opacity-0 translate-x-full" : ""}
       `}
     >
-      <Icon size={18} className={`${styles.icon} shrink-0 mt-0.5`} />
+      <Icon
+        size={18}
+        className={`${styles.icon} shrink-0 ${hasBody ? "mt-0.5" : ""}`}
+      />
       <div className="flex-1 min-w-0">
         <p className="text-xs font-medium leading-tight">{msg.title}</p>
         {msg.message && (
           <p className="text-[11px] leading-tight mt-0.5 opacity-70">{msg.message}</p>
         )}
+        {msg.action && (
+          <button
+            onClick={() => {
+              msg.action?.onClick();
+              handleDismiss();
+            }}
+            className="mt-1.5 text-[11px] font-semibold underline underline-offset-2
+              hover:opacity-80 transition-opacity"
+          >
+            {msg.action.label}
+          </button>
+        )}
       </div>
       <button
         onClick={handleDismiss}
-        className="shrink-0 opacity-50 hover:opacity-100 transition-opacity mt-0.5"
+        className={`shrink-0 opacity-50 hover:opacity-100 transition-opacity ${hasBody ? "mt-0.5" : ""}`}
       >
         <X size={14} />
       </button>

--- a/web/src/components/paste-grid/PasteCard.tsx
+++ b/web/src/components/paste-grid/PasteCard.tsx
@@ -225,11 +225,11 @@ export function PasteCard({ data, onClick, onDelete }: Props) {
   const handleCopy = useCallback(async () => {
     try {
       await copyPasteData(data);
-      NotificationManager.success("Copied");
+      NotificationManager.success(t("copy_successful"));
     } catch {
-      NotificationManager.error("Copy failed");
+      NotificationManager.error(t("copy_failed"));
     }
-  }, [data]);
+  }, [data, t]);
 
   const handleDownload = useCallback(async () => {
     const item = data.pasteAppearItem ?? data.pasteCollection.pasteItems[0];

--- a/web/src/components/paste-grid/PasteGrid.tsx
+++ b/web/src/components/paste-grid/PasteGrid.tsx
@@ -9,15 +9,6 @@ import { NotificationManager } from "@/shared/notification/notification-manager"
 import { PasteTypeInt } from "@/shared/models/paste-item";
 import { useI18n } from "@/shared/i18n/use-i18n";
 
-async function copyItem(data: PasteData) {
-  try {
-    await copyPasteData(data);
-    NotificationManager.success("Copied");
-  } catch {
-    NotificationManager.error("Copy failed");
-  }
-}
-
 /** Each entry maps to an i18n key; null value = "all types" */
 const TYPE_OPTIONS: ReadonlyArray<{ value: number | null; i18nKey: string }> = [
   { value: null, i18nKey: "all_types" },
@@ -63,6 +54,18 @@ export function PasteGrid() {
   const { items, loading, hasMore, loadMore, deletePaste } = usePasteList(searchParams);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const observer = useRef<IntersectionObserver | null>(null);
+
+  const copyItem = useCallback(
+    async (data: PasteData) => {
+      try {
+        await copyPasteData(data);
+        NotificationManager.success(t("copy_successful"));
+      } catch {
+        NotificationManager.error(t("copy_failed"));
+      }
+    },
+    [t],
+  );
 
   const lastItemRef = useCallback(
     (node: HTMLDivElement | null) => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -11,6 +11,7 @@
 
   /* M3 Primary */
   --color-m3-primary: #3B82F6;
+  --color-m3-on-primary: #FFFFFF;
   --color-m3-primary-container: #DBEAFE;
   --color-m3-on-primary-container: #1E3A8A;
 
@@ -56,6 +57,7 @@
   --color-m3-on-surface-variant: #9CA3AF;
 
   --color-m3-primary: #60A5FA;
+  --color-m3-on-primary: #0A0A0A;
   --color-m3-primary-container: #1E3A8A;
   --color-m3-on-primary-container: #DBEAFE;
 

--- a/web/src/shared/app/app-urls.ts
+++ b/web/src/shared/app/app-urls.ts
@@ -1,0 +1,10 @@
+/**
+ * App-wide external URLs. Mirrors the desktop `AppUrls` interface.
+ * Desktop reads these from `app-urls.properties`; the extension keeps
+ * them as constants since it has no classpath resources.
+ */
+export const AppUrls = {
+  homeUrl: "https://crosspaste.com",
+  changeLogUrl: "https://github.com/crosspaste/crosspaste-desktop/blob/main/CHANGELOG.md",
+  issueTrackerUrl: "https://github.com/CrossPaste/crosspaste-desktop/issues",
+} as const;

--- a/web/src/shared/app/cross-paste-web-service.ts
+++ b/web/src/shared/app/cross-paste-web-service.ts
@@ -1,0 +1,58 @@
+import { AppUrls } from "./app-urls";
+import { getActiveLanguage } from "@/shared/i18n/i18n-core";
+
+/**
+ * Mirrors the Kotlin [CrossPasteWebService] — resolves the locale path
+ * segment of https://crosspaste.com so we can deep-link users to the
+ * localized landing / download page.
+ *
+ * The desktop app fetches `/api/meta.json` and caches `localePathMap`;
+ * we do the same here (lazy, in-memory) with a hard-coded fallback for
+ * the cold-start case (no network or before refresh completes).
+ */
+
+interface WebLocale {
+  code: string;
+  label: string;
+  path: string;
+}
+
+interface WebMeta {
+  locales: WebLocale[];
+}
+
+let localePathMap: Record<string, string> = {};
+
+async function refresh(): Promise<void> {
+  try {
+    const response = await fetch(`${AppUrls.homeUrl}/api/meta.json`, { cache: "no-cache" });
+    if (!response.ok) return;
+    const meta = (await response.json()) as WebMeta;
+    localePathMap = Object.fromEntries(meta.locales.map((l) => [l.code, l.path]));
+  } catch (e) {
+    console.warn("[CrossPasteWebService] Failed to fetch web meta:", e);
+  }
+}
+
+function resolveLocalePath(language: string): string {
+  const map = localePathMap;
+  if (Object.keys(map).length > 0) {
+    return map[language] ?? map["en"] ?? "/en/";
+  }
+  // Fallback before meta.json loads, matching the desktop default.
+  return language === "zh" ? "/" : "/en/";
+}
+
+export const CrossPasteWebService = {
+  refresh,
+
+  /** Build a localized URL like `https://crosspaste.com/en/download`. */
+  getWebUrl(language: string, path = ""): string {
+    return `${AppUrls.homeUrl}${resolveLocalePath(language)}${path}`;
+  },
+
+  /** Shortcut that reads the active UI language from storage. */
+  async getLocalizedUrl(path = ""): Promise<string> {
+    return this.getWebUrl(await getActiveLanguage(), path);
+  },
+};

--- a/web/src/shared/app/ui-support.ts
+++ b/web/src/shared/app/ui-support.ts
@@ -1,0 +1,23 @@
+import { CrossPasteWebService } from "./cross-paste-web-service";
+
+/**
+ * Extension-side equivalent of the Kotlin [UISupport] interface — only the
+ * methods the extension can actually fulfil (no file-system or OS integration).
+ */
+
+/** Open [url] in a new browser tab. */
+export function openUrlInBrowser(url: string): void {
+  if (chrome?.tabs?.create) {
+    void chrome.tabs.create({ url }).catch(() => {
+      window.open(url, "_blank", "noopener");
+    });
+  } else {
+    window.open(url, "_blank", "noopener");
+  }
+}
+
+/** Open the localized CrossPaste website — [path] is appended after the locale segment. */
+export async function openCrossPasteWebInBrowser(path = ""): Promise<void> {
+  const url = await CrossPasteWebService.getLocalizedUrl(path);
+  openUrlInBrowser(url);
+}

--- a/web/src/shared/hooks/use-oversize-notice.ts
+++ b/web/src/shared/hooks/use-oversize-notice.ts
@@ -1,5 +1,8 @@
 import { useEffect } from "react";
 import { NotificationManager } from "@/shared/notification/notification-manager";
+import { openCrossPasteWebInBrowser } from "@/shared/app/ui-support";
+import { CrossPasteWebService } from "@/shared/app/cross-paste-web-service";
+import { useI18n } from "@/shared/i18n/use-i18n";
 
 interface OversizeNoticeMessage {
   type: "OVERSIZE_NOTICE";
@@ -9,16 +12,27 @@ interface OversizeNoticeMessage {
 
 /**
  * Listen for PASTE_REJECTED_OVERSIZE events relayed by the service worker
- * and show a persistent in-panel notification (dismissed manually).
+ * and show a persistent in-panel notification (dismissed manually), with a
+ * CTA that deep-links the user to the desktop-client download page.
  */
 export function useOversizeNoticeListener(): void {
+  const t = useI18n();
   useEffect(() => {
+    // Warm the locale path map so the CTA can open the correct localized URL
+    // (also gracefully falls back to /en/ if the fetch fails or is slow).
+    void CrossPasteWebService.refresh();
+
     const listener = (message: { type: string } & Partial<OversizeNoticeMessage>) => {
       if (message.type !== "OVERSIZE_NOTICE") return;
       if (!message.title) return;
-      NotificationManager.warning(message.title, message.message, null);
+      NotificationManager.warning(message.title, message.message, null, {
+        label: t("install_desktop_client"),
+        onClick: () => {
+          void openCrossPasteWebInBrowser("download");
+        },
+      });
     };
     chrome.runtime.onMessage.addListener(listener);
     return () => chrome.runtime.onMessage.removeListener(listener);
-  }, []);
+  }, [t]);
 }

--- a/web/src/shared/i18n/extension-messages.ts
+++ b/web/src/shared/i18n/extension-messages.ts
@@ -37,6 +37,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_not_synced_title: "CrossPaste: paste from %s not synced",
     paste_oversize_file: "\"%s\" (%s) exceeds the %s per-file limit",
     paste_oversize_total: "Total size %s exceeds the %s limit",
+    install_desktop_client: "Install the desktop client for full functionality",
   },
   de: {
     clipboard: "Zwischenablage",
@@ -72,6 +73,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_not_synced_title: "CrossPaste: Einfügung von %s nicht synchronisiert",
     paste_oversize_file: "„%s\" (%s) überschreitet das Limit von %s pro Datei",
     paste_oversize_total: "Gesamtgröße %s überschreitet das Limit von %s",
+    install_desktop_client: "Desktop-Client für alle Funktionen installieren",
   },
   es: {
     clipboard: "Portapapeles",
@@ -107,6 +109,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_not_synced_title: "CrossPaste: pegado de %s no sincronizado",
     paste_oversize_file: "\"%s\" (%s) supera el límite de %s por archivo",
     paste_oversize_total: "El tamaño total %s supera el límite de %s",
+    install_desktop_client: "Instala el cliente de escritorio para todas las funciones",
   },
   fr: {
     clipboard: "Presse-papiers",
@@ -142,6 +145,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_not_synced_title: "CrossPaste : collage depuis %s non synchronisé",
     paste_oversize_file: "« %s » (%s) dépasse la limite de %s par fichier",
     paste_oversize_total: "La taille totale %s dépasse la limite de %s",
+    install_desktop_client: "Installer le client de bureau pour toutes les fonctionnalités",
   },
   ja: {
     clipboard: "クリップボード",
@@ -176,6 +180,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_not_synced_title: "CrossPaste: %s からのペーストは同期されませんでした",
     paste_oversize_file: "「%s」(%s) が1ファイルあたりの上限 %s を超えています",
     paste_oversize_total: "合計サイズ %s が上限 %s を超えています",
+    install_desktop_client: "すべての機能を利用するためにデスクトップクライアントをインストール",
   },
   ko: {
     clipboard: "클립보드",
@@ -209,6 +214,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_not_synced_title: "CrossPaste: %s 의 붙여넣기가 동기화되지 않았습니다",
     paste_oversize_file: "\"%s\"(%s)이(가) 파일당 한도 %s 을(를) 초과합니다",
     paste_oversize_total: "총 크기 %s 이(가) 한도 %s 을(를) 초과합니다",
+    install_desktop_client: "전체 기능을 위해 데스크톱 클라이언트 설치",
   },
   zh: {
     clipboard: "剪贴板",
@@ -241,6 +247,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_not_synced_title: "CrossPaste：来自 %s 的剪贴板未同步",
     paste_oversize_file: "文件「%s」大小为 %s，超过单文件上限 %s",
     paste_oversize_total: "总大小 %s 超过 %s 上限",
+    install_desktop_client: "安装桌面客户端以支持完整功能",
   },
   zh_hant: {
     clipboard: "剪貼簿",
@@ -273,5 +280,6 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_not_synced_title: "CrossPaste：來自 %s 的剪貼簿未同步",
     paste_oversize_file: "檔案「%s」大小為 %s，超過單檔上限 %s",
     paste_oversize_total: "總大小 %s 超過 %s 上限",
+    install_desktop_client: "安裝桌面客戶端以支援完整功能",
   },
 };

--- a/web/src/shared/i18n/i18n-core.ts
+++ b/web/src/shared/i18n/i18n-core.ts
@@ -39,12 +39,19 @@ export function buildTranslator(lang: string): TranslateFn {
 }
 
 /**
+ * Read the user's active UI language — persisted preference if present,
+ * otherwise browser detection. Safe to call from service-workers.
+ */
+export async function getActiveLanguage(): Promise<string> {
+  const stored = await chrome.storage.local.get(LANGUAGE_STORAGE_KEY);
+  return (stored[LANGUAGE_STORAGE_KEY] as string) || detectLanguage();
+}
+
+/**
  * Build a translator using the language persisted by the side panel UI,
  * falling back to browser detection. Safe to call from service-workers
  * (no React / DOM dependencies beyond `chrome.storage`).
  */
 export async function buildTranslatorFromStorage(): Promise<TranslateFn> {
-  const stored = await chrome.storage.local.get(LANGUAGE_STORAGE_KEY);
-  const lang = (stored[LANGUAGE_STORAGE_KEY] as string) || detectLanguage();
-  return buildTranslator(lang);
+  return buildTranslator(await getActiveLanguage());
 }

--- a/web/src/shared/notification/notification-manager.ts
+++ b/web/src/shared/notification/notification-manager.ts
@@ -1,5 +1,10 @@
 export type MessageType = "info" | "success" | "warning" | "error";
 
+export interface MessageAction {
+  label: string;
+  onClick: () => void;
+}
+
 export interface Message {
   id: number;
   title: string;
@@ -7,6 +12,8 @@ export interface Message {
   type: MessageType;
   /** Auto-dismiss duration in ms. Null = persistent until manually dismissed. */
   duration: number | null;
+  /** Optional call-to-action button rendered inside the notification. */
+  action?: MessageAction;
 }
 
 type Listener = (messages: Message[]) => void;
@@ -32,14 +39,20 @@ export const NotificationManager = {
   },
 
   /** Show a notification. Debounces identical content within 300ms. */
-  show(title: string, type: MessageType = "info", message?: string, duration: number | null = 3000) {
+  show(
+    title: string,
+    type: MessageType = "info",
+    message?: string,
+    duration: number | null = 3000,
+    action?: MessageAction,
+  ) {
     const contentKey = `${type}:${title}:${message ?? ""}`;
     const now = Date.now();
     if (contentKey === lastContent && now - lastContentTime < DEBOUNCE_MS) return;
     lastContent = contentKey;
     lastContentTime = now;
 
-    const msg: Message = { id: nextId++, title, message, type, duration };
+    const msg: Message = { id: nextId++, title, message, type, duration, action };
     messages = [msg, ...messages];
     notify();
 
@@ -58,16 +71,16 @@ export const NotificationManager = {
   },
 
   /** Convenience methods */
-  info(title: string, message?: string, duration?: number | null) {
-    this.show(title, "info", message, duration);
+  info(title: string, message?: string, duration?: number | null, action?: MessageAction) {
+    this.show(title, "info", message, duration, action);
   },
-  success(title: string, message?: string, duration?: number | null) {
-    this.show(title, "success", message, duration);
+  success(title: string, message?: string, duration?: number | null, action?: MessageAction) {
+    this.show(title, "success", message, duration, action);
   },
-  warning(title: string, message?: string, duration?: number | null) {
-    this.show(title, "warning", message, duration);
+  warning(title: string, message?: string, duration?: number | null, action?: MessageAction) {
+    this.show(title, "warning", message, duration, action);
   },
-  error(title: string, message?: string, duration?: number | null) {
-    this.show(title, "error", message, duration);
+  error(title: string, message?: string, duration?: number | null, action?: MessageAction) {
+    this.show(title, "error", message, duration, action);
   },
 };

--- a/web/src/sidepanel/App.tsx
+++ b/web/src/sidepanel/App.tsx
@@ -40,15 +40,21 @@ function DesktopActiveBanner() {
   );
 }
 
+/** Placed inside I18nProvider so hooks that depend on `useI18n` can run. */
+function OversizeNoticeRelay() {
+  useOversizeNoticeListener();
+  return null;
+}
+
 export default function App() {
   const { devices, connect, pair, rePair, removeDevice, updateNote } = useConnection();
   const [activeTab, setActiveTab] = usePersistedTab();
   const desktopConnected = useDesktopStatus();
-  useOversizeNoticeListener();
 
   return (
     <ThemeProvider>
       <I18nProvider>
+        <OversizeNoticeRelay />
         <div className="relative flex flex-col h-screen bg-m3-surface">
           <NotificationHost />
           <Header activeTab={activeTab} onTabChange={setActiveTab} />


### PR DESCRIPTION
Closes #4230

Follow-up to #4229 (already merged).

## Summary

- **UISupport port**: new `shared/app/{app-urls,cross-paste-web-service,ui-support}.ts` mirror the desktop `UISupport` / `CrossPasteWebService` / `AppUrls`. `getWebUrl(lang, path)` resolves the locale path via `/api/meta.json` with a hard-coded fallback (`/` for zh, `/en/` otherwise).
- **Notification action API**: `Message` gains an optional `action { label, onClick }`; `NotificationHost` renders it and auto-dismisses after click.
- **Install CTA**: the oversize notice introduced by #4229 now shows "Install the desktop client for full functionality", opening `https://crosspaste.com/<locale>/download`. i18n added for all 8 supported languages.
- **Startup crash fix**: moved `useOversizeNoticeListener` into an in-provider `OversizeNoticeRelay` component. The previous placement ran `useI18n` before `<I18nProvider>` mounted and threw `"useI18n must be used within I18nProvider"`, crashing the side panel entirely.
- **Color bug fix**: `--color-m3-on-primary` was never defined in `index.css`, so the type-filter pill's selected state (`text-m3-on-primary` on a blue background) rendered with very low contrast. Added light `#FFFFFF` / dark `#0A0A0A` values.
- **i18n tidy**: `PasteCard` / `PasteGrid` hard-coded "Copied" / "Copy failed" toasts now go through `t()`.

## Test plan

- [x] `npx tsc --noEmit` (web) — clean
- [x] `npm test` — 79/79 passing
- [ ] Manual: copy a >1MB image on Desktop while Chrome extension is paired → amber banner appears, click "Install the desktop client…" → opens `https://crosspaste.com/<locale>/download` in a new tab.
- [ ] Manual: select the "Link" type filter in the paste grid → label is readable (white on blue in light mode, near-black on light blue in dark mode).