### PR TITLE
:hammer: extract AbstractGlobalCopywriter to commonMain

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/i18n/AbstractGlobalCopywriter.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/i18n/AbstractGlobalCopywriter.kt
@@ -24,6 +24,8 @@ abstract class AbstractGlobalCopywriter(
 
     private val cache = LanguageCache(factory)
 
+    protected val enCopywriter by lazy { cache.getOrCreate(EN) }
+
     init {
         val initial = configManager.getCurrentConfig().language
         if (!LANGUAGE_LIST.contains(initial)) {
@@ -37,8 +39,6 @@ abstract class AbstractGlobalCopywriter(
     protected var copywriter: Copywriter by mutableStateOf(
         cache.getOrCreate(configManager.getCurrentConfig().language),
     )
-
-    protected fun copywriterFor(language: String): Copywriter = cache.getOrCreate(language)
 
     override fun language(): String = copywriter.language()
 

--- a/app/src/commonMain/kotlin/com/crosspaste/i18n/AbstractGlobalCopywriter.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/i18n/AbstractGlobalCopywriter.kt
@@ -1,0 +1,74 @@
+package com.crosspaste.i18n
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.i18n.SupportedLanguages.EN
+import com.crosspaste.i18n.SupportedLanguages.LANGUAGE_LIST
+import com.crosspaste.utils.DateTimeFormatOptions
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.datetime.LocalDateTime
+
+/**
+ * Shared base for every platform's [GlobalCopywriter]. Owns the cache, the validate-or-default
+ * language bootstrap, switch dispatch, and the trivial delegating overrides — leaving subclasses
+ * to supply only the per-platform [Copywriter] factory and any post-switch side effects.
+ */
+abstract class AbstractGlobalCopywriter(
+    private val configManager: CommonConfigManager,
+    factory: (String) -> Copywriter,
+) : GlobalCopywriter {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val cache = LanguageCache(factory)
+
+    init {
+        val initial = configManager.getCurrentConfig().language
+        if (!LANGUAGE_LIST.contains(initial)) {
+            configManager.updateConfig("language", EN)
+        }
+    }
+
+    // mutableStateOf is intentionally used here to trigger Compose recomposition when the
+    // language changes. Writes from non-Compose threads (e.g., switchLanguage()) are safe
+    // because Compose's global snapshot system handles cross-thread state mutations.
+    protected var copywriter: Copywriter by mutableStateOf(
+        cache.getOrCreate(configManager.getCurrentConfig().language),
+    )
+
+    protected fun copywriterFor(language: String): Copywriter = cache.getOrCreate(language)
+
+    override fun language(): String = copywriter.language()
+
+    override fun switchLanguage(language: String) {
+        logger.info { "Switching language to $language" }
+        copywriter = cache.getOrCreate(language)
+        configManager.updateConfig("language", language)
+        onLanguageSwitched(language)
+    }
+
+    /** Subclass hook for post-switch side effects (e.g. dispatching a sync task). */
+    protected open fun onLanguageSwitched(language: String) {}
+
+    override fun getAllLanguages(): List<Language> =
+        LANGUAGE_LIST.map {
+            val cw = cache.getOrCreate(it)
+            Language(cw.getAbridge(), cw.getText("current_language"))
+        }
+
+    override fun getText(
+        id: String,
+        vararg args: Any?,
+    ): String = copywriter.getText(id, *args)
+
+    override fun getKeys(): Set<String> = copywriter.getKeys()
+
+    override fun getDate(
+        date: LocalDateTime,
+        options: DateTimeFormatOptions,
+    ): String = copywriter.getDate(date, options)
+
+    override fun getAbridge(): String = copywriter.getAbridge()
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/i18n/I18n.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/i18n/I18n.kt
@@ -1,15 +1,11 @@
 package com.crosspaste.i18n
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.task.SwitchLanguageInfo
 import com.crosspaste.db.task.TaskDao
 import com.crosspaste.db.task.TaskType
 import com.crosspaste.i18n.DesktopGlobalCopywriter.Companion.EMPTY_STRING
 import com.crosspaste.i18n.SupportedLanguages.EN
-import com.crosspaste.i18n.SupportedLanguages.LANGUAGE_LIST
 import com.crosspaste.task.TaskExecutor
 import com.crosspaste.utils.DateTimeFormatOptions
 import com.crosspaste.utils.GlobalCoroutineScope.cpuCoroutineDispatcher
@@ -23,10 +19,10 @@ import java.nio.charset.StandardCharsets
 import java.util.Properties
 
 class DesktopGlobalCopywriter(
-    private val configManager: CommonConfigManager,
+    configManager: CommonConfigManager,
     private val lazyTaskExecutor: Lazy<TaskExecutor>,
     private val taskDao: TaskDao,
-) : GlobalCopywriter {
+) : AbstractGlobalCopywriter(configManager, { DesktopCopywriter(it) }) {
 
     companion object {
 
@@ -35,46 +31,17 @@ class DesktopGlobalCopywriter(
 
     private val logger = KotlinLogging.logger {}
 
-    private val cache = LanguageCache { DesktopCopywriter(it) }
-
-    private var language: String =
-        run {
-            val language = configManager.getCurrentConfig().language
-            if (!LANGUAGE_LIST.contains(language)) {
-                configManager.updateConfig("language", EN)
-                EN
-            } else {
-                language
-            }
-        }
-
-    // mutableStateOf is intentionally used here to trigger Compose recomposition when the
-    // language changes. Writes from non-Compose threads (e.g., switchLanguage()) are safe
-    // because Compose's global snapshot system handles cross-thread state mutations.
-    private var copywriter: Copywriter by mutableStateOf(cache.getOrCreate(language))
-
-    private val enCopywriter by lazy { cache.getOrCreate(EN) }
+    private val enCopywriter by lazy { copywriterFor(EN) }
 
     private val taskExecutor by lazy { lazyTaskExecutor.value }
 
-    override fun language(): String = copywriter.language()
-
-    override fun switchLanguage(language: String) {
-        logger.info { "Switching language $language" }
-        copywriter = cache.getOrCreate(language)
-        configManager.updateConfig("language", language)
+    override fun onLanguageSwitched(language: String) {
         cpuCoroutineDispatcher.launch {
             taskExecutor.submitTask(
                 taskDao.createTask(null, TaskType.SWITCH_LANGUAGE_TASK, SwitchLanguageInfo(language)),
             )
         }
     }
-
-    override fun getAllLanguages(): List<Language> =
-        LANGUAGE_LIST.map {
-            val cw = cache.getOrCreate(it)
-            Language(cw.getAbridge(), cw.getText("current_language"))
-        }
 
     override fun getText(
         id: String,
@@ -94,15 +61,6 @@ class DesktopGlobalCopywriter(
             text
         }
     }
-
-    override fun getKeys(): Set<String> = copywriter.getKeys()
-
-    override fun getDate(
-        date: LocalDateTime,
-        options: DateTimeFormatOptions,
-    ): String = copywriter.getDate(date, options)
-
-    override fun getAbridge(): String = copywriter.getAbridge()
 }
 
 class DesktopCopywriter(

--- a/app/src/desktopMain/kotlin/com/crosspaste/i18n/I18n.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/i18n/I18n.kt
@@ -31,8 +31,6 @@ class DesktopGlobalCopywriter(
 
     private val logger = KotlinLogging.logger {}
 
-    private val enCopywriter by lazy { copywriterFor(EN) }
-
     private val taskExecutor by lazy { lazyTaskExecutor.value }
 
     override fun onLanguageSwitched(language: String) {


### PR DESCRIPTION
Closes #4337

Following #4335 (which hoisted `SupportedLanguages` + `LanguageCache` to commonMain), each platform's `GlobalCopywriter` still duplicated ~50 lines of identical boilerplate. Lift the shared parts into a single abstract base class so subclasses declare only what actually differs.

## What's in commonMain

`AbstractGlobalCopywriter` owns:
- `LanguageCache` wiring and validate-or-default-EN bootstrap
- protected `copywriter` `mutableStateOf` field (subclasses with custom `getText` need to read it)
- `switchLanguage` with a protected `onLanguageSwitched(language)` hook for post-switch side effects
- `getAllLanguages`, `language()`, `getText`, `getKeys`, `getDate`, `getAbridge`

## What stays in `DesktopGlobalCopywriter`

Only the parts that diverge from mobile:
- `TaskExecutor` + `TaskDao` wiring
- `onLanguageSwitched` override → dispatches `SwitchLanguageTask` so other devices get notified
- `getText` override → desktop-only English-fallback + bracketed-id missing-key UX (mobile returns the literal `"null"` string today; aligning that is a separate decision)

## Mobile follow-up

In the mobile private repos, `AndroidGlobalCopywriter` and `IOSGlobalCopywriterImpl` become near-empty subclasses that just pass the factory closure through:

```kotlin
class AndroidGlobalCopywriter(
    configManager: CommonConfigManager,
    context: Context,
) : AbstractGlobalCopywriter(configManager, { AndroidCopywriter(it, context) })

class IOSGlobalCopywriterImpl(
    configManager: CommonConfigManager,
) : AbstractGlobalCopywriter(configManager, { CopywriterImpl(it) })
```

## Test plan
- [x] `./gradlew :app:compileKotlinDesktop :app:compileTestKotlinDesktop` — green
- [x] `./gradlew ktlintFormat` — clean
- [x] `./gradlew :app:desktopTest --tests "com.crosspaste.i18n.*"` — 7/7 pass
- [ ] Smoke test app's language switcher in a running build