### PR TITLE
Skip iPhone/iPad peers for Apple Universal Clipboard pastes

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
@@ -121,7 +121,10 @@ class MacosPasteboardService(
                                                     syncManager
                                                         .getSyncHandlers()
                                                         .filterValues { handler ->
-                                                            !handler.currentSyncRuntimeInfo.platform.isMacos()
+                                                            val platform = handler.currentSyncRuntimeInfo.platform
+                                                            !platform.isIphone() &&
+                                                                !platform.isIpad() &&
+                                                                !platform.isMacos()
                                                         }.keys
                                                 } else {
                                                     null


### PR DESCRIPTION
Closes #4354

## Summary

- Apple Universal Clipboard syncs to Macs, iPhones, and iPads via iCloud — not just Macs.
- The Universal Clipboard routing in #4344 only excluded macOS peers, so iOS / iPadOS peers still received the same paste twice (once via iCloud, once via CrossPaste).
- Extend the platform filter to also skip iPhone and iPad. Forwarding targets become: Windows, Linux, Android.

## Test plan

- [ ] Copy something on another Apple device (iPhone / iPad / another Mac), wait for iCloud to propagate to this Mac.
- [ ] Verify iPhone / iPad CrossPaste peers do NOT receive a duplicate paste from this Mac.
- [ ] Verify Windows / Linux / Android peers DO receive the paste (so non-Apple peers still get the cross-device benefit).
- [ ] Local Mac → CrossPaste sync to all peers (non-Universal-Clipboard path) is unaffected.