### PR TITLE
:bug: serialize oversize-notice drains to prevent duplicate display

### DIFF
--- a/web/src/shared/hooks/use-oversize-notice.ts
+++ b/web/src/shared/hooks/use-oversize-notice.ts
@@ -34,19 +34,27 @@ export function useOversizeNoticeListener(): void {
     };
 
     let cancelled = false;
-    const drainAndShow = async () => {
-      const pending = await drainOversizeNotices();
-      if (cancelled) {
-        // Unmounted mid-drain — put the already-drained notices back so the
-        // next mount can replay them instead of silently losing them.
-        for (const notice of pending) {
-          await enqueueOversizeNotice(notice);
+    // Serialize drains via a promise chain. Without this, the mount drain and
+    // an immediate drain ping can both read the queue before either removes
+    // it, causing the same notice to be shown twice.
+    let chain: Promise<unknown> = Promise.resolve();
+    const drainAndShow = (): Promise<void> => {
+      const next = chain.then(async () => {
+        const pending = await drainOversizeNotices();
+        if (cancelled) {
+          // Unmounted mid-drain — put the already-drained notices back so the
+          // next mount can replay them instead of silently losing them.
+          for (const notice of pending) {
+            await enqueueOversizeNotice(notice);
+          }
+          return;
         }
-        return;
-      }
-      for (const notice of pending) {
-        showNotice(notice.title, notice.message);
-      }
+        for (const notice of pending) {
+          showNotice(notice.title, notice.message);
+        }
+      });
+      chain = next.catch(() => {});
+      return next;
     };
 
     void drainAndShow();


### PR DESCRIPTION
Closes #4274

## Summary
- Two concurrent `drainAndShow()` calls in `useOversizeNoticeListener` (mount drain + `OVERSIZE_NOTICE_DRAIN` ping) could both read the `chrome.storage.session` queue before either removed it, surfacing the same notice twice.
- Chain drain invocations through a single promise so they run sequentially within the side-panel realm.

## Scope
- Fixes the within-realm drain/drain race.
- Does **not** address the cross-realm SW-enqueue vs panel-drain race (a separate concurrent-write bug on `chrome.storage.session`).

## Test plan
- [ ] `tsc --noEmit` passes (verified locally).
- [ ] Manually trigger two quick oversize pastes from desktop while the side panel is open and confirm each notice is shown exactly once.
- [ ] Close the side panel, trigger an oversize paste, reopen the panel, confirm the queued notice is shown exactly once.