### PR TITLE
:art: remove redundant casts in DtoSerializationTest

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
@@ -77,13 +77,13 @@ class DtoSerializationTest {
             WsPullFileRequest.WholeFileRequest(hash = "h", fileName = "f.png")
         val decodedWhole = json.decodeFromString<WsPullFileRequest>(json.encodeToString(whole))
         assertTrue(decodedWhole is WsPullFileRequest.WholeFileRequest)
-        assertEquals("h", (decodedWhole as WsPullFileRequest.WholeFileRequest).hash)
+        assertEquals("h", decodedWhole.hash)
         assertEquals("f.png", decodedWhole.fileName)
 
         val chunk: WsPullFileRequest = WsPullFileRequest.ChunkRequest(id = 5L, chunkIndex = 2)
         val decodedChunk = json.decodeFromString<WsPullFileRequest>(json.encodeToString(chunk))
         assertTrue(decodedChunk is WsPullFileRequest.ChunkRequest)
-        assertEquals(5L, (decodedChunk as WsPullFileRequest.ChunkRequest).id)
+        assertEquals(5L, decodedChunk.id)
         assertEquals(2, decodedChunk.chunkIndex)
     }
 


### PR DESCRIPTION
Closes #4268

## Summary
- Remove two redundant `as` casts in `DtoSerializationTest.testWsPullFileRequestPolymorphicSerialization`. Kotlin smart-casts after `assertTrue(x is Y)`, so the explicit casts are unnecessary.

## Test plan
- [x] `./gradlew ktlintCheck` (style unchanged)
- [x] `./gradlew app:desktopTest --tests "com.crosspaste.dto.DtoSerializationTest"` still passes