### PR TITLE
:bug: align PasteCard canDrag with handleDragStart guards

### DIFF
--- a/web/src/components/paste-grid/PasteCard.tsx
+++ b/web/src/components/paste-grid/PasteCard.tsx
@@ -280,9 +280,9 @@ export function PasteCard({ data, onClick, onDelete }: Props) {
   }, [data.pasteType, dragText, dragImageUrl, dragImageFileName, t, handleDownload]);
 
   const canDrag =
-    dragText != null ||
+    !!dragText ||
     data.pasteType === PasteTypeInt.FILE ||
-    (data.pasteType === PasteTypeInt.IMAGE && dragImageUrl != null);
+    (data.pasteType === PasteTypeInt.IMAGE && !!dragImageUrl && !!dragImageFileName);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();


### PR DESCRIPTION
Closes #4292

## Summary
\`canDrag\` and \`handleDragStart\` in \`PasteCard.tsx\` disagreed on two cases:

- Empty-string \`dragText\` (\`""\`) was truthy under \`dragText != null\` but falsy under \`if (!dragText)\` — card showed drag cursor, drag was cancelled instantly.
- IMAGE type only checked \`dragImageUrl\` in \`canDrag\` but also required \`dragImageFileName\` in \`handleDragStart\`.

Aligned \`canDrag\` to use the same truthiness checks (\`!!dragText\`, \`!!dragImageUrl && !!dragImageFileName\`).

The FILE branch still returns \`true\` intentionally — \`handleDragStart\` needs the drag event to fire so it can \`preventDefault()\` and surface the "file_drag_not_supported" warning.

## Test plan
- [ ] Drag an empty-text paste card → no drag cursor, no silent cancel
- [ ] Drag an image card with missing \`relativePathList\` → no drag cursor
- [ ] Drag a normal text card → still drags as expected
- [ ] Drag a FILE card → still shows the "file_drag_not_supported" warning