### PR TITLE
:hammer: deduplicate IMAGE_MIME_MAP into shared utility

### DIFF
--- a/web/src/shared/hooks/use-object-url.ts
+++ b/web/src/shared/hooks/use-object-url.ts
@@ -1,22 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-
-const MIME_MAP: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  svg: "image/svg+xml",
-  bmp: "image/bmp",
-  ico: "image/x-icon",
-  tiff: "image/tiff",
-  tif: "image/tiff",
-};
-
-function mimeFromExt(fileName: string): string | undefined {
-  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
-  return MIME_MAP[ext];
-}
+import { imageMimeFromFileName } from "@/shared/utils/mime";
 
 export function useObjectUrl(
   data: ArrayBuffer | undefined,
@@ -36,7 +19,7 @@ export function useObjectUrl(
     }
 
     if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
-    const mime = mimeFromExt(fileName);
+    const mime = imageMimeFromFileName(fileName);
     const blob = mime ? new Blob([data], { type: mime }) : new Blob([data]);
     objectUrlRef.current = URL.createObjectURL(blob);
     setUrl(objectUrlRef.current);

--- a/web/src/shared/paste/paste-drag.ts
+++ b/web/src/shared/paste/paste-drag.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/shared/models/paste-item";
 import type { PasteData } from "@/shared/models/paste-data";
 import { argbToHex } from "@/shared/utils/color";
+import { imageMimeFromFileName } from "@/shared/utils/mime";
 
 /**
  * Extract plain text for HTML5 drag-and-drop into input fields.
@@ -44,24 +45,6 @@ export function getDragText(data: PasteData): string | null {
   return null;
 }
 
-const IMAGE_MIME_MAP: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  svg: "image/svg+xml",
-  bmp: "image/bmp",
-  ico: "image/x-icon",
-  tiff: "image/tiff",
-  tif: "image/tiff",
-};
-
-function imageMimeFromFileName(fileName: string): string {
-  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
-  return IMAGE_MIME_MAP[ext] ?? "image/png";
-}
-
 /**
  * Populate a DataTransfer with image drag payloads. Covers three drop targets:
  * - `text/plain` / `text/uri-list` — URL text into inputs or address bars.
@@ -74,7 +57,7 @@ export function applyImageDragData(
   imageUrl: string,
   fileName: string,
 ): void {
-  const mime = imageMimeFromFileName(fileName);
+  const mime = imageMimeFromFileName(fileName) ?? "image/png";
   dataTransfer.setData("text/plain", fileName);
   dataTransfer.setData("text/uri-list", imageUrl);
   dataTransfer.setData("text/html", `<img src="${imageUrl}" alt="${fileName}">`);

--- a/web/src/shared/utils/mime.ts
+++ b/web/src/shared/utils/mime.ts
@@ -1,0 +1,17 @@
+export const IMAGE_MIME_MAP: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+  tiff: "image/tiff",
+  tif: "image/tiff",
+};
+
+export function imageMimeFromFileName(fileName: string): string | undefined {
+  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+  return IMAGE_MIME_MAP[ext];
+}


### PR DESCRIPTION
Closes #4294

## Summary
- Extract the duplicated 10-entry MIME map and `imageMimeFromFileName` helper from `paste-drag.ts` and `use-object-url.ts` into a single `web/src/shared/utils/mime.ts`.
- Both call sites now import from the shared utility — adding a new image format (e.g. AVIF) is a one-line change in one file.
- No behavior change. `applyImageDragData` keeps the existing `?? "image/png"` fallback at the call site since the shared helper now returns `undefined` instead of forcing a default.

## Test plan
- [x] `npx tsc --noEmit -p web/tsconfig.json` passes
- [ ] Drag image from sidepanel into Gmail/Docs — image MIME on `DownloadURL` payload still correct
- [ ] Image preview still renders in `PasteCard`