### PR TITLE
:bookmark: bump version to 2.0.0

### DIFF
--- a/app/src/desktopMain/resources/crosspaste-version.properties
+++ b/app/src/desktopMain/resources/crosspaste-version.properties
@@ -1,1 +1,1 @@
-version=1.2.9
+version=2.0.0


### PR DESCRIPTION
Closes #4242

## Summary
Bump `app/src/desktopMain/resources/crosspaste-version.properties` from `1.2.9` to `2.0.0` in preparation for the 2.0 release line.

## Why a major bump
The 2.0 series introduces first-class Chrome extension support as a new CrossPaste client, along with the WebSocket sync protocol and the extension release pipeline (#4240, #4241).

## Test plan
- [ ] CI passes (app-build only — no web/ changes)
- [ ] After merge, tagging `2.0.0.<revision>` triggers `build-release.yml` and produces desktop installers + Chrome extension zip under `oss://crosspaste-desktop/2.0.0.<revision>/`