### PR TITLE
:hammer: introduce PasteSourceContext to bundle paste origin metadata

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
@@ -18,7 +18,7 @@ class PasteCollector(
     private val appInfo: AppInfo,
     private val pasteDao: PasteDao,
     private val pasteReleaseService: PasteReleaseService,
-    private val dragAndDrop: Boolean = false,
+    private val sourceContext: PasteSourceContext,
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -72,10 +72,7 @@ class PasteCollector(
         existError = true
     }
 
-    suspend fun createPrePasteData(
-        source: String?,
-        remote: Boolean,
-    ): Long? =
+    suspend fun createPrePasteData(): Long? =
         logSuspendExecutionTime(logger, "createPrePasteData") {
             val collector = preCollectors.filter { it.isNotEmpty() }
             if (collector.isEmpty()) {
@@ -90,21 +87,18 @@ class PasteCollector(
                         appInstanceId = appInfo.appInstanceId,
                         pasteCollection = pasteCollection,
                         pasteType = PasteType.INVALID_TYPE.type,
-                        source = source,
+                        source = sourceContext.source,
                         size = 0L,
                         hash = "",
                         pasteState = PasteState.LOADING,
-                        remote = remote,
+                        remote = sourceContext.remote,
                     )
 
                 pasteDao.createPasteData(pasteData)
             }
         }
 
-    suspend fun completeCollect(
-        id: Long,
-        targetAppInstanceIds: Set<String>? = null,
-    ) {
+    suspend fun completeCollect(id: Long) {
         logSuspendExecutionTime(logger, "completeCollect") {
             val activeIndices = preCollectors.indices.filter { preCollectors[it].isNotEmpty() }
             if (activeIndices.isEmpty() || (existError && activeIndices.all { updateErrors[it] != null })) {
@@ -112,7 +106,7 @@ class PasteCollector(
             } else {
                 runCatching {
                     var pasteItems = preCollectors.flatMap { it.values }
-                    if (dragAndDrop) {
+                    if (sourceContext.dragAndDrop) {
                         pasteItems =
                             pasteItems.map { item ->
                                 if (item is PasteFiles) {
@@ -124,7 +118,7 @@ class PasteCollector(
                                 }
                             }
                     }
-                    pasteReleaseService.releaseLocalPasteData(id, pasteItems, targetAppInstanceIds)
+                    pasteReleaseService.releaseLocalPasteData(id, pasteItems, sourceContext.targetAppInstanceIds)
                 }.onFailure { e ->
                     logger.error(e) { "Failed to complete paste $id" }
                     markDeletePasteData(id)

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteSourceContext.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteSourceContext.kt
@@ -1,0 +1,8 @@
+package com.crosspaste.paste
+
+data class PasteSourceContext(
+    val source: String?,
+    val remote: Boolean,
+    val dragAndDrop: Boolean = false,
+    val targetAppInstanceIds: Set<String>? = null,
+)

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
@@ -11,10 +11,7 @@ interface TransferableConsumer {
 
     suspend fun consume(
         pasteTransferable: PasteTransferable,
-        source: String?,
-        remote: Boolean,
-        dragAndDrop: Boolean = false,
-        targetAppInstanceIds: Set<String>? = null,
+        sourceContext: PasteSourceContext,
     ): Result<Unit>
 
     fun getPlugin(identity: String): PasteTypePlugin?

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopTransferableConsumer.kt
@@ -36,10 +36,7 @@ class DesktopTransferableConsumer(
 
     override suspend fun consume(
         pasteTransferable: PasteTransferable,
-        source: String?,
-        remote: Boolean,
-        dragAndDrop: Boolean,
-        targetAppInstanceIds: Set<String>?,
+        sourceContext: PasteSourceContext,
     ): Result<Unit> {
         return runCatching {
             logSuspendExecutionTime(logger, "consume") {
@@ -56,13 +53,13 @@ class DesktopTransferableConsumer(
                         appInfo,
                         pasteDao,
                         pasteReleaseService,
-                        dragAndDrop,
+                        sourceContext,
                     )
 
                 preCollect(dataFlavorMap, pasteTransferable, pasteCollector)
-                pasteCollector.createPrePasteData(source, remote = remote)?.also { id ->
+                pasteCollector.createPrePasteData()?.also { id ->
                     updatePasteData(id, dataFlavorMap, pasteTransferable, pasteCollector)
-                    pasteCollector.completeCollect(id, targetAppInstanceIds)
+                    pasteCollector.completeCollect(id)
                 }
             }
         }.onFailure { e ->

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/LinuxPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/LinuxPasteboardService.kt
@@ -153,7 +153,10 @@ class LinuxPasteboardService(
                 ownerTransferable = it
                 scope.launch(CoroutineName("LinuxPasteboardServiceConsumer")) {
                     val pasteTransferable = DesktopReadTransferable(it)
-                    pasteConsumer.consume(pasteTransferable, source, remote = false)
+                    pasteConsumer.consume(
+                        pasteTransferable,
+                        PasteSourceContext(source = source, remote = false),
+                    )
                 }
             }
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
@@ -115,7 +115,13 @@ class MacosPasteboardService(
                                             ownerTransferable = it
                                             launch(CoroutineName("MacPasteboardServiceConsumer")) {
                                                 val pasteTransferable = DesktopReadTransferable(it)
-                                                pasteConsumer.consume(pasteTransferable, source, remote.value != 0)
+                                                pasteConsumer.consume(
+                                                    pasteTransferable,
+                                                    PasteSourceContext(
+                                                        source = source,
+                                                        remote = remote.value != 0,
+                                                    ),
+                                                )
                                             }
                                         }
                                     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
@@ -209,7 +209,10 @@ class WindowsPasteboardService(
                     serviceConsumerScope.launch(CoroutineName("WindowsPasteboardConsumer")) {
                         val pasteTransferable = DesktopReadTransferable(it)
                         // in windows, we don't know if the pasteboard is local or remote
-                        pasteConsumer.consume(pasteTransferable, source, remote = false)
+                        pasteConsumer.consume(
+                            pasteTransferable,
+                            PasteSourceContext(source = source, remote = false),
+                        )
                     }
                 }
             }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/DragTargetContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/DragTargetContentView.kt
@@ -47,6 +47,7 @@ import com.composables.icons.materialsymbols.rounded.Content_paste
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.paste.DesktopReadTransferable
+import com.crosspaste.paste.PasteSourceContext
 import com.crosspaste.paste.TransferableConsumer
 import com.crosspaste.ui.theme.AppUISize.enormous
 import com.crosspaste.ui.theme.AppUISize.medium
@@ -89,7 +90,14 @@ fun DragTargetContentView() {
                     val source: String? = appWindowManager.getCurrentActiveAppName()
                     val pasteTransferable = DesktopReadTransferable(transferable)
                     return runBlocking {
-                        pasteConsumer.consume(pasteTransferable, source, remote = false, dragAndDrop = true)
+                        pasteConsumer.consume(
+                            pasteTransferable,
+                            PasteSourceContext(
+                                source = source,
+                                remote = false,
+                                dragAndDrop = true,
+                            ),
+                        )
                     }.isSuccess
                 }
             }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
@@ -30,19 +30,21 @@ class PasteCollectorTest {
     private val pasteDao: PasteDao = mockk(relaxed = true)
     private val pasteReleaseService: PasteReleaseService = mockk(relaxed = true)
 
+    private val sourceContext = PasteSourceContext(source = null, remote = false)
+
     private interface TestPasteTypePlugin : PasteTypePlugin
 
     // ========== needPreCollectionItem ==========
 
     @Test
     fun `needPreCollectionItem returns true when not collected yet`() {
-        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
         assertTrue(collector.needPreCollectionItem(0, TestPasteTypePlugin::class))
     }
 
     @Test
     fun `needPreCollectionItem returns false after preCollectItem`() {
-        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
         val item = createTextPasteItem(text = "test")
         collector.preCollectItem(0, TestPasteTypePlugin::class, item)
         assertFalse(collector.needPreCollectionItem(0, TestPasteTypePlugin::class))
@@ -52,13 +54,13 @@ class PasteCollectorTest {
 
     @Test
     fun `needUpdateCollectItem returns true when not updated yet`() {
-        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
         assertTrue(collector.needUpdateCollectItem(0, TestPasteTypePlugin::class))
     }
 
     @Test
     fun `needUpdateCollectItem returns false after updateCollectItem`() {
-        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
         val item = createTextPasteItem(text = "test")
         collector.preCollectItem(0, TestPasteTypePlugin::class, item)
         collector.updateCollectItem(0, TestPasteTypePlugin::class) { it }
@@ -69,7 +71,7 @@ class PasteCollectorTest {
 
     @Test
     fun `preCollectItem stores item at correct index`() {
-        val collector = PasteCollector(3, appInfo, pasteDao, pasteReleaseService)
+        val collector = PasteCollector(3, appInfo, pasteDao, pasteReleaseService, sourceContext)
         val item = createTextPasteItem(text = "item2")
         collector.preCollectItem(1, TestPasteTypePlugin::class, item)
 
@@ -83,7 +85,7 @@ class PasteCollectorTest {
 
     @Test
     fun `updateCollectItem applies transform to pre-collected item`() {
-        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
         val item = createTextPasteItem(text = "original")
         collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 
@@ -96,7 +98,7 @@ class PasteCollectorTest {
 
     @Test
     fun `updateCollectItem without pre-collect does nothing`() {
-        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
         // Try to update without pre-collecting - should not crash
         collector.updateCollectItem(0, TestPasteTypePlugin::class) { it }
         // needUpdateCollectItem should still be true since no pre-collect happened
@@ -107,7 +109,7 @@ class PasteCollectorTest {
 
     @Test
     fun `collectError records error`() {
-        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+        val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
         collector.collectError(1L, 0, RuntimeException("test error"))
         // Error recorded, but we can't directly assert existError
         // We verify indirectly through completeCollect behavior
@@ -118,21 +120,28 @@ class PasteCollectorTest {
     @Test
     fun `createPrePasteData with no items returns null`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
-            val result = collector.createPrePasteData(null, false)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
+            val result = collector.createPrePasteData()
             assertNull(result)
         }
 
     @Test
     fun `createPrePasteData with items calls pasteDao createPasteData`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+            val collector =
+                PasteCollector(
+                    1,
+                    appInfo,
+                    pasteDao,
+                    pasteReleaseService,
+                    PasteSourceContext(source = "source", remote = false),
+                )
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 
             coEvery { pasteDao.createPasteData(any()) } returns 42L
 
-            val result = collector.createPrePasteData("source", false)
+            val result = collector.createPrePasteData()
 
             assertEquals(42L, result)
             coVerify { pasteDao.createPasteData(any()) }
@@ -143,7 +152,7 @@ class PasteCollectorTest {
     @Test
     fun `completeCollect with no items marks paste for deletion`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
             collector.completeCollect(1L)
             coVerify { pasteDao.markDeletePasteData(1L) }
         }
@@ -151,7 +160,7 @@ class PasteCollectorTest {
     @Test
     fun `completeCollect with items calls releaseLocalPasteData`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 
@@ -163,7 +172,7 @@ class PasteCollectorTest {
     @Test
     fun `completeCollect with all indices errored marks paste for deletion`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
             collector.collectError(1L, 0, RuntimeException("error"))
@@ -176,7 +185,7 @@ class PasteCollectorTest {
     @Test
     fun `completeCollect with partial errors releases remaining items`() =
         runTest {
-            val collector = PasteCollector(2, appInfo, pasteDao, pasteReleaseService)
+            val collector = PasteCollector(2, appInfo, pasteDao, pasteReleaseService, sourceContext)
             val item0 = createTextPasteItem(text = "test0")
             val item1 = createTextPasteItem(text = "test1")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item0)
@@ -194,7 +203,7 @@ class PasteCollectorTest {
     @Test
     fun `completeCollect with exception marks paste for deletion`() =
         runTest {
-            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService)
+            val collector = PasteCollector(1, appInfo, pasteDao, pasteReleaseService, sourceContext)
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 


### PR DESCRIPTION
Closes #4341

## Summary

- Add `PasteSourceContext` data class in `commonMain` to group `source`, `remote`, `dragAndDrop`, `targetAppInstanceIds`.
- `TransferableConsumer.consume(...)` now takes `(pasteTransferable, sourceContext)` instead of five flat params.
- `PasteCollector` stores `sourceContext` once at construction; `createPrePasteData()` and `completeCollect(id)` no longer take redundant sub-params.
- All four call sites updated: `MacosPasteboardService`, `WindowsPasteboardService`, `LinuxPasteboardService`, `DragTargetContentView`.
- `PasteCollectorTest` updated with a shared `sourceContext` fixture; the test that exercises `source = "source"` uses an explicit context.

Future origin fields (e.g., distinguishing Apple Universal Clipboard from other remote sources) can be added to `PasteSourceContext` without touching method signatures or platform call sites.

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew :app:compileKotlinDesktop :app:compileTestKotlinDesktop`
- [x] `./gradlew :app:desktopTest --tests "com.crosspaste.paste.PasteCollectorTest"` — 14/14 passing