### PR TITLE
:construction_worker: build Chrome extension zip and upload to OSS on release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -238,6 +238,21 @@ jobs:
           chmod +x ./.github/scripts/package_appimage.sh
           ./.github/scripts/package_appimage.sh
 
+      - name: Set up Node.js 20 for web extension
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build Chrome extension
+        run: ./gradlew :web:build
+
+      - name: Package Chrome extension zip
+        run: |
+          cd web/dist
+          zip -r "${{ github.workspace }}/output/crosspaste-chrome-extension-${{ env.VERSION }}.${{ env.REVISION }}.zip" .
+
       - name: CheckSum
         run: |
           rm -f icon.svg download.html


### PR DESCRIPTION
Closes #4240

## Summary
- Add Chrome extension build steps to the `build-ubuntu` job in `build-release.yml`
- Set up Node.js 20 in parallel to the existing Node 16 (Vite 6 / Vitest 4 require Node >=18; existing release scripts stay on Node 16)
- Run `./gradlew :web:build` and zip `web/dist/` into `output/crosspaste-chrome-extension-${VERSION}.${REVISION}.zip`

The zip lands in the existing `output/` directory, so it is automatically included in `checksum.txt` and uploaded to `oss://crosspaste-desktop/${VERSION}.${REVISION}/` by the existing `ossutil cp -r output/` step — no new upload logic needed.

## Test plan
- [ ] Next tag push produces `output/crosspaste-chrome-extension-<version>.<revision>.zip`
- [ ] The zip appears in `oss://crosspaste-desktop/<version>.<revision>/`
- [ ] The zip hash shows up in `checksum.txt`
- [ ] Unzipping the artifact and loading `manifest.json` as an unpacked extension in Chrome works