### PR TITLE
:bug: rethrow CancellationException in WsSession.ping

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Unified wrapper around Ktor WebSocket sessions (server or client).
@@ -39,7 +40,14 @@ class WsSession(
 
     suspend fun ping(): Boolean =
         withTimeoutOrNull(PING_TIMEOUT_MS) {
-            runCatching { session.send(Frame.Ping(PING_PAYLOAD)) }.isSuccess
+            try {
+                session.send(Frame.Ping(PING_PAYLOAD))
+                true
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                false
+            }
         } ?: false
 
     suspend fun close(reason: String = "Normal closure") {

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import java.io.IOException
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -43,7 +44,7 @@ class WsSessionTest {
         }
 
     @Test
-    fun ping_sendThrowsCancellation_returnsFalse() =
+    fun ping_sendThrowsCancellation_propagates() =
         runTest {
             val inner = mockSession(active = false)
             coEvery { inner.send(any<Frame.Ping>()) } throws
@@ -51,7 +52,7 @@ class WsSessionTest {
 
             val wsSession = WsSession(inner, "remote-id")
 
-            assertFalse(wsSession.ping())
+            assertFailsWith<kotlinx.coroutines.CancellationException> { wsSession.ping() }
         }
 
     @Test


### PR DESCRIPTION
Closes #4253

## Summary
- `WsSession.ping()` used `runCatching { ... }.isSuccess`, which catches `Throwable` — including `CancellationException`. A coroutine cancelled mid-ping would see the cancellation swallowed and surfaced as "ping failed" instead of unwinding, leaving callers (e.g. `WsSessionManager.probe`) potentially stuck awaiting a job that won't complete.
- Replace with an explicit try/catch that rethrows `CancellationException` and returns `false` only for other exceptions.

## Test plan
- [ ] Normal ping path still returns `true` on success and `false` on send failure.
- [ ] Timeout path still returns `false` via `withTimeoutOrNull`.
- [ ] Cancelling the scope that called `ping()` propagates the cancellation up (no "ping failed" log under normal shutdown).