### PR TITLE
:white_check_mark: cover NativeMessagingHostService parsing, manifest, bridge scripts

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/NativeMessagingHostService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/NativeMessagingHostService.kt
@@ -26,11 +26,64 @@ class NativeMessagingHostService(
             NativeMessagingHostService::class.java
                 .getResourceAsStream("/native-messaging.properties")
                 ?.use { props.load(it) }
-            props
+            parseExtensionIds(props)
+        }
+
+        internal fun parseExtensionIds(properties: Properties): List<String> =
+            properties
                 .getProperty("chrome.extension.ids", "")
                 .split(",")
                 .map { it.trim() }
                 .filter { it.isNotEmpty() }
+
+        internal fun buildManifest(
+            extensionIds: List<String>,
+            bridgeScriptPath: String,
+        ): String {
+            val origins = extensionIds.joinToString(", ") { "\"chrome-extension://$it/\"" }
+            return """
+                {
+                  "name": "$HOST_NAME",
+                  "description": "CrossPaste Desktop Native Messaging Host",
+                  "path": "${bridgeScriptPath.replace("\\", "/")}",
+                  "type": "stdio",
+                  "allowed_origins": [$origins]
+                }
+                """.trimIndent()
+        }
+
+        internal fun buildUnixBridgeScript(pidFilePath: String): String =
+            """
+            #!/bin/bash
+            cat > /dev/null &
+            PID_FILE="$pidFilePath"
+            send_message() {
+                local msg="${'$'}1"
+                local len=${'$'}{#msg}
+                printf "\\x$(printf '%02x' ${'$'}((len & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 8) & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 16) & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 24) & 0xFF)))"
+                printf '%s' "${'$'}msg"
+            }
+            is_running() {
+                [ -f "${'$'}PID_FILE" ] || return 1
+                local pid
+                pid=${'$'}(cat "${'$'}PID_FILE" 2>/dev/null) || return 1
+                kill -0 "${'$'}pid" 2>/dev/null
+            }
+            while true; do
+                if ! is_running; then
+                    exit 0
+                fi
+                send_message '{"status":"running"}'
+                sleep 5
+            done
+            """.trimIndent()
+
+        internal fun buildWindowsBridgeScript(pidFilePath: String): String {
+            val normalized = pidFilePath.replace("/", "\\")
+            return """
+                @echo off
+                powershell -NoProfile -Command "${'$'}stdin=[Console]::OpenStandardInput(); ${'$'}null=[System.Threading.Tasks.Task]::Run({${'$'}buf=New-Object byte[] 4096; while(${'$'}stdin.Read(${'$'}buf,0,4096) -gt 0){}}); ${'$'}stdout=[Console]::OpenStandardOutput(); ${'$'}msg=[System.Text.Encoding]::UTF8.GetBytes('{\"status\":\"running\"}'); ${'$'}lenBytes=[System.BitConverter]::GetBytes(${'$'}msg.Length); ${'$'}pidFile='$normalized'; while(${'$'}true){ if(-not(Test-Path ${'$'}pidFile)){exit}; ${'$'}pid=[int](Get-Content ${'$'}pidFile -ErrorAction SilentlyContinue); if(-not(Get-Process -Id ${'$'}pid -ErrorAction SilentlyContinue)){exit}; ${'$'}stdout.Write(${'$'}lenBytes,0,4); ${'$'}stdout.Write(${'$'}msg,0,${'$'}msg.Length); ${'$'}stdout.Flush(); Start-Sleep -Seconds 5 }"
+                """.trimIndent()
         }
     }
 
@@ -46,11 +99,12 @@ class NativeMessagingHostService(
 
     private fun writeBridgeScript(): Path {
         val scriptPath = getBridgeScriptPath()
+        val pidFilePath = pidFileService.pidFilePath.toString()
         val content =
             if (platform.isWindows()) {
-                windowsBridgeScript()
+                buildWindowsBridgeScript(pidFilePath)
             } else {
-                unixBridgeScript()
+                buildUnixBridgeScript(pidFilePath)
             }
         FilePersist
             .createOneFilePersist(scriptPath)
@@ -62,17 +116,7 @@ class NativeMessagingHostService(
     }
 
     private fun writeManifests(bridgeScriptPath: Path) {
-        val origins = CHROME_EXTENSION_IDS.joinToString(", ") { "\"chrome-extension://$it/\"" }
-        val manifest =
-            """
-            {
-              "name": "$HOST_NAME",
-              "description": "CrossPaste Desktop Native Messaging Host",
-              "path": "${bridgeScriptPath.toString().replace("\\", "/")}",
-              "type": "stdio",
-              "allowed_origins": [$origins]
-            }
-            """.trimIndent()
+        val manifest = buildManifest(CHROME_EXTENSION_IDS, bridgeScriptPath.toString())
 
         for (dir in getManifestDirs()) {
             val dirFile = dir.toFile()
@@ -129,41 +173,5 @@ class NativeMessagingHostService(
             "BraveSoftware/Brave-Browser/User Data/NativeMessagingHosts",
             "Microsoft/Edge/User Data/NativeMessagingHosts",
         ).map { File(localAppData).resolve(it).toOkioPath() }
-    }
-
-    private fun unixBridgeScript(): String {
-        val pidFilePath = pidFileService.pidFilePath.toString()
-        return """
-            #!/bin/bash
-            cat > /dev/null &
-            PID_FILE="$pidFilePath"
-            send_message() {
-                local msg="${'$'}1"
-                local len=${'$'}{#msg}
-                printf "\\x$(printf '%02x' ${'$'}((len & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 8) & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 16) & 0xFF)))\\x$(printf '%02x' ${'$'}(((len >> 24) & 0xFF)))"
-                printf '%s' "${'$'}msg"
-            }
-            is_running() {
-                [ -f "${'$'}PID_FILE" ] || return 1
-                local pid
-                pid=${'$'}(cat "${'$'}PID_FILE" 2>/dev/null) || return 1
-                kill -0 "${'$'}pid" 2>/dev/null
-            }
-            while true; do
-                if ! is_running; then
-                    exit 0
-                fi
-                send_message '{"status":"running"}'
-                sleep 5
-            done
-            """.trimIndent()
-    }
-
-    private fun windowsBridgeScript(): String {
-        val pidFilePath = pidFileService.pidFilePath.toString().replace("/", "\\")
-        return """
-            @echo off
-            powershell -NoProfile -Command "${'$'}stdin=[Console]::OpenStandardInput(); ${'$'}null=[System.Threading.Tasks.Task]::Run({${'$'}buf=New-Object byte[] 4096; while(${'$'}stdin.Read(${'$'}buf,0,4096) -gt 0){}}); ${'$'}stdout=[Console]::OpenStandardOutput(); ${'$'}msg=[System.Text.Encoding]::UTF8.GetBytes('{\"status\":\"running\"}'); ${'$'}lenBytes=[System.BitConverter]::GetBytes(${'$'}msg.Length); ${'$'}pidFile='$pidFilePath'; while(${'$'}true){ if(-not(Test-Path ${'$'}pidFile)){exit}; ${'$'}pid=[int](Get-Content ${'$'}pidFile -ErrorAction SilentlyContinue); if(-not(Get-Process -Id ${'$'}pid -ErrorAction SilentlyContinue)){exit}; ${'$'}stdout.Write(${'$'}lenBytes,0,4); ${'$'}stdout.Write(${'$'}msg,0,${'$'}msg.Length); ${'$'}stdout.Flush(); Start-Sleep -Seconds 5 }"
-            """.trimIndent()
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/NativeMessagingHostServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/NativeMessagingHostServiceTest.kt
@@ -1,0 +1,129 @@
+package com.crosspaste.app
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.util.Properties
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NativeMessagingHostServiceTest {
+
+    @Test
+    fun parseExtensionIds_emptyOrMissing() {
+        assertEquals(emptyList(), NativeMessagingHostService.parseExtensionIds(Properties()))
+
+        val empty = Properties().apply { setProperty("chrome.extension.ids", "") }
+        assertEquals(emptyList(), NativeMessagingHostService.parseExtensionIds(empty))
+    }
+
+    @Test
+    fun parseExtensionIds_singleAndMultiple() {
+        val single = Properties().apply { setProperty("chrome.extension.ids", "abc123") }
+        assertEquals(listOf("abc123"), NativeMessagingHostService.parseExtensionIds(single))
+
+        val multiple =
+            Properties().apply {
+                setProperty("chrome.extension.ids", "aaa,bbb,ccc")
+            }
+        assertEquals(
+            listOf("aaa", "bbb", "ccc"),
+            NativeMessagingHostService.parseExtensionIds(multiple),
+        )
+    }
+
+    @Test
+    fun parseExtensionIds_trimsWhitespaceAndDropsEmpties() {
+        val messy =
+            Properties().apply {
+                setProperty("chrome.extension.ids", " aaa , , bbb ,,ccc, ")
+            }
+        assertEquals(
+            listOf("aaa", "bbb", "ccc"),
+            NativeMessagingHostService.parseExtensionIds(messy),
+        )
+    }
+
+    @Test
+    fun buildManifest_isParseableJsonWithRequiredFields() {
+        val manifest =
+            NativeMessagingHostService.buildManifest(
+                extensionIds = listOf("aaa", "bbb"),
+                bridgeScriptPath = "/Users/me/data/native-messaging-host.sh",
+            )
+
+        val parsed = Json.parseToJsonElement(manifest).jsonObject
+        assertEquals(
+            NativeMessagingHostService.HOST_NAME,
+            parsed.getValue("name").jsonPrimitive.content,
+        )
+        assertEquals("stdio", parsed.getValue("type").jsonPrimitive.content)
+        assertEquals(
+            "/Users/me/data/native-messaging-host.sh",
+            parsed.getValue("path").jsonPrimitive.content,
+        )
+
+        val origins: JsonArray = parsed.getValue("allowed_origins").jsonArray
+        assertEquals(
+            listOf("chrome-extension://aaa/", "chrome-extension://bbb/"),
+            origins.map { it.jsonPrimitive.content },
+        )
+    }
+
+    @Test
+    fun buildManifest_normalizesWindowsBackslashesInPath() {
+        val manifest =
+            NativeMessagingHostService.buildManifest(
+                extensionIds = listOf("aaa"),
+                bridgeScriptPath = "C:\\Users\\me\\data\\native-messaging-host.bat",
+            )
+
+        val parsed = Json.parseToJsonElement(manifest).jsonObject
+        assertEquals(
+            "C:/Users/me/data/native-messaging-host.bat",
+            parsed.getValue("path").jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun buildManifest_emptyExtensionIdsProducesValidEmptyArray() {
+        val manifest =
+            NativeMessagingHostService.buildManifest(
+                extensionIds = emptyList(),
+                bridgeScriptPath = "/tmp/host.sh",
+            )
+
+        val parsed = Json.parseToJsonElement(manifest).jsonObject
+        assertEquals(0, parsed.getValue("allowed_origins").jsonArray.size)
+    }
+
+    @Test
+    fun buildUnixBridgeScript_hasShebangAndPidFileSubstitution() {
+        val script = NativeMessagingHostService.buildUnixBridgeScript("/tmp/crosspaste.pid")
+
+        assertTrue(script.startsWith("#!/bin/bash"), "missing shebang")
+        assertTrue(
+            script.contains("PID_FILE=\"/tmp/crosspaste.pid\""),
+            "PID_FILE not substituted",
+        )
+        assertTrue(
+            script.contains("send_message '{\"status\":\"running\"}'"),
+            "status payload missing",
+        )
+    }
+
+    @Test
+    fun buildWindowsBridgeScript_normalizesForwardSlashesAndContainsEchoOff() {
+        val script =
+            NativeMessagingHostService.buildWindowsBridgeScript("C:/Users/me/data/crosspaste.pid")
+
+        assertTrue(script.startsWith("@echo off"), "missing @echo off")
+        assertTrue(
+            script.contains("\$pidFile='C:\\Users\\me\\data\\crosspaste.pid'"),
+            "pidFile path not normalized to backslashes",
+        )
+    }
+}


### PR DESCRIPTION
Closes #4300

## Summary
- Promote the parsing / manifest / bridge-script logic in `NativeMessagingHostService` from inline private code into pure companion functions: `parseExtensionIds`, `buildManifest`, `buildUnixBridgeScript`, `buildWindowsBridgeScript`. Each takes inputs as parameters and returns a string — testable without instantiating the service or hitting the filesystem.
- Inline the two thin platform-branch wrappers (`unixBridgeScript` / `windowsBridgeScript`) since the companion functions now take the path directly.
- Add `NativeMessagingHostServiceTest` with 8 tests covering the silent-failure surfaces:
  - Extension IDs: empty / missing key, single, multiple, whitespace + trailing comma + empty entries.
  - Manifest: parsed back via `kotlinx.serialization.Json.parseToJsonElement` so any future malformed-JSON regression (trailing comma, broken `joinToString`) fails the test instead of Chrome silently rejecting the host. Includes Windows backslash normalization and empty-`allowed_origins` cases.
  - Unix script: shebang and `PID_FILE` substitution.
  - Windows script: `@echo off` and `/` → `\\` normalization in `\$pidFile`.

No runtime behavior change.

## Test plan
- [x] `./gradlew :app:ktlintFormat` passes
- [x] `./gradlew :app:desktopTest --tests com.crosspaste.app.NativeMessagingHostServiceTest` — 8/8 passing