### PR TITLE
:white_check_mark: deflake SerializerTest.testPasteData createTime assertion

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/serializer/SerializerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/serializer/SerializerTest.kt
@@ -27,6 +27,8 @@ class SerializerTest {
                 text = "testPasteData",
             )
 
+        val testStart = DateUtils.nowEpochMilliseconds()
+        val sentinelCreateTime = testStart - 10_000L
         val pasteData =
             PasteData(
                 pasteAppearItem = textPasteItem,
@@ -36,7 +38,7 @@ class SerializerTest {
                 hash = textPasteItem.hash,
                 size = textPasteItem.size,
                 pasteState = PasteState.LOADED,
-                createTime = DateUtils.nowEpochMilliseconds(),
+                createTime = sentinelCreateTime,
                 appInstanceId = UUID.randomUUID().toString(),
             )
 
@@ -53,7 +55,10 @@ class SerializerTest {
         assertEquals(pasteData.pasteType, newPasteData.pasteType)
         assertEquals(pasteData.hash, newPasteData.hash)
         assertEquals(PasteState.LOADING, newPasteData.pasteState)
-        assertNotEquals(pasteData.createTime, newPasteData.createTime)
+        // createTime is @Transient: not serialized, defaults to now() on deserialize,
+        // so it must drop the sentinel and land at or after the test start.
+        assertNotEquals(sentinelCreateTime, newPasteData.createTime)
+        assertTrue(newPasteData.createTime >= testStart)
         assertEquals(pasteData.appInstanceId, newPasteData.appInstanceId)
         // Default value for @Transient remote is false; callers set it explicitly
         assertEquals(false, newPasteData.remote)


### PR DESCRIPTION
## Summary
- `SerializerTest.testPasteData` asserted that the original `createTime` and the deserialized `createTime` differ, implicitly assuming two `DateUtils.nowEpochMilliseconds()` calls land in different milliseconds.
- On fast CI the two calls can fall in the same millisecond, so the test fails with `expected: not equal but was: <...>` (see https://github.com/CrossPaste/crosspaste-desktop/actions/runs/24763970663/job/72453756549).

## Fix
- Seed `pasteData.createTime` with a sentinel 10 s before test start.
- After roundtrip, assert:
  - `newPasteData.createTime != sentinel` — confirms `@Transient` dropped the serialized value.
  - `newPasteData.createTime >= testStart` — confirms the deserializer repopulated it via `now()`.
- This verifies the `@Transient` contract without depending on clock resolution.

## Test plan
- [x] `./gradlew app:desktopTest --tests "com.crosspaste.serializer.SerializerTest"` passes locally.
- [ ] CI green.