### PR TITLE
:hammer: extract useCopyWithNotification hook

### DIFF
--- a/web/src/components/paste-grid/PasteCard.tsx
+++ b/web/src/components/paste-grid/PasteCard.tsx
@@ -17,9 +17,9 @@ import { argbToHex, argbToRgba } from "@/shared/utils/color";
 import { formatSize } from "@/shared/utils/format";
 import { relativeTime } from "@/shared/utils/date";
 import { isDarkColor } from "@/shared/utils/html-color";
-import { copyPasteData } from "@/shared/clipboard/clipboard-writer";
 import { NotificationManager } from "@/shared/notification/notification-manager";
 import { useImageItemUrl } from "@/shared/hooks/use-image-url";
+import { useCopyWithNotification } from "@/shared/hooks/use-copy-with-notification";
 
 const MAX_SIZE = 5 * 1024 * 1024;
 
@@ -216,20 +216,13 @@ function renderContent(item: PasteItem) {
 
 export function PasteCard({ data, onClick, onDelete }: Props) {
   const t = useI18n();
-  const displayItem = data.pasteAppearItem ?? data.pasteCollection.pasteItems[0];
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const copyWithNotification = useCopyWithNotification();
+  const handleCopy = useCallback(() => copyWithNotification(data), [copyWithNotification, data]);
 
+  const displayItem = data.pasteAppearItem ?? data.pasteCollection.pasteItems[0];
   const isDownloadable = data.pasteType === PasteTypeInt.FILE || data.pasteType === PasteTypeInt.IMAGE;
-
-  const handleCopy = useCallback(async () => {
-    try {
-      await copyPasteData(data);
-      NotificationManager.success(t("copy_successful"));
-    } catch {
-      NotificationManager.error(t("copy_failed"));
-    }
-  }, [data, t]);
 
   const handleDownload = useCallback(async () => {
     const item = data.pasteAppearItem ?? data.pasteCollection.pasteItems[0];

--- a/web/src/components/paste-grid/PasteGrid.tsx
+++ b/web/src/components/paste-grid/PasteGrid.tsx
@@ -3,9 +3,7 @@ import { usePasteList } from "@/shared/hooks/use-paste-list";
 import { PasteCard } from "./PasteCard";
 import { PasteDetailView } from "./PasteDetailView";
 import { EmptyState } from "./EmptyState";
-import type { PasteData } from "@/shared/models/paste-data";
-import { copyPasteData } from "@/shared/clipboard/clipboard-writer";
-import { NotificationManager } from "@/shared/notification/notification-manager";
+import { useCopyWithNotification } from "@/shared/hooks/use-copy-with-notification";
 import { PasteTypeInt } from "@/shared/models/paste-item";
 import { useI18n } from "@/shared/i18n/use-i18n";
 
@@ -55,17 +53,7 @@ export function PasteGrid() {
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const observer = useRef<IntersectionObserver | null>(null);
 
-  const copyItem = useCallback(
-    async (data: PasteData) => {
-      try {
-        await copyPasteData(data);
-        NotificationManager.success(t("copy_successful"));
-      } catch {
-        NotificationManager.error(t("copy_failed"));
-      }
-    },
-    [t],
-  );
+  const copyItem = useCopyWithNotification();
 
   const lastItemRef = useCallback(
     (node: HTMLDivElement | null) => {

--- a/web/src/shared/hooks/use-copy-with-notification.ts
+++ b/web/src/shared/hooks/use-copy-with-notification.ts
@@ -1,0 +1,24 @@
+import { useCallback } from "react";
+import { copyPasteData } from "@/shared/clipboard/clipboard-writer";
+import { NotificationManager } from "@/shared/notification/notification-manager";
+import { useI18n } from "@/shared/i18n/use-i18n";
+import type { PasteData } from "@/shared/models/paste-data";
+
+/**
+ * Copy a paste item to the system clipboard and surface a success/error toast.
+ * The callback reference is stable across renders for the same translator.
+ */
+export function useCopyWithNotification(): (data: PasteData) => Promise<void> {
+  const t = useI18n();
+  return useCallback(
+    async (data: PasteData) => {
+      try {
+        await copyPasteData(data);
+        NotificationManager.success(t("copy_successful"));
+      } catch {
+        NotificationManager.error(t("copy_failed"));
+      }
+    },
+    [t],
+  );
+}


### PR DESCRIPTION
Closes #4248

## Summary
- Extract the duplicated copy-to-clipboard-with-toast pattern from `PasteCard` and `PasteGrid` into a shared `useCopyWithNotification` hook.
- `PasteCard` now uses the hook for its context-menu Copy action.
- `PasteGrid` now uses the hook for the detail-view `onCopy` handler.

Pure refactor, no behavior change.

## Test plan
- [ ] Right-click a paste card → "Copy" → clipboard is populated and a success toast appears.
- [ ] Open paste detail view → click Copy → clipboard is populated and a success toast appears.
- [ ] Force a copy failure (e.g. revoke clipboard permission) → error toast appears in both entry points.