### PR TITLE
:hammer: e2e DiscoveryDriver close()/browse() fixes and DateUtils alignment

### DIFF
--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
@@ -14,6 +14,7 @@ import com.crosspaste.e2e.scenario.ScenarioContext
 import com.crosspaste.e2e.scenario.ScenarioResult
 import com.crosspaste.e2e.scenario.TargetSpec
 import com.crosspaste.e2e.scenario.WrongTokenScenario
+import com.crosspaste.utils.getDateUtils
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.parameters.options.default
@@ -99,12 +100,13 @@ class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
                     tokenProvider = ::promptToken,
                 )
 
+            val now = getDateUtils().nowEpochMilliseconds()
             val payloads =
                 Payloads(
-                    text = pushText ?: "e2e-ping ${System.currentTimeMillis()}",
-                    url = pushUrl ?: "https://crosspaste.com/?e2e=${System.currentTimeMillis()}",
-                    html = pushHtml ?: "<p>e2e-ping ${System.currentTimeMillis()}</p>",
-                    rtf = pushRtf ?: "{\\rtf1 e2e-ping ${System.currentTimeMillis()}}",
+                    text = pushText ?: "e2e-ping $now",
+                    url = pushUrl ?: "https://crosspaste.com/?e2e=$now",
+                    html = pushHtml ?: "<p>e2e-ping $now</p>",
+                    rtf = pushRtf ?: "{\\rtf1 e2e-ping $now}",
                     color = pushColor?.let(::parseColor) ?: 0xFFFF0000.toInt(),
                 )
 

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
@@ -3,6 +3,7 @@ package com.crosspaste.e2e.protocol
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.e2e.net.NetworkUtils
 import com.crosspaste.utils.TxtRecordUtils
+import com.crosspaste.utils.getDateUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.ConcurrentMap
 import kotlinx.coroutines.channels.Channel
@@ -22,6 +23,8 @@ class DiscoveryDriver {
     }
 
     private val logger = KotlinLogging.logger {}
+
+    private val dateUtils = getDateUtils()
 
     private val jmdnsInstances: List<JmDNS> = createJmdnsInstances()
 
@@ -85,9 +88,12 @@ class DiscoveryDriver {
         targetAppInstanceId: String? = null,
         pollIntervalMs: Long = 200,
     ): List<SyncInfo> {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
+        val deadline = dateUtils.nowEpochMilliseconds() + timeoutMs
+        while (dateUtils.nowEpochMilliseconds() < deadline) {
             if (targetAppInstanceId != null && resolved.containsKey(targetAppInstanceId)) {
+                break
+            }
+            if (targetAppInstanceId == null && resolved.isNotEmpty()) {
                 break
             }
             delay(pollIntervalMs)
@@ -98,15 +104,16 @@ class DiscoveryDriver {
     fun snapshot(): Map<String, SyncInfo> = resolved.toMap()
 
     fun close() {
-        runCatching {
-            jmdnsInstances.forEach { jm ->
+        jmdnsInstances.forEach { jm ->
+            runCatching {
                 jm.removeServiceListener(SERVICE_TYPE, listener)
                 jm.close()
+            }.onFailure { e ->
+                logger.debug(e) { "Error closing JmDNS instance" }
             }
-            events.close()
-        }.onFailure { e ->
-            logger.debug(e) { "Error closing DiscoveryDriver" }
         }
+        runCatching { events.close() }
+            .onFailure { e -> logger.debug(e) { "Error closing events channel" } }
     }
 
     private fun createJmdnsInstances(): List<JmDNS> {


### PR DESCRIPTION
Closes #4331

## Summary
- `DiscoveryDriver.close()`: per-iteration `runCatching` so one failing JmDNS close no longer leaks the remaining instances (matches `BonjourAdvertiser.close()`); `events.close()` split into its own `runCatching`.
- `DiscoveryDriver.browse()`: early-exit when no `--target-app-id` is supplied and at least one peer has resolved, instead of always waiting the full timeout.
- Replace `System.currentTimeMillis()` with `getDateUtils().nowEpochMilliseconds()` in `DiscoveryDriver` and `cli/Main.kt`. In `Main.kt`, capture once and share across all four push payload defaults so a single e2e run is identifiable by one timestamp.

## Test plan
- [x] `./gradlew ktlintFormat -p e2e`
- [x] `./gradlew :e2e:compileKotlinDesktop`
- [ ] Manual: run `crosspaste-e2e --scenario discovery` against a live peer; confirm it returns as soon as a peer resolves rather than blocking 10s.
- [ ] Manual: run a `--scenario all` end-to-end and confirm every payload string carries the same timestamp.