### PR TITLE
Fix MV3 download + add image download to Chrome extension

### DIFF
--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "CrossPaste",
-  "description": "Clipboard sync with CrossPaste desktop",
+  "description": "Clipboard sync with CrossPaste",
   "version": "0.1.0",
   "permissions": ["storage", "sidePanel", "alarms", "offscreen", "clipboardRead", "clipboardWrite", "downloads", "nativeMessaging"],
   "host_permissions": ["http://*/*", "https://crosspaste.com/*"],

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -145,6 +145,18 @@ function dataUrlToArrayBuffer(dataUrl: string): ArrayBuffer {
   return bytes.buffer;
 }
 
+// MV3 service workers don't expose URL.createObjectURL or the Blob URL scheme,
+// so chrome.downloads.download has to be fed a data URL instead.
+function arrayBufferToDataUrl(buffer: ArrayBuffer, mime = "application/octet-stream"): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + CHUNK)));
+  }
+  return `data:${mime};base64,${btoa(binary)}`;
+}
+
 /** Store file blobs grouped by their hash. */
 async function storeFileBlobs(collected: { hash: string; fileBlobs: Array<{ name: string; dataUrl: string; hash?: string }> }): Promise<void> {
   if (collected.fileBlobs.length === 0) return;
@@ -832,24 +844,11 @@ async function handleDownloadFile(hash: string, fileName: string): Promise<unkno
   const data = await BlobStore.get(hash, fileName);
   if (!data) return { success: false, error: "File not found" };
 
-  const blob = new Blob([data]);
-  const url = URL.createObjectURL(blob);
+  const url = arrayBufferToDataUrl(data);
   try {
-    const downloadId = await chrome.downloads.download({ url, filename: fileName, saveAs: true });
-
-    const listener = (delta: chrome.downloads.DownloadDelta) => {
-      if (delta.id !== downloadId) return;
-      const state = delta.state?.current;
-      if (state === "complete" || state === "interrupted") {
-        chrome.downloads.onChanged.removeListener(listener);
-        URL.revokeObjectURL(url);
-      }
-    };
-    chrome.downloads.onChanged.addListener(listener);
-
+    await chrome.downloads.download({ url, filename: fileName, saveAs: true });
     return { success: true };
   } catch (e) {
-    URL.revokeObjectURL(url);
     return { success: false, error: String(e) };
   }
 }

--- a/web/src/components/paste-grid/PasteCard.tsx
+++ b/web/src/components/paste-grid/PasteCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { Copy, Trash2, Download } from "lucide-react";
 import type { PasteData } from "@/shared/models/paste-data";
-import { PasteType, PASTE_TYPE_FROM_INT, PASTE_TYPE_I18N_KEYS } from "@/shared/models/paste-item";
+import { PasteType, PasteTypeInt, PASTE_TYPE_FROM_INT, PASTE_TYPE_I18N_KEYS } from "@/shared/models/paste-item";
 import { useI18n } from "@/shared/i18n/use-i18n";
 import type {
   PasteItem,
@@ -220,7 +220,7 @@ export function PasteCard({ data, onClick, onDelete }: Props) {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  const isFileType = data.pasteType === 3; // PasteTypeInt.FILE
+  const isDownloadable = data.pasteType === PasteTypeInt.FILE || data.pasteType === PasteTypeInt.IMAGE;
 
   const handleCopy = useCallback(async () => {
     try {
@@ -310,7 +310,7 @@ export function PasteCard({ data, onClick, onDelete }: Props) {
             <Copy size={16} className="text-m3-on-surface-variant" />
             <span>{t("copy")}</span>
           </button>
-          {isFileType && (
+          {isDownloadable && (
             <button
               onClick={() => { setContextMenu(null); handleDownload(); }}
               className="flex items-center gap-3 w-full px-4 py-2.5 text-sm text-m3-on-surface hover:bg-m3-surface-container transition-colors"


### PR DESCRIPTION
Closes #4232

## Summary
- Service worker `handleDownloadFile` was calling `URL.createObjectURL(blob)`, which doesn't exist in MV3 service workers. Right-click → Download on a file item threw `TypeError: URL.createObjectURL is not a function`.
- Replaced with a chunked base64 `data:` URL built directly from the `ArrayBuffer`; `chrome.downloads.download` accepts data URLs. Dropped the `URL.revokeObjectURL` lifecycle code (data URLs don't need it).
- `PasteCard` now also shows the right-click **Download** menu item for `IMAGE` paste items, not just `FILE`. Images are already stored in `BlobStore` (with `relativePathList: ["clipboard-image.png"]`), so the existing `DOWNLOAD_FILE` message handler works for them unchanged — only the UI gate had to widen. The magic `pasteType === 3` check is also replaced with `PasteTypeInt` constants.
- Minor: tighten the `manifest.json` extension description.

## Test plan
- [ ] Build the Chrome extension, load it in `chrome://extensions` (Developer mode → Load unpacked).
- [ ] Copy a regular file from Finder/Explorer → open CrossPaste side panel → right-click the file card → **Download** → file saves via the browser download dialog, no console error.
- [ ] Copy an image (screenshot) → right-click the image card → **Download** appears → clicking it saves `clipboard-image.png` (or similar) successfully.
- [ ] Copy text / URL / color → right-click → Download option is NOT shown (only Copy + Delete).
- [ ] Verify no `URL.createObjectURL is not a function` in the service worker console.