### PR TITLE
:zap: stop firing side search load-more on every scroll frame

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
@@ -190,9 +190,11 @@ fun SidePasteboardContentView() {
     }
 
     LaunchedEffect(searchListState) {
+        // Key on indices only; LazyListItemInfo.offset changes per frame and defeats distinctUntilChanged.
         snapshotFlow {
-            searchListState.layoutInfo.visibleItemsInfo
-        }.distinctUntilChanged().collect { visibleItems ->
+            searchListState.layoutInfo.visibleItemsInfo.map { it.index }
+        }.distinctUntilChanged().collect {
+            val visibleItems = searchListState.layoutInfo.visibleItemsInfo
             if (visibleItems.isNotEmpty()) {
                 // Only consider data items, exclude the loading indicator item
                 val lastDataItem = visibleItems.lastOrNull { it.index < latestSearchResult.value.size }
@@ -302,6 +304,7 @@ fun SidePasteboardContentView() {
                 itemsIndexed(
                     searchResult,
                     key = { _, item -> item.id },
+                    contentType = { _, item -> item.pasteType },
                 ) { index, pasteData ->
 
                     val currentIndex by rememberUpdatedState(index)


### PR DESCRIPTION
Closes #4350

## Summary
- `SidePasteboardContentView` keys its lazy-load `snapshotFlow` on `visibleItemsInfo.map { it.index }` instead of the full `List<LazyListItemInfo>`. Per-frame `offset` changes no longer defeat `distinctUntilChanged`, so `tryAddLimit` / scrollbar logic only run when the visible index range actually changes.
- Adds `contentType = pasteData.pasteType` on `itemsIndexed` so `LazyRow` recycles per paste type and keeps the loading-indicator item in its own bucket.

The scrollbar `isScrollInProgress` rewrite from the original fork suggestion was intentionally **not** included — it caused the scrollbar to remain visible indefinitely after `LaunchedEffect(searchResult)` set `showScrollbar = true` without a subsequent scroll start/stop transition.

Inspired by @Pandas886's fork PR (load-more decouple + `contentType` portion only; scrollbar rewrite and CI workflow_dispatch dropped).

## Test plan
- [ ] `./gradlew ktlintCheck` clean
- [ ] `./gradlew :app:compileKotlinDesktop` builds
- [ ] Manual: open search window, fast horizontal scroll on a long history, verify load-more still kicks in near the tail and scrollbar still auto-hides 1s after scrolling stops
- [ ] Manual: with mixed paste types in the list, verify no visual regressions while scrolling