### PR TITLE
:bug: always enqueue oversize-paste notices before notifying side panel

### DIFF
--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -30,6 +30,10 @@ import {
   PROTOCOL_VERSION,
   isCompatibleVersion,
 } from "@/shared/sync/protocol-version";
+import {
+  enqueueOversizeNotice,
+  type OversizeNoticeMessage,
+} from "@/shared/oversize-notice-queue";
 
 // ─── Per-device runtime facts (source of truth) ───────────────────────
 //
@@ -635,7 +639,14 @@ async function showOversizePasteNotice(
       ? t("paste_oversize_file", notice.fileName ?? "", actual, limit)
       : t("paste_oversize_total", actual, limit);
 
-  broadcastToSidePanel({ type: "OVERSIZE_NOTICE", title, message });
+  const payload: OversizeNoticeMessage = { type: "OVERSIZE_NOTICE", title, message };
+  // Always enqueue, then ping the side panel to drain. Avoids the MV3 quirk
+  // where sendMessage resolves (not rejects) when the offscreen listener
+  // receives but doesn't handle the message, which would silently drop notices.
+  await enqueueOversizeNotice(payload);
+  chrome.runtime.sendMessage({ type: "OVERSIZE_NOTICE_DRAIN" }).catch(() => {
+    // Side panel not open — next mount will drain.
+  });
 }
 
 // ─── Message handling ───────────────────────────────────────────────────

--- a/web/src/shared/hooks/use-oversize-notice.ts
+++ b/web/src/shared/hooks/use-oversize-notice.ts
@@ -3,17 +3,19 @@ import { NotificationManager } from "@/shared/notification/notification-manager"
 import { openCrossPasteWebInBrowser } from "@/shared/app/ui-support";
 import { CrossPasteWebService } from "@/shared/app/cross-paste-web-service";
 import { useI18n } from "@/shared/i18n/use-i18n";
-
-interface OversizeNoticeMessage {
-  type: "OVERSIZE_NOTICE";
-  title: string;
-  message: string;
-}
+import {
+  drainOversizeNotices,
+  enqueueOversizeNotice,
+} from "@/shared/oversize-notice-queue";
 
 /**
- * Listen for PASTE_REJECTED_OVERSIZE events relayed by the service worker
- * and show a persistent in-panel notification (dismissed manually), with a
- * CTA that deep-links the user to the desktop-client download page.
+ * Drain oversize-paste notices persisted by the service worker and surface
+ * them as in-panel notifications with a CTA to download the desktop client.
+ *
+ * The service worker always enqueues a notice first, then sends a drain ping.
+ * We drain on mount (to catch any queued while the panel was closed) and on
+ * each drain ping. This sidesteps the MV3 behavior where sendMessage resolves
+ * with undefined when the offscreen listener receives but doesn't handle it.
  */
 export function useOversizeNoticeListener(): void {
   const t = useI18n();
@@ -22,17 +24,41 @@ export function useOversizeNoticeListener(): void {
     // (also gracefully falls back to /en/ if the fetch fails or is slow).
     void CrossPasteWebService.refresh();
 
-    const listener = (message: { type: string } & Partial<OversizeNoticeMessage>) => {
-      if (message.type !== "OVERSIZE_NOTICE") return;
-      if (!message.title) return;
-      NotificationManager.warning(message.title, message.message, null, {
+    const showNotice = (title: string, message: string) => {
+      NotificationManager.warning(title, message, null, {
         label: t("install_desktop_client"),
         onClick: () => {
           void openCrossPasteWebInBrowser("download");
         },
       });
     };
+
+    let cancelled = false;
+    const drainAndShow = async () => {
+      const pending = await drainOversizeNotices();
+      if (cancelled) {
+        // Unmounted mid-drain — put the already-drained notices back so the
+        // next mount can replay them instead of silently losing them.
+        for (const notice of pending) {
+          await enqueueOversizeNotice(notice);
+        }
+        return;
+      }
+      for (const notice of pending) {
+        showNotice(notice.title, notice.message);
+      }
+    };
+
+    void drainAndShow();
+
+    const listener = (message: { type: string }) => {
+      if (message.type !== "OVERSIZE_NOTICE_DRAIN") return;
+      void drainAndShow();
+    };
     chrome.runtime.onMessage.addListener(listener);
-    return () => chrome.runtime.onMessage.removeListener(listener);
+    return () => {
+      cancelled = true;
+      chrome.runtime.onMessage.removeListener(listener);
+    };
   }, [t]);
 }

--- a/web/src/shared/oversize-notice-queue.ts
+++ b/web/src/shared/oversize-notice-queue.ts
@@ -1,0 +1,27 @@
+export interface OversizeNoticeMessage {
+  type: "OVERSIZE_NOTICE";
+  title: string;
+  message: string;
+}
+
+const STORAGE_KEY = "pending_oversize_notices";
+const MAX_QUEUED = 20;
+
+export async function enqueueOversizeNotice(
+  notice: OversizeNoticeMessage,
+): Promise<void> {
+  const store = await chrome.storage.session.get(STORAGE_KEY);
+  const pending = (store[STORAGE_KEY] as OversizeNoticeMessage[] | undefined) ?? [];
+  pending.push(notice);
+  const trimmed =
+    pending.length > MAX_QUEUED ? pending.slice(-MAX_QUEUED) : pending;
+  await chrome.storage.session.set({ [STORAGE_KEY]: trimmed });
+}
+
+export async function drainOversizeNotices(): Promise<OversizeNoticeMessage[]> {
+  const store = await chrome.storage.session.get(STORAGE_KEY);
+  const pending = (store[STORAGE_KEY] as OversizeNoticeMessage[] | undefined) ?? [];
+  if (pending.length === 0) return [];
+  await chrome.storage.session.remove(STORAGE_KEY);
+  return pending;
+}


### PR DESCRIPTION
Closes #4246

## Summary
- `showOversizePasteNotice` previously tried `chrome.runtime.sendMessage` first and fell back to the session-storage queue only on reject. Under MV3 that reject never fires when the offscreen document's listener is alive — it receives the message, returns `undefined`, and the promise resolves silently, dropping the notice whenever the side panel is closed.
- Switch to **enqueue-first + drain ping**: always persist to `chrome.storage.session`, then fire-and-forget `OVERSIZE_NOTICE_DRAIN`.
- Side-panel hook drains on mount and on each ping. If it unmounts mid-drain, already-drained notices are re-enqueued so they aren't lost to the `drainOversizeNotices` (read + delete) race.

## Files
- `web/src/shared/oversize-notice-queue.ts` — moved the queue helpers + `OversizeNoticeMessage` type to a dedicated module so both service-worker and the hook can import it.
- `web/src/background/service-worker.ts` — `showOversizePasteNotice` now `await`s `enqueueOversizeNotice` then pings `OVERSIZE_NOTICE_DRAIN`.
- `web/src/shared/hooks/use-oversize-notice.ts` — listens for `OVERSIZE_NOTICE_DRAIN`, shares a `drainAndShow()` between mount-time drain and ping-time drain, re-enqueues on unmount-mid-drain.

## Test plan
- [ ] Trigger an oversize paste on the desktop with the Chrome side panel closed → open the side panel → warning appears with "Install desktop client" CTA.
- [ ] Trigger an oversize paste with the side panel open → warning appears immediately.
- [ ] Trigger multiple oversize pastes while side panel is closed → all of them show up on next open (up to the 20-item cap).
- [ ] Close the side panel quickly after opening (mid-drain) → re-open later → notices still appear.