### PR TITLE
:construction_worker: split CI into app-build and web-build with path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,32 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            app:
+              - '!web/**'
+            web:
+              - 'web/**'
+              - 'core/**'
+              - 'gradle/**'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - 'settings.gradle.kts'
+              - 'build.gradle.kts'
+              - 'gradle.properties'
+
+  app-build:
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     env:
       BUILD_FULL_PLATFORM: YES
@@ -38,3 +63,59 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew app:build
+
+  web-build:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          check-latest: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: >
+            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*',
+            '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+
+      - name: Build web extension
+        run: ./gradlew :web:build
+
+      - name: Test web extension
+        working-directory: web
+        run: npm test
+
+  ci:
+    needs: [app-build, web-build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify CI results
+        run: |
+          app_result="${{ needs.app-build.result }}"
+          web_result="${{ needs.web-build.result }}"
+          echo "app-build: $app_result"
+          echo "web-build: $web_result"
+          for result in "$app_result" "$web_result"; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "CI failed"
+              exit 1
+            fi
+          done
+          echo "CI passed"


### PR DESCRIPTION
Closes #4238

## Summary
- Split `.github/workflows/ci.yml` into path-filtered jobs using `dorny/paths-filter@v4` so pure web-extension PRs skip the desktop Gradle build
- Add `web-build` job running `./gradlew :web:build` + `npm test` (vitest) — previously the web extension had no CI coverage
- Add `ci` aggregator job with `if: always()` as the single required check for branch protection (skipped path-filtered jobs won't block merges)

## Behavior
| Changed files | `app-build` | `web-build` |
| --- | --- | --- |
| Only `web/**` | skipped | runs |
| Only `core/**` or root gradle files | runs | runs |
| Anything else (e.g. `app/**`) | runs | skipped |

## Test plan
- [ ] CI runs on this PR: `web-build` should be skipped (no `web/**` or shared changes), `app-build` should run
- [ ] After merge, the branch protection required check needs to be switched from `build` to `ci`