### PR TITLE
:construction_worker: ignore /.dev-context/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ node_modules/
 output*/
 /.claude/commands/
 /.claude/skills/
+/.dev-context/
 /code-review/
 /ai/
 /.claude/skills/ui-ux-pro-max/


### PR DESCRIPTION
## Summary
- Add `/.dev-context/` to `.gitignore` so local development context files are not tracked.

## Test plan
- [x] `git status` no longer shows `.dev-context/` as untracked when the directory exists locally.