### PR TITLE
:sparkles: allow native messaging from Chrome Web Store release extension ID

### DIFF
--- a/app/src/desktopMain/resources/native-messaging.properties
+++ b/app/src/desktopMain/resources/native-messaging.properties
@@ -1,1 +1,1 @@
-chrome.extension.ids=nhgceglolckclkadihbcjgnbdlfbkkal
+chrome.extension.ids=aajpcfbdbnaidaaljamjpmmjcfebhmlh,nhgceglolckclkadihbcjgnbdlfbkkal


### PR DESCRIPTION
Closes #4286

## Summary
Adds the Chrome Web Store release extension ID (`aajpcfbdbnaidaaljamjpmmjcfebhmlh`) to the native-messaging host whitelist so the published build can communicate with the desktop app. The existing dev/unpacked ID is kept for local development.

## Test plan
- [ ] Install the extension from the Chrome Web Store and confirm it can reach the desktop host.
- [ ] Load the unpacked extension locally and confirm it still works.