### PR TITLE
:bug: preserve Chrome extension scroll position on paste delete

### DIFF
--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -858,7 +858,7 @@ async function handleDeletePaste(pasteId: number): Promise<unknown> {
   if (hash !== null) {
     await BlobStore.deleteForPaste(hash);
     await PasteStore.purgeDeleted();
-    broadcastToSidePanel({ type: "PASTE_UPDATED" });
+    broadcastToSidePanel({ type: "PASTE_DELETED", pasteId });
   }
   return { success: hash !== null };
 }

--- a/web/src/shared/hooks/use-paste-list.ts
+++ b/web/src/shared/hooks/use-paste-list.ts
@@ -63,9 +63,23 @@ export function usePasteList(searchParams: SearchParams) {
     busyRef.current = false;
   }, []);
 
-  const deletePaste = useCallback(async (pasteId: number) => {
-    await chrome.runtime.sendMessage({ type: "DELETE_PASTE", pasteId });
+  const removeLocal = useCallback((pasteId: number) => {
+    setItems((prev) => {
+      const next = prev.filter((i) => i._id !== pasteId);
+      if (next.length !== prev.length) {
+        offsetRef.current = Math.max(0, offsetRef.current - (prev.length - next.length));
+      }
+      return next;
+    });
   }, []);
+
+  const deletePaste = useCallback(
+    async (pasteId: number) => {
+      removeLocal(pasteId);
+      await chrome.runtime.sendMessage({ type: "DELETE_PASTE", pasteId });
+    },
+    [removeLocal],
+  );
 
   // Reload when search params change
   useEffect(() => {
@@ -75,16 +89,18 @@ export function usePasteList(searchParams: SearchParams) {
     reload().then(() => setLoading(false));
   }, [searchParams.query, searchParams.pasteType, reload]);
 
-  // Listen for paste notifications → full reload
+  // Listen for paste notifications
   useEffect(() => {
     const listener = (message: Record<string, unknown>) => {
       if (message.type === "PASTE_UPDATED") {
         reload();
+      } else if (message.type === "PASTE_DELETED") {
+        removeLocal(message.pasteId as number);
       }
     };
     chrome.runtime.onMessage.addListener(listener);
     return () => chrome.runtime.onMessage.removeListener(listener);
-  }, [reload]);
+  }, [reload, removeLocal]);
 
   return { items, loading, hasMore, loadMore, deletePaste };
 }


### PR DESCRIPTION
Closes #4236

## Summary
- Background `handleDeletePaste` broadcasts `PASTE_DELETED` with the `pasteId` instead of the generic `PASTE_UPDATED`, so deletion no longer triggers a full first-page reload.
- `usePasteList` removes the deleted id from local state and adjusts `offsetRef`; `deletePaste` also updates state optimistically for instant UX. `PASTE_UPDATED` is still used for new paste arrivals that need a reload.

## Why this fixes the scroll jump
When the user scrolled past the first page and then deleted an item, the old flow reloaded only 30 items and replaced the entire list. The scroll container's content shrank and the browser clamped `scrollTop` back to the top. Now only the deleted card's DOM node unmounts; all other cards stay mounted and the scroll container's `scrollTop` is naturally preserved.

## Test plan
- [ ] Load the extension, open the sidepanel with >30 paste items.
- [ ] Scroll down past the first page.
- [ ] Right-click any card → Delete; verify the list stays put and only that card disappears.
- [ ] Delete a card from the detail view and verify the same behavior.
- [ ] New paste arriving from desktop still refreshes the first page (PASTE_UPDATED path).
- [ ] With multiple Chrome windows each showing the sidepanel, deleting in one window removes the same card in the other (PASTE_DELETED broadcast).