### PR TITLE
:hammer: switch Chrome extension to optional_host_permissions

### DIFF
--- a/web/manifest.json
+++ b/web/manifest.json
@@ -4,7 +4,7 @@
   "description": "Clipboard sync with CrossPaste",
   "version": "2.0.0",
   "permissions": ["storage", "sidePanel", "alarms", "offscreen", "clipboardRead", "clipboardWrite", "downloads", "nativeMessaging"],
-  "host_permissions": ["http://*/*", "https://crosspaste.com/*"],
+  "optional_host_permissions": ["http://*/*"],
   "side_panel": {
     "default_path": "src/sidepanel/index.html"
   },

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -663,8 +663,17 @@ async function handleGetDevices(): Promise<unknown> {
   return { devices: await getDevicesWithStatus() };
 }
 
+// Host permission is granted by the sidepanel via `chrome.permissions.request`
+// during a user gesture; the service worker can only verify, never request.
+async function hasHostPermission(host: string, port: number): Promise<boolean> {
+  return chrome.permissions.contains({ origins: [`http://${host}:${port}/*`] });
+}
+
 async function handleConnect(host: string, port: number): Promise<unknown> {
   try {
+    if (!(await hasHostPermission(host, port))) {
+      return { success: false, error: "host_permission_denied" };
+    }
     const appInstanceId = await getAppInstanceId();
     const config = { host, port, appInstanceId };
 
@@ -782,6 +791,9 @@ async function handlePair(token: number): Promise<unknown> {
 async function handleRePair(targetAppInstanceId: string): Promise<unknown> {
   const device = await DeviceStore.get(targetAppInstanceId);
   if (!device) return { success: false, error: "Device not found" };
+  if (!(await hasHostPermission(device.host, device.port))) {
+    return { success: false, error: "host_permission_denied" };
+  }
   try {
     const appInstanceId = await getAppInstanceId();
     const config = { host: device.host, port: device.port, appInstanceId };

--- a/web/src/shared/hooks/use-connection.ts
+++ b/web/src/shared/hooks/use-connection.ts
@@ -15,6 +15,18 @@ async function sendMessage(
   return chrome.runtime.sendMessage(message);
 }
 
+/**
+ * Request host permission for the target device over a user gesture (UI thread).
+ * Service worker cannot call `chrome.permissions.request` — the gesture is lost
+ * by the time the message is dispatched, so the prompt must be raised here.
+ */
+async function ensureHostPermission(host: string, port: number): Promise<boolean> {
+  const origins = [`http://${host}:${port}/*`];
+  const already = await chrome.permissions.contains({ origins });
+  if (already) return true;
+  return chrome.permissions.request({ origins });
+}
+
 export function useConnection() {
   const [devices, setDevices] = useState<DeviceInfo[]>([]);
 
@@ -45,6 +57,10 @@ export function useConnection() {
   }, [loadDevices]);
 
   const connect = useCallback(async (host: string, port: number) => {
+    const granted = await ensureHostPermission(host, port);
+    if (!granted) {
+      return { success: false, error: "host_permission_denied" };
+    }
     const result = (await sendMessage({ type: "CONNECT", host, port })) as {
       success: boolean;
       syncInfo?: SyncInfo;
@@ -68,13 +84,21 @@ export function useConnection() {
 
   const rePair = useCallback(
     async (targetAppInstanceId: string) => {
+      const device = devices.find((d) => d.targetAppInstanceId === targetAppInstanceId);
+      if (!device) {
+        return { success: false, error: "Device not found" };
+      }
+      const granted = await ensureHostPermission(device.host, device.port);
+      if (!granted) {
+        return { success: false, error: "host_permission_denied" };
+      }
       const result = (await sendMessage({
         type: "REPAIR",
         targetAppInstanceId,
       })) as { success: boolean; syncInfo?: SyncInfo; error?: string; incompatible?: boolean };
       return result;
     },
-    [],
+    [devices],
   );
 
   const removeDevice = useCallback(


### PR DESCRIPTION
Closes #4280

## Summary
- Replace broad `host_permissions: ["http://*/*"]` with `optional_host_permissions: ["http://*/*"]` to satisfy Chrome Web Store review guidance on broad host permissions.
- Request the specific `http://<host>:<port>/*` origin from the sidepanel (user-gesture context) immediately before dispatching `CONNECT` / `REPAIR` to the service worker.
- Service worker adds a defensive `chrome.permissions.contains` check in `handleConnect` / `handleRePair`; returns `host_permission_denied` when the permission has been revoked.

## Why not host_permissions anymore
`chrome.permissions.request` must be called from a user gesture. Service workers can't raise the prompt, so the sidepanel owns the request path. Existing WebSocket connections are unaffected — they don't require host permissions under MV3.

## Test plan
- [ ] Pair a fresh LAN device: Chrome prompts once for the specific `http://<ip>:<port>/*` origin; pairing then completes.
- [ ] After pairing, reload the extension: alarm-driven `pullPaste` continues to work because the permission persists.
- [ ] Manually revoke the host permission from `chrome://extensions`: subsequent `CONNECT` / `REPAIR` immediately returns `host_permission_denied`; WebSocket channel still works.
- [ ] `./gradlew :web:build` — passes.