### PR TITLE
:hammer: stop leaking raw exception messages to notifications

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceActionButton.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceActionButton.kt
@@ -86,7 +86,6 @@ fun DeviceScope.DeviceActionButton(
                         updateRefreshing(false)
                         notificationManager.sendNotification(
                             title = { it.getText("refresh_connection_failed") },
-                            message = e.message?.let { message -> { message } },
                             messageType = MessageType.Error,
                         )
                     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/listener/DesktopShortKeysAction.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/listener/DesktopShortKeysAction.kt
@@ -192,7 +192,6 @@ class DesktopShortKeysAction(
             }.onFailure {
                 notificationManager.sendNotification(
                     title = { copyWriter -> copyWriter.getText("copy_failed") },
-                    message = it.message?.let { message -> { message } },
                     messageType = MessageType.Error,
                 )
             }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/AbstractPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/AbstractPasteboardService.kt
@@ -111,7 +111,6 @@ abstract class AbstractPasteboardService :
                     ).onFailure {
                         notificationManager.sendNotification(
                             title = { copyWriter -> copyWriter.getText("copy_failed") },
-                            message = it.message?.let { message -> { message } },
                             messageType = MessageType.Error,
                         )
                     }
@@ -140,7 +139,6 @@ abstract class AbstractPasteboardService :
                     ).onFailure {
                         notificationManager.sendNotification(
                             title = { copyWriter -> copyWriter.getText("copy_failed") },
-                            message = it.message?.let { message -> { message } },
                             messageType = MessageType.Error,
                         )
                     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteMenuService.kt
@@ -91,10 +91,9 @@ class DesktopPasteMenuService(
                         title = { it.getText("copy_successful") },
                         messageType = MessageType.Success,
                     )
-                }.onFailure { e ->
+                }.onFailure {
                     notificationManager.sendNotification(
                         title = { it.getText("copy_failed") },
-                        message = e.message?.let { message -> { message } },
                         messageType = MessageType.Error,
                     )
                 }
@@ -112,10 +111,9 @@ class DesktopPasteMenuService(
                         title = { it.getText("copy_successful") },
                         messageType = MessageType.Success,
                     )
-                }.onFailure { e ->
+                }.onFailure {
                     notificationManager.sendNotification(
                         title = { it.getText("copy_failed") },
-                        message = e.message?.let { message -> { message } },
                         messageType = MessageType.Error,
                     )
                 }
@@ -144,10 +142,9 @@ class DesktopPasteMenuService(
                         title = { it.getText("copy_successful") },
                         messageType = MessageType.Success,
                     )
-                }.onFailure { e ->
+                }.onFailure {
                     notificationManager.sendNotification(
                         title = { it.getText("copy_failed") },
-                        message = e.message?.let { message -> { message } },
                         messageType = MessageType.Error,
                     )
                 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/edit/PasteHtmlEditContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/edit/PasteHtmlEditContentView.kt
@@ -222,10 +222,9 @@ fun PasteDataScope.PasteHtmlEditContentView() {
                             messageType = MessageType.Success,
                         )
                         appWindowManager.hideBubbleWindow()
-                    }.onFailure { error ->
+                    }.onFailure {
                         notificationManager.sendNotification(
                             title = { copywriter.getText("save_failed") },
-                            message = { error.message ?: "" },
                             messageType = MessageType.Error,
                         )
                     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/edit/PasteTextEditContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/edit/PasteTextEditContentView.kt
@@ -113,10 +113,9 @@ fun PasteDataScope.PasteTextEditContentView() {
                             messageType = MessageType.Success,
                         )
                         appWindowManager.hideBubbleWindow()
-                    }.onFailure { error ->
+                    }.onFailure {
                         notificationManager.sendNotification(
                             title = { copywriter.getText("save_failed") },
-                            message = { error.message ?: "" },
                             messageType = MessageType.Error,
                         )
                     }


### PR DESCRIPTION
Closes #4290

## Summary

- Remove `message = e.message?.let { ... }` / `message = { error.message ?: "" }` from 9 `NotificationManager.sendNotification` call sites
- Error notifications now show only the localized title (`copy_failed`, `save_failed`, `refresh_connection_failed`)
- `DesktopGlobalListener.kt` is intentionally left as-is (native hook error code is useful for support)

## Test plan

- [ ] `./gradlew ktlintCheck` passes
- [ ] `./gradlew app:desktopTest` passes
- [ ] Trigger a copy/save failure and confirm the notification shows only the localized title