### PR TITLE
:bug: fix Chrome extension right-click Copy duplicating HTML/image pastes

### DIFF
--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -103,6 +103,12 @@ let offscreenReady = false;
 
 const CLIPBOARD_POLL_INTERVAL_MS = 1000; // 1 second
 const STORAGE_KEY_LAST_HASH = "clipboard_lastHash";
+// After a LOCAL_COPY, Chrome's clipboard.write sanitizes text/html and may
+// regenerate text/plain from the HTML, so the first post-write poll reads
+// bytes that don't match the original paste's hash. Within this window we
+// absorb the re-read hash into lastHash once instead of ingesting it.
+const STORAGE_KEY_LOCAL_COPY_UNTIL = "clipboard_localCopyUntil";
+const LOCAL_COPY_SUPPRESS_MS = 2000;
 
 
 async function ensureOffscreen(): Promise<void> {
@@ -132,6 +138,15 @@ async function getLastHash(): Promise<string> {
 
 async function setLastHash(hash: string): Promise<void> {
   await chrome.storage.session.set({ [STORAGE_KEY_LAST_HASH]: hash });
+}
+
+async function getLocalCopyUntil(): Promise<number> {
+  const result = await chrome.storage.session.get(STORAGE_KEY_LOCAL_COPY_UNTIL);
+  return (result[STORAGE_KEY_LOCAL_COPY_UNTIL] as number) ?? 0;
+}
+
+async function setLocalCopyUntil(value: number): Promise<void> {
+  await chrome.storage.session.set({ [STORAGE_KEY_LOCAL_COPY_UNTIL]: value });
 }
 
 /** Convert a data URL to ArrayBuffer */
@@ -220,6 +235,13 @@ async function pollClipboard(): Promise<void> {
 
     const lastHash = await getLastHash();
     if (collected.hash === lastHash) return;
+
+    const suppressUntil = await getLocalCopyUntil();
+    if (Date.now() < suppressUntil) {
+      await setLastHash(collected.hash);
+      await setLocalCopyUntil(0);
+      return;
+    }
 
     await setLastHash(collected.hash);
 
@@ -825,6 +847,7 @@ async function handleLocalCopy(pasteId: number): Promise<unknown> {
   const hash = await PasteStore.moveToTop(pasteId);
   if (hash) {
     await setLastHash(hash);
+    await setLocalCopyUntil(Date.now() + LOCAL_COPY_SUPPRESS_MS);
     broadcastToSidePanel({ type: "PASTE_UPDATED" });
   }
   return { success: hash !== null };


### PR DESCRIPTION
Closes #4234

## Summary

Right-clicking a paste item in the Chrome extension side panel and choosing Copy produces a duplicate entry (`source="Chrome"`) within ~1s for HTML/image items. Chrome's `navigator.clipboard.write` sanitizes `text/html` and regenerates `text/plain` from HTML, so bytes re-read by the 1s clipboard poll don't match the `lastHash` pre-set via `LOCAL_COPY` → dedup misses → a duplicate is ingested.

## Fix

- On `LOCAL_COPY`, arm a 2s session-scoped suppress window (`clipboard_localCopyUntil`) alongside `setLastHash(hash)`.
- In `pollClipboard`, after the normal `lastHash` dedup check fails, if the suppress window is active, absorb the re-read hash into `lastHash` once, skip ingestion, and clear the window. Subsequent polls dedup normally.

## Test plan

- [x] Right-click Copy on an HTML paste → no duplicate row appears.
- [x] Right-click Copy on an image paste → no duplicate row appears.
- [x] Right-click Copy on a plain-text paste → behavior unchanged (no duplicate).
- [x] Copy from an external source within 2s of a right-click Copy → the external copy may be absorbed once but only if the first post-copy poll hasn't fired; otherwise the window is already cleared and the external copy is ingested normally.
- [x] Service worker restart between `LOCAL_COPY` and the next poll → window persists via `chrome.storage.session`, still suppresses correctly.