### PR TITLE
:hammer: harden appInstanceId migration against corrupt metadata

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
@@ -1,7 +1,10 @@
 package com.crosspaste.config
 
 import com.crosspaste.presist.OneFilePersist
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
+
+private val logger = KotlinLogging.logger {}
 
 @Serializable
 private data class LegacyAppInstanceIdHolder(
@@ -12,12 +15,18 @@ fun migrateAppInstanceIdIfNeeded(
     metadataPersist: OneFilePersist,
     legacyConfigPersist: OneFilePersist,
 ) {
-    if (metadataPersist.read(AppMetadata::class) != null) return
+    if (runCatching { metadataPersist.read(AppMetadata::class) }.getOrNull() != null) return
     runCatching {
         legacyConfigPersist
             .read(LegacyAppInstanceIdHolder::class)
             ?.appInstanceId
             ?.takeIf { it.isNotBlank() }
             ?.let { metadataPersist.save(AppMetadata(it)) }
+    }.onFailure {
+        logger.error(it) {
+            "Failed to migrate appInstanceId from legacy config; " +
+                "a new appInstanceId will be generated and this device " +
+                "will appear as a new peer to previously paired devices"
+        }
     }
 }


### PR DESCRIPTION
Closes #4316

## Summary
- Log errors on legacy-config migration failure so silent identity loss leaves a diagnostic trail
- Wrap the `.metadata` exists-guard in `runCatching` so a corrupt/partially-written metadata file is treated as missing and migration retries from the legacy config

## Test plan
- [ ] `./gradlew app:desktopTest` passes
- [ ] Manual: delete `.metadata`, confirm legacy `appInstanceId` is migrated and logged
- [ ] Manual: truncate `.metadata` to invalid bytes, confirm migration retries on next startup instead of throwing