### PR TITLE
:hammer: use Duration form for kotlinx.coroutines.delay calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ SQLDelight manages database schema in `.sq` files:
 - **Utility usage**: Always check `com.crosspaste.utils` and prefer existing utility classes (e.g., FileUtils, DateUtils, StringUtils) instead of implementing new ones.
 - **UI sizing**: When adding size/dimension constants in UI code, prefer using values defined in `com.crosspaste.ui.theme.AppUISize` instead of inline literal `dp`/`sp` values.
 - **Thread-safe collections**: In `commonMain` code, prefer thread-safe Map/Set from `io.ktor.util.collections` (e.g., `ConcurrentMap`, `ConcurrentSet`) over platform-specific concurrent collections.
+- **Coroutine `delay`**: Always pass a `Duration` to `kotlinx.coroutines.delay`, never a raw number. Write `delay(280L.milliseconds)` / `delay(2.seconds)`, not `delay(280L)` or `delay(2000)`. Add `import kotlin.time.Duration.Companion.milliseconds` (or `.seconds`) as needed. This applies to both production code and tests.
 
 ## Key Technical Details
 

--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.milliseconds
 
 abstract class AppTokenService : AppTokenApi {
 
@@ -53,7 +54,7 @@ abstract class AppTokenService : AppTokenApi {
                         val totalSteps = 100
                         for (i in 0..totalSteps) {
                             _refreshProgress.value = i / totalSteps.toFloat()
-                            delay(300)
+                            delay(300.milliseconds)
                         }
                     }
                 } else {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/settings/StorageStatisticsView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/settings/StorageStatisticsView.kt
@@ -54,6 +54,7 @@ import com.crosspaste.utils.Quadruple
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun StorageStatisticsScope.StorageStatisticsHeader() {
@@ -90,7 +91,7 @@ fun StorageStatisticsScope.StorageStatisticsContentView() {
     LaunchedEffect(Unit) {
         while (true) {
             refresh()
-            delay(5000)
+            delay(5000.milliseconds)
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 class LinuxAppWindowManager(
     private val appInfo: AppInfo,
@@ -154,7 +155,7 @@ class LinuxAppWindowManager(
         logger.info { "unActive search window" }
         bringToBack(preparePaste(0))
         for (i in 1 until size) {
-            delay(1000)
+            delay(1000.milliseconds)
             if (preparePaste(i)) {
                 toPaste()
             }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/MacAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/MacAppWindowManager.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 class MacAppWindowManager(
     private val appInfo: AppInfo,
@@ -146,7 +147,7 @@ class MacAppWindowManager(
                 pair.second,
             )
             for (i in 1 until size) {
-                delay(1000)
+                delay(1000.milliseconds)
                 if (preparePaste(i)) {
                     toPaste()
                 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/WinAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/WinAppWindowManager.kt
@@ -16,6 +16,7 @@ import com.sun.jna.platform.win32.WinDef.HWND
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlin.time.Duration.Companion.milliseconds
 
 class WinAppWindowManager(
     appInfo: AppInfo,
@@ -105,7 +106,7 @@ class WinAppWindowManager(
 
     override suspend fun focusMainWindow(windowTrigger: WindowTrigger) {
         // Wait for the window to be ready, otherwise bringToFront may cause the window to fail to get focus
-        delay(500)
+        delay(500.milliseconds)
         WindowsFocusUtils.bringToFront(
             windowFocusRecorder.lastWinAppInfo.value?.getThreadId(winAppInfoCaches),
             mainHWND,
@@ -120,7 +121,7 @@ class WinAppWindowManager(
 
     override suspend fun focusSearchWindow(windowTrigger: WindowTrigger) {
         // Wait for the window to be ready, otherwise bringToFront may cause the window to fail to get focus
-        delay(500)
+        delay(500.milliseconds)
         WindowsFocusUtils.bringToFront(
             windowFocusRecorder.lastWinAppInfo.value?.getThreadId(winAppInfoCaches),
             searchHWND,
@@ -128,7 +129,7 @@ class WinAppWindowManager(
     }
 
     override suspend fun focusBubbleWindow() {
-        delay(500)
+        delay(500.milliseconds)
         WindowsFocusUtils.bringToFront(
             windowFocusRecorder.lastWinAppInfo.value?.getThreadId(winAppInfoCaches),
             bubbleHWND,
@@ -142,7 +143,7 @@ class WinAppWindowManager(
         logger.info { "unActive search window" }
         bringToBack(preparePaste(0), searchHWND)
         for (i in 1 until size) {
-            delay(1000)
+            delay(1000.milliseconds)
             if (preparePaste(i)) {
                 toPaste()
             }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import java.awt.Toolkit
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.Transferable
+import kotlin.time.Duration.Companion.milliseconds
 
 class MacosPasteboardService(
     override val appWindowManager: DesktopAppWindowManager,
@@ -125,7 +126,7 @@ class MacosPasteboardService(
                 }.onFailure { e ->
                     logger.error(e) { "Failed to consume transferable" }
                 }
-                delay(280L)
+                delay(280L.milliseconds)
             }
         }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/X11Api.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/X11Api.kt
@@ -12,6 +12,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
 import java.nio.file.Path
 import javax.imageio.ImageIO
+import kotlin.time.Duration.Companion.milliseconds
 
 interface X11Api : X11 {
 
@@ -104,7 +105,7 @@ interface X11Api : X11 {
                 for (keyCode in keyCodes) {
                     xTest.XTestFakeKeyEvent(display, keyCode, true, NativeLong(0))
                 }
-                delay(100)
+                delay(100.milliseconds)
 
                 for (keyCode in keyCodes.reversed()) {
                     xTest.XTestFakeKeyEvent(display, keyCode, false, NativeLong(0))

--- a/app/src/desktopMain/kotlin/com/crosspaste/share/Facebook.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/share/Facebook.kt
@@ -22,6 +22,7 @@ import com.crosspaste.utils.ioDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.net.URLEncoder
+import kotlin.time.Duration.Companion.milliseconds
 
 class Facebook(
     private val notificationManager: NotificationManager,
@@ -66,7 +67,7 @@ class Facebook(
             title = { it.getText("copy_successful") },
             messageType = MessageType.Success,
         )
-        delay(2000)
+        delay(2000.milliseconds)
         uiSupport.openUrlInBrowser(facebookUrl)
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/share/LinkedIn.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/share/LinkedIn.kt
@@ -22,6 +22,7 @@ import com.crosspaste.utils.ioDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.net.URLEncoder
+import kotlin.time.Duration.Companion.milliseconds
 
 class LinkedIn(
     private val notificationManager: NotificationManager,
@@ -69,7 +70,7 @@ class LinkedIn(
             title = { it.getText("copy_successful") },
             messageType = MessageType.Success,
         )
-        delay(2000)
+        delay(2000.milliseconds)
         uiSupport.openUrlInBrowser(url)
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/share/Mail.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/share/Mail.kt
@@ -18,6 +18,7 @@ import com.crosspaste.ui.theme.AppUISize.huge
 import com.crosspaste.ui.theme.AppUISize.mediumRoundedCornerShape
 import com.crosspaste.ui.theme.AppUISize.xxLarge
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 class Mail(
     private val notificationManager: NotificationManager,
@@ -56,7 +57,7 @@ class Mail(
             title = { it.getText("copy_successful") },
             messageType = MessageType.Success,
         )
-        delay(2000)
+        delay(2000.milliseconds)
         uiSupport.openEmailClient(null)
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/BubbleWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/BubbleWindow.kt
@@ -62,6 +62,7 @@ import org.koin.compose.koinInject
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * A bubble shape: rounded rectangle body with a triangular tail at the bottom,
@@ -215,7 +216,7 @@ fun BubbleWindow(windowIcon: Painter?) {
     LaunchedEffect(itemCenterXInSearchWindow, bubbleWindowInfo.show) {
         if (bubbleWindowInfo.show && itemCenterXInSearchWindow == null) {
             // Small delay to avoid flicker during fast scroll
-            delay(100)
+            delay(100.milliseconds)
             if (pasteSelectionViewModel.searchListState
                     ?.layoutInfo
                     ?.visibleItemsInfo
@@ -238,7 +239,7 @@ fun BubbleWindow(windowIcon: Painter?) {
         if (bubbleWindowInfo.show) {
             ignoreFocusLoss.set(true)
             appWindowManager.focusBubbleWindow()
-            delay(1000)
+            delay(1000.milliseconds)
         }
         ignoreFocusLoss.set(false)
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
@@ -36,6 +36,7 @@ import org.koin.compose.koinInject
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun SearchWindow(windowIcon: Painter?) {
@@ -99,7 +100,7 @@ fun SearchWindow(windowIcon: Painter?) {
         if (searchWindowInfo.show) {
             ignoreFocusLoss.set(true)
             appWindowManager.focusSearchWindow(searchWindowInfo.trigger)
-            delay(1000)
+            delay(1000.milliseconds)
         }
         ignoreFocusLoss.set(false)
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
@@ -79,6 +79,7 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import java.awt.event.KeyEvent.VK_1
 import java.awt.event.KeyEvent.VK_9
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -209,7 +210,7 @@ fun SidePasteboardContentView() {
                 scrollJob?.cancel()
                 scrollJob =
                     coroutineScope.launch {
-                        delay(1000)
+                        delay(1000.milliseconds)
                         showScrollbar = false
                     }
             }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/GrantAccessibilityDialog.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/GrantAccessibilityDialog.kt
@@ -39,6 +39,7 @@ import com.crosspaste.ui.theme.AppUISize.tiny
 import com.crosspaste.ui.theme.AppUISize.xLarge
 import kotlinx.coroutines.delay
 import org.koin.compose.koinInject
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun GrantAccessibilityDialog(cancelAction: () -> Unit) {
@@ -58,7 +59,7 @@ fun GrantAccessibilityDialog(cancelAction: () -> Unit) {
                 restart = true
                 break
             } else {
-                delay(2000)
+                delay(2000.milliseconds)
             }
         }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/MigrationStorageDialog.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/MigrationStorageDialog.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import okio.Path
 import org.koin.compose.koinInject
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun MigrationStorageDialog(
@@ -143,7 +144,7 @@ fun MigrationStorageDialog(
                     coroutineScope.launch {
                         while (progress < 0.99f && isMigration) {
                             progress += 0.01f
-                            delay(100)
+                            delay(100.milliseconds)
                         }
                     }
                 }
@@ -153,7 +154,7 @@ fun MigrationStorageDialog(
                         desktopMigration.migration(path)
                         coroutineScope.launch {
                             progress = 1f
-                            delay(500)
+                            delay(500.milliseconds)
                             isMigration = false
                         }
                     }.onFailure {

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/AppLockTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/AppLockTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class AppLockTest : KoinTest {
 
@@ -52,7 +53,7 @@ class AppLockTest : KoinTest {
                     assertTrue(appLockState.firstLaunch, "First instance should be considered as the first launch")
                 }
 
-            delay(100)
+            delay(100.milliseconds)
 
             val job2 =
                 launch {

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/TestWindowManager.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/TestWindowManager.kt
@@ -3,6 +3,7 @@ package com.crosspaste.app
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.time.Duration.Companion.milliseconds
 
 class TestWindowManager(
     appSize: DesktopAppSize,
@@ -52,7 +53,7 @@ class TestWindowManager(
         val toPaste = preparePaste(0)
         bringToBack(toPaste)
         for (i in 1 until size) {
-            delay(1000)
+            delay(1000.milliseconds)
             if (preparePaste(i)) {
                 toPaste()
             }

--- a/app/src/desktopTest/kotlin/com/crosspaste/image/GenerateImageServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/image/GenerateImageServiceTest.kt
@@ -9,6 +9,7 @@ import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class GenerateImageServiceTest {
 
@@ -52,7 +53,7 @@ class GenerateImageServiceTest {
                 }
 
             // Give some time for awaitGeneration to register
-            delay(50)
+            delay(50.milliseconds)
 
             // Mark generation complete
             service.markGenerationComplete(path)
@@ -85,7 +86,7 @@ class GenerateImageServiceTest {
             val deferred1 = async { service.awaitGeneration(path, timeoutMillis = 5000) }
             val deferred2 = async { service.awaitGeneration(path, timeoutMillis = 5000) }
 
-            delay(50)
+            delay(50.milliseconds)
 
             service.markGenerationComplete(path)
 
@@ -106,7 +107,7 @@ class GenerateImageServiceTest {
                     val path = tempDir.toOkioPath().resolve("concurrent_$i.png")
                     val deferred = async { service.awaitGeneration(path, timeoutMillis = 5000) }
                     launch {
-                        delay(20)
+                        delay(20.milliseconds)
                         service.markGenerationComplete(path)
                     }
                     deferred

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class SyncIntegrationTest {
 
@@ -200,7 +201,7 @@ class SyncIntegrationTest {
             c.start()
             // Allow Netty event loops to stabilize after starting 3 servers
             // in the same JVM to avoid ClosedReadChannelException from resource contention
-            kotlinx.coroutines.delay(200)
+            kotlinx.coroutines.delay(200.milliseconds)
 
             // B trusts A
             trustBToA(a, b)
@@ -365,7 +366,7 @@ class SyncIntegrationTest {
             b.syncClientApi.notifyExit(urlFor(a))
 
             // Give the coroutine scope time to execute markExit
-            kotlinx.coroutines.delay(200)
+            kotlinx.coroutines.delay(200.milliseconds)
 
             // markExit should have been called on B's handler in A
             coVerify { mockHandler.markExit() }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/DefaultPasteSyncProcessManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/DefaultPasteSyncProcessManagerTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class DefaultPasteSyncProcessManagerTest {
 
@@ -174,11 +175,11 @@ class DefaultPasteSyncProcessManagerTest {
             val tasks =
                 listOf<suspend () -> Pair<Int, ClientApiResult>>(
                     {
-                        delay(50)
+                        delay(50.milliseconds)
                         Pair(0, SuccessResult("Task 0"))
                     },
                     {
-                        delay(100)
+                        delay(100.milliseconds)
                         Pair(1, SuccessResult("Task 1"))
                     },
                 )
@@ -232,7 +233,7 @@ class DefaultPasteSyncProcessManagerTest {
                 (0..4).map { index ->
                     suspend {
                         val startTime = System.currentTimeMillis()
-                        delay(50) // Simulate work
+                        delay(50.milliseconds) // Simulate work
                         executionOrder[index] = startTime
                         Pair(index, SuccessResult("Task $index"))
                     }
@@ -261,7 +262,7 @@ class DefaultPasteSyncProcessManagerTest {
                     suspend {
                         val current = concurrentTasks.incrementAndGet()
                         maxConcurrency.set(maxOf(maxConcurrency.get(), current))
-                        delay(100) // Simulate work
+                        delay(100.milliseconds) // Simulate work
                         concurrentTasks.decrementAndGet()
                         Pair(index, SuccessResult("Task $index"))
                     }
@@ -285,7 +286,7 @@ class DefaultPasteSyncProcessManagerTest {
                         val tasks =
                             (0..2).map { taskIndex ->
                                 suspend {
-                                    delay(50)
+                                    delay(50.milliseconds)
                                     Pair(taskIndex, SuccessResult("Task $taskIndex for paste $pasteDataId"))
                                 }
                             }
@@ -351,23 +352,23 @@ class DefaultPasteSyncProcessManagerTest {
                     }
                 }
 
-            delay(50) // Let collection start
+            delay(50.milliseconds) // Let collection start
 
             val tasks =
                 listOf<suspend () -> Pair<Int, ClientApiResult>>(
                     {
-                        delay(100)
+                        delay(100.milliseconds)
                         Pair(0, SuccessResult("Task 0"))
                     },
                     {
-                        delay(200)
+                        delay(200.milliseconds)
                         Pair(1, SuccessResult("Task 1"))
                     },
                 )
 
             manager.runTask(pasteDataId, tasks)
 
-            delay(50) // Let final progress update propagate
+            delay(50.milliseconds) // Let final progress update propagate
             collectJob.cancel()
 
             assertTrue(progressValues.contains(0.0f), "Should contain initial progress")

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteSingleProcessImplTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteSingleProcessImplTest.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class PasteSingleProcessImplTest {
 
@@ -210,17 +211,17 @@ class PasteSingleProcessImplTest {
                     }
                 }
 
-            kotlinx.coroutines.delay(50) // Let collection start
+            kotlinx.coroutines.delay(50.milliseconds) // Let collection start
 
             // Update progress
             process.success(0)
-            kotlinx.coroutines.delay(10)
+            kotlinx.coroutines.delay(10.milliseconds)
 
             process.success(1)
-            kotlinx.coroutines.delay(10)
+            kotlinx.coroutines.delay(10.milliseconds)
 
             process.success(2)
-            kotlinx.coroutines.delay(10)
+            kotlinx.coroutines.delay(10.milliseconds)
 
             collectJob.cancel()
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncPollingManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncPollingManagerTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -34,7 +35,7 @@ class SyncPollingManagerTest {
 
             withTimeout(5.seconds) {
                 while (actionCount == 0) {
-                    delay(50)
+                    delay(50.milliseconds)
                 }
             }
 
@@ -66,7 +67,7 @@ class SyncPollingManagerTest {
 
             withTimeout(10.seconds) {
                 while (actionCount == countAt1s) {
-                    delay(50)
+                    delay(50.milliseconds)
                 }
             }
 
@@ -120,7 +121,7 @@ class SyncPollingManagerTest {
 
             withTimeout(5.seconds) {
                 while (actionCount == 0) {
-                    delay(50)
+                    delay(50.milliseconds)
                 }
             }
             val countBeforeCancel = actionCount
@@ -156,7 +157,7 @@ class SyncPollingManagerTest {
 
             withTimeout(5.seconds) {
                 while (actionCount == 0) {
-                    delay(50)
+                    delay(50.milliseconds)
                 }
             }
 
@@ -183,7 +184,7 @@ class SyncPollingManagerTest {
             // Wait for first execution
             withTimeout(5.seconds) {
                 while (actionCount == 0) {
-                    delay(50)
+                    delay(50.milliseconds)
                 }
             }
             val firstCount = actionCount
@@ -194,7 +195,7 @@ class SyncPollingManagerTest {
             // Wait for second execution
             withTimeout(5.seconds) {
                 while (actionCount <= firstCount) {
-                    delay(50)
+                    delay(50.milliseconds)
                 }
             }
 
@@ -218,7 +219,7 @@ class SyncPollingManagerTest {
 
             withTimeout(5.seconds) {
                 while (actionCount == 0) {
-                    delay(50)
+                    delay(50.milliseconds)
                 }
             }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/StripedMutexTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/StripedMutexTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class StripedMutexTest {
 
@@ -27,12 +28,12 @@ class StripedMutexTest {
                 async {
                     mutex.withLock("sameKey") {
                         log.add("start1")
-                        delay(50)
+                        delay(50.milliseconds)
                         log.add("end1")
                     }
                 }
             // Give job1 time to acquire the lock
-            delay(10)
+            delay(10.milliseconds)
             val job2 =
                 async {
                     mutex.withLock("sameKey") {
@@ -60,16 +61,16 @@ class StripedMutexTest {
                 async {
                     mutex.withLock("keyA") {
                         log.add("startA")
-                        delay(50)
+                        delay(50.milliseconds)
                         log.add("endA")
                     }
                 }
-            delay(10)
+            delay(10.milliseconds)
             val job2 =
                 async {
                     mutex.withLock("keyB") {
                         log.add("startB")
-                        delay(50)
+                        delay(50.milliseconds)
                         log.add("endB")
                     }
                 }
@@ -93,11 +94,11 @@ class StripedMutexTest {
                 async {
                     mutex.withLock("anyKey1") {
                         log.add("start1")
-                        delay(50)
+                        delay(50.milliseconds)
                         log.add("end1")
                     }
                 }
-            delay(10)
+            delay(10.milliseconds)
             val job2 =
                 async {
                     mutex.withLock("anyKey2") {


### PR DESCRIPTION
Closes #4339

## Summary
- Convert every `delay(<long>)` call to the `kotlin.time.Duration` form (e.g. `delay(280L.milliseconds)`) across `commonMain`, `desktopMain`, and `desktopTest`. Behavior is unchanged — same delay durations, just expressed via `Duration` so the unit is explicit at the call site.
- Add a "Coroutine `delay`" rule to `CLAUDE.md` under Code Style and Conventions to prevent regression.

## Test plan
- [x] `./gradlew ktlintFormat` passes
- [ ] CI green