### PR TITLE
:bug: accept java.net.URL transfer data in DesktopUrlTypePlugin

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopUrlTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopUrlTypePlugin.kt
@@ -49,16 +49,20 @@ class DesktopUrlTypePlugin(
         pasteTransferable: PasteTransferable,
         pasteCollector: PasteCollector,
     ) {
-        if (transferData is String) {
-            val update: (PasteItem) -> PasteItem = { pasteItem ->
-                createUrlPasteItem(
-                    identifiers = pasteItem.identifiers,
-                    url = transferData,
-                    extraInfo = pasteItem.extraInfo,
-                )
+        val urlString =
+            when (transferData) {
+                is String -> transferData
+                is URL -> transferData.toString()
+                else -> return
             }
-            pasteCollector.updateCollectItem(itemIndex, this::class, update)
+        val update: (PasteItem) -> PasteItem = { pasteItem ->
+            createUrlPasteItem(
+                identifiers = pasteItem.identifiers,
+                url = urlString,
+                extraInfo = pasteItem.extraInfo,
+            )
         }
+        pasteCollector.updateCollectItem(itemIndex, this::class, update)
     }
 
     override fun collectError(


### PR DESCRIPTION
Closes #4348

## Summary
- `DesktopUrlTypePlugin.doLoadRepresentation` previously only handled `transferData` when it was a `String`, so URL data delivered as `java.net.URL` (e.g., from Apple Universal Clipboard) was silently dropped.
- Accept both `String` and `java.net.URL`, converting the latter via `toString()`. This mirrors `buildTransferable`, which already publishes `URL_FLAVOR` as a `java.net.URL`.

## Test plan
- [ ] Copy a URL on a paired iPhone/Mac via Apple Universal Clipboard, paste into a peer device through CrossPaste, verify the URL paste item is non-empty.
- [ ] Regression: copy a URL within the desktop OS clipboard normally and confirm it still pastes correctly.