### PR TITLE
:art: fix deprecated decodeBase64String and redundant cast warnings

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -30,7 +30,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
-import io.ktor.util.*
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
 fun Routing.syncRouting(
     appInfo: AppInfo,
@@ -49,10 +50,11 @@ fun Routing.syncRouting(
     val logger = KotlinLogging.logger {}
     val json = getJsonUtils().JSON
 
+    @OptIn(ExperimentalEncodingApi::class)
     fun ApplicationCall.clientSyncInfo(): SyncInfo? =
         request.headers["crosspaste-sync-info"]?.let { encoded ->
             runCatching {
-                val decoded = encoded.decodeBase64String()
+                val decoded = Base64.decode(encoded).decodeToString()
                 json.decodeFromString<SyncInfo>(decoded)
             }.onFailure { e -> logger.warn(e) { "Failed to parse crosspaste-sync-info header" } }
                 .getOrNull()

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
@@ -243,7 +243,7 @@ class FilePullService(
                     createFailureResult(
                         StandardErrorCode.PULL_FILE_CHUNK_TASK_FAIL,
                         "WS file pull failed: ${e.message}",
-                    ) as FailureResult
+                    )
             }
         }
 


### PR DESCRIPTION
Closes #4263

## Summary
- Replace deprecated `io.ktor.util.decodeBase64String()` with `kotlin.io.encoding.Base64.decode()` in `SyncRouting.clientSyncInfo()`. The web client encodes the `crosspaste-sync-info` header via `btoa(JSON.stringify(...))`, which is standard Base64 and compatible with the stdlib decoder.
- Remove redundant `as FailureResult` cast in `FilePullService.pullFilesViaWebSocket()` — `createFailureResult(...)` already returns `FailureResult`.

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew app:compileKotlinDesktop`
- [x] Both compiler warnings no longer emitted