### PR TITLE
:bug: use imageFlavor instead of javaFileListFlavor for single-image clipboard writes

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
@@ -219,25 +219,20 @@ class DesktopImageTypePlugin(
         val fileList: List<File> = filePaths.map { it.toFile() }
 
         if (fileList.size == 1) {
-            var imageAdded = false
             runCatching {
                 val start = System.currentTimeMillis()
                 val image: BufferedImage? = imageHandler.readImage(fileList[0].toOkioPath())
                 image?.let {
                     map[DataFlavor.imageFlavor.toPasteDataFlavor()] = it
-                    imageAdded = true
                 }
                 val end = System.currentTimeMillis()
                 logger.debug { "read image ${fileList[0].absolutePath} use time: ${end - start} ms" }
             }.onFailure { e ->
                 logger.error(e) { "read image fail" }
             }
-            if (!imageAdded) {
-                map[DataFlavor.javaFileListFlavor.toPasteDataFlavor()] = fileList
-            }
-        } else {
-            map[DataFlavor.javaFileListFlavor.toPasteDataFlavor()] = fileList
         }
+
+        map[DataFlavor.javaFileListFlavor.toPasteDataFlavor()] = fileList
 
         if (mixedCategory) {
             map[PasteDataFlavors.URI_LIST_FLAVOR.toPasteDataFlavor()] =

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
@@ -217,7 +217,27 @@ class DesktopImageTypePlugin(
         pasteItem as ImagesPasteItem
         val filePaths = pasteItem.getFilePaths(userDataPathProvider)
         val fileList: List<File> = filePaths.map { it.toFile() }
-        map[DataFlavor.javaFileListFlavor.toPasteDataFlavor()] = fileList
+
+        if (fileList.size == 1) {
+            var imageAdded = false
+            runCatching {
+                val start = System.currentTimeMillis()
+                val image: BufferedImage? = imageHandler.readImage(fileList[0].toOkioPath())
+                image?.let {
+                    map[DataFlavor.imageFlavor.toPasteDataFlavor()] = it
+                    imageAdded = true
+                }
+                val end = System.currentTimeMillis()
+                logger.debug { "read image ${fileList[0].absolutePath} use time: ${end - start} ms" }
+            }.onFailure { e ->
+                logger.error(e) { "read image fail" }
+            }
+            if (!imageAdded) {
+                map[DataFlavor.javaFileListFlavor.toPasteDataFlavor()] = fileList
+            }
+        } else {
+            map[DataFlavor.javaFileListFlavor.toPasteDataFlavor()] = fileList
+        }
 
         if (mixedCategory) {
             map[PasteDataFlavors.URI_LIST_FLAVOR.toPasteDataFlavor()] =
@@ -234,15 +254,6 @@ class DesktopImageTypePlugin(
 
             if (fileList.size == 1) {
                 map[URL_FLAVOR.toPasteDataFlavor()] = fileList[0].toURI().toURL()
-                runCatching {
-                    val start = System.currentTimeMillis()
-                    val image: BufferedImage? = imageHandler.readImage(fileList[0].toOkioPath())
-                    image?.let { map[DataFlavor.imageFlavor.toPasteDataFlavor()] = it }
-                    val end = System.currentTimeMillis()
-                    logger.debug { "read image ${fileList[0].absolutePath} use time: ${end - start} ms" }
-                }.onFailure { e ->
-                    logger.error(e) { "read image fail" }
-                }
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #2729

When pasting a single image from CrossPaste history (right-click copy or double-click quick paste), apps like WeChat and Notes on macOS receive a `file:///` path instead of the actual image. This is because `DesktopImageTypePlugin.buildTransferable()` places `javaFileListFlavor` (file list) on the clipboard, which macOS translates to `public.file-url` pasteboard entries. Apps that prefer text/URL types over image types end up pasting the file path.

This PR changes single-image clipboard writes to use `imageFlavor` (BufferedImage) as the primary clipboard data, matching the behavior of native macOS screenshot paste (`public.tiff`). Falls back to `javaFileListFlavor` only when the image cannot be read. Multi-image clipboard writes remain unchanged.

## Changes

- For single images: place `imageFlavor` (BufferedImage) on the clipboard instead of `javaFileListFlavor`
- Fall back to `javaFileListFlavor` when `imageHandler.readImage()` returns null or throws
- Multi-image behavior unchanged (still uses `javaFileListFlavor`)

## Test plan

- [x] Take a screenshot on macOS, copy from CrossPaste history, paste into WeChat — image pastes correctly
- [x] Take a screenshot on macOS, copy from CrossPaste history, paste into Notes — image pastes correctly
- [ ] Verify multi-image paste still works as file list
- [ ] Verify drag-and-drop from side panel still works
- [ ] Verify on Windows and Linux that existing behavior is preserved