### PR TITLE
Add native app download banner to extension settings

### DIFF
--- a/web/src/components/settings/SettingsView.tsx
+++ b/web/src/components/settings/SettingsView.tsx
@@ -6,6 +6,8 @@ import {
   ChevronDown,
   ChevronRight,
   Check,
+  Download,
+  ArrowRight,
 } from "lucide-react";
 import {
   useI18n,
@@ -14,6 +16,8 @@ import {
   getLanguageName,
 } from "@/shared/i18n/use-i18n";
 import { useTheme, type ThemeMode } from "@/shared/theme/use-theme";
+import { useDesktopStatus } from "@/shared/hooks/use-desktop-status";
+import { openCrossPasteWebInBrowser } from "@/shared/app/ui-support";
 import { APP_VERSION } from "@/shared/app/version.generated";
 import { AboutView } from "./AboutView";
 
@@ -90,6 +94,36 @@ function LanguageDropdown({ onClose }: { onClose: () => void }) {
   );
 }
 
+// ─── Download Banner ────────────────────────────────────────────────────
+
+function DownloadBanner() {
+  const t = useI18n();
+  return (
+    <button
+      onClick={() => {
+        void openCrossPasteWebInBrowser("download");
+      }}
+      className="group relative flex items-center gap-3 w-full overflow-hidden rounded-[14px] px-4 py-3 text-left bg-gradient-to-r from-settings-indigo-bg via-settings-blue-bg to-settings-purple-bg ring-1 ring-settings-indigo/10 hover:ring-settings-indigo/30 hover:shadow-md shadow-sm transition-shadow"
+    >
+      <div className="flex items-center justify-center w-10 h-10 rounded-[12px] bg-m3-surface/70 shrink-0 shadow-sm">
+        <Download size={20} className="text-settings-indigo" />
+      </div>
+      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+        <span className="text-sm font-semibold text-m3-on-surface truncate">
+          {t("get_native_app")}
+        </span>
+        <span className="text-xs text-m3-on-surface-variant truncate">
+          {t("download")} · crosspaste.com
+        </span>
+      </div>
+      <ArrowRight
+        size={18}
+        className="text-settings-indigo shrink-0 transition-transform group-hover:translate-x-0.5"
+      />
+    </button>
+  );
+}
+
 // ─── Divider ────────────────────────────────────────────────────────────
 
 function Divider() {
@@ -105,6 +139,7 @@ function Divider() {
 export function SettingsView() {
   const t = useI18n();
   const { language } = useLanguageSettings();
+  const desktopConnected = useDesktopStatus();
   const [showAbout, setShowAbout] = useState(false);
   const [showLanguages, setShowLanguages] = useState(false);
 
@@ -114,6 +149,12 @@ export function SettingsView() {
 
   return (
     <div className="flex flex-col gap-2 h-full overflow-y-auto px-5 py-4">
+      {!desktopConnected && (
+        <div className="pb-1">
+          <DownloadBanner />
+        </div>
+      )}
+
       {/* Section Title */}
       <span className="text-[13px] font-semibold text-m3-on-surface-variant">
         {t("general")}

--- a/web/src/shared/i18n/extension-messages.ts
+++ b/web/src/shared/i18n/extension-messages.ts
@@ -38,6 +38,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_oversize_file: "\"%s\" (%s) exceeds the %s per-file limit",
     paste_oversize_total: "Total size %s exceeds the %s limit",
     install_desktop_client: "Install the desktop client for full functionality",
+    get_native_app: "Get the native app",
   },
   de: {
     clipboard: "Zwischenablage",
@@ -74,6 +75,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_oversize_file: "„%s\" (%s) überschreitet das Limit von %s pro Datei",
     paste_oversize_total: "Gesamtgröße %s überschreitet das Limit von %s",
     install_desktop_client: "Desktop-Client für alle Funktionen installieren",
+    get_native_app: "Native App laden",
   },
   es: {
     clipboard: "Portapapeles",
@@ -110,6 +112,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_oversize_file: "\"%s\" (%s) supera el límite de %s por archivo",
     paste_oversize_total: "El tamaño total %s supera el límite de %s",
     install_desktop_client: "Instala el cliente de escritorio para todas las funciones",
+    get_native_app: "Obtener la app nativa",
   },
   fr: {
     clipboard: "Presse-papiers",
@@ -146,6 +149,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_oversize_file: "« %s » (%s) dépasse la limite de %s par fichier",
     paste_oversize_total: "La taille totale %s dépasse la limite de %s",
     install_desktop_client: "Installer le client de bureau pour toutes les fonctionnalités",
+    get_native_app: "Obtenir l'application native",
   },
   ja: {
     clipboard: "クリップボード",
@@ -181,6 +185,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_oversize_file: "「%s」(%s) が1ファイルあたりの上限 %s を超えています",
     paste_oversize_total: "合計サイズ %s が上限 %s を超えています",
     install_desktop_client: "すべての機能を利用するためにデスクトップクライアントをインストール",
+    get_native_app: "ネイティブアプリを入手",
   },
   ko: {
     clipboard: "클립보드",
@@ -215,6 +220,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_oversize_file: "\"%s\"(%s)이(가) 파일당 한도 %s 을(를) 초과합니다",
     paste_oversize_total: "총 크기 %s 이(가) 한도 %s 을(를) 초과합니다",
     install_desktop_client: "전체 기능을 위해 데스크톱 클라이언트 설치",
+    get_native_app: "네이티브 앱 받기",
   },
   zh: {
     clipboard: "剪贴板",
@@ -248,6 +254,7 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_oversize_file: "文件「%s」大小为 %s，超过单文件上限 %s",
     paste_oversize_total: "总大小 %s 超过 %s 上限",
     install_desktop_client: "安装桌面客户端以支持完整功能",
+    get_native_app: "获取原生应用",
   },
   zh_hant: {
     clipboard: "剪貼簿",
@@ -281,5 +288,6 @@ export const extensionMessages: Record<string, Record<string, string>> = {
     paste_oversize_file: "檔案「%s」大小為 %s，超過單檔上限 %s",
     paste_oversize_total: "總大小 %s 超過 %s 上限",
     install_desktop_client: "安裝桌面客戶端以支援完整功能",
+    get_native_app: "取得原生應用",
   },
 };


### PR DESCRIPTION
Closes #4288

## Summary
- Adds a download banner at the top of the Chrome extension's Settings view that promotes the native CrossPaste desktop app. Clicking opens the localized download page on crosspaste.com via `openCrossPasteWebInBrowser("download")` (the TypeScript mirror of the Kotlin `UISupport` method).
- Hidden when `useDesktopStatus()` reports the desktop app is already running, so it only appears to users who are likely to benefit.
- Introduces a new extension-only i18n key `get_native_app` with translations for the 8 languages defined in `extension-messages.ts` (en/de/es/fr/ja/ko/zh/zh_hant). pt/fa fall back to English, matching the existing `install_desktop_client` pattern.

## UI notes
- Gradient card (`from-settings-indigo-bg via-settings-blue-bg to-settings-purple-bg`) with rounded-14px corners so it sits comfortably above the Material 3 settings cards without mimicking them.
- Hover feedback uses a ring color shift (`ring-settings-indigo/10` → `/30`) plus shadow elevation (`shadow-sm` → `shadow-md`) rather than a filter-based brightness change, which had proven nearly invisible in light mode.

## Test plan
- [ ] Open the side panel in light theme; the banner is visible above "General" and has a clear hover state (ring + shadow).
- [ ] Repeat in dark theme; gradient and hover state remain legible.
- [ ] Launch the desktop app — verify the banner disappears from Settings (and the existing "Desktop app is running" bar takes over at the app level).
- [ ] Click the banner in zh / en locales and confirm the opened URL is `https://crosspaste.com/<locale>/download`.
- [ ] `npm run build` succeeds in `web/`.