### PR TITLE
Extract appInstanceId out of AppConfig

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -25,7 +25,9 @@ import com.crosspaste.app.ExitMode
 import com.crosspaste.app.NativeMessagingHostService
 import com.crosspaste.bootstrap.JvmSystemPropertiesOverride
 import com.crosspaste.clean.CleanScheduler
+import com.crosspaste.config.AppMetadataRepository
 import com.crosspaste.config.DesktopConfigManager
+import com.crosspaste.config.migrateAppInstanceIdIfNeeded
 import com.crosspaste.db.DriverFactory
 import com.crosspaste.listener.GlobalListener
 import com.crosspaste.log.DesktopCrossPasteLogger
@@ -99,14 +101,25 @@ class CrossPaste {
             )
         }
 
-        private val configManager =
-            DesktopConfigManager(
-                FilePersist.createOneFilePersist(
-                    appPathProvider.resolve("appConfig.json", AppFileType.USER),
-                ),
-                deviceUtils,
-                localeUtils,
+        private val configFilePersist =
+            FilePersist.createOneFilePersist(
+                appPathProvider.resolve("appConfig.json", AppFileType.USER),
             )
+
+        private val metadataFilePersist =
+            FilePersist.createOneFilePersist(
+                appPathProvider.resolve(".metadata", AppFileType.USER),
+            )
+
+        init {
+            migrateAppInstanceIdIfNeeded(metadataFilePersist, configFilePersist)
+        }
+
+        private val appMetadataRepository =
+            AppMetadataRepository(metadataFilePersist, deviceUtils)
+
+        private val configManager =
+            DesktopConfigManager(configFilePersist, localeUtils)
 
         private val crossPasteLogger =
             DesktopCrossPasteLogger(
@@ -128,6 +141,7 @@ class CrossPaste {
             module =
                 DesktopModule(
                     appEnv,
+                    appMetadataRepository,
                     appPathProvider,
                     configManager,
                     crossPasteLogger,

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
@@ -27,6 +27,7 @@ import com.crosspaste.app.DesktopAppUrls
 import com.crosspaste.app.DesktopPidFileService
 import com.crosspaste.app.EndpointInfoFactory
 import com.crosspaste.app.NativeMessagingHostService
+import com.crosspaste.config.AppMetadataRepository
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.config.DesktopSimpleConfigFactory
@@ -80,6 +81,7 @@ import java.awt.image.BufferedImage
 @Suppress("UNCHECKED_CAST")
 fun desktopAppModule(
     appEnv: AppEnv,
+    appMetadataRepository: AppMetadataRepository,
     appPathProvider: AppPathProvider,
     configManager: DesktopConfigManager,
     crossPasteLogger: CrossPasteLogger,
@@ -93,6 +95,7 @@ fun desktopAppModule(
         single<AppExitService> { DesktopAppExitService }
         single<AppInfo> { get<AppInfoFactory>().createAppInfo() }
         single<AppInfoFactory> { DesktopAppInfoFactory(get()) }
+        single<AppMetadataRepository> { appMetadataRepository }
         single<AppLaunchState> { get<DesktopAppLaunchState>() }
         single<AppLock> { get<DesktopAppLaunch>() }
         single<AppPathProvider> { appPathProvider }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -1,6 +1,7 @@
 package com.crosspaste
 
 import com.crosspaste.app.AppEnv
+import com.crosspaste.config.AppMetadataRepository
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.config.DevConfig
 import com.crosspaste.db.DesktopDriverFactory
@@ -61,6 +62,7 @@ import org.koin.dsl.module
 
 class DesktopModule(
     private val appEnv: AppEnv,
+    private val appMetadataRepository: AppMetadataRepository,
     private val appPathProvider: AppPathProvider,
     private val configManager: DesktopConfigManager,
     private val crossPasteLogger: CrossPasteLogger,
@@ -75,6 +77,7 @@ class DesktopModule(
     override fun appModule() =
         desktopAppModule(
             appEnv,
+            appMetadataRepository,
             appPathProvider,
             configManager,
             crossPasteLogger,

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppInfoFactory.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppInfoFactory.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.app
 
-import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.config.AppMetadataRepository
 import com.crosspaste.net.SyncApi
 import com.crosspaste.utils.getAppEnvUtils
 import com.crosspaste.utils.getSystemProperty
@@ -9,7 +9,7 @@ import java.nio.file.Paths
 import java.util.Properties
 
 class DesktopAppInfoFactory(
-    private val configManager: CommonConfigManager,
+    private val appMetadataRepository: AppMetadataRepository,
 ) : AppInfoFactory {
 
     private val logger = KotlinLogging.logger {}
@@ -30,16 +30,14 @@ class DesktopAppInfoFactory(
             logger.error(e) { "Failed to read version" }
         }.getOrNull()
 
-    override fun createAppInfo(): AppInfo {
-        val appInstanceId = configManager.getCurrentConfig().appInstanceId
-        return AppInfo(
-            appInstanceId = appInstanceId,
+    override fun createAppInfo(): AppInfo =
+        AppInfo(
+            appInstanceId = appMetadataRepository.appInstanceId,
             appVersion = getVersion(),
             appRevision = getRevision(),
             userName = getUserName(),
             pairingVersion = SyncApi.PAIRING_VERSION,
         )
-    }
 
     override fun getVersion(): String = getVersion(appEnvUtils.getCurrentAppEnv(), properties)
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppConfig.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppConfig.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class DesktopAppConfig(
-    override val appInstanceId: String,
     override val language: String,
     override val font: String = "",
     val enableAutoStartUp: Boolean = true,
@@ -67,7 +66,6 @@ data class DesktopAppConfig(
         value: Any,
     ): DesktopAppConfig =
         this.copy(
-            appInstanceId = appInstanceId,
             language = if (key == "language") toString(value) else language,
             font = if (key == "font") toString(value) else font,
             enableAutoStartUp = if (key == "enableAutoStartUp") toBoolean(value) else enableAutoStartUp,

--- a/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
@@ -1,0 +1,23 @@
+package com.crosspaste.config
+
+import com.crosspaste.presist.OneFilePersist
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data class LegacyAppInstanceIdHolder(
+    val appInstanceId: String = "",
+)
+
+fun migrateAppInstanceIdIfNeeded(
+    metadataPersist: OneFilePersist,
+    legacyConfigPersist: OneFilePersist,
+) {
+    if (metadataPersist.read(AppMetadata::class) != null) return
+    runCatching {
+        legacyConfigPersist
+            .read(LegacyAppInstanceIdHolder::class)
+            ?.appInstanceId
+            ?.takeIf { it.isNotBlank() }
+            ?.let { metadataPersist.save(AppMetadata(it)) }
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopConfigManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopConfigManager.kt
@@ -3,7 +3,6 @@ package com.crosspaste.config
 import com.crosspaste.notification.MessageType
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.presist.OneFilePersist
-import com.crosspaste.utils.DeviceUtils
 import com.crosspaste.utils.LocaleUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,7 +10,6 @@ import kotlinx.coroutines.flow.StateFlow
 
 class DesktopConfigManager(
     private val configFilePersist: OneFilePersist,
-    override val deviceUtils: DeviceUtils,
     private val localeUtils: LocaleUtils,
 ) : ConfigManager<DesktopAppConfig> {
 
@@ -34,7 +32,6 @@ class DesktopConfigManager(
 
     private fun createDefaultAppConfig(): DesktopAppConfig =
         DesktopAppConfig(
-            appInstanceId = deviceUtils.createAppInstanceId(),
             language = localeUtils.getLanguage(),
         )
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/DesktopAppControlTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/DesktopAppControlTest.kt
@@ -17,7 +17,6 @@ class DesktopAppControlTest {
     ): DesktopAppControl {
         val config =
             DesktopAppConfig(
-                appInstanceId = "test",
                 language = "en",
                 enabledSyncFileSizeLimit = enabledSyncFileSizeLimit,
                 maxSyncFileSize = maxSyncFileSize,

--- a/app/src/desktopTest/kotlin/com/crosspaste/config/DesktopAppConfigTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/config/DesktopAppConfigTest.kt
@@ -9,14 +9,12 @@ class DesktopAppConfigTest {
 
     private fun createDefaultConfig(): DesktopAppConfig =
         DesktopAppConfig(
-            appInstanceId = "test-instance",
             language = "en",
         )
 
     @Test
     fun `default config has expected values`() {
         val config = createDefaultConfig()
-        assertEquals("test-instance", config.appInstanceId)
         assertEquals("en", config.language)
         assertEquals("", config.font)
         assertTrue(config.enableAutoStartUp)
@@ -72,13 +70,6 @@ class DesktopAppConfigTest {
         val config: AppConfig = createDefaultConfig()
         val updated = config.copy("maxStorage", 4096L)
         assertEquals(4096L, updated.maxStorage)
-    }
-
-    @Test
-    fun `copy preserves appInstanceId`() {
-        val config: AppConfig = createDefaultConfig()
-        val updated = config.copy("language", "ja")
-        assertEquals("test-instance", updated.appInstanceId)
     }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/config/DesktopConfigManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/config/DesktopConfigManagerTest.kt
@@ -1,9 +1,7 @@
 package com.crosspaste.config
 
 import com.crosspaste.presist.OneFilePersist
-import com.crosspaste.utils.DesktopDeviceUtils
 import com.crosspaste.utils.DesktopLocaleUtils
-import com.crosspaste.utils.getPlatformUtils
 import okio.Path.Companion.toOkioPath
 import java.nio.file.Files
 import kotlin.test.Test
@@ -14,8 +12,6 @@ import kotlin.test.assertTrue
 
 class DesktopConfigManagerTest {
 
-    private val platform = getPlatformUtils().platform
-
     private fun createConfigManager(): Pair<DesktopConfigManager, okio.Path> {
         val configDirPath = Files.createTempDirectory("configDir").toOkioPath()
         configDirPath.toFile().deleteOnExit()
@@ -23,17 +19,9 @@ class DesktopConfigManagerTest {
         val manager =
             DesktopConfigManager(
                 OneFilePersist(configPath),
-                DesktopDeviceUtils(platform),
                 DesktopLocaleUtils,
             )
         return Pair(manager, configPath)
-    }
-
-    @Test
-    fun `initial config has non-empty appInstanceId`() {
-        val (manager, _) = createConfigManager()
-        val config = manager.getCurrentConfig()
-        assertTrue(config.appInstanceId.isNotBlank())
     }
 
     @Test
@@ -108,20 +96,16 @@ class DesktopConfigManagerTest {
         val manager1 =
             DesktopConfigManager(
                 OneFilePersist(configPath),
-                DesktopDeviceUtils(platform),
                 DesktopLocaleUtils,
             )
         manager1.updateConfig("port", 5555)
-        val instanceId = manager1.getCurrentConfig().appInstanceId
 
         val manager2 =
             DesktopConfigManager(
                 OneFilePersist(configPath),
-                DesktopDeviceUtils(platform),
                 DesktopLocaleUtils,
             )
         assertEquals(5555, manager2.getCurrentConfig().port)
-        assertEquals(instanceId, manager2.getCurrentConfig().appInstanceId)
     }
 
     @Test
@@ -134,7 +118,6 @@ class DesktopConfigManagerTest {
         val manager =
             DesktopConfigManager(
                 OneFilePersist(configPath),
-                DesktopDeviceUtils(platform),
                 DesktopLocaleUtils,
             )
         // First save should work
@@ -150,7 +133,6 @@ class DesktopConfigManagerTest {
         val manager =
             DesktopConfigManager(
                 OneFilePersist(configPath),
-                DesktopDeviceUtils(platform),
                 DesktopLocaleUtils,
             )
         // Initial config should still be created from defaults

--- a/app/src/desktopTest/kotlin/com/crosspaste/config/TestAppConfig.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/config/TestAppConfig.kt
@@ -3,7 +3,6 @@ package com.crosspaste.config
 import com.crosspaste.config.AppConfig.Companion.toBoolean
 
 data class TestAppConfig(
-    override val appInstanceId: String = "test",
     override val language: String = "en",
     override val font: String = "",
     override val isFollowSystemTheme: Boolean = true,

--- a/app/src/desktopTest/kotlin/com/crosspaste/config/TestConfigManager.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/config/TestConfigManager.kt
@@ -1,11 +1,9 @@
 package com.crosspaste.config
 
-import com.crosspaste.utils.DeviceUtils
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class TestConfigManager(
-    override val deviceUtils: DeviceUtils,
     private val initialConfig: AppConfig,
 ) : CommonConfigManager {
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/i18n/GlobalCopywriterTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/i18n/GlobalCopywriterTest.kt
@@ -9,9 +9,7 @@ import com.crosspaste.i18n.DesktopGlobalCopywriter.Companion.EMPTY_STRING
 import com.crosspaste.i18n.DesktopGlobalCopywriter.Companion.EN
 import com.crosspaste.presist.OneFilePersist
 import com.crosspaste.task.TaskExecutor
-import com.crosspaste.utils.DesktopDeviceUtils
 import com.crosspaste.utils.DesktopLocaleUtils
-import com.crosspaste.utils.getPlatformUtils
 import okio.Path.Companion.toOkioPath
 import java.nio.file.Files
 import kotlin.test.Test
@@ -26,13 +24,10 @@ class GlobalCopywriterTest {
         configDirPath.toFile().deleteOnExit()
         val configPath = configDirPath.resolve("appConfig.json")
 
-        val platform = getPlatformUtils().platform
-
         @Suppress("UNCHECKED_CAST")
         val configManager =
             DesktopConfigManager(
                 OneFilePersist(configPath),
-                DesktopDeviceUtils(platform),
                 DesktopLocaleUtils,
             ) as CommonConfigManager
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
@@ -120,7 +120,7 @@ class SyncTest : KoinTest {
                         get(),
                     )
                 }
-                single<CommonConfigManager> { TestConfigManager(get(), TestAppConfig()) }
+                single<CommonConfigManager> { TestConfigManager(TestAppConfig()) }
                 single<PendingKeyExchangeStore> { PendingKeyExchangeStore() }
                 single<SyncApi> { SyncApi }
                 single<ServerFactory<NettyApplicationEngine, NettyApplicationEngine.Configuration>> {

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
@@ -87,7 +87,7 @@ class TestInstance(
         TestServerModule(
             appInfo = appInfo,
             appTokenApi = appTokenApi,
-            configManager = TestConfigManager(deviceUtils, TestAppConfig(appInstanceId = appInstanceId)),
+            configManager = TestConfigManager(TestAppConfig()),
             exceptionHandler = exceptionHandler,
             networkInterfaceService = networkInterfaceService,
             pendingKeyExchangeStore = pendingKeyExchangeStore,

--- a/shared/src/commonMain/kotlin/com/crosspaste/config/AppConfig.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/config/AppConfig.kt
@@ -1,7 +1,6 @@
 package com.crosspaste.config
 
 interface AppConfig {
-    val appInstanceId: String
     val language: String
     val font: String
     val isFollowSystemTheme: Boolean

--- a/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadata.kt
@@ -1,0 +1,8 @@
+package com.crosspaste.config
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppMetadata(
+    val appInstanceId: String,
+)

--- a/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadataRepository.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadataRepository.kt
@@ -1,0 +1,15 @@
+package com.crosspaste.config
+
+import com.crosspaste.presist.OneFilePersist
+import com.crosspaste.utils.DeviceUtils
+
+class AppMetadataRepository(
+    private val persist: OneFilePersist,
+    private val deviceUtils: DeviceUtils,
+) {
+    val appInstanceId: String by lazy { loadOrCreate().appInstanceId }
+
+    private fun loadOrCreate(): AppMetadata =
+        persist.read(AppMetadata::class)
+            ?: AppMetadata(deviceUtils.createAppInstanceId()).also { persist.save(it) }
+}

--- a/shared/src/commonMain/kotlin/com/crosspaste/config/ConfigManager.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/config/ConfigManager.kt
@@ -1,13 +1,10 @@
 package com.crosspaste.config
 
-import com.crosspaste.utils.DeviceUtils
 import kotlinx.coroutines.flow.StateFlow
 
 typealias CommonConfigManager = ConfigManager<AppConfig>
 
 interface ConfigManager<T : AppConfig> {
-
-    val deviceUtils: DeviceUtils
 
     val config: StateFlow<T>
 


### PR DESCRIPTION
Closes #4312

## Summary

- Remove `appInstanceId` from the `AppConfig` interface and `DesktopAppConfig` data class.
- Introduce `AppMetadataRepository` in `shared/commonMain` backed by a dedicated JSON file (`.metadata`); the hardware-ID read is deferred via a `lazy` delegate until `AppInfo` is first constructed.
- Add a one-time desktop migration that copies any existing `appInstanceId` from the legacy `appConfig.json` into `.metadata`, so paired devices keep their identity after upgrading.
- Drop the now-unused `deviceUtils` parameter from `ConfigManager` / `DesktopConfigManager` / `TestConfigManager`.

## Why

`appInstanceId` is an immutable device identity, not a user preference, so it does not belong in `AppConfig`. More importantly, generating it inside `createDefaultAppConfig()` forced a hardware-ID read at startup — incompatible with the mobile project's requirement to defer such reads until the user accepts the privacy policy (Chinese app store regulation).

After this change, loading the configuration no longer touches any hardware identifier; the read happens only on the first access to `AppMetadataRepository.appInstanceId`.

## Test plan

- [x] `./gradlew app:compileKotlinDesktop` passes
- [x] `./gradlew app:desktopTest` passes (full desktop test suite)
- [x] `./gradlew ktlintFormat` clean
- [ ] Manual upgrade test on macOS: existing install with `appConfig.json` containing `appInstanceId` retains the same `appInstanceId` in `.metadata` after first run; previously paired devices stay paired
- [ ] Fresh install on macOS: `.metadata` is created on first `AppInfo` access; `appConfig.json` no longer carries `appInstanceId`