### PR TITLE
:art: align add-device button style with current-device button

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -124,15 +123,33 @@ fun DevicesContentView(guideContent: (@Composable () -> Unit)? = null) {
                     )
                 }
 
-                ExtendedFloatingActionButton(
-                    onClick = {
-                        showAddDeviceDialog = true
-                    },
-                    containerColor = LocalThemeExtState.current.success.surface,
-                    contentColor = LocalThemeExtState.current.success.onContainer,
-                    icon = { Icon(MaterialSymbols.Rounded.Add, contentDescription = null) },
-                    text = { Text(copywriter.getText("add_device_manually")) },
-                )
+                FilledTonalButton(
+                    onClick = { showAddDeviceDialog = true },
+                    contentPadding = PaddingValues(horizontal = medium, vertical = tiny),
+                    colors =
+                        ButtonDefaults.filledTonalButtonColors(
+                            containerColor = LocalThemeExtState.current.success.surface,
+                            contentColor = LocalThemeExtState.current.success.onContainer,
+                        ),
+                    elevation =
+                        ButtonDefaults.filledTonalButtonElevation(
+                            defaultElevation = tiny3X,
+                            pressedElevation = tiny5X,
+                            hoveredElevation = tiny2X,
+                            focusedElevation = tiny3X,
+                        ),
+                ) {
+                    Icon(
+                        imageVector = MaterialSymbols.Rounded.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(small),
+                    )
+                    Spacer(modifier = Modifier.width(tiny3X))
+                    Text(
+                        text = copywriter.getText("add_device_manually"),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                }
             }
         },
     ) { innerPadding ->


### PR DESCRIPTION
Closes #4272

## Summary
- On the devices screen, the "manually add device" button previously used `ExtendedFloatingActionButton` while the "current device" button used `FilledTonalButton`, resulting in mismatched shape, height, padding, and elevation even though they sit in the same floating column.
- Replace the `ExtendedFloatingActionButton` with a `FilledTonalButton` that mirrors the current-device button's shape, height, content padding, and elevation.
- Preserve the success (green) color palette via `ButtonDefaults.filledTonalButtonColors(containerColor = success.surface, contentColor = success.onContainer)`.

## Test plan
- [ ] `./gradlew ktlintFormat` passes
- [ ] `./gradlew :app:compileKotlinDesktop` passes
- [ ] Launch the desktop app, open the devices screen, and verify the "manually add device" button now matches the "current device" button in shape/height/padding/elevation while keeping its green color
- [ ] Tapping the button still opens the `AddDeviceDialog`