### PR TITLE
:hammer: e2e harness review follow-ups

### DIFF
--- a/e2e/build.gradle.kts
+++ b/e2e/build.gradle.kts
@@ -1,16 +1,13 @@
-import java.io.FileReader
 import java.util.Properties
 
 val versionProperties = Properties()
-versionProperties.load(
-    FileReader(
-        project.projectDir
-            .toPath()
-            .parent
-            .resolve("app/src/desktopMain/resources/crosspaste-version.properties")
-            .toFile(),
-    ),
-)
+project.projectDir
+    .toPath()
+    .parent
+    .resolve("app/src/desktopMain/resources/crosspaste-version.properties")
+    .toFile()
+    .reader()
+    .use { versionProperties.load(it) }
 
 group = "com.crosspaste"
 version = versionProperties.getProperty("version")

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
@@ -193,7 +193,8 @@ private fun parseColor(raw: String): Int {
             trimmed.startsWith("#") -> trimmed.substring(1) to 16
             else -> trimmed to 10
         }
-    return text.toUInt(radix).toInt()
+    val value = text.toUInt(radix)
+    return if (radix == 16 && text.length <= 6) (value or 0xFF000000u).toInt() else value.toInt()
 }
 
 private fun promptToken(): Int {

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/net/NetworkUtils.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/net/NetworkUtils.kt
@@ -1,0 +1,42 @@
+package com.crosspaste.e2e.net
+
+import com.crosspaste.net.AbstractNetworkInterfaceService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import java.util.Collections
+
+object NetworkUtils {
+
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * Enumerate usable LAN IPv4 addresses across all physical, up, non-loopback,
+     * non-virtual interfaces. Each entry pairs the address with its network prefix
+     * length (callers that only need the address can `.map { it.first }`).
+     */
+    fun enumerateLanInet4(): List<Pair<Inet4Address, Short>> {
+        val nics =
+            runCatching { Collections.list(NetworkInterface.getNetworkInterfaces()) }
+                .getOrElse {
+                    logger.warn(it) { "Failed to enumerate network interfaces." }
+                    emptyList()
+                }
+        return nics
+            .asSequence()
+            .filter { nic ->
+                runCatching { nic.isUp && !nic.isLoopback && !nic.isVirtual }.getOrDefault(false)
+            }.filterNot { nic ->
+                AbstractNetworkInterfaceService.isLikelyVirtual(
+                    nic.name,
+                    AbstractNetworkInterfaceService.getMacAddress(nic),
+                )
+            }.flatMap { it.interfaceAddresses.asSequence() }
+            .mapNotNull { ifAddr ->
+                val addr = ifAddr.address
+                if (addr is Inet4Address) addr to ifAddr.networkPrefixLength else null
+            }.filterNot { (addr, _) ->
+                addr.isLoopbackAddress || addr.isLinkLocalAddress || addr.isAnyLocalAddress
+            }.toList()
+    }
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/BonjourAdvertiser.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/BonjourAdvertiser.kt
@@ -4,13 +4,10 @@ import com.crosspaste.app.AppInfo
 import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.dto.sync.EndpointInfo
 import com.crosspaste.dto.sync.SyncInfo
-import com.crosspaste.net.AbstractNetworkInterfaceService
+import com.crosspaste.e2e.net.NetworkUtils
 import com.crosspaste.platform.Platform
 import com.crosspaste.utils.TxtRecordUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.net.Inet4Address
-import java.net.NetworkInterface
-import java.util.Collections
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceInfo
 
@@ -41,7 +38,7 @@ class BonjourAdvertiser(
     private val instances: MutableList<JmDNS> = mutableListOf()
 
     fun start() {
-        val addresses = enumerateLanInet4Addresses()
+        val addresses = NetworkUtils.enumerateLanInet4()
         if (addresses.isEmpty()) {
             logger.warn { "No usable LAN IPv4 addresses; mDNS advertising skipped." }
             return
@@ -101,30 +98,5 @@ class BonjourAdvertiser(
             }
         }
         instances.clear()
-    }
-
-    private fun enumerateLanInet4Addresses(): List<Pair<Inet4Address, Short>> {
-        val nics =
-            runCatching { Collections.list(NetworkInterface.getNetworkInterfaces()) }
-                .getOrElse {
-                    logger.warn(it) { "Failed to enumerate network interfaces." }
-                    emptyList()
-                }
-        return nics
-            .asSequence()
-            .filter { nic ->
-                runCatching { nic.isUp && !nic.isLoopback && !nic.isVirtual }.getOrDefault(false)
-            }.filterNot { nic ->
-                AbstractNetworkInterfaceService.isLikelyVirtual(
-                    nic.name,
-                    AbstractNetworkInterfaceService.getMacAddress(nic),
-                )
-            }.flatMap { it.interfaceAddresses.asSequence() }
-            .mapNotNull { ifAddr ->
-                val addr = ifAddr.address
-                if (addr is Inet4Address) addr to ifAddr.networkPrefixLength else null
-            }.filterNot { (addr, _) ->
-                addr.isLoopbackAddress || addr.isLinkLocalAddress || addr.isAnyLocalAddress
-            }.toList()
     }
 }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
@@ -1,7 +1,7 @@
 package com.crosspaste.e2e.protocol
 
 import com.crosspaste.dto.sync.SyncInfo
-import com.crosspaste.net.AbstractNetworkInterfaceService
+import com.crosspaste.e2e.net.NetworkUtils
 import com.crosspaste.utils.TxtRecordUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.ConcurrentMap
@@ -9,10 +9,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
-import java.net.Inet4Address
-import java.net.InetAddress
-import java.net.NetworkInterface
-import java.util.Collections
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceEvent
 import javax.jmdns.ServiceListener
@@ -114,7 +110,7 @@ class DiscoveryDriver {
     }
 
     private fun createJmdnsInstances(): List<JmDNS> {
-        val addresses = enumerateLanInet4Addresses()
+        val addresses = NetworkUtils.enumerateLanInet4().map { it.first }
         if (addresses.isEmpty()) {
             logger.warn { "No usable LAN IPv4 interfaces found; falling back to default JmDNS." }
             return listOf(JmDNS.create())
@@ -127,27 +123,5 @@ class DiscoveryDriver {
                     .getOrNull()
             }
         return instances.ifEmpty { listOf(JmDNS.create()) }
-    }
-
-    private fun enumerateLanInet4Addresses(): List<InetAddress> {
-        val nics =
-            runCatching { Collections.list(NetworkInterface.getNetworkInterfaces()) }
-                .getOrElse {
-                    logger.warn(it) { "Failed to enumerate network interfaces." }
-                    emptyList()
-                }
-        return nics
-            .asSequence()
-            .filter { nic ->
-                runCatching { nic.isUp && !nic.isLoopback && !nic.isVirtual }.getOrDefault(false)
-            }.filterNot { nic ->
-                AbstractNetworkInterfaceService.isLikelyVirtual(
-                    nic.name,
-                    AbstractNetworkInterfaceService.getMacAddress(nic),
-                )
-            }.flatMap { it.inetAddresses.asSequence() }
-            .filterIsInstance<Inet4Address>()
-            .filterNot { it.isLoopbackAddress || it.isLinkLocalAddress || it.isAnyLocalAddress }
-            .toList()
     }
 }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/DiscoveryScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/DiscoveryScenario.kt
@@ -22,6 +22,7 @@ class DiscoveryScenario : Scenario {
                     "Target appInstanceId '$expected' not seen. Discovered: [$seen]",
                 )
             }
+            resolveTarget(ctx, found)?.let { ctx.targetCache.resolved = it }
             val summary =
                 found.joinToString { si ->
                     "${si.appInfo.appInstanceId}@${si.endpointInfo.hostInfoList.firstOrNull()?.hostAddress}:${si.endpointInfo.port}"

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
@@ -80,11 +80,12 @@ internal suspend fun ensureTrust(
 
 internal suspend fun resolveOrDiscover(ctx: ScenarioContext): TargetSpec? {
     if (ctx.target != null) return ctx.target
+    ctx.targetCache.resolved?.let { return it }
     val driver = DiscoveryDriver()
     return try {
         driver.start()
         val found = driver.browse(ctx.discoveryTimeoutMs, ctx.targetAppInstanceId)
-        resolveTarget(ctx, found)
+        resolveTarget(ctx, found)?.also { ctx.targetCache.resolved = it }
     } finally {
         driver.close()
     }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
@@ -33,12 +33,22 @@ data class TargetSpec(
     val appInstanceId: String?,
 )
 
+/**
+ * Holds a discovered target across scenarios so the second-onwards run in a multi-scenario
+ * batch skips a redundant 1.5–10s mDNS round.
+ */
+class TargetCache {
+    @Volatile
+    var resolved: TargetSpec? = null
+}
+
 data class ScenarioContext(
     val peer: HeadlessPeer,
     val target: TargetSpec?,
     val targetAppInstanceId: String?,
     val discoveryTimeoutMs: Long,
     val tokenProvider: suspend () -> Int,
+    val targetCache: TargetCache = TargetCache(),
 )
 
 /**


### PR DESCRIPTION
Closes #4328

## Summary
Post-merge review fixes for the `:e2e` real-device test harness (#4318).

- **Bug fix — parseColor alpha channel.** `--push-color #FF0000` was parsed as `0x00FF0000` (fully transparent). When the hex input is ≤ 6 digits, default alpha to `0xFF` so CSS-style colors render opaque.
- **Refactor — DRY network interface enumeration.** `BonjourAdvertiser` and `DiscoveryDriver` had near-identical NIC enumeration / filtering logic. Extracted to `NetworkUtils.enumerateLanInet4()`; both call sites now share one filtering policy.
- **Refactor — cache discovered target across scenarios.** `--scenario all` previously ran up to eight independent mDNS rounds (one per scenario, each 1.5–10s). Added a `TargetCache` on `ScenarioContext`; `DiscoveryScenario` and `resolveOrDiscover()` write to it, so subsequent scenarios reuse the resolved `TargetSpec`. Explicit `--target` still bypasses the cache; `WrongTokenScenario` is unaffected because the cache only stores endpoint info, not trust state.
- **Hygiene — close `FileReader` in `e2e/build.gradle.kts`.** Switched to `.reader().use { }` so the reader is properly closed during Gradle configuration.

## Test plan
- [x] `./gradlew :e2e:compileKotlinDesktop` passes
- [x] `./gradlew ktlintFormat` passes
- [ ] Manual smoke: `--scenario push-color --push-color #FF0000` against a real peer renders opaque red on the target
- [ ] Manual smoke: `--scenario all` against a real peer completes discovery once (single `[DiscoveryDriver]` log block), and remaining 7 scenarios skip mDNS