### PR TITLE
:bug: handle DECRYPT_FAIL inline in syncAllDevices

### DIFF
--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -385,9 +385,11 @@ async function syncAllDevices(): Promise<void> {
         s.lastHttpSuccessAt = Date.now();
       });
     } catch (e) {
-      if (e instanceof SyncApiError) {
-        // Peer is reachable but returned an error — freshness stays;
-        // heartbeat will classify it (DECRYPT_FAIL etc.) on its next tick.
+      if (e instanceof SyncApiError && e.isDecryptFail()) {
+        await handleDecryptFail(device.targetAppInstanceId);
+      } else if (e instanceof SyncApiError) {
+        // Peer is reachable but returned a non-crypto error — freshness stays;
+        // heartbeat will classify it on its next tick.
       } else {
         // Transport failure = peer unreachable. Collapse the freshness window
         // so the UI flips to DISCONNECTED instead of lingering as CONNECTED.


### PR DESCRIPTION
Closes #4250

## Summary
- `sendHeartbeats` already checks `SyncApiError.isDecryptFail()` and calls `handleDecryptFail(targetId)` inline, but `syncAllDevices`'s catch block was still on the older "freshness stays, heartbeat will classify" comment.
- When the pull path was the first thing to surface a decrypt failure, recovery waited up to one heartbeat interval and the side panel lingered as CONNECTED during that window.
- Mirror the heartbeat pattern so recovery happens on the same tick that surfaces the error.

## Test plan
- [ ] Pair with a desktop peer, then simulate a key mismatch (desktop DB wipe or crypto rotation) so pulls return DECRYPT_FAIL.
- [ ] Observe: as soon as the next pull runs, the device flips to `needsRePair` and WS is disconnected — no longer waits for the heartbeat tick.
- [ ] Non-decrypt errors (e.g. transient 500s) still keep freshness intact and don't trigger re-pair.