### PR TITLE
:white_check_mark: add :e2e real-device test harness

### DIFF
--- a/e2e/build.gradle.kts
+++ b/e2e/build.gradle.kts
@@ -1,0 +1,89 @@
+import java.io.FileReader
+import java.util.Properties
+
+val versionProperties = Properties()
+versionProperties.load(
+    FileReader(
+        project.projectDir
+            .toPath()
+            .parent
+            .resolve("app/src/desktopMain/resources/crosspaste-version.properties")
+            .toFile(),
+    ),
+)
+
+group = "com.crosspaste"
+version = versionProperties.getProperty("version")
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.ktlint)
+}
+
+ktlint {
+    verbose = true
+    android = false
+    ignoreFailures = false
+}
+
+kotlin {
+    jvm("desktop") {}
+
+    sourceSets {
+        val desktopMain by getting {
+            dependencies {
+                implementation(project(":app"))
+                implementation(project(":shared"))
+                implementation(project(":core"))
+                implementation(libs.clikt)
+                implementation(libs.cryptography.core)
+                implementation(libs.cryptography.provider.jdk)
+                implementation(libs.jmdns)
+                implementation(libs.kotlin.logging)
+                implementation(libs.kotlinx.coroutines.core)
+                implementation(libs.kotlinx.serialization.json)
+                implementation(libs.ktor.client.cio)
+                implementation(libs.ktor.client.content.negotiation)
+                implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.logging)
+                implementation(libs.ktor.serialization.kotlinx.json)
+                implementation(libs.logback.classic)
+            }
+        }
+
+        configurations.configureEach {
+            exclude(group = "io.opentelemetry")
+            exclude(group = "io.opentelemetry.semconv")
+            exclude(group = "net.java.dev.jna", module = "jna-jpms")
+            exclude(group = "net.java.dev.jna", module = "jna-platform-jpms")
+        }
+    }
+}
+
+// Match :app's `ui=awt` attribute so depending on it resolves the correct variant.
+configurations.all {
+    if (isCanBeResolved || isCanBeConsumed) {
+        attributes {
+            attribute(Attribute.of("ui", String::class.java), "awt")
+        }
+    }
+}
+
+tasks.register<JavaExec>("run") {
+    group = "application"
+    description = "Run the CrossPaste e2e harness against a target device."
+    mainClass.set("com.crosspaste.e2e.cli.MainKt")
+    val desktopMain =
+        kotlin.targets
+            .getByName("desktop")
+            .compilations
+            .getByName("main")
+    val runtimeFiles = desktopMain.runtimeDependencyFiles ?: project.files()
+    classpath = runtimeFiles + desktopMain.output.allOutputs
+    standardInput = System.`in`
+    jvmArgs(
+        "-Djava.net.preferIPv4Stack=true",
+        "-Djava.net.preferIPv6Addresses=false",
+    )
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
@@ -1,0 +1,279 @@
+package com.crosspaste.e2e.cli
+
+import com.crosspaste.e2e.peer.HeadlessPeer
+import com.crosspaste.e2e.scenario.DiscoveryScenario
+import com.crosspaste.e2e.scenario.PairScenario
+import com.crosspaste.e2e.scenario.PullIconScenario
+import com.crosspaste.e2e.scenario.PushColorScenario
+import com.crosspaste.e2e.scenario.PushHtmlScenario
+import com.crosspaste.e2e.scenario.PushRtfScenario
+import com.crosspaste.e2e.scenario.PushTextScenario
+import com.crosspaste.e2e.scenario.PushUrlScenario
+import com.crosspaste.e2e.scenario.Scenario
+import com.crosspaste.e2e.scenario.ScenarioContext
+import com.crosspaste.e2e.scenario.ScenarioResult
+import com.crosspaste.e2e.scenario.TargetSpec
+import com.crosspaste.e2e.scenario.WrongTokenScenario
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.long
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
+    private val scenario by option(
+        "--scenario",
+        "-s",
+        help =
+            "Scenario to run: discovery, pair, wrong-token, push-text, push-url, " +
+                "push-html, push-rtf, push-color, pull-icon, or all.",
+    ).default("discovery")
+
+    private val target by option(
+        "--target",
+        help = "Target host[:port]. If omitted, mDNS discovery is used.",
+    )
+
+    private val targetAppId by option(
+        "--target-app-id",
+        help = "Filter discovery (or attach to --target) by appInstanceId.",
+    )
+
+    private val discoveryTimeout by option(
+        "--discovery-timeout",
+        help = "Seconds to wait for mDNS discovery.",
+    ).long().default(10)
+
+    private val appInstanceId by option(
+        "--app-instance-id",
+        help = "appInstanceId for this peer (random UUID if unset).",
+    )
+
+    private val pushText by option(
+        "--push-text",
+        help = "Text payload for push-text scenario.",
+    )
+
+    private val pushUrl by option(
+        "--push-url",
+        help = "URL payload for push-url scenario.",
+    )
+
+    private val pushHtml by option(
+        "--push-html",
+        help = "HTML payload for push-html scenario.",
+    )
+
+    private val pushRtf by option(
+        "--push-rtf",
+        help = "RTF payload for push-rtf scenario.",
+    )
+
+    private val pushColor by option(
+        "--push-color",
+        help = "Color (ARGB hex like 0xFFFF0000 or decimal int) for push-color scenario.",
+    )
+
+    private val iconSource by option(
+        "--icon-source",
+        help = "Source key for pull-icon scenario (required for pull-icon).",
+    ).default("")
+
+    private val junitXml by option(
+        "--junit-xml",
+        help = "Optional path to write a JUnit XML report.",
+    )
+
+    override fun run() {
+        val peer =
+            appInstanceId?.let { HeadlessPeer(appInstanceId = it) } ?: HeadlessPeer()
+        try {
+            val ctx =
+                ScenarioContext(
+                    peer = peer,
+                    target = target?.let(::parseTarget)?.copy(appInstanceId = targetAppId),
+                    targetAppInstanceId = targetAppId,
+                    discoveryTimeoutMs = discoveryTimeout * 1000,
+                    tokenProvider = ::promptToken,
+                )
+
+            val payloads =
+                Payloads(
+                    text = pushText ?: "e2e-ping ${System.currentTimeMillis()}",
+                    url = pushUrl ?: "https://crosspaste.com/?e2e=${System.currentTimeMillis()}",
+                    html = pushHtml ?: "<p>e2e-ping ${System.currentTimeMillis()}</p>",
+                    rtf = pushRtf ?: "{\\rtf1 e2e-ping ${System.currentTimeMillis()}}",
+                    color = pushColor?.let(::parseColor) ?: 0xFFFF0000.toInt(),
+                )
+
+            val scenarios = selectScenarios(scenario, payloads, iconSource)
+            val results =
+                runBlocking {
+                    scenarios.map { s ->
+                        val started = System.nanoTime()
+                        val result = s.run(ctx)
+                        val durationMs = (System.nanoTime() - started) / 1_000_000.0
+                        RunResult(s.name, result, durationMs)
+                    }
+                }
+
+            printSummary(peer.appInfo.appInstanceId, results)
+            junitXml?.let { writeJUnitReport(File(it), results) }
+
+            val failed = results.count { it.result is ScenarioResult.Fail }
+            if (failed > 0) kotlin.system.exitProcess(1)
+        } finally {
+            peer.close()
+        }
+    }
+}
+
+private data class Payloads(
+    val text: String,
+    val url: String,
+    val html: String,
+    val rtf: String,
+    val color: Int,
+)
+
+private data class RunResult(
+    val name: String,
+    val result: ScenarioResult,
+    val durationMs: Double,
+)
+
+private fun selectScenarios(
+    name: String,
+    payloads: Payloads,
+    iconSource: String,
+): List<Scenario> =
+    when (name.lowercase()) {
+        "discovery" -> listOf(DiscoveryScenario())
+        "pair" -> listOf(PairScenario())
+        "wrong-token" -> listOf(WrongTokenScenario())
+        "push-text" -> listOf(PushTextScenario(payloads.text))
+        "push-url" -> listOf(PushUrlScenario(payloads.url))
+        "push-html" -> listOf(PushHtmlScenario(payloads.html))
+        "push-rtf" -> listOf(PushRtfScenario(payloads.rtf))
+        "push-color" -> listOf(PushColorScenario(payloads.color))
+        "pull-icon" -> listOf(PullIconScenario(iconSource))
+        "all" ->
+            listOf(
+                // wrong-token first so the failure path runs against an untrusted state
+                DiscoveryScenario(),
+                WrongTokenScenario(),
+                PairScenario(),
+                PushTextScenario(payloads.text),
+                PushUrlScenario(payloads.url),
+                PushHtmlScenario(payloads.html),
+                PushRtfScenario(payloads.rtf),
+                PushColorScenario(payloads.color),
+            )
+        else -> error("Unknown scenario: $name")
+    }
+
+private fun parseTarget(spec: String): TargetSpec {
+    val (host, port) =
+        if (spec.contains(":")) {
+            val (h, p) = spec.split(":", limit = 2)
+            h to p.toInt()
+        } else {
+            spec to DEFAULT_PORT
+        }
+    return TargetSpec(host = host, port = port, appInstanceId = null)
+}
+
+private fun parseColor(raw: String): Int {
+    val trimmed = raw.trim()
+    val (text, radix) =
+        when {
+            trimmed.startsWith("0x", ignoreCase = true) -> trimmed.substring(2) to 16
+            trimmed.startsWith("#") -> trimmed.substring(1) to 16
+            else -> trimmed to 10
+        }
+    return text.toUInt(radix).toInt()
+}
+
+private fun promptToken(): Int {
+    print("Enter the token shown on the target device: ")
+    System.out.flush()
+    val line = readlnOrNull()?.trim() ?: error("No token entered.")
+    return line.toIntOrNull() ?: error("Invalid token: '$line' (must be an integer).")
+}
+
+private fun printSummary(
+    peerId: String,
+    results: List<RunResult>,
+) {
+    println()
+    println("=== e2e summary (peer=$peerId) ===")
+    results.forEach { run ->
+        when (val result = run.result) {
+            is ScenarioResult.Pass -> println("  PASS  ${run.name}  — ${result.message}")
+            is ScenarioResult.Fail -> {
+                println("  FAIL  ${run.name}  — ${result.reason}")
+                result.cause?.let { println("        cause: ${it.message}") }
+            }
+        }
+    }
+}
+
+private fun writeJUnitReport(
+    file: File,
+    results: List<RunResult>,
+) {
+    file.parentFile?.mkdirs()
+    val totalSeconds = results.sumOf { it.durationMs } / 1000.0
+    val failures = results.count { it.result is ScenarioResult.Fail }
+    val xml =
+        buildString {
+            appendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+            append("<testsuite name=\"crosspaste-e2e\" tests=\"${results.size}\"")
+            append(" failures=\"$failures\" errors=\"0\" skipped=\"0\"")
+            appendLine(" time=\"${"%.3f".format(totalSeconds)}\">")
+            results.forEach { run ->
+                val seconds = "%.3f".format(run.durationMs / 1000.0)
+                append("  <testcase classname=\"crosspaste-e2e\"")
+                append(" name=\"${xmlAttr(run.name)}\"")
+                append(" time=\"$seconds\"")
+                when (val result = run.result) {
+                    is ScenarioResult.Pass -> appendLine("/>")
+                    is ScenarioResult.Fail -> {
+                        appendLine(">")
+                        append("    <failure message=\"${xmlAttr(result.reason)}\">")
+                        val causeMessage = result.cause?.let { it.message ?: it::class.qualifiedName }
+                        val body =
+                            buildString {
+                                append(result.reason)
+                                if (causeMessage != null) append("\nCause: ").append(causeMessage)
+                            }
+                        append(xmlText(body))
+                        appendLine("</failure>")
+                        appendLine("  </testcase>")
+                    }
+                }
+            }
+            appendLine("</testsuite>")
+        }
+    file.writeText(xml)
+    println("JUnit XML report written to ${file.absolutePath}")
+}
+
+private fun xmlAttr(value: String): String =
+    value
+        .replace("&", "&amp;")
+        .replace("\"", "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+
+private fun xmlText(value: String): String =
+    value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+
+private const val DEFAULT_PORT = 13129
+
+fun main(args: Array<String>) = E2eCommand().main(args)

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/BonjourAdvertiser.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/BonjourAdvertiser.kt
@@ -1,0 +1,130 @@
+package com.crosspaste.e2e.peer
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.dto.sync.EndpointInfo
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.net.AbstractNetworkInterfaceService
+import com.crosspaste.platform.Platform
+import com.crosspaste.utils.TxtRecordUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import java.util.Collections
+import javax.jmdns.JmDNS
+import javax.jmdns.ServiceInfo
+
+/**
+ * Advertises this peer as a CrossPaste device via mDNS so the target's nearbyDeviceManager
+ * sees it. Without this, target's `/sync/trust` succeeds but never writes SyncRuntimeInfo
+ * (because trustSyncInfo() only registers peers it has discovered), and subsequent
+ * `/sync/paste` calls fail with NOT_FOUND_APP_INSTANCE_ID.
+ *
+ * The peer does not run a real server — the advertised port is a placeholder. Target may
+ * fail to reach back for heartbeat, but the SyncHandler stays registered, which is all
+ * push scenarios need.
+ */
+class BonjourAdvertiser(
+    private val appInfo: AppInfo,
+    private val advertisedPort: Int = ADVERTISED_PORT,
+) {
+
+    companion object {
+        const val SERVICE_TYPE: String = "_crosspasteService._tcp.local."
+
+        // No real server is bound; this is a marker port baked into the announcement.
+        const val ADVERTISED_PORT: Int = 13139
+    }
+
+    private val logger = KotlinLogging.logger {}
+
+    private val instances: MutableList<JmDNS> = mutableListOf()
+
+    fun start() {
+        val addresses = enumerateLanInet4Addresses()
+        if (addresses.isEmpty()) {
+            logger.warn { "No usable LAN IPv4 addresses; mDNS advertising skipped." }
+            return
+        }
+        addresses.forEach { (addr, prefix) ->
+            runCatching {
+                val jm = JmDNS.create(addr)
+                val hostInfo =
+                    HostInfo(
+                        networkPrefixLength = prefix,
+                        hostAddress = addr.hostAddress,
+                    )
+                val syncInfo =
+                    SyncInfo(
+                        appInfo = appInfo,
+                        endpointInfo =
+                            EndpointInfo(
+                                deviceId = appInfo.appInstanceId,
+                                deviceName = appInfo.userName,
+                                platform =
+                                    Platform(
+                                        name = Platform.UNKNOWN_OS,
+                                        arch = "x64",
+                                        bitMode = 64,
+                                        version = appInfo.appVersion,
+                                    ),
+                                hostInfoList = listOf(hostInfo),
+                                port = advertisedPort,
+                            ),
+                    )
+                val txt = TxtRecordUtils.encodeToTxtRecordDict(syncInfo)
+                val info =
+                    ServiceInfo.create(
+                        SERVICE_TYPE,
+                        "crosspaste@${appInfo.appInstanceId}@${addr.hostAddress.replace(".", "_")}",
+                        advertisedPort,
+                        0,
+                        0,
+                        txt,
+                    )
+                jm.registerService(info)
+                instances.add(jm)
+                logger.info { "Advertised mDNS service on ${addr.hostAddress}" }
+            }.onFailure { e ->
+                logger.warn(e) { "Failed to register mDNS on ${addr.hostAddress}" }
+            }
+        }
+    }
+
+    fun close() {
+        instances.forEach { jm ->
+            runCatching {
+                jm.unregisterAllServices()
+                jm.close()
+            }.onFailure { e ->
+                logger.debug(e) { "Error closing JmDNS instance" }
+            }
+        }
+        instances.clear()
+    }
+
+    private fun enumerateLanInet4Addresses(): List<Pair<Inet4Address, Short>> {
+        val nics =
+            runCatching { Collections.list(NetworkInterface.getNetworkInterfaces()) }
+                .getOrElse {
+                    logger.warn(it) { "Failed to enumerate network interfaces." }
+                    emptyList()
+                }
+        return nics
+            .asSequence()
+            .filter { nic ->
+                runCatching { nic.isUp && !nic.isLoopback && !nic.isVirtual }.getOrDefault(false)
+            }.filterNot { nic ->
+                AbstractNetworkInterfaceService.isLikelyVirtual(
+                    nic.name,
+                    AbstractNetworkInterfaceService.getMacAddress(nic),
+                )
+            }.flatMap { it.interfaceAddresses.asSequence() }
+            .mapNotNull { ifAddr ->
+                val addr = ifAddr.address
+                if (addr is Inet4Address) addr to ifAddr.networkPrefixLength else null
+            }.filterNot { (addr, _) ->
+                addr.isLoopbackAddress || addr.isLinkLocalAddress || addr.isAnyLocalAddress
+            }.toList()
+    }
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/E2eAppConfig.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/E2eAppConfig.kt
@@ -1,0 +1,85 @@
+package com.crosspaste.e2e.peer
+
+import com.crosspaste.config.AppConfig
+import com.crosspaste.config.AppConfig.Companion.toBoolean
+import com.crosspaste.config.CommonConfigManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Minimal [AppConfig] for the headless peer. All sync-content flags default to true and
+ * encrypted sync is on so we exercise the production-equivalent paths.
+ */
+data class E2eAppConfig(
+    override val language: String = "en",
+    override val font: String = "",
+    override val isFollowSystemTheme: Boolean = true,
+    override val isDarkTheme: Boolean = false,
+    override val port: Int = 0,
+    override val enableEncryptSync: Boolean = true,
+    override val enableExpirationCleanup: Boolean = false,
+    override val imageCleanTimeIndex: Int = 6,
+    override val fileCleanTimeIndex: Int = 6,
+    override val enableThresholdCleanup: Boolean = false,
+    override val maxStorage: Long = 2048,
+    override val cleanupPercentage: Int = 20,
+    override val enableDiscovery: Boolean = true,
+    override val blacklist: String = "[]",
+    override val enableSkipPreLaunchPasteboardContent: Boolean = true,
+    override val lastPasteboardChangeCount: Int = -1,
+    override val enablePasteboardListening: Boolean = false,
+    override val maxBackupFileSize: Long = 32,
+    override val enabledSyncFileSizeLimit: Boolean = true,
+    override val maxSyncFileSize: Long = 512,
+    override val useDefaultStoragePath: Boolean = true,
+    override val storagePath: String = "",
+    override val enableSoundEffect: Boolean = false,
+    override val pastePrimaryTypeOnly: Boolean = true,
+    override val useNetworkInterfaces: String = "[]",
+    override val enableSyncText: Boolean = true,
+    override val enableSyncUrl: Boolean = true,
+    override val enableSyncHtml: Boolean = true,
+    override val enableSyncRtf: Boolean = true,
+    override val enableSyncImage: Boolean = true,
+    override val enableSyncFile: Boolean = true,
+    override val enableSyncColor: Boolean = true,
+    override val enableRemoteShowPairingCode: Boolean = true,
+) : AppConfig {
+    override fun copy(
+        key: String,
+        value: Any,
+    ): E2eAppConfig =
+        when (key) {
+            "enableEncryptSync" -> copy(enableEncryptSync = toBoolean(value))
+            "enableRemoteShowPairingCode" -> copy(enableRemoteShowPairingCode = toBoolean(value))
+            else -> this
+        }
+}
+
+class E2eConfigManager(
+    initial: E2eAppConfig = E2eAppConfig(),
+) : CommonConfigManager {
+    private val _config = MutableStateFlow<AppConfig>(initial)
+
+    override val config: StateFlow<AppConfig> = _config
+
+    override fun loadConfig(): AppConfig = _config.value
+
+    override fun updateConfig(
+        key: String,
+        value: Any,
+    ) {
+        _config.value = _config.value.copy(key, value)
+    }
+
+    override fun updateConfig(
+        keys: List<String>,
+        values: List<Any>,
+    ) {
+        var current = _config.value
+        for (i in keys.indices) {
+            current = current.copy(keys[i], values[i])
+        }
+        _config.value = current
+    }
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
@@ -73,7 +73,10 @@ class HeadlessPeer(
 
     val pullClientApi: PullClientApi = PullClientApi(pasteClient, configManager)
 
+    val bonjourAdvertiser: BonjourAdvertiser = BonjourAdvertiser(appInfo).also { it.start() }
+
     fun close() {
+        bonjourAdvertiser.close()
         pasteClient.close()
     }
 }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
@@ -1,0 +1,79 @@
+package com.crosspaste.e2e.peer
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.net.PasteClient
+import com.crosspaste.net.SyncApi
+import com.crosspaste.net.clientapi.PasteClientApi
+import com.crosspaste.net.clientapi.PullClientApi
+import com.crosspaste.net.clientapi.SyncClientApi
+import com.crosspaste.net.exception.DesktopExceptionHandler
+import com.crosspaste.net.exception.ExceptionHandler
+import com.crosspaste.net.plugin.ClientDecryptPlugin
+import com.crosspaste.net.plugin.ClientEncryptPlugin
+import com.crosspaste.secure.GeneralSecureStore
+import com.crosspaste.secure.SecureKeyPair
+import com.crosspaste.secure.SecureKeyPairSerializer
+import com.crosspaste.secure.SecureStore
+import com.crosspaste.utils.CryptographyUtils.generateSecureKeyPair
+import com.crosspaste.utils.getJsonUtils
+import kotlinx.coroutines.runBlocking
+import java.util.UUID
+
+class HeadlessPeer(
+    appInstanceId: String = UUID.randomUUID().toString(),
+    userName: String = "e2e-peer",
+    appVersion: String = "0.0.0-e2e",
+    appRevision: String = "Unknown",
+) {
+    // Force JsonUtils to fully initialize before anything else touches PasteItem
+    // serializer registration. See MEMORY.md "PasteItem / JsonUtils Circular Class
+    // Initialization".
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    val appInfo: AppInfo =
+        AppInfo(
+            appInstanceId = appInstanceId,
+            appVersion = appVersion,
+            appRevision = appRevision,
+            userName = userName,
+        )
+
+    val secureKeyPairSerializer: SecureKeyPairSerializer = SecureKeyPairSerializer()
+
+    val secureKeyPair: SecureKeyPair = runBlocking { generateSecureKeyPair() }
+
+    val secureIO: InMemorySecureIO = InMemorySecureIO()
+
+    val secureStore: SecureStore =
+        GeneralSecureStore(secureKeyPair, secureKeyPairSerializer, secureIO)
+
+    val exceptionHandler: ExceptionHandler = DesktopExceptionHandler()
+
+    val syncApi: SyncApi = SyncApi
+
+    private val clientEncryptPlugin = ClientEncryptPlugin(secureStore)
+    private val clientDecryptPlugin = ClientDecryptPlugin(secureStore)
+
+    val pasteClient: PasteClient = PasteClient(appInfo, clientEncryptPlugin, clientDecryptPlugin)
+
+    val configManager: CommonConfigManager = E2eConfigManager()
+
+    val syncClientApi: SyncClientApi =
+        SyncClientApi(
+            pasteClient,
+            exceptionHandler,
+            secureKeyPairSerializer,
+            secureStore,
+            syncApi,
+        )
+
+    val pasteClientApi: PasteClientApi = PasteClientApi(pasteClient, configManager)
+
+    val pullClientApi: PullClientApi = PullClientApi(pasteClient, configManager)
+
+    fun close() {
+        pasteClient.close()
+    }
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/InMemorySecureIO.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/InMemorySecureIO.kt
@@ -1,0 +1,25 @@
+package com.crosspaste.e2e.peer
+
+import com.crosspaste.db.secure.SecureIO
+import io.ktor.util.collections.ConcurrentMap
+
+class InMemorySecureIO : SecureIO {
+
+    private val cryptPublicKeyMap = ConcurrentMap<String, ByteArray>()
+
+    override suspend fun saveCryptPublicKey(
+        appInstanceId: String,
+        serialized: ByteArray,
+    ) {
+        cryptPublicKeyMap[appInstanceId] = serialized
+    }
+
+    override suspend fun existCryptPublicKey(appInstanceId: String): Boolean =
+        cryptPublicKeyMap.containsKey(appInstanceId)
+
+    override suspend fun deleteCryptPublicKey(appInstanceId: String) {
+        cryptPublicKeyMap.remove(appInstanceId)
+    }
+
+    override suspend fun serializedPublicKey(appInstanceId: String): ByteArray? = cryptPublicKeyMap[appInstanceId]
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
@@ -1,0 +1,95 @@
+package com.crosspaste.e2e.protocol
+
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.utils.TxtRecordUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.util.collections.ConcurrentMap
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import javax.jmdns.JmDNS
+import javax.jmdns.ServiceEvent
+import javax.jmdns.ServiceListener
+import javax.jmdns.impl.util.ByteWrangler
+
+class DiscoveryDriver {
+
+    companion object {
+        const val SERVICE_TYPE: String = "_crosspasteService._tcp.local."
+    }
+
+    private val logger = KotlinLogging.logger {}
+
+    private val jmdns: JmDNS = JmDNS.create()
+
+    private val resolved: ConcurrentMap<String, SyncInfo> = ConcurrentMap()
+
+    private val events: Channel<SyncInfo> = Channel(Channel.UNLIMITED)
+
+    val syncInfoFlow: Flow<SyncInfo> = events.consumeAsFlow()
+
+    private val listener =
+        object : ServiceListener {
+            override fun serviceAdded(event: ServiceEvent) {
+                jmdns.requestServiceInfo(SERVICE_TYPE, event.info.name)
+            }
+
+            override fun serviceRemoved(event: ServiceEvent) {
+                val parts = event.info.name.split("@")
+                if (parts.size == 3 && parts[0] == "crosspaste") {
+                    resolved.remove(parts[1])
+                }
+            }
+
+            override fun serviceResolved(event: ServiceEvent) {
+                val textBytes = event.info.textBytes ?: return
+                if (textBytes.isEmpty()) return
+                runCatching {
+                    val raw: Map<String, ByteArray> = mutableMapOf()
+                    ByteWrangler.readProperties(raw, textBytes)
+                    val syncInfo = TxtRecordUtils.decodeFromTxtRecordDict<SyncInfo>(raw)
+                    resolved[syncInfo.appInfo.appInstanceId] = syncInfo
+                    events.trySend(syncInfo)
+                }.onFailure { e ->
+                    logger.debug(e) { "Failed to decode resolved service: ${event.info.name}" }
+                }
+            }
+        }
+
+    fun start() {
+        jmdns.addServiceListener(SERVICE_TYPE, listener)
+    }
+
+    /**
+     * Block until [timeoutMs] elapses, returning all distinct SyncInfo records resolved
+     * during that window. Optionally filter to a specific appInstanceId — return as soon
+     * as that one is found instead of waiting for the full timeout.
+     */
+    suspend fun browse(
+        timeoutMs: Long,
+        targetAppInstanceId: String? = null,
+        pollIntervalMs: Long = 200,
+    ): List<SyncInfo> {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (targetAppInstanceId != null && resolved.containsKey(targetAppInstanceId)) {
+                break
+            }
+            delay(pollIntervalMs)
+        }
+        return resolved.values.toList()
+    }
+
+    fun snapshot(): Map<String, SyncInfo> = resolved.toMap()
+
+    fun close() {
+        runCatching {
+            jmdns.removeServiceListener(SERVICE_TYPE, listener)
+            jmdns.close()
+            events.close()
+        }.onFailure { e ->
+            logger.debug(e) { "Error closing DiscoveryDriver" }
+        }
+    }
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.e2e.protocol
 
 import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.net.AbstractNetworkInterfaceService
 import com.crosspaste.utils.TxtRecordUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.ConcurrentMap
@@ -8,6 +9,10 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.NetworkInterface
+import java.util.Collections
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceEvent
 import javax.jmdns.ServiceListener
@@ -17,11 +22,12 @@ class DiscoveryDriver {
 
     companion object {
         const val SERVICE_TYPE: String = "_crosspasteService._tcp.local."
+        private const val ACTIVE_SCAN_TIMEOUT_MS = 1500L
     }
 
     private val logger = KotlinLogging.logger {}
 
-    private val jmdns: JmDNS = JmDNS.create()
+    private val jmdnsInstances: List<JmDNS> = createJmdnsInstances()
 
     private val resolved: ConcurrentMap<String, SyncInfo> = ConcurrentMap()
 
@@ -32,7 +38,7 @@ class DiscoveryDriver {
     private val listener =
         object : ServiceListener {
             override fun serviceAdded(event: ServiceEvent) {
-                jmdns.requestServiceInfo(SERVICE_TYPE, event.info.name)
+                event.dns.requestServiceInfo(SERVICE_TYPE, event.info.name)
             }
 
             override fun serviceRemoved(event: ServiceEvent) {
@@ -58,7 +64,19 @@ class DiscoveryDriver {
         }
 
     fun start() {
-        jmdns.addServiceListener(SERVICE_TYPE, listener)
+        jmdnsInstances.forEach { jm ->
+            jm.addServiceListener(SERVICE_TYPE, listener)
+            // JmDNS.list() blocks; run per interface on a daemon thread so the active PTR
+            // query fires alongside the passive listener instead of waiting for peer announces.
+            Thread {
+                runCatching { jm.list(SERVICE_TYPE, ACTIVE_SCAN_TIMEOUT_MS) }
+                    .onFailure { e -> logger.debug(e) { "Active scan failed" } }
+            }.apply {
+                name = "DiscoveryDriver-active-scan"
+                isDaemon = true
+                start()
+            }
+        }
     }
 
     /**
@@ -85,11 +103,51 @@ class DiscoveryDriver {
 
     fun close() {
         runCatching {
-            jmdns.removeServiceListener(SERVICE_TYPE, listener)
-            jmdns.close()
+            jmdnsInstances.forEach { jm ->
+                jm.removeServiceListener(SERVICE_TYPE, listener)
+                jm.close()
+            }
             events.close()
         }.onFailure { e ->
             logger.debug(e) { "Error closing DiscoveryDriver" }
         }
+    }
+
+    private fun createJmdnsInstances(): List<JmDNS> {
+        val addresses = enumerateLanInet4Addresses()
+        if (addresses.isEmpty()) {
+            logger.warn { "No usable LAN IPv4 interfaces found; falling back to default JmDNS." }
+            return listOf(JmDNS.create())
+        }
+        val instances =
+            addresses.mapNotNull { addr ->
+                runCatching { JmDNS.create(addr) }
+                    .onSuccess { logger.info { "JmDNS bound to ${addr.hostAddress}" } }
+                    .onFailure { e -> logger.warn(e) { "Failed to bind JmDNS to ${addr.hostAddress}" } }
+                    .getOrNull()
+            }
+        return instances.ifEmpty { listOf(JmDNS.create()) }
+    }
+
+    private fun enumerateLanInet4Addresses(): List<InetAddress> {
+        val nics =
+            runCatching { Collections.list(NetworkInterface.getNetworkInterfaces()) }
+                .getOrElse {
+                    logger.warn(it) { "Failed to enumerate network interfaces." }
+                    emptyList()
+                }
+        return nics
+            .asSequence()
+            .filter { nic ->
+                runCatching { nic.isUp && !nic.isLoopback && !nic.isVirtual }.getOrDefault(false)
+            }.filterNot { nic ->
+                AbstractNetworkInterfaceService.isLikelyVirtual(
+                    nic.name,
+                    AbstractNetworkInterfaceService.getMacAddress(nic),
+                )
+            }.flatMap { it.inetAddresses.asSequence() }
+            .filterIsInstance<Inet4Address>()
+            .filterNot { it.isLoopbackAddress || it.isLinkLocalAddress || it.isAnyLocalAddress }
+            .toList()
     }
 }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/DiscoveryScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/DiscoveryScenario.kt
@@ -1,0 +1,34 @@
+package com.crosspaste.e2e.scenario
+
+import com.crosspaste.e2e.protocol.DiscoveryDriver
+
+class DiscoveryScenario : Scenario {
+    override val name: String = "discovery"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val driver = DiscoveryDriver()
+        try {
+            driver.start()
+            val found = driver.browse(ctx.discoveryTimeoutMs, ctx.targetAppInstanceId)
+            if (found.isEmpty()) {
+                return ScenarioResult.Fail(
+                    "No CrossPaste services discovered within ${ctx.discoveryTimeoutMs}ms.",
+                )
+            }
+            val expected = ctx.targetAppInstanceId
+            if (expected != null && found.none { it.appInfo.appInstanceId == expected }) {
+                val seen = found.joinToString { it.appInfo.appInstanceId }
+                return ScenarioResult.Fail(
+                    "Target appInstanceId '$expected' not seen. Discovered: [$seen]",
+                )
+            }
+            val summary =
+                found.joinToString { si ->
+                    "${si.appInfo.appInstanceId}@${si.endpointInfo.hostInfoList.firstOrNull()?.hostAddress}:${si.endpointInfo.port}"
+                }
+            return ScenarioResult.Pass("Discovered ${found.size} peer(s): $summary")
+        } finally {
+            driver.close()
+        }
+    }
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
@@ -12,8 +12,29 @@ class PairScenario : Scenario {
         val target = resolveOrDiscover(ctx) ?: return ScenarioResult.Fail("Could not resolve target.")
         val targetAppId = target.appInstanceId ?: return ScenarioResult.Fail("Target has no appInstanceId.")
         println("[pair] Target: $targetAppId at ${target.host}:${target.port}")
+        requestShowToken(ctx, target)?.let { return it }
         val token = ctx.tokenProvider()
         return performTrust(ctx, target, targetAppId, token)
+    }
+}
+
+/**
+ * Ask the target device to display its pairing token. Mirrors what the real client does
+ * before prompting the user — without this call, the target UI never shows a code and
+ * the user has nothing to type in.
+ */
+internal suspend fun requestShowToken(
+    ctx: ScenarioContext,
+    target: TargetSpec,
+): ScenarioResult? {
+    val result =
+        ctx.peer.syncClientApi.showToken(
+            toUrl = { buildUrl(HostAndPort(target.host, target.port)) },
+        )
+    return if (result is SuccessResult) {
+        null
+    } else {
+        ScenarioResult.Fail("showToken call failed: ${describeFailure(result)}")
     }
 }
 
@@ -32,7 +53,7 @@ internal suspend fun performTrust(
         )
 
     if (result !is SuccessResult) {
-        return ScenarioResult.Fail("Trust call failed: $result")
+        return ScenarioResult.Fail("Trust call failed: ${describeFailure(result)}")
     }
     if (!ctx.peer.secureIO.existCryptPublicKey(targetAppId)) {
         return ScenarioResult.Fail("Trust returned success but target's public key was not stored.")
@@ -51,6 +72,7 @@ internal suspend fun ensureTrust(
     val id = target.appInstanceId ?: return ScenarioResult.Fail("Target has no appInstanceId.")
     if (ctx.peer.secureIO.existCryptPublicKey(id)) return null
     println("[ensureTrust] Not paired with $id yet — pairing first.")
+    requestShowToken(ctx, target)?.let { return it }
     val token = ctx.tokenProvider()
     val result = performTrust(ctx, target, id, token)
     return if (result is ScenarioResult.Fail) result else null

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
@@ -1,0 +1,69 @@
+package com.crosspaste.e2e.scenario
+
+import com.crosspaste.e2e.protocol.DiscoveryDriver
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.utils.HostAndPort
+import com.crosspaste.utils.buildUrl
+
+class PairScenario : Scenario {
+    override val name: String = "pair"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val target = resolveOrDiscover(ctx) ?: return ScenarioResult.Fail("Could not resolve target.")
+        val targetAppId = target.appInstanceId ?: return ScenarioResult.Fail("Target has no appInstanceId.")
+        println("[pair] Target: $targetAppId at ${target.host}:${target.port}")
+        val token = ctx.tokenProvider()
+        return performTrust(ctx, target, targetAppId, token)
+    }
+}
+
+internal suspend fun performTrust(
+    ctx: ScenarioContext,
+    target: TargetSpec,
+    targetAppId: String,
+    token: Int,
+): ScenarioResult {
+    val result =
+        ctx.peer.syncClientApi.trust(
+            targetAppInstanceId = targetAppId,
+            host = target.host,
+            token = token,
+            toUrl = { buildUrl(HostAndPort(target.host, target.port)) },
+        )
+
+    if (result !is SuccessResult) {
+        return ScenarioResult.Fail("Trust call failed: $result")
+    }
+    if (!ctx.peer.secureIO.existCryptPublicKey(targetAppId)) {
+        return ScenarioResult.Fail("Trust returned success but target's public key was not stored.")
+    }
+    return ScenarioResult.Pass("Paired with $targetAppId; target public key persisted.")
+}
+
+/**
+ * Pair with [target] if not already trusted. Returns null on success, or a Fail to
+ * propagate. Prompts for a token via [ScenarioContext.tokenProvider] when needed.
+ */
+internal suspend fun ensureTrust(
+    ctx: ScenarioContext,
+    target: TargetSpec,
+): ScenarioResult? {
+    val id = target.appInstanceId ?: return ScenarioResult.Fail("Target has no appInstanceId.")
+    if (ctx.peer.secureIO.existCryptPublicKey(id)) return null
+    println("[ensureTrust] Not paired with $id yet — pairing first.")
+    val token = ctx.tokenProvider()
+    val result = performTrust(ctx, target, id, token)
+    return if (result is ScenarioResult.Fail) result else null
+}
+
+internal suspend fun resolveOrDiscover(ctx: ScenarioContext): TargetSpec? {
+    if (ctx.target != null) return ctx.target
+    val driver = DiscoveryDriver()
+    return try {
+        driver.start()
+        val found = driver.browse(ctx.discoveryTimeoutMs, ctx.targetAppInstanceId)
+        resolveTarget(ctx, found)
+    } finally {
+        driver.close()
+    }
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PullIconScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PullIconScenario.kt
@@ -22,7 +22,7 @@ class PullIconScenario(
             )
 
         if (result !is SuccessResult) {
-            return ScenarioResult.Fail("pullIcon failed: $result")
+            return ScenarioResult.Fail("pullIcon failed: ${describeFailure(result)}")
         }
         return ScenarioResult.Pass("Icon source='$source' fetched from ${target.host}:${target.port}.")
     }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PullIconScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PullIconScenario.kt
@@ -1,0 +1,29 @@
+package com.crosspaste.e2e.scenario
+
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.utils.HostAndPort
+import com.crosspaste.utils.buildUrl
+
+class PullIconScenario(
+    private val source: String,
+) : Scenario {
+    override val name: String = "pull-icon"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        if (source.isBlank()) {
+            return ScenarioResult.Fail("--icon-source is required for pull-icon.")
+        }
+        val target = resolveOrDiscover(ctx) ?: return ScenarioResult.Fail("Could not resolve target.")
+
+        val result =
+            ctx.peer.pullClientApi.pullIcon(
+                source = source,
+                toUrl = { buildUrl(HostAndPort(target.host, target.port)) },
+            )
+
+        if (result !is SuccessResult) {
+            return ScenarioResult.Fail("pullIcon failed: $result")
+        }
+        return ScenarioResult.Pass("Icon source='$source' fetched from ${target.host}:${target.port}.")
+    }
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PushScenarios.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PushScenarios.kt
@@ -38,7 +38,7 @@ internal suspend fun pushPasteData(
         )
 
     if (result !is SuccessResult) {
-        return ScenarioResult.Fail("sendPaste failed: $result")
+        return ScenarioResult.Fail("sendPaste failed: ${describeFailure(result)}")
     }
     return ScenarioResult.Pass(summary(targetAppId))
 }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PushScenarios.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PushScenarios.kt
@@ -1,0 +1,109 @@
+package com.crosspaste.e2e.scenario
+
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.paste.PasteCollection
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteType
+import com.crosspaste.paste.item.CreatePasteItemHelper
+import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.utils.HostAndPort
+import com.crosspaste.utils.buildUrl
+
+internal suspend fun pushPasteData(
+    ctx: ScenarioContext,
+    pasteType: PasteType,
+    item: PasteItem,
+    summary: (String) -> String,
+): ScenarioResult {
+    val target = resolveOrDiscover(ctx) ?: return ScenarioResult.Fail("Could not resolve target.")
+    val targetAppId = target.appInstanceId ?: return ScenarioResult.Fail("Target has no appInstanceId.")
+
+    ensureTrust(ctx, target)?.let { return it }
+
+    val pasteData =
+        PasteData(
+            appInstanceId = ctx.peer.appInfo.appInstanceId,
+            pasteAppearItem = item,
+            pasteCollection = PasteCollection(emptyList()),
+            pasteType = pasteType.type,
+            size = item.size,
+            hash = item.hash,
+        )
+
+    val result =
+        ctx.peer.pasteClientApi.sendPaste(
+            pasteData = pasteData,
+            targetAppInstanceId = targetAppId,
+            toUrl = { buildUrl(HostAndPort(target.host, target.port)) },
+        )
+
+    if (result !is SuccessResult) {
+        return ScenarioResult.Fail("sendPaste failed: $result")
+    }
+    return ScenarioResult.Pass(summary(targetAppId))
+}
+
+class PushTextScenario(
+    private val text: String,
+) : Scenario {
+    override val name: String = "push-text"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val item = CreatePasteItemHelper.createTextPasteItem(text = text)
+        return pushPasteData(ctx, PasteType.TEXT_TYPE, item) { id ->
+            "Pushed text (${item.size} bytes) to $id."
+        }
+    }
+}
+
+class PushUrlScenario(
+    private val url: String,
+) : Scenario {
+    override val name: String = "push-url"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val item = CreatePasteItemHelper.createUrlPasteItem(url = url)
+        return pushPasteData(ctx, PasteType.URL_TYPE, item) { id ->
+            "Pushed url ($url) to $id."
+        }
+    }
+}
+
+class PushHtmlScenario(
+    private val html: String,
+) : Scenario {
+    override val name: String = "push-html"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val item = CreatePasteItemHelper.createHtmlPasteItem(html = html)
+        return pushPasteData(ctx, PasteType.HTML_TYPE, item) { id ->
+            "Pushed html (${item.size} bytes) to $id."
+        }
+    }
+}
+
+class PushRtfScenario(
+    private val rtf: String,
+) : Scenario {
+    override val name: String = "push-rtf"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val item = CreatePasteItemHelper.createRtfPasteItem(rtf = rtf)
+        return pushPasteData(ctx, PasteType.RTF_TYPE, item) { id ->
+            "Pushed rtf (${item.size} bytes) to $id."
+        }
+    }
+}
+
+class PushColorScenario(
+    private val color: Int,
+) : Scenario {
+    override val name: String = "push-color"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val item = CreatePasteItemHelper.createColorPasteItem(color = color)
+        return pushPasteData(ctx, PasteType.COLOR_TYPE, item) { id ->
+            "Pushed color (0x${color.toUInt().toString(16).padStart(8, '0')}) to $id."
+        }
+    }
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
@@ -1,0 +1,60 @@
+package com.crosspaste.e2e.scenario
+
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.e2e.peer.HeadlessPeer
+
+sealed class ScenarioResult {
+    data class Pass(
+        val message: String = "",
+    ) : ScenarioResult()
+
+    data class Fail(
+        val reason: String,
+        val cause: Throwable? = null,
+    ) : ScenarioResult()
+}
+
+interface Scenario {
+    val name: String
+
+    suspend fun run(ctx: ScenarioContext): ScenarioResult
+}
+
+data class TargetSpec(
+    val host: String,
+    val port: Int,
+    val appInstanceId: String?,
+)
+
+data class ScenarioContext(
+    val peer: HeadlessPeer,
+    val target: TargetSpec?,
+    val targetAppInstanceId: String?,
+    val discoveryTimeoutMs: Long,
+    val tokenProvider: suspend () -> Int,
+)
+
+/**
+ * Resolve a target connection from either an explicit [ScenarioContext.target] or by
+ * walking [discovered] for a matching appInstanceId. Returns null if no match.
+ */
+fun resolveTarget(
+    ctx: ScenarioContext,
+    discovered: List<SyncInfo>,
+): TargetSpec? {
+    ctx.target?.let { return it }
+    val match =
+        when (val id = ctx.targetAppInstanceId) {
+            null -> discovered.firstOrNull()
+            else -> discovered.firstOrNull { it.appInfo.appInstanceId == id }
+        } ?: return null
+    val host =
+        match.endpointInfo.hostInfoList
+            .firstOrNull()
+            ?.hostAddress ?: return null
+    return TargetSpec(
+        host = host,
+        port = match.endpointInfo.port,
+        appInstanceId = match.appInfo.appInstanceId,
+    )
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
@@ -2,6 +2,13 @@ package com.crosspaste.e2e.scenario
 
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.e2e.peer.HeadlessPeer
+import com.crosspaste.net.clientapi.ClientApiResult
+import com.crosspaste.net.clientapi.ConnectionRefused
+import com.crosspaste.net.clientapi.DecryptFail
+import com.crosspaste.net.clientapi.EncryptFail
+import com.crosspaste.net.clientapi.FailureResult
+import com.crosspaste.net.clientapi.RequestTimeout
+import com.crosspaste.net.clientapi.UnknownError
 
 sealed class ScenarioResult {
     data class Pass(
@@ -58,3 +65,17 @@ fun resolveTarget(
         appInstanceId = match.appInfo.appInstanceId,
     )
 }
+
+fun describeFailure(result: ClientApiResult): String =
+    when (result) {
+        is FailureResult ->
+            "FailureResult(code=${result.exception.getErrorCode().code}, " +
+                "name=${result.exception.getErrorCode().name}, " +
+                "message='${result.exception.message ?: ""}')"
+        is ConnectionRefused -> "ConnectionRefused"
+        is EncryptFail -> "EncryptFail"
+        is DecryptFail -> "DecryptFail"
+        is RequestTimeout -> "RequestTimeout"
+        is UnknownError -> "UnknownError"
+        else -> result::class.simpleName ?: result.toString()
+    }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/WrongTokenScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/WrongTokenScenario.kt
@@ -1,0 +1,34 @@
+package com.crosspaste.e2e.scenario
+
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.utils.HostAndPort
+import com.crosspaste.utils.buildUrl
+
+class WrongTokenScenario : Scenario {
+    override val name: String = "wrong-token"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val target = resolveOrDiscover(ctx) ?: return ScenarioResult.Fail("Could not resolve target.")
+        val targetAppId = target.appInstanceId ?: return ScenarioResult.Fail("Target has no appInstanceId.")
+
+        val result =
+            ctx.peer.syncClientApi.trust(
+                targetAppInstanceId = targetAppId,
+                host = target.host,
+                token = WRONG_TOKEN,
+                toUrl = { buildUrl(HostAndPort(target.host, target.port)) },
+            )
+
+        if (result is SuccessResult) {
+            return ScenarioResult.Fail("Trust unexpectedly succeeded with wrong token $WRONG_TOKEN.")
+        }
+        if (ctx.peer.secureIO.existCryptPublicKey(targetAppId)) {
+            return ScenarioResult.Fail("Target public key was stored despite trust failure.")
+        }
+        return ScenarioResult.Pass("Wrong token rejected; no key stored.")
+    }
+
+    companion object {
+        const val WRONG_TOKEN: Int = 999999
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 include(":app")
 include(":cli")
 include(":core")
+include(":e2e")
 include(":shared")
 include(":shared-ui")
 include(":web")


### PR DESCRIPTION
## Summary

Adds a new `:e2e` Gradle subproject — a headless CrossPaste peer that speaks the real protocol (mDNS, HTTPS, encrypted envelope, trust v1) against a running CrossPaste app. Intended as a pre-release sanity check across Mac/Win/Linux from a single driver host.

CLI:
```
./gradlew :e2e:run --args="--scenario all --target-app-id <appInstanceId>"
```

Scenarios shipped:
- `discovery`, `pair`, `wrong-token`
- `push-text`, `push-url`, `push-html`, `push-rtf`, `push-color`
- `pull-icon`
- `all` runs them in dependency order (`discovery → wrong-token → pair → push-*`)

Optional `--junit-xml <path>` writes a JUnit XML report for CI consumption.

### Design notes

- **Client-side only** — no peer-side server yet. Reverse push (app → peer) and WS sync are deferred so we don't have to stub `AppControl`/`CacheManager`/`PasteDao`/`WsMessageHandler`/`WsSessionManager`.
- **Depends on `:app` directly** — accepts Compose/Skiko/JNA as transitive dead weight. Extracting a `:protocol` module is a separate refactor.
- **`enableEncryptSync = true`** — unlike `TestAppConfig`, the harness exercises the production encrypted path.
- **In-memory `secureStore`** — fresh state every run; pairing happens each invocation. `ensureTrust` auto-pairs before push/pull scenarios.
- **Bonjour browse-only** — peer doesn't advertise itself; reverse discovery needs a peer-side server (Phase 3).
- **`wrong-token` runs before `pair` in `all`** — once trusted, the wrong-token path no longer tests the untrusted-attacker codepath.

### Phase 3 still pending

- WebSocket sync (`/ws/sync`) — needs `WsMessageHandler`/`WsSessionManager` stubs
- Peer-side Ktor server for app → peer reverse push
- File/image push variants (need real files + `FileInfoTree`)

## Test plan

- [ ] `./gradlew :e2e:compileKotlinDesktop` — compiles cleanly
- [ ] `./gradlew ktlintCheck` — passes
- [ ] Run a real app instance, then `./gradlew :e2e:run --args="--scenario discovery"` — finds the instance via mDNS
- [ ] `--scenario pair` — completes pairing (interactive token entry)
- [ ] `--scenario wrong-token` — fails as expected without leaving trust state
- [ ] `--scenario all --target-app-id <id>` — full suite passes against a real running app
- [ ] `--junit-xml /tmp/e2e.xml` — emits a valid JUnit report