### PR TITLE
:hammer: harden appInstanceId loadOrCreate and surface OneFilePersist write failures

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
@@ -16,17 +16,19 @@ fun migrateAppInstanceIdIfNeeded(
     legacyConfigPersist: OneFilePersist,
 ) {
     if (runCatching { metadataPersist.read(AppMetadata::class) }.getOrNull() != null) return
-    runCatching {
-        legacyConfigPersist
-            .read(LegacyAppInstanceIdHolder::class)
-            ?.appInstanceId
-            ?.takeIf { it.isNotBlank() }
-            ?.let { metadataPersist.save(AppMetadata(it)) }
-    }.onFailure {
-        logger.error(it) {
-            "Failed to migrate appInstanceId from legacy config; " +
-                "a new appInstanceId will be generated and this device " +
-                "will appear as a new peer to previously paired devices"
-        }
-    }
+    val legacyId =
+        runCatching {
+            legacyConfigPersist
+                .read(LegacyAppInstanceIdHolder::class)
+                ?.appInstanceId
+                ?.takeIf { it.isNotBlank() }
+        }.onFailure {
+            logger.error(it) {
+                "Failed to read legacy appInstanceId; " +
+                    "a new appInstanceId will be generated and this device " +
+                    "will appear as a new peer to previously paired devices"
+            }
+        }.getOrNull() ?: return
+
+    metadataPersist.save(AppMetadata(legacyId))
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadataRepository.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadataRepository.kt
@@ -10,6 +10,6 @@ class AppMetadataRepository(
     val appInstanceId: String by lazy { loadOrCreate().appInstanceId }
 
     private fun loadOrCreate(): AppMetadata =
-        persist.read(AppMetadata::class)
+        runCatching { persist.read(AppMetadata::class) }.getOrNull()
             ?: AppMetadata(deviceUtils.createAppInstanceId()).also { persist.save(it) }
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/OneFilePersist.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/OneFilePersist.kt
@@ -34,6 +34,7 @@ class OneFilePersist(
             null
         }
 
+    /** @throws okio.IOException if the filesystem write fails (disk full, permission denied, etc.) */
     @OptIn(InternalSerializationApi::class)
     fun <T : Any> save(config: T) {
         val serializer: KSerializer<T> = config::class.serializer() as KSerializer<T>
@@ -41,14 +42,12 @@ class OneFilePersist(
         writeWithParentDirs { writeUtf8(jsonString) }
     }
 
+    /** @throws okio.IOException if the filesystem write fails (disk full, permission denied, etc.) */
     fun saveBytes(bytes: ByteArray) {
         writeWithParentDirs { write(bytes) }
     }
 
-    fun createEmptyFile() {
-        writeWithParentDirs { }
-    }
-
+    /** @throws okio.IOException if deletion fails (e.g. permission denied). */
     fun delete(): Boolean =
         if (fileSystem.exists(path)) {
             fileSystem.delete(path)


### PR DESCRIPTION
Closes #4321

## Changes

- `AppMetadataRepository.loadOrCreate`: wrap `read` in `runCatching` so a
  corrupt `.metadata` file is treated as missing and a fresh metadata is
  generated and written, mirroring the migration hardening from #4317.
- `migrateAppInstanceIdIfNeeded`: scope `runCatching` to cover only the
  legacy `read`. Save IOExceptions now propagate to startup instead of being
  silently logged, preventing silent appInstanceId churn when disk writes
  fail.
- `OneFilePersist`: document that `save` / `saveBytes` / `delete` can throw
  `okio.IOException`, and remove the unused `createEmptyFile` helper.