### PR TITLE
:bug: fix side search crashes on fast horizontal scroll

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/edit/PasteHtmlEditContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/edit/PasteHtmlEditContentView.kt
@@ -65,6 +65,7 @@ import com.crosspaste.ui.theme.AppUISize.mediumRoundedCornerShape
 import com.crosspaste.ui.theme.AppUISize.small2X
 import com.crosspaste.ui.theme.AppUISize.tinyRoundedCornerShape
 import com.crosspaste.utils.ColorAccessibility
+import com.crosspaste.utils.getHtmlUtils
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
@@ -90,7 +91,11 @@ fun PasteDataScope.PasteHtmlEditContentView() {
     val isMac = remember { platform.isMacos() }
 
     val htmlPasteItem = getPasteItem(HtmlPasteItem::class)
-    val originalHtml = remember(pasteData.id, pasteData.hash) { htmlPasteItem.html }
+    val htmlUtils = remember { getHtmlUtils() }
+    val originalHtml =
+        remember(pasteData.id, pasteData.hash) {
+            htmlUtils.sanitizeForRichText(htmlPasteItem.html)
+        }
     val richTextState = rememberRichTextState()
 
     val currentThemeState = LocalThemeState.current

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/edit/PasteHtmlEditContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/edit/PasteHtmlEditContentView.kt
@@ -91,10 +91,9 @@ fun PasteDataScope.PasteHtmlEditContentView() {
     val isMac = remember { platform.isMacos() }
 
     val htmlPasteItem = getPasteItem(HtmlPasteItem::class)
-    val htmlUtils = remember { getHtmlUtils() }
     val originalHtml =
         remember(pasteData.id, pasteData.hash) {
-            htmlUtils.sanitizeForRichText(htmlPasteItem.html)
+            getHtmlUtils().sanitizeForRichText(htmlPasteItem.html)
         }
     val richTextState = rememberRichTextState()
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteItemView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteItemView.kt
@@ -46,6 +46,7 @@ import org.koin.compose.koinInject
 @Composable
 fun PasteDataScope.SidePasteItemView(
     selected: Boolean,
+    isScrolling: Boolean,
     onPress: () -> Unit,
     onDoubleTap: () -> Unit,
     pasteContent: @Composable PasteData.() -> Unit,
@@ -120,10 +121,26 @@ fun PasteDataScope.SidePasteItemView(
                 Modifier
                     .fillMaxSize()
                     .drawWithContent {
-                        graphicsLayer.record {
-                            this@drawWithContent.drawContent()
+                        // Always render the visible content directly. The graphics
+                        // layer is only used to provide a drag preview, so we keep
+                        // recording off the per-frame draw path of the visible UI.
+                        drawContent()
+                        // Skip layer recording while the LazyRow is actively
+                        // scrolling. During fast recycling a freshly composed text
+                        // child can still have a null MultiParagraphLayoutCache,
+                        // and re-driving the child draw via record { drawContent() }
+                        // would crash. The previously recorded layer remains
+                        // available for any drag started mid-scroll.
+                        if (!isScrolling) {
+                            try {
+                                graphicsLayer.record {
+                                    this@drawWithContent.drawContent()
+                                }
+                            } catch (_: IllegalStateException) {
+                                // Residual race on the first stable frame: keep
+                                // the prior recording and try again next frame.
+                            }
                         }
-                        drawLayer(graphicsLayer)
                     },
         ) {
             Card(

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
@@ -320,6 +320,7 @@ fun SidePasteboardContentView() {
                         Spacer(modifier = Modifier.width(appSizeValue.sideSearchPaddingSize))
                         scope.SidePasteItemView(
                             selected = currentIndex in selectedIndexes,
+                            isScrolling = searchListState.isScrollInProgress,
                             onPress = {
                                 pasteSelectionViewModel.clickSelectedIndex(currentIndex, isShiftPressed)
                             },

--- a/shared/src/commonMain/kotlin/com/crosspaste/utils/HtmlUtils.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/utils/HtmlUtils.kt
@@ -71,6 +71,48 @@ object HtmlUtils {
             Ksoup.clean(str, Safelist.none(), "", outputSettings)
         }.getOrNull()
 
+    /**
+     * Strip declarations that crash richeditor + Compose Multiplatform when
+     * rendered through `RichTextState.setHtml`. richeditor's CSS parser maps
+     * `em`, `rem`, and `%` to `TextUnit.Em`, but Compose's
+     * `ParagraphBuilder.textStyleToParagraphStyle` calls `Density.toPx` on
+     * `TextIndent.firstLine`/`restLine`, which only accepts `Sp` and throws
+     * "Only Sp can convert to Px" otherwise. Stripping `text-indent` from
+     * inline styles is acceptable for our previews/editor — the lost
+     * indentation is purely cosmetic and not worth a full CSS rewrite.
+     */
+    fun sanitizeForRichText(html: String): String {
+        if (!html.contains("text-indent", ignoreCase = true)) return html
+        return runCatching {
+            val doc = Ksoup.parse(html)
+            doc.select("[style]").forEach { el ->
+                val original = el.attr("style")
+                val sanitized = stripTextIndent(original)
+                if (sanitized != original) {
+                    if (sanitized.isEmpty()) {
+                        el.removeAttr("style")
+                    } else {
+                        el.attr("style", sanitized)
+                    }
+                }
+            }
+            doc.outerHtml()
+        }.getOrElse { html }
+    }
+
+    private fun stripTextIndent(style: String): String =
+        style
+            .split(';')
+            .filter { decl ->
+                val colonIndex = decl.indexOf(':')
+                if (colonIndex < 0) return@filter decl.isNotBlank()
+                // Match the exact property name to avoid stripping vendor
+                // prefixes such as `mso-text-indent` from Word-pasted HTML.
+                val property = decl.substring(0, colonIndex).trim().lowercase()
+                property != "text-indent"
+            }.joinToString("; ") { it.trim() }
+            .trim()
+
     fun ensureHtmlCharsetUtf8(html: String): String =
         runCatching {
             val doc = Ksoup.parse(html)
@@ -101,17 +143,18 @@ object HtmlUtils {
         maxLines: Int = PREVIEW_MAX_LINES,
         charsPerLine: Int = PREVIEW_CHARS_PER_LINE,
     ): String {
-        if (html.length < maxLines * charsPerLine) return html
+        val sanitized = sanitizeForRichText(html)
+        if (sanitized.length < maxLines * charsPerLine) return sanitized
 
         return runCatching {
-            val doc = Ksoup.parse(html)
+            val doc = Ksoup.parse(sanitized)
             val body = doc.body()
 
             body.select("script, style, noscript, template").remove()
 
             truncateElement(body, maxLines, charsPerLine)
             doc.outerHtml()
-        }.getOrElse { html }
+        }.getOrElse { sanitized }
     }
 
     /**


### PR DESCRIPTION
Closes #4346.

## Summary

Two independent crashes were both reachable by flicking the side search window horizontally fast. They share the same trigger (a freshly composed item being measured / drawn before its inner state is ready), but have different root causes — fixed together because the symptom is single.

### 1. richeditor + CMP 1.10.3 `text-indent` em incompatibility

richeditor 1.0.0-rc14's `parseCssTextSize` maps CSS `em` / `rem` / `%` to `TextUnit.Em`; `parseCssTextIndent` puts that into `TextIndent`. When this `TextIndent` reaches Skia's `ParagraphBuilder.textStyleToParagraphStyle` in CMP 1.10.3, it is converted via the raw `Density.toPx(TextUnit)`, which only accepts `Sp` and throws `Only Sp can convert to Px`. Reported upstream as [MohamedRejeb/compose-rich-editor#724](https://github.com/MohamedRejeb/compose-rich-editor/issues/724) — rc14 release notes do not mention a fix and the parser sources are unchanged from rc13.

Fix: strip `text-indent` declarations from inline styles before any HTML reaches `RichTextState.setHtml(...)`.

- New `HtmlUtils.sanitizeForRichText(html)` walks elements with a `style` attribute and drops only the exact `text-indent` declaration. Property name match is exact, so vendor prefixes like Word's `mso-text-indent` are preserved.
- `HtmlUtils.truncateForPreview` now always sanitizes (covers `HtmlSidePreviewView` / `RtfSidePreviewView` via `getPreviewHtml`).
- `PasteHtmlEditContentView` sanitizes `originalHtml` before `richTextState.setHtml(...)`; subsequent undo/redo state passes through richeditor's own roundtrip and stays clean.

The lost indentation is purely cosmetic in our previews/editor and is the trade-off until the upstream fix lands.

### 2. `graphicsLayer.record { drawContent() }` race in SidePasteItemView

`SidePasteItemView` recorded the visible content into a `GraphicsLayer` every frame inside `drawWithContent` to power the drag-and-drop preview. Recording inside the draw phase re-drives child drawing; during fast `LazyRow` recycling a freshly composed text child can still have a `null` `MultiParagraphLayoutCache.textLayoutResult`, and that recursive draw triggers `MultiParagraphLayoutCache could not provide TextLayoutResult during the draw phase`.

Fix:
- Render the visible content with a plain `drawContent()` — the layer is only needed for the drag preview, no longer for the visible UI path.
- Only call `graphicsLayer.record` when the `LazyRow` is not actively scrolling. The previously recorded layer remains usable for any drag started mid-scroll.
- Wrap the record call in a try/catch as a residual safety net for first-stable-frame timing edge cases.
- `SidePasteboardContentView` plumbs `searchListState.isScrollInProgress` down to the item.

## Test plan

- [ ] Build: `./gradlew app:run`
- [ ] Copy a paragraph from Microsoft Word, Google Docs, or a typical web page (so the HTML contains `text-indent: 2em` / `1.5rem` / `50%`) into CrossPaste.
- [ ] Open the side search window with enough items that the row can scroll.
- [ ] Flick the row horizontally fast — repeatedly. Confirm no `Only Sp can convert to Px` and no `could not provide TextLayoutResult` exceptions.
- [ ] Edit the same HTML paste item (`PasteHtmlEditContentView`) and confirm it loads without crashing.
- [ ] Drag a side paste item out (e.g. into Finder / another app) and confirm the drag preview still appears.