### PR TITLE
:sparkles: make device info values selectable for copy

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/InfoItem.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/InfoItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,13 +33,15 @@ fun InfoItem(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             fontWeight = FontWeight.Medium,
         )
-        Text(
-            modifier = Modifier.weight(1f),
-            text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.Normal,
-            textAlign = TextAlign.End,
-        )
+        SelectionContainer(modifier = Modifier.weight(1f)) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Normal,
+                textAlign = TextAlign.End,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }


### PR DESCRIPTION
Closes #4319

## Summary

Wraps the value `Text` inside the shared `InfoItem` composable with `SelectionContainer`, enabling platform-native text selection + copy:

- **Desktop**: drag-select + Cmd/Ctrl+C, plus right-click "Copy" context menu
- **Android**: long-press to select, system Copy menu
- **iOS**: native selection bubble

Because the change lives in `InfoItem`, all three call sites pick it up with no caller modifications:

- `CurrentDeviceDialog` — current device base info
- `NearbyDeviceInfoSection` — discovered/nearby device base info
- `DeviceInfoSection` — paired device base info

The label text remains non-selectable — copying i18n labels has no use case.

## Why selection over click-to-copy

A click-to-copy variant was prototyped first and rejected:
- Rectangular click ripple looked out of place inside the rounded info cards
- Whole-row click target was over-eager (easy to misfire while reading)
- Couldn't copy partial values (e.g. just the IP without the port)

Native text selection is the right primitive here — it's how every settings UI on macOS/Windows/Linux behaves, and it works identically on mobile via Compose Multiplatform.

## Test plan

- [ ] `./gradlew :app:compileKotlinDesktop` passes
- [ ] `./gradlew ktlintCheck` passes
- [ ] In-app: open the **Current Device** dialog → drag-select any value (e.g. `device_id`, `port`) → Cmd+C → paste elsewhere shows the value
- [ ] Right-click on a selected value shows the desktop "Copy" context menu
- [ ] Repeat on a **Nearby Device** card (discovered, unpaired) and on a **Paired Device** base info card
- [ ] Label text (e.g. "Device Name", "Port") cannot be selected