### PR TITLE
:hammer: lazy-init deviceId/deviceName in EndpointInfoFactory

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/EndpointInfoFactory.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/EndpointInfoFactory.kt
@@ -8,13 +8,13 @@ import com.crosspaste.utils.DeviceUtils
 import kotlinx.coroutines.flow.first
 
 class EndpointInfoFactory(
-    deviceUtils: DeviceUtils,
+    private val deviceUtils: DeviceUtils,
     private val pasteServer: Lazy<Server>,
     private val platform: Platform,
 ) {
-    private val deviceName = deviceUtils.getDeviceName()
+    private val deviceName: String by lazy { deviceUtils.getDeviceName() }
 
-    private val deviceId = deviceUtils.getDeviceId()
+    private val deviceId: String by lazy { deviceUtils.getDeviceId() }
 
     suspend fun createEndpointInfo(hostInfoList: List<HostInfo>): EndpointInfo {
         val port = pasteServer.value.portFlow.first { it > 0 }


### PR DESCRIPTION
Closes #4310

## Summary
Defer `deviceUtils.getDeviceId()` / `getDeviceName()` calls in
`EndpointInfoFactory` from class construction to first access by
switching the two properties to `by lazy`.

## Why
The `commonMain` source set is copied into the CrossPaste mobile
project. On Android, `DeviceUtils.getDeviceId()` reads
`Settings.Secure.ANDROID_ID`, and the domestic (Chinese app store)
flavor must not read hardware identifiers before the user consents to
the privacy policy. With this change, the values are only computed
when `createEndpointInfo()` is actually invoked (i.e. when device
sync begins), so Phase 0 startup on mobile no longer triggers the
hardware-ID read.

## Desktop impact
None observable.
- `EndpointInfoFactory` is only consumed once the network server is
  ready, and `createEndpointInfo()` is the only reader of these fields.
- Desktop `getDeviceId()` does not touch hardware identifiers.
- `LazyThreadSafetyMode.SYNCHRONIZED` (the default for `by lazy`)
  preserves the once-only initialization guarantee.

## Test plan
- [x] `./gradlew ktlintFormat` clean
- [x] `./gradlew :app:compileKotlinDesktop` succeeds
- [ ] Existing desktop test suite passes in CI
- [ ] Manual: pair a desktop device and confirm `EndpointInfo`
  `deviceId` / `deviceName` fields are populated as before