### PR TITLE
:bug: route Apple Universal Clipboard pastes to non-Mac peers

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteSourceContext.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteSourceContext.kt
@@ -3,6 +3,7 @@ package com.crosspaste.paste
 data class PasteSourceContext(
     val source: String?,
     val remote: Boolean,
+    val appleRemoteClipboard: Boolean = false,
     val dragAndDrop: Boolean = false,
     val targetAppInstanceIds: Set<String>? = null,
 )

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
@@ -144,6 +144,7 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
                     get(),
                     get(),
                     get(),
+                    get(),
                 )
             }
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopPasteboardService.kt
@@ -5,6 +5,7 @@ import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.platform.Platform
 import com.crosspaste.sound.SoundService
+import com.crosspaste.sync.SyncManager
 
 fun getDesktopPasteboardService(
     appWindowManager: DesktopAppWindowManager,
@@ -17,6 +18,7 @@ fun getDesktopPasteboardService(
     platform: Platform,
     soundService: SoundService,
     sourceExclusionService: DesktopSourceExclusionService,
+    syncManager: SyncManager,
 ): AbstractPasteboardService =
     if (platform.isMacos()) {
         MacosPasteboardService(
@@ -29,6 +31,7 @@ fun getDesktopPasteboardService(
             pasteReleaseService,
             soundService,
             sourceExclusionService,
+            syncManager,
         )
     } else if (platform.isWindows()) {
         WindowsPasteboardService(

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
@@ -6,6 +6,7 @@ import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.platform.macos.api.MacosApi
 import com.crosspaste.sound.SoundService
+import com.crosspaste.sync.SyncManager
 import com.crosspaste.utils.getControlUtils
 import com.sun.jna.ptr.IntByReference
 import io.github.oshai.kotlinlogging.KLogger
@@ -30,6 +31,7 @@ class MacosPasteboardService(
     override val pasteReleaseService: PasteReleaseService,
     override val soundService: SoundService,
     override val sourceExclusionService: DesktopSourceExclusionService,
+    private val syncManager: SyncManager,
 ) : AbstractPasteboardService() {
     override val logger: KLogger = KotlinLogging.logger {}
 
@@ -113,13 +115,26 @@ class MacosPasteboardService(
                                     if (contents != ownerTransferable) {
                                         contents?.let {
                                             ownerTransferable = it
+                                            val isAppleRemoteClipboard = remote.value != 0
+                                            val targetAppInstanceIds =
+                                                if (isAppleRemoteClipboard) {
+                                                    syncManager
+                                                        .getSyncHandlers()
+                                                        .filterValues { handler ->
+                                                            !handler.currentSyncRuntimeInfo.platform.isMacos()
+                                                        }.keys
+                                                } else {
+                                                    null
+                                                }
                                             launch(CoroutineName("MacPasteboardServiceConsumer")) {
                                                 val pasteTransferable = DesktopReadTransferable(it)
                                                 pasteConsumer.consume(
                                                     pasteTransferable,
                                                     PasteSourceContext(
                                                         source = source,
-                                                        remote = remote.value != 0,
+                                                        remote = false,
+                                                        appleRemoteClipboard = isAppleRemoteClipboard,
+                                                        targetAppInstanceIds = targetAppInstanceIds,
                                                     ),
                                                 )
                                             }


### PR DESCRIPTION
Closes #4343

## Summary

- Disambiguate Apple Universal Clipboard origin from the CrossPaste-remote concept. `MacosPasteboardService` no longer sets `PasteData.remote = true` for `com.apple.is-remote-clipboard` events.
- New `PasteSourceContext.appleRemoteClipboard` field captures the macOS-specific origin so future consumers (telemetry, UI) can distinguish it without re-reading native flags.
- When Apple Universal Clipboard is detected: target sync to **non-Mac peers only** (Mac peers already receive it via Apple's own channel; Win/Linux/extension peers had no path before this fix).
- Inject `SyncManager` into `MacosPasteboardService` and the desktop pasteboard factory so peer platforms can be enumerated at consume time.

## Behavior change

Before: paste arrived on Mac via Universal Clipboard → `remote=true` → `PasteReleaseService` skipped the sync task → no peers received it.
After: same scenario → `remote=false`, `appleRemoteClipboard=true`, `targetAppInstanceIds = {non-Mac peer ids}` → sync task runs and reaches Win/Linux/extension peers.

## Test plan

- [x] `./gradlew ktlintFormat`
- [x] `./gradlew :app:compileKotlinDesktop :app:compileTestKotlinDesktop`
- [x] `./gradlew :app:desktopTest --tests "com.crosspaste.paste.PasteCollectorTest"` — 14/14 passing
- [ ] Manual: copy on iPhone → confirm Mac receives via Universal Clipboard → confirm Windows peer receives via CrossPaste sync
- [ ] Manual: copy on Mac (no Universal Clipboard) → confirm broadcast still reaches all peers including other Macs

## Out of scope

- De-duplication when multiple Macs receive the same Universal Clipboard event and each pushes to the same Win/Linux peer (current behavior: peer gets the same content multiple times). Tracked separately if observed in practice.
- Surfacing `appleRemoteClipboard` in `PasteData` / UI (no DB schema change here).