### PR TITLE
:hammer: clarify DiscoveryDriver.browse contract and make TargetCache atomic

### DIFF
--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/protocol/DiscoveryDriver.kt
@@ -79,9 +79,16 @@ class DiscoveryDriver {
     }
 
     /**
-     * Block until [timeoutMs] elapses, returning all distinct SyncInfo records resolved
-     * during that window. Optionally filter to a specific appInstanceId — return as soon
-     * as that one is found instead of waiting for the full timeout.
+     * Poll until either [timeoutMs] elapses or at least one matching peer is resolved,
+     * then return a snapshot of every SyncInfo seen so far (which may include peers
+     * resolved before this call). Early-exits as soon as:
+     *   - [targetAppInstanceId] is non-null and that specific peer has been resolved, or
+     *   - [targetAppInstanceId] is null and any peer has been resolved.
+     *
+     * Because of the early exit, the returned list is not guaranteed to contain every
+     * peer reachable on the LAN — only those resolved by the time the first match arrives.
+     * Callers that need the full set should either pass a [targetAppInstanceId] or call
+     * [snapshot] after waiting out [timeoutMs] another way.
      */
     suspend fun browse(
         timeoutMs: Long,

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/DiscoveryScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/DiscoveryScenario.kt
@@ -22,7 +22,7 @@ class DiscoveryScenario : Scenario {
                     "Target appInstanceId '$expected' not seen. Discovered: [$seen]",
                 )
             }
-            resolveTarget(ctx, found)?.let { ctx.targetCache.resolved = it }
+            resolveTarget(ctx, found)?.let { ctx.targetCache.resolved.compareAndSet(null, it) }
             val summary =
                 found.joinToString { si ->
                     "${si.appInfo.appInstanceId}@${si.endpointInfo.hostInfoList.firstOrNull()?.hostAddress}:${si.endpointInfo.port}"

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
@@ -80,12 +80,14 @@ internal suspend fun ensureTrust(
 
 internal suspend fun resolveOrDiscover(ctx: ScenarioContext): TargetSpec? {
     if (ctx.target != null) return ctx.target
-    ctx.targetCache.resolved?.let { return it }
+    ctx.targetCache.resolved
+        .get()
+        ?.let { return it }
     val driver = DiscoveryDriver()
     return try {
         driver.start()
         val found = driver.browse(ctx.discoveryTimeoutMs, ctx.targetAppInstanceId)
-        resolveTarget(ctx, found)?.also { ctx.targetCache.resolved = it }
+        resolveTarget(ctx, found)?.also { ctx.targetCache.resolved.compareAndSet(null, it) }
     } finally {
         driver.close()
     }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
@@ -9,6 +9,7 @@ import com.crosspaste.net.clientapi.EncryptFail
 import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.RequestTimeout
 import com.crosspaste.net.clientapi.UnknownError
+import java.util.concurrent.atomic.AtomicReference
 
 sealed class ScenarioResult {
     data class Pass(
@@ -35,11 +36,12 @@ data class TargetSpec(
 
 /**
  * Holds a discovered target across scenarios so the second-onwards run in a multi-scenario
- * batch skips a redundant 1.5–10s mDNS round.
+ * batch skips a redundant 1.5–10s mDNS round. AtomicReference + CAS keeps the cache
+ * coherent if scenarios are ever fanned out concurrently — first writer wins, later
+ * writes are dropped instead of clobbering.
  */
 class TargetCache {
-    @Volatile
-    var resolved: TargetSpec? = null
+    val resolved: AtomicReference<TargetSpec?> = AtomicReference(null)
 }
 
 data class ScenarioContext(


### PR DESCRIPTION
Closes #4333

Two follow-ups from the #4331 / #4332 review.

## Summary

- **`DiscoveryDriver.browse()` KDoc** — rewritten to document the early-exit behavior. The previous wording promised "all distinct SyncInfo records resolved during that window", which stopped being true when the early-exit branch for `targetAppInstanceId == null` was added. Now the doc spells out that the returned list is a snapshot taken as soon as the first matching peer arrives, and is not exhaustive.
- **`TargetCache.resolved`** — switched from `@Volatile var TargetSpec?` to `AtomicReference<TargetSpec?>`. Writes use `compareAndSet(null, value)` for first-writer-wins, so the cache stays coherent even if scenarios are ever fanned out with `async` instead of the current sequential `scenarios.map { ... }`.

No behavior change for the current sequential e2e harness.

## Test plan
- [x] `./gradlew :e2e:compileKotlinDesktop` — passes
- [x] `./gradlew ktlintFormat` — clean
- [ ] Existing e2e scenarios still pass on a real LAN (single-peer path is unchanged)