### PR TITLE
:hammer: pass desktopConnected as prop to SettingsView

### DIFF
--- a/web/src/components/settings/SettingsView.tsx
+++ b/web/src/components/settings/SettingsView.tsx
@@ -16,7 +16,6 @@ import {
   getLanguageName,
 } from "@/shared/i18n/use-i18n";
 import { useTheme, type ThemeMode } from "@/shared/theme/use-theme";
-import { useDesktopStatus } from "@/shared/hooks/use-desktop-status";
 import { openCrossPasteWebInBrowser } from "@/shared/app/ui-support";
 import { APP_VERSION } from "@/shared/app/version.generated";
 import { AboutView } from "./AboutView";
@@ -136,10 +135,13 @@ function Divider() {
 
 // ─── Main View ──────────────────────────────────────────────────────────
 
-export function SettingsView() {
+interface Props {
+  desktopConnected?: boolean;
+}
+
+export function SettingsView({ desktopConnected }: Props) {
   const t = useI18n();
   const { language } = useLanguageSettings();
-  const desktopConnected = useDesktopStatus();
   const [showAbout, setShowAbout] = useState(false);
   const [showLanguages, setShowLanguages] = useState(false);
 

--- a/web/src/sidepanel/App.tsx
+++ b/web/src/sidepanel/App.tsx
@@ -75,7 +75,7 @@ export default function App() {
                 <PasteGrid />
               </div>
             ) : (
-              <SettingsView />
+              <SettingsView desktopConnected={desktopConnected} />
             )}
           </main>
         </div>


### PR DESCRIPTION
Closes #4296

## Summary
- `SettingsView` previously called `useDesktopStatus()` itself, registering a duplicate `chrome.runtime.onMessage` listener and duplicate initial IPC ping alongside `App.tsx`.
- Drop the in-component hook call; accept `desktopConnected` as a prop, mirroring how `DevicesView` already consumes the same value.
- `App.tsx` keeps the single source of truth for desktop status and forwards it to both children.

## Test plan
- [x] `npx tsc --noEmit -p web/tsconfig.json` passes
- [ ] With desktop app running: open extension → Settings tab — `DownloadBanner` is hidden (correct), `DesktopActiveBanner` shown
- [ ] With desktop app stopped: open Settings tab — `DownloadBanner` shown