### PR TITLE
:bug: skip empty Apple sync tasks and harden side drag preview

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -121,7 +121,10 @@ class PasteReleaseService(
                     // Skip syncing for remote clipboard data (e.g., Apple Universal Clipboard / Handoff).
                     // These items are already from another device, so re-syncing them would cause
                     // unnecessary duplication or sync loops.
-                    if (!pasteData.remote) {
+                    // An empty target set means every paired peer was filtered out (e.g. all-Apple
+                    // peers for an Apple Universal Clipboard event) — skip the task instead of
+                    // creating one that can't sync anywhere.
+                    if (!pasteData.remote && targetAppInstanceIds?.isEmpty() != true) {
                         addSyncTask(id, maxFileSize, pasteData.appInstanceId, targetAppInstanceIds)
                     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteSourceContext.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteSourceContext.kt
@@ -3,7 +3,6 @@ package com.crosspaste.paste
 data class PasteSourceContext(
     val source: String?,
     val remote: Boolean,
-    val appleRemoteClipboard: Boolean = false,
     val dragAndDrop: Boolean = false,
     val targetAppInstanceIds: Set<String>? = null,
 )

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/MacosPasteboardService.kt
@@ -115,9 +115,8 @@ class MacosPasteboardService(
                                     if (contents != ownerTransferable) {
                                         contents?.let {
                                             ownerTransferable = it
-                                            val isAppleRemoteClipboard = remote.value != 0
                                             val targetAppInstanceIds =
-                                                if (isAppleRemoteClipboard) {
+                                                if (remote.value != 0) {
                                                     syncManager
                                                         .getSyncHandlers()
                                                         .filterValues { handler ->
@@ -136,7 +135,6 @@ class MacosPasteboardService(
                                                     PasteSourceContext(
                                                         source = source,
                                                         remote = false,
-                                                        appleRemoteClipboard = isAppleRemoteClipboard,
                                                         targetAppInstanceIds = targetAppInstanceIds,
                                                     ),
                                                 )

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteItemView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteItemView.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.paste.DesktopPasteMenuService
@@ -60,13 +61,23 @@ fun PasteDataScope.SidePasteItemView(
     val appSizeValue = LocalDesktopAppSizeValueState.current
 
     val graphicsLayer = rememberGraphicsLayer()
+    val placeholderColor = AppUIColors.pasteBackground
 
     Row(
         modifier =
             Modifier
                 .dragAndDropSource(
                     drawDragDecoration = {
-                        drawLayer(graphicsLayer)
+                        // The graphics layer is empty until the first non-scrolling
+                        // frame records it. If a drag starts before that, fall back
+                        // to a blank tile sized to the source so the preview is
+                        // still visible — the drag itself shouldn't be blocked by
+                        // rendering state.
+                        if (graphicsLayer.size == IntSize.Zero) {
+                            drawRect(color = placeholderColor)
+                        } else {
+                            drawLayer(graphicsLayer)
+                        }
                     },
                 ) { offset ->
                     DragAndDropTransferData(


### PR DESCRIPTION
Closes #4356

## Summary
Three small follow-ups from review of the merged work behind #4355 (Apple Universal Clipboard peer filter) and #4347 (side search drag crash fix).

- **Dead `appleRemoteClipboard` field**: removed from `PasteSourceContext`. Written in `MacosPasteboardService` but never read; was also leaking into the mobile copy of the data class.
- **Wasted sync task**: when every paired peer is Apple (iPhone/iPad/Mac) and the paste came from Apple Universal Clipboard, the target set is empty. The empty set used to flow all the way into `SyncPasteTaskExecutor`, which created and persisted a task that ultimately matched nothing. Skipped at `PasteReleaseService.releaseLocalPasteData` when `targetAppInstanceIds?.isEmpty() == true`. `null` still means "broadcast to all".
- **Drag preview race**: `graphicsLayer` is empty until the first non-scrolling frame records it (gated by the `!isScrolling` guard from #4347). A drag started before that would paint an empty preview. Fixed by falling back to a `drawRect` placeholder of the source size in the card background color when `graphicsLayer.size == IntSize.Zero`. Drag is no longer blocked by rendering state; the existing `!isScrolling` guard and `try/catch` backstop are untouched.

## Test plan
- [ ] `./gradlew ktlintFormat` passes
- [ ] `./gradlew :app:compileKotlinDesktop` passes
- [ ] Copy text on macOS without any paired peers — paste appears locally, no sync task is created (was already the case; verify regression-free).
- [ ] Pair a Mac + iPhone, copy text on iPhone (delivered to Mac via Universal Clipboard) — paste shows up in CrossPaste history, **no** sync task is created.
- [ ] Pair Mac + iPhone + a non-Apple peer, copy on iPhone (Universal Clipboard event on Mac) — sync task targets only the non-Apple peer.
- [ ] Pair Mac + a non-Apple peer, copy locally on Mac — paste syncs to peer normally.
- [ ] Drag an item from the side panel during fast horizontal scrolling — drag starts, preview shows either the recorded layer or a same-size blank tile (never a missed/blocked drag).