### PR TITLE
:hammer: dedupe concurrent refresh() and support zh_hant fallback

### DIFF
--- a/web/src/shared/app/cross-paste-web-service.ts
+++ b/web/src/shared/app/cross-paste-web-service.ts
@@ -22,16 +22,23 @@ interface WebMeta {
 }
 
 let localePathMap: Record<string, string> = {};
+let inFlightRefresh: Promise<void> | null = null;
 
 async function refresh(): Promise<void> {
-  try {
-    const response = await fetch(`${AppUrls.homeUrl}/api/meta.json`, { cache: "no-cache" });
-    if (!response.ok) return;
-    const meta = (await response.json()) as WebMeta;
-    localePathMap = Object.fromEntries(meta.locales.map((l) => [l.code, l.path]));
-  } catch (e) {
-    console.warn("[CrossPasteWebService] Failed to fetch web meta:", e);
-  }
+  if (inFlightRefresh) return inFlightRefresh;
+  inFlightRefresh = (async () => {
+    try {
+      const response = await fetch(`${AppUrls.homeUrl}/api/meta.json`, { cache: "no-cache" });
+      if (!response.ok) return;
+      const meta = (await response.json()) as WebMeta;
+      localePathMap = Object.fromEntries(meta.locales.map((l) => [l.code, l.path]));
+    } catch (e) {
+      console.warn("[CrossPasteWebService] Failed to fetch web meta:", e);
+    } finally {
+      inFlightRefresh = null;
+    }
+  })();
+  return inFlightRefresh;
 }
 
 function resolveLocalePath(language: string): string {
@@ -40,7 +47,8 @@ function resolveLocalePath(language: string): string {
     return map[language] ?? map["en"] ?? "/en/";
   }
   // Fallback before meta.json loads, matching the desktop default.
-  return language === "zh" ? "/" : "/en/";
+  // Matches both "zh" (Simplified) and "zh_hant" (Traditional).
+  return language.startsWith("zh") ? "/" : "/en/";
 }
 
 export const CrossPasteWebService = {


### PR DESCRIPTION
Closes #4252

## Summary
- `CrossPasteWebService.refresh()` now caches an in-flight Promise so concurrent callers share a single `fetch(/api/meta.json)` instead of racing several requests that each overwrite `localePathMap`.
- `resolveLocalePath` cold-start fallback now uses `language.startsWith("zh")` so Traditional Chinese (`zh_hant`) maps to `/` like Simplified, consistent with the desktop default.

## Test plan
- [ ] Mount the side panel multiple times quickly (dev reload): only one `/api/meta.json` request goes out.
- [ ] With `meta.json` unreachable (block the domain), a `zh_hant` user lands on `/` and not `/en/`; `zh` user still lands on `/`; `en` still on `/en/`.
- [ ] With `meta.json` reachable, locale paths come from the fetched map as before.