### PR TITLE
:bug: use probe() instead of isConnected() for extension reconnect

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -212,13 +212,14 @@ class SyncResolver(
                 // probe success → stay CONNECTED
             }
             SyncState.DISCONNECTED -> {
-                if (wsSessionManager.isConnected(appInstanceId)) {
+                if (wsSessionManager.probe(appInstanceId)) {
                     logger.info { "Extension $appInstanceId WebSocket back, marking CONNECTED" }
                     callback.updateVersionRelation(VersionRelation.EQUAL_TO)
                     updateConnectState(SyncState.CONNECTED)
                 } else {
-                    // WS still gone; only scheduled polling will actually escalate backoff
-                    // (force-resolve / first-value paths pass a no-op markPollFailure).
+                    // WS still gone (or half-open); only scheduled polling will actually
+                    // escalate backoff (force-resolve / first-value paths pass a no-op
+                    // markPollFailure).
                     callback.markPollFailure()
                 }
             }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -67,10 +67,7 @@ class SyncResolverTest {
                 every { isDesktop() } returns true
             }
         val wsClientConnector: WsClientConnector = mockk(relaxed = true)
-        val wsSessionManager: WsSessionManager =
-            mockk(relaxed = true) {
-                every { isConnected(any()) } returns false
-            }
+        val wsSessionManager: WsSessionManager = mockk(relaxed = true)
 
         fun stubDbRead(syncRuntimeInfo: SyncRuntimeInfo) {
             coEvery { syncRuntimeInfoDao.getSyncRuntimeInfo(syncRuntimeInfo.appInstanceId) } returns syncRuntimeInfo
@@ -960,7 +957,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createExtensionSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
 
             deps.stubDbRead(syncRuntimeInfo)
-            every { deps.wsSessionManager.isConnected(syncRuntimeInfo.appInstanceId) } returns true
+            coEvery { deps.wsSessionManager.probe(syncRuntimeInfo.appInstanceId) } returns true
 
             val captured = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(captured)) } returns
@@ -986,7 +983,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createExtensionSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
 
             deps.stubDbRead(syncRuntimeInfo)
-            every { deps.wsSessionManager.isConnected(syncRuntimeInfo.appInstanceId) } returns false
+            coEvery { deps.wsSessionManager.probe(syncRuntimeInfo.appInstanceId) } returns false
 
             var failureCalls = 0
             val callback =


### PR DESCRIPTION
Closes #4254

## Summary
- `SyncResolver.resolveExtension()`'s DISCONNECTED branch used `wsSessionManager.isConnected(appInstanceId)`, which only tests `session.isActive` and returns true for half-open sockets (TCP RST not yet observed, keepalive not yet fired). A stale session could flip the device CONNECTED while the underlying channel was dead, and it stuck there until the next heartbeat surfaced the failure.
- Swap to `wsSessionManager.probe(appInstanceId)` — actively sends a ping and awaits the pong, detecting half-open sockets immediately. The CONNECTED branch already uses `probe`; this aligns DISCONNECTED-recovery with it.

## Test plan
- [ ] Kill the extension's side panel while the desktop peer keeps its socket half-open (e.g. unplug network without a graceful close) → device stays DISCONNECTED instead of flipping CONNECTED on the next resolve.
- [ ] Reconnect cleanly → probe succeeds and device transitions to CONNECTED as before.