### PR TITLE
:hammer: split AppSourceIcon and SideAppSourceIcon transformer pipelines

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
@@ -16,7 +16,7 @@ import com.crosspaste.i18n.DesktopGlobalCopywriter
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.image.DesktopIconColorExtractor
 import com.crosspaste.image.coil.AppSourceIconTransformer
-import com.crosspaste.image.coil.DesktopAppSourceIconTransformer
+import com.crosspaste.image.coil.DefaultAppSourceIconTransformer
 import com.crosspaste.listener.ActiveGraphicsDevice
 import com.crosspaste.listener.DesktopGlobalListener
 import com.crosspaste.listener.DesktopShortKeysAction
@@ -59,7 +59,7 @@ fun desktopUiModule(): Module =
         single<ActiveGraphicsDevice> { get<DesktopAppSize>() }
         single<AppFileChooser> { DesktopAppFileChooser(get()) }
         single<AppSize> { get<DesktopAppSize>() }
-        single<AppSourceIconTransformer> { DesktopAppSourceIconTransformer }
+        single<AppSourceIconTransformer> { DefaultAppSourceIconTransformer }
         single<AppTokenApi> { DesktopAppTokenService(get(), get()) }
         single<AppWindowManager> { get<DesktopAppWindowManager>() }
         single<DesktopAppSize> { DesktopAppSize(get()) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/coil/AppSourceIconAlphaTrim.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/coil/AppSourceIconAlphaTrim.kt
@@ -1,0 +1,136 @@
+package com.crosspaste.image.coil
+
+import coil3.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.IRect
+import org.jetbrains.skia.ImageInfo
+import kotlin.math.roundToInt
+
+internal object AppSourceIconAlphaTrim {
+
+    // Pixels whose normalized alpha is at or below this value are treated as transparent.
+    // Kept low so anti-aliased edge pixels survive the trim.
+    private const val ALPHA_THRESHOLD_BYTE: Int = 4
+
+    // Safety margin kept around the alpha bounding box so that subtle shadows or
+    // glow pixels at the border of a Mac-style icon are not clipped.
+    private const val MARGIN_RATIO: Float = 0.025f
+
+    // Trim thinner than this ratio of the shorter side is ignored.
+    private const val MIN_TRIM_RATIO: Float = 0.02f
+
+    // Typical transparent padding on each side of a Mac-style icon. Used only when
+    // sizing the Coil request so that, after alpha trim (and any additional crop),
+    // the resulting bitmap still has roughly sizePx pixels along each dimension.
+    const val TYPICAL_PADDING_RATIO: Float = 0.075f
+
+    /**
+     * Returns a bitmap containing the pixels of [input] inside [rect], or [input]
+     * itself if the copy cannot be produced. Prefers the zero-copy [Bitmap.extractSubset]
+     * path and falls back to an explicit pixel copy when the fast path fails.
+     */
+    fun copySubset(
+        input: Bitmap,
+        rect: IRect,
+    ): Bitmap {
+        val result = Bitmap()
+        if (input.extractSubset(result, rect)) return result
+
+        val outWidth = rect.width
+        val outHeight = rect.height
+        val outInfo = ImageInfo.makeN32(outWidth, outHeight, ColorAlphaType.PREMUL)
+        val pixels = input.readPixels(outInfo, outWidth * 4, rect.left, rect.top) ?: return input
+        val copy = Bitmap()
+        if (!copy.setImageInfo(outInfo)) return input
+        if (!copy.installPixels(pixels)) return input
+        return copy
+    }
+
+    fun detectSymmetricTrim(bitmap: Bitmap): Int {
+        val width = bitmap.width
+        val height = bitmap.height
+        val pixels = readN32Pixels(bitmap) ?: return 0
+        val bounds = findContentBounds(pixels, width, height) ?: return 0
+        val minPadding =
+            minOf(
+                bounds.left,
+                bounds.top,
+                width - 1 - bounds.right,
+                height - 1 - bounds.bottom,
+            )
+        return resolveTrim(minPadding, minOf(width, height))
+    }
+
+    // One JNI hop to pull every pixel in N32 layout; alpha sits at byte 3 of every 4-byte pixel.
+    private fun readN32Pixels(bitmap: Bitmap): ByteArray? {
+        val info = ImageInfo.makeN32(bitmap.width, bitmap.height, ColorAlphaType.PREMUL)
+        return bitmap.readPixels(info, bitmap.width * 4, 0, 0)
+    }
+
+    private fun findContentBounds(
+        pixels: ByteArray,
+        width: Int,
+        height: Int,
+    ): ContentBounds? {
+        var top = 0
+        while (top < height && isRowTransparent(pixels, width, top)) top++
+        if (top == height) return null
+
+        var bottom = height - 1
+        while (bottom > top && isRowTransparent(pixels, width, bottom)) bottom--
+
+        var left = 0
+        while (left < width && isColumnTransparent(pixels, width, left, top, bottom)) left++
+
+        var right = width - 1
+        while (right > left && isColumnTransparent(pixels, width, right, top, bottom)) right--
+
+        return ContentBounds(left, top, right, bottom)
+    }
+
+    private fun isRowTransparent(
+        pixels: ByteArray,
+        width: Int,
+        y: Int,
+    ): Boolean {
+        var offset = y * width * 4 + 3
+        repeat(width) {
+            if (pixels[offset].toInt() and 0xFF > ALPHA_THRESHOLD_BYTE) return false
+            offset += 4
+        }
+        return true
+    }
+
+    private fun isColumnTransparent(
+        pixels: ByteArray,
+        width: Int,
+        x: Int,
+        yStart: Int,
+        yEnd: Int,
+    ): Boolean {
+        val rowStride = width * 4
+        var offset = (yStart * width + x) * 4 + 3
+        repeat(yEnd - yStart + 1) {
+            if (pixels[offset].toInt() and 0xFF > ALPHA_THRESHOLD_BYTE) return false
+            offset += rowStride
+        }
+        return true
+    }
+
+    private fun resolveTrim(
+        minPadding: Int,
+        shortSide: Int,
+    ): Int {
+        val marginPx = (shortSide * MARGIN_RATIO).roundToInt()
+        val minTrimPx = (shortSide * MIN_TRIM_RATIO).roundToInt().coerceAtLeast(1)
+        val appliedTrim = (minPadding - marginPx).coerceAtLeast(0)
+        return if (appliedTrim < minTrimPx) 0 else appliedTrim
+    }
+
+    private data class ContentBounds(
+        val left: Int,
+        val top: Int,
+        val right: Int,
+        val bottom: Int,
+    )
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/coil/AppSourceIconCropTransformation.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/coil/AppSourceIconCropTransformation.kt
@@ -3,9 +3,7 @@ package com.crosspaste.image.coil
 import coil3.Bitmap
 import coil3.size.Size
 import coil3.transform.Transformation
-import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.IRect
-import org.jetbrains.skia.ImageInfo
 import kotlin.math.roundToInt
 
 object AppSourceIconCropTransformation : Transformation() {
@@ -15,25 +13,10 @@ object AppSourceIconCropTransformation : Transformation() {
     private const val CROP_LEFT: Float = 0f
     private const val CROP_RIGHT: Float = 0.12f
 
-    // Pixels whose normalized alpha is at or below this value are treated as transparent.
-    private const val ALPHA_THRESHOLD_BYTE: Int = 12
-
-    // Safety margin kept around the alpha bounding box so that subtle shadows or
-    // glow pixels at the border of a Mac-style icon are not clipped.
-    private const val MARGIN_RATIO: Float = 0.015f
-
-    // Trim thinner than this ratio of the shorter side is ignored.
-    private const val MIN_TRIM_RATIO: Float = 0.02f
-
-    // Typical transparent padding on each side of a Mac-style icon. Used only when
-    // sizing the Coil request so that, after alpha trim and the fixed crop, the
-    // resulting bitmap still has roughly sizePx pixels along each dimension.
-    private const val TYPICAL_PADDING_RATIO: Float = 0.075f
-
     override val cacheKey: String = "appSourceIconCrop"
 
     fun requestSize(sizePx: Int): Int {
-        val trimFactor = 1f - 2f * TYPICAL_PADDING_RATIO
+        val trimFactor = 1f - 2f * AppSourceIconAlphaTrim.TYPICAL_PADDING_RATIO
         val cropFactor = 1f - CROP_TOP - CROP_BOTTOM
         return (sizePx / (trimFactor * cropFactor)).roundToInt()
     }
@@ -47,7 +30,7 @@ object AppSourceIconCropTransformation : Transformation() {
         if (width < 4 || height < 4) return input
 
         // Step 1: normalize by symmetrically trimming transparent padding.
-        val trim = detectSymmetricTrim(input)
+        val trim = AppSourceIconAlphaTrim.detectSymmetricTrim(input)
         val trimmedWidth = width - 2 * trim
         val trimmedHeight = height - 2 * trim
         if (trimmedWidth <= 0 || trimmedHeight <= 0) return input
@@ -61,104 +44,9 @@ object AppSourceIconCropTransformation : Transformation() {
         val outWidth = (right - left).coerceAtLeast(1)
         val outHeight = (bottom - top).coerceAtLeast(1)
 
-        val subsetRect = IRect.makeXYWH(left, top, outWidth, outHeight)
-
-        val result = coil3.Bitmap()
-        if (input.extractSubset(result, subsetRect)) return result
-
-        val outInfo = ImageInfo.makeN32(outWidth, outHeight, ColorAlphaType.PREMUL)
-        val pixels = input.readPixels(outInfo, outWidth * 4, left, top) ?: return input
-        val copy = coil3.Bitmap()
-        if (!copy.setImageInfo(outInfo)) return input
-        if (!copy.installPixels(pixels)) return input
-        return copy
+        return AppSourceIconAlphaTrim.copySubset(
+            input,
+            IRect.makeXYWH(left, top, outWidth, outHeight),
+        )
     }
-
-    private fun detectSymmetricTrim(bitmap: Bitmap): Int {
-        val width = bitmap.width
-        val height = bitmap.height
-        val pixels = readN32Pixels(bitmap) ?: return 0
-        val bounds = findContentBounds(pixels, width, height) ?: return 0
-        val minPadding =
-            minOf(
-                bounds.left,
-                bounds.top,
-                width - 1 - bounds.right,
-                height - 1 - bounds.bottom,
-            )
-        return resolveTrim(minPadding, minOf(width, height))
-    }
-
-    // One JNI hop to pull every pixel in N32 layout; alpha sits at byte 3 of every 4-byte pixel.
-    private fun readN32Pixels(bitmap: Bitmap): ByteArray? {
-        val info = ImageInfo.makeN32(bitmap.width, bitmap.height, ColorAlphaType.PREMUL)
-        return bitmap.readPixels(info, bitmap.width * 4, 0, 0)
-    }
-
-    private fun findContentBounds(
-        pixels: ByteArray,
-        width: Int,
-        height: Int,
-    ): ContentBounds? {
-        var top = 0
-        while (top < height && isRowTransparent(pixels, width, top)) top++
-        if (top == height) return null
-
-        var bottom = height - 1
-        while (bottom > top && isRowTransparent(pixels, width, bottom)) bottom--
-
-        var left = 0
-        while (left < width && isColumnTransparent(pixels, width, left, top, bottom)) left++
-
-        var right = width - 1
-        while (right > left && isColumnTransparent(pixels, width, right, top, bottom)) right--
-
-        return ContentBounds(left, top, right, bottom)
-    }
-
-    private fun isRowTransparent(
-        pixels: ByteArray,
-        width: Int,
-        y: Int,
-    ): Boolean {
-        var offset = y * width * 4 + 3
-        repeat(width) {
-            if (pixels[offset].toInt() and 0xFF > ALPHA_THRESHOLD_BYTE) return false
-            offset += 4
-        }
-        return true
-    }
-
-    private fun isColumnTransparent(
-        pixels: ByteArray,
-        width: Int,
-        x: Int,
-        yStart: Int,
-        yEnd: Int,
-    ): Boolean {
-        val rowStride = width * 4
-        var offset = (yStart * width + x) * 4 + 3
-        repeat(yEnd - yStart + 1) {
-            if (pixels[offset].toInt() and 0xFF > ALPHA_THRESHOLD_BYTE) return false
-            offset += rowStride
-        }
-        return true
-    }
-
-    private fun resolveTrim(
-        minPadding: Int,
-        shortSide: Int,
-    ): Int {
-        val marginPx = (shortSide * MARGIN_RATIO).roundToInt()
-        val minTrimPx = (shortSide * MIN_TRIM_RATIO).roundToInt().coerceAtLeast(1)
-        val appliedTrim = (minPadding - marginPx).coerceAtLeast(0)
-        return if (appliedTrim < minTrimPx) 0 else appliedTrim
-    }
-
-    private data class ContentBounds(
-        val left: Int,
-        val top: Int,
-        val right: Int,
-        val bottom: Int,
-    )
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/coil/AppSourceIconTrimTransformation.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/coil/AppSourceIconTrimTransformation.kt
@@ -1,0 +1,43 @@
+package com.crosspaste.image.coil
+
+import coil3.Bitmap
+import coil3.size.Size
+import coil3.transform.Transformation
+import org.jetbrains.skia.IRect
+import kotlin.math.roundToInt
+
+object AppSourceIconTrimTransformation : Transformation() {
+
+    override val cacheKey: String = "appSourceIconTrim"
+
+    // Over-request 2× of the post-trim target so Coil/Skia has enough source
+    // pixels to downsample smoothly — removes the jagged edges that appear when
+    // the trimmed bitmap is only slightly larger than the display size.
+    private const val OVERSAMPLE_FACTOR: Float = 2f
+
+    fun requestSize(sizePx: Int): Int {
+        val trimFactor = 1f - 2f * AppSourceIconAlphaTrim.TYPICAL_PADDING_RATIO
+        return (sizePx * OVERSAMPLE_FACTOR / trimFactor).roundToInt()
+    }
+
+    override suspend fun transform(
+        input: Bitmap,
+        size: Size,
+    ): Bitmap {
+        val width = input.width
+        val height = input.height
+        if (width < 4 || height < 4) return input
+
+        val trim = AppSourceIconAlphaTrim.detectSymmetricTrim(input)
+        if (trim <= 0) return input
+
+        val trimmedWidth = width - 2 * trim
+        val trimmedHeight = height - 2 * trim
+        if (trimmedWidth <= 0 || trimmedHeight <= 0) return input
+
+        return AppSourceIconAlphaTrim.copySubset(
+            input,
+            IRect.makeXYWH(trim, trim, trimmedWidth, trimmedHeight),
+        )
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/coil/DefaultAppSourceIconTransformer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/coil/DefaultAppSourceIconTransformer.kt
@@ -1,0 +1,10 @@
+package com.crosspaste.image.coil
+
+import coil3.transform.Transformation
+
+object DefaultAppSourceIconTransformer : AppSourceIconTransformer {
+
+    override val transformations: List<Transformation> = listOf(AppSourceIconTrimTransformation)
+
+    override fun requestSize(sizePx: Int): Int = AppSourceIconTrimTransformation.requestSize(sizePx)
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/coil/SideAppSourceIconTransformer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/coil/SideAppSourceIconTransformer.kt
@@ -2,7 +2,7 @@ package com.crosspaste.image.coil
 
 import coil3.transform.Transformation
 
-object DesktopAppSourceIconTransformer : AppSourceIconTransformer {
+object SideAppSourceIconTransformer : AppSourceIconTransformer {
 
     override val transformations: List<Transformation> = listOf(AppSourceIconCropTransformation)
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/SideAppSourceIcon.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/SideAppSourceIcon.kt
@@ -15,9 +15,9 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.request.transformations
 import coil3.size.Precision
-import com.crosspaste.image.coil.AppSourceIconTransformer
 import com.crosspaste.image.coil.AppSourceItem
 import com.crosspaste.image.coil.ImageLoaderQualifiers
+import com.crosspaste.image.coil.SideAppSourceIconTransformer
 import com.crosspaste.ui.LocalDesktopAppSizeValueState
 import com.crosspaste.ui.paste.PasteDataScope
 import org.koin.compose.koinInject
@@ -28,7 +28,6 @@ fun PasteDataScope.SideAppSourceIcon(
     defaultIcon: @Composable () -> Unit = {},
 ) {
     val appSourceLoader = koinInject<ImageLoader>(qualifier = ImageLoaderQualifiers.APP_SOURCE)
-    val transformer = koinInject<AppSourceIconTransformer>()
     val platformContext = koinInject<PlatformContext>()
 
     val appSizeValue = LocalDesktopAppSizeValueState.current
@@ -36,14 +35,14 @@ fun PasteDataScope.SideAppSourceIcon(
     val density = LocalDensity.current
 
     val sizePx = with(density) { appSizeValue.sideTitleHeight.roundToPx() }
-    val requestSizePx = transformer.requestSize(sizePx)
+    val requestSizePx = SideAppSourceIconTransformer.requestSize(sizePx)
 
     val model =
         remember(pasteData.source, pasteData.appInstanceId, requestSizePx) {
             ImageRequest
                 .Builder(platformContext)
                 .data(AppSourceItem(pasteData.source, pasteData.appInstanceId))
-                .transformations(transformer.transformations)
+                .transformations(SideAppSourceIconTransformer.transformations)
                 .size(requestSizePx)
                 .precision(Precision.INEXACT)
                 .crossfade(true)


### PR DESCRIPTION
Closes #4270

## Summary
- Split the single `DesktopAppSourceIconTransformer` into two implementations so that `AppSourceIcon` (main views) and `SideAppSourceIcon` (side title bar) no longer share the same pipeline.
  - `DefaultAppSourceIconTransformer` — trim-only (only removes transparent padding), used by `AppSourceIcon`.
  - `SideAppSourceIconTransformer` — trim + fixed-ratio crop (existing behavior), used by `SideAppSourceIcon`.
- Extract shared alpha-detection and subset-copy logic into `AppSourceIconAlphaTrim` to deduplicate the two transformations.
- Lower the alpha threshold (12 → 4) and raise the safety margin (1.5% → 2.5%) so anti-aliased edge pixels survive the trim.
- Oversample the trim-only `requestSize` by 2× so downsampling to the display size stays smooth and avoids jagged edges.
- `SideAppSourceIcon` now references `SideAppSourceIconTransformer` directly (desktopMain object). The `commonMain` `AppSourceIcon` keeps its Koin injection unchanged; `DesktopUiModule` binds `AppSourceIconTransformer` to `DefaultAppSourceIconTransformer`.

## Test plan
- [ ] `./gradlew ktlintFormat` passes
- [ ] `./gradlew :app:compileKotlinDesktop` passes
- [ ] Launch the desktop app and verify app-source icons in main paste views render without the previous fixed crop
- [ ] Verify the side title bar still uses the cropped variant
- [ ] Visually confirm edges are smooth (no jagged edges) after the trim-only transformation