### PR TITLE
:hammer: unify Chrome extension version with crosspaste-version.properties

### DIFF
--- a/app/src/desktopMain/resources/crosspaste-version.properties
+++ b/app/src/desktopMain/resources/crosspaste-version.properties
@@ -1,1 +1,1 @@
-version=1.2.9
+version=2.0.0

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -23,22 +23,43 @@ tasks.register("generateVersion") {
             .parent
             .resolve("app/src/desktopMain/resources/crosspaste-version.properties")
             .toFile()
-    val outputFile = project.file("src/shared/app/version.generated.ts")
+    val tsOutputFile = project.file("src/shared/app/version.generated.ts")
+    val manifestFile = project.file("manifest.json")
 
     inputs.file(versionFile)
-    outputs.file(outputFile)
+    outputs.file(tsOutputFile)
+    outputs.file(manifestFile)
 
     doLast {
-        outputFile.parentFile.mkdirs()
-        outputFile.writeText(
+        val props = Properties()
+        FileReader(versionFile).use { props.load(it) }
+        val version = props.getProperty("version")
+        val revision = props.getProperty("revision")
+        val fullVersion = if (revision.isNullOrBlank()) version else "$version.$revision"
+
+        tsOutputFile.parentFile.mkdirs()
+        tsOutputFile.writeText(
             """
             |// Auto-generated from app/src/desktopMain/resources/crosspaste-version.properties
             |// Do not edit manually — run ./gradlew :web:generateVersion to regenerate
             |
-            |export const APP_VERSION = "${versionProperties.getProperty("version")}";
+            |export const APP_VERSION = "$fullVersion";
             |
             """.trimMargin(),
         )
+
+        val manifestText = manifestFile.readText()
+        val updatedManifest =
+            manifestText.replaceFirst(
+                Regex("\"version\"\\s*:\\s*\"[^\"]*\""),
+                "\"version\": \"$fullVersion\"",
+            )
+        check(updatedManifest != manifestText || manifestText.contains("\"version\": \"$fullVersion\"")) {
+            "Failed to update version field in $manifestFile"
+        }
+        if (updatedManifest != manifestText) {
+            manifestFile.writeText(updatedManifest)
+        }
     }
 }
 

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "CrossPaste",
   "description": "Clipboard sync with CrossPaste",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "permissions": ["storage", "sidePanel", "alarms", "offscreen", "clipboardRead", "clipboardWrite", "downloads", "nativeMessaging"],
   "host_permissions": ["http://*/*", "https://crosspaste.com/*"],
   "side_panel": {

--- a/web/src/shared/app/version.generated.ts
+++ b/web/src/shared/app/version.generated.ts
@@ -1,4 +1,4 @@
 // Auto-generated from app/src/desktopMain/resources/crosspaste-version.properties
 // Do not edit manually — run ./gradlew :web:generateVersion to regenerate
 
-export const APP_VERSION = "1.2.9";
+export const APP_VERSION = "2.0.0";


### PR DESCRIPTION
Closes #4244

Depends on #4243 — this branch is stacked on top of the 2.0.0 version bump. Please merge #4243 first, then rebase and merge this one.

## Summary
Extend the existing `:web:generateVersion` Gradle task so a single source (`app/src/desktopMain/resources/crosspaste-version.properties`) drives:
- `web/src/shared/app/version.generated.ts` — UI-displayed `APP_VERSION`
- `web/manifest.json` — Chrome's extension version

The task now reads both `version` and (optionally) `revision` from the properties file; when `revision=` is present (release pipeline appends it), it emits a 4-part `<version>.<revision>` — matching the desktop installer version scheme.

No workflow changes needed: `:web:build` already `dependsOn("generateVersion")`, so CI and release pipelines regenerate both files automatically.

## Regenerated snapshots
- `version.generated.ts`: `1.2.9` → `2.0.0`
- `manifest.json`: `0.1.0` → `2.0.0`

## Test plan
- [ ] `./gradlew :web:generateVersion` is idempotent (verified: second run reports UP-TO-DATE)
- [ ] `./gradlew :web:build` produces a Chrome extension zip whose `manifest.json` version matches `crosspaste-version.properties`
- [ ] In release CI, after `Set Revision` appends `revision=1883`, the packaged manifest reads `"version": "2.0.0.1883"` and the UI shows `v2.0.0.1883`