### PR TITLE
:bug: fail fast when crosspaste-version.properties is missing the version key

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -14,7 +14,10 @@ versionProperties.load(
 )
 
 group = "com.crosspaste"
-version = versionProperties.getProperty("version")
+version =
+    checkNotNull(versionProperties.getProperty("version")) {
+        "Missing 'version' in crosspaste-version.properties"
+    }
 
 tasks.register("generateVersion") {
     val versionFile =
@@ -33,7 +36,10 @@ tasks.register("generateVersion") {
     doLast {
         val props = Properties()
         FileReader(versionFile).use { props.load(it) }
-        val version = props.getProperty("version")
+        val version =
+            checkNotNull(props.getProperty("version")) {
+                "Missing 'version' in crosspaste-version.properties"
+            }
         val revision = props.getProperty("revision")
         val fullVersion = if (revision.isNullOrBlank()) version else "$version.$revision"
 

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -36,10 +36,6 @@ tasks.register("generateVersion") {
     doLast {
         val props = Properties()
         FileReader(versionFile).use { props.load(it) }
-        val version =
-            checkNotNull(props.getProperty("version")) {
-                "Missing 'version' in crosspaste-version.properties"
-            }
         val revision = props.getProperty("revision")
         val fullVersion = if (revision.isNullOrBlank()) version else "$version.$revision"
 


### PR DESCRIPTION
Closes #4276

## Summary
- `Properties.getProperty` returns `String?`, and a missing `version` key silently produced `APP_VERSION = "null"` in `version.generated.ts` and `"version": "null"` in `manifest.json`.
- Both read sites in `web/build.gradle.kts` now use `checkNotNull` so Gradle fails immediately with a clear message.
- `revision` stays optional — legitimately blank in the current properties file.

## Test plan
- [x] `./gradlew ktlintFormat` clean.
- [x] `./gradlew :web:generateVersion --rerun-tasks` still succeeds with the current valid properties file.
- [ ] Manually removing the `version` line from `crosspaste-version.properties` fails the task with the expected "Missing 'version'" message.