### PR TITLE
:construction_worker: tighten CI path filters and unify Node version in build-release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -121,7 +121,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
         run: npm install semver fs-extra axios
@@ -237,13 +239,6 @@ jobs:
         run: |
           chmod +x ./.github/scripts/package_appimage.sh
           ./.github/scripts/package_appimage.sh
-
-      - name: Set up Node.js 20 for web extension
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web/package-lock.json
 
       - name: Build Chrome extension
         run: ./gradlew :web:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,17 @@ jobs:
         with:
           filters: |
             app:
-              - '!web/**'
+              - 'app/**'
+              - 'shared/**'
+              - 'core/**'
+              - 'gradle/**'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - 'settings.gradle.kts'
+              - 'build.gradle.kts'
+              - 'gradle.properties'
+              - 'compose-stability.conf'
+              - '.github/workflows/ci.yml'
             web:
               - 'web/**'
               - 'core/**'
@@ -29,6 +39,7 @@ jobs:
               - 'settings.gradle.kts'
               - 'build.gradle.kts'
               - 'gradle.properties'
+              - '.github/workflows/ci.yml'
 
   app-build:
     needs: changes


### PR DESCRIPTION
Closes #4278

## Summary
Two focused workflow cleanups in one PR (separate commits for reviewability).

### ci.yml — tighter path filters
- `app` filter was `!web/**`, which triggered a full desktop build on doc, CLAUDE.md, cli/, shared-ui/, and conveyor config edits — none of which affect `./gradlew app:build`.
- Replaced with explicit includes matching the real dependency chain (`:app → :shared → :core`) plus `compose-stability.conf` and `.github/workflows/ci.yml` itself.
- Same explicit style applied to `web`; added `.github/workflows/ci.yml` there so workflow changes exercise it too.

### build-release.yml — single Node 20 setup
- `build-ubuntu` installed Node 16 (EOL April 2024) for the version/JAR scripts, then reinstalled Node 20 with npm cache for the web extension. Two sequential `setup-node` calls reconfigure the runner's npm cache mid-job, which is fragile.
- Collapsed to a single Node 20 setup at the top with `cache: 'npm'` pointing at `web/package-lock.json`.
- `.github/scripts/*.js` use plain CommonJS (`semver` / `fs-extra` / `axios`) — all run on Node 20 unchanged.

## Test plan
- [ ] Push a docs-only change (e.g. README) and confirm neither `app-build` nor `web-build` runs.
- [ ] Push a `shared/**` change and confirm only `app-build` runs.
- [ ] Push a `core/**` change and confirm both jobs run.
- [ ] Next release tag builds successfully with the unified Node 20 setup.