### PR TITLE
:bug: lower mac paste window level so drag preview is visible

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/macos/MacAppUtils.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/macos/MacAppUtils.kt
@@ -37,8 +37,8 @@ object MacAppUtils {
         INSTANCE.searchToBackAndPaste(appName, array, count)
     }
 
-    fun setWindowLevelScreenSaver(windowPtr: Pointer?) {
-        INSTANCE.setWindowLevelScreenSaver(windowPtr)
+    fun setWindowLevelPopUpMenu(windowPtr: Pointer?) {
+        INSTANCE.setWindowLevelPopUpMenu(windowPtr)
     }
 
     fun applyAcrylicBackground(

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/macos/api/MacosApi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/macos/api/MacosApi.kt
@@ -74,7 +74,7 @@ interface MacosApi : Library {
         count: Int,
     )
 
-    fun setWindowLevelScreenSaver(windowPtr: Pointer?)
+    fun setWindowLevelPopUpMenu(windowPtr: Pointer?)
 
     fun applyAcrylicBackground(
         windowPtr: Pointer?,

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/BubbleWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/BubbleWindow.kt
@@ -381,7 +381,7 @@ fun MacAcrylicEffect(window: ComposeWindow) {
         withContext(cpuDispatcher) {
             runCatching {
                 val pointer = Pointer(window.windowHandle)
-                MacAppUtils.setWindowLevelScreenSaver(pointer)
+                MacAppUtils.setWindowLevelPopUpMenu(pointer)
             }
         }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
@@ -181,7 +181,7 @@ fun MacAcrylicEffect(
         withContext(cpuDispatcher) {
             runCatching {
                 val pointer = Pointer(window.windowHandle)
-                MacAppUtils.setWindowLevelScreenSaver(pointer)
+                MacAppUtils.setWindowLevelPopUpMenu(pointer)
                 MacAppUtils.applyAcrylicBackground(pointer, isDark)
             }
         }

--- a/app/src/desktopMain/swift/MacosApi.swift
+++ b/app/src/desktopMain/swift/MacosApi.swift
@@ -327,8 +327,8 @@ private func hideWindowAndActivateApp(hideTitle: String, appName: String) {
     }
 }
 
-@_cdecl("setWindowLevelScreenSaver")
-public func setWindowLevelScreenSaver(_ rawPtr: UnsafeRawPointer?) {
+@_cdecl("setWindowLevelPopUpMenu")
+public func setWindowLevelPopUpMenu(_ rawPtr: UnsafeRawPointer?) {
     guard let rawPtr = rawPtr else { return }
 
     let window = Unmanaged<NSWindow>.fromOpaque(rawPtr).takeUnretainedValue()
@@ -338,8 +338,8 @@ public func setWindowLevelScreenSaver(_ rawPtr: UnsafeRawPointer?) {
             return
         }
 
-        let screenSaverLevel = CGWindowLevelForKey(.screenSaverWindow)
-        window.level = NSWindow.Level(rawValue: Int(screenSaverLevel))
+        let popUpMenuLevel = CGWindowLevelForKey(.popUpMenuWindow)
+        window.level = NSWindow.Level(rawValue: Int(popUpMenuLevel))
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     }
 }


### PR DESCRIPTION
Closes #4360

## Summary

On macOS, dragging a paste item out of the side search / bubble window left the system drag preview hidden behind the window. Root cause: `setWindowLevelScreenSaver` set the window to `kCGScreenSaverWindowLevel` (1000), which is above the system drag image level `kCGDraggingWindowLevel` (500).

Lower the window level to `kCGPopUpMenuWindowLevel` (101). It still sits above the Dock (20) so the paste window is not covered by the Dock, but it sits below the drag image so the preview now renders on top. `canJoinAllSpaces + fullScreenAuxiliary` collection behavior is unchanged — the window still floats above fullscreen apps. This is the same window level used by Alfred / Raycast.

The Swift `@_cdecl` function, JNA interface, Kotlin wrapper, and the two call sites are renamed from `setWindowLevelScreenSaver` to `setWindowLevelPopUpMenu` so the name reflects the actual behavior.

## Test plan

- [ ] Set Dock to a large size at the bottom of the screen — side window still appears above the Dock
- [ ] Drag a paste item from the side window to Finder / Notes — drag preview is visible following the cursor
- [ ] Drag a paste item from the bubble window — drag preview is visible
- [ ] Open a fullscreen Safari window — invoking the side window still floats above it
- [ ] Multi-Space switching — `canJoinAllSpaces` still works