### PR TITLE
Add Chrome Web Store release tooling: zip packaging and marketing preview

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+public/marketing/
 
 # Override root-level package*.json ignore
 !package.json

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -19,6 +19,18 @@ version =
         "Missing 'version' in crosspaste-version.properties"
     }
 
+fun gitRevision(): String? =
+    runCatching {
+        val process =
+            ProcessBuilder("git", "rev-list", "--count", "HEAD")
+                .directory(project.projectDir.parentFile)
+                .redirectErrorStream(true)
+                .start()
+        process.inputStream.bufferedReader().use { it.readText() }.trim().also {
+            process.waitFor()
+        }
+    }.getOrNull()?.takeIf { it.isNotBlank() && it.all(Char::isDigit) }
+
 tasks.register("generateVersion") {
     val versionFile =
         project.projectDir
@@ -138,6 +150,54 @@ tasks.register<Exec>("npmBuild") {
     inputs.file("vite.config.ts")
     inputs.file("tsconfig.json")
     outputs.dir("dist")
+}
+
+tasks.register("patchDistManifestRevision") {
+    dependsOn("npmBuild")
+    val distManifest = project.file("dist/manifest.json")
+    outputs.file(distManifest)
+    outputs.upToDateWhen { false }
+
+    doLast {
+        val revision =
+            versionProperties.getProperty("revision")?.takeIf { it.isNotBlank() }
+                ?: gitRevision()
+                ?: error("Cannot resolve revision: 'revision' missing in properties and 'git rev-list --count HEAD' failed")
+        val fullVersion = "$version.$revision"
+
+        check(distManifest.exists()) { "dist/manifest.json not found — run :web:npmBuild first" }
+        val text = distManifest.readText()
+        val patched =
+            text.replaceFirst(
+                Regex("\"version\"\\s*:\\s*\"[^\"]*\""),
+                "\"version\": \"$fullVersion\"",
+            )
+        check(patched.contains("\"version\": \"$fullVersion\"")) {
+            "Failed to inject version into $distManifest"
+        }
+        distManifest.writeText(patched)
+        logger.lifecycle("Patched dist/manifest.json version → $fullVersion")
+    }
+}
+
+tasks.register<Zip>("packageExtension") {
+    dependsOn("patchDistManifestRevision")
+    from(layout.projectDirectory.dir("dist"))
+    archiveFileName.set(
+        provider {
+            val rev =
+                versionProperties.getProperty("revision")?.takeIf { it.isNotBlank() }
+                    ?: gitRevision()
+                    ?: error("Cannot resolve revision for zip name")
+            "crosspaste-extension-$version.$rev.zip"
+        },
+    )
+    destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+    exclude("**/.DS_Store")
+
+    doLast {
+        logger.lifecycle("Chrome extension zip: ${archiveFile.get().asFile.absolutePath}")
+    }
 }
 
 tasks.register<Delete>("clean") {

--- a/web/package.json
+++ b/web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:marketing": "VITE_MARKETING_MODE=true vite --open /src/sidepanel/index.html",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/web/src/shared/marketing/chrome-stub.ts
+++ b/web/src/shared/marketing/chrome-stub.ts
@@ -1,0 +1,158 @@
+import { getMarketingDevices } from "./marketing-devices";
+import { getMarketingPastes, invalidateMarketingCache } from "./marketing-fixtures";
+
+type Listener = (msg: Record<string, unknown>, sender?: unknown, sendResponse?: (r: unknown) => void) => void | boolean;
+
+const LANGUAGE_STORAGE_KEY = "ui_language";
+
+const messageListeners = new Set<Listener>();
+
+function broadcast(msg: Record<string, unknown>): void {
+  for (const fn of messageListeners) {
+    try {
+      fn(msg);
+    } catch {
+      /* swallow listener errors so one bad listener doesn't break others */
+    }
+  }
+}
+
+async function handleSendMessage(message: Record<string, unknown>): Promise<unknown> {
+  const type = message.type as string;
+  switch (type) {
+    case "GET_PASTES": {
+      const all = await getMarketingPastes();
+      const offset = (message.offset as number) ?? 0;
+      const limit = (message.limit as number) ?? all.length;
+      const query = ((message.query as string) ?? "").trim().toLowerCase();
+      const pasteType = message.pasteType as number | null | undefined;
+      let filtered = all;
+      if (typeof pasteType === "number") {
+        filtered = filtered.filter((p) => p.pasteType === pasteType);
+      }
+      if (query) {
+        filtered = filtered.filter((p) => {
+          const item = p.pasteAppearItem;
+          if (!item) return false;
+          if (item.type === "text") return item.text.toLowerCase().includes(query);
+          if (item.type === "url") return item.url.toLowerCase().includes(query);
+          if (item.type === "html") return item.html.toLowerCase().includes(query);
+          return false;
+        });
+      }
+      return { items: filtered.slice(offset, offset + limit) };
+    }
+    case "DELETE_PASTE":
+      return { success: true };
+    case "DOWNLOAD_FILE":
+      return { success: true };
+    case "GET_DEVICES":
+      return { devices: getMarketingDevices() };
+    case "GET_WS_STATUS": {
+      const statuses: Record<string, string> = {};
+      for (const d of getMarketingDevices()) {
+        statuses[d.targetAppInstanceId] = "ws_connected";
+      }
+      return { statuses };
+    }
+    case "GET_DESKTOP_STATUS":
+      return { desktopConnected: false };
+    case "CONNECT":
+    case "PAIR":
+    case "REPAIR":
+    case "REMOVE_DEVICE":
+    case "UPDATE_NOTE":
+    case "LOCAL_COPY":
+    case "COPY_ITEM":
+      return { success: true };
+    default:
+      return undefined;
+  }
+}
+
+function makeStorageArea(backing: Storage): chrome.storage.StorageArea {
+  const get = (
+    keys?: string | string[] | Record<string, unknown> | null,
+  ): Promise<Record<string, unknown>> => {
+    const result: Record<string, unknown> = {};
+    const collect = (k: string, fallback?: unknown) => {
+      const raw = backing.getItem(k);
+      if (raw !== null) {
+        try {
+          result[k] = JSON.parse(raw);
+        } catch {
+          result[k] = raw;
+        }
+      } else if (fallback !== undefined) {
+        result[k] = fallback;
+      }
+    };
+    if (keys == null) {
+      for (let i = 0; i < backing.length; i++) {
+        const k = backing.key(i);
+        if (k) collect(k);
+      }
+    } else if (typeof keys === "string") {
+      collect(keys);
+    } else if (Array.isArray(keys)) {
+      keys.forEach((k) => collect(k));
+    } else {
+      Object.entries(keys).forEach(([k, fallback]) => collect(k, fallback));
+    }
+    return Promise.resolve(result);
+  };
+
+  const set = (items: Record<string, unknown>): Promise<void> => {
+    let languageChanged = false;
+    Object.entries(items).forEach(([k, v]) => {
+      if (k === LANGUAGE_STORAGE_KEY && backing === window.localStorage) {
+        const prev = backing.getItem(k);
+        if (prev !== JSON.stringify(v)) languageChanged = true;
+      }
+      backing.setItem(k, JSON.stringify(v));
+    });
+    if (languageChanged) {
+      invalidateMarketingCache();
+      broadcast({ type: "PASTE_UPDATED" });
+    }
+    return Promise.resolve();
+  };
+
+  const remove = (keys: string | string[]): Promise<void> => {
+    const list = Array.isArray(keys) ? keys : [keys];
+    list.forEach((k) => backing.removeItem(k));
+    return Promise.resolve();
+  };
+
+  return { get, set, remove } as unknown as chrome.storage.StorageArea;
+}
+
+export function buildMarketingChrome(): typeof chrome {
+  const stub = {
+    runtime: {
+      sendMessage: (message: Record<string, unknown>) => handleSendMessage(message),
+      onMessage: {
+        addListener: (fn: Listener) => messageListeners.add(fn),
+        removeListener: (fn: Listener) => messageListeners.delete(fn),
+        hasListener: (fn: Listener) => messageListeners.has(fn),
+      },
+      getURL: (path: string) => path,
+      id: "marketing-mode",
+    },
+    storage: {
+      local: makeStorageArea(window.localStorage),
+      session: makeStorageArea(window.sessionStorage),
+    },
+    tabs: {
+      create: (props: { url?: string }) => {
+        if (props.url) window.open(props.url, "_blank", "noopener");
+        return Promise.resolve({} as chrome.tabs.Tab);
+      },
+    },
+    permissions: {
+      contains: () => Promise.resolve(true),
+      request: () => Promise.resolve(true),
+    },
+  };
+  return stub as unknown as typeof chrome;
+}

--- a/web/src/shared/marketing/install.ts
+++ b/web/src/shared/marketing/install.ts
@@ -1,0 +1,9 @@
+import { buildMarketingChrome } from "./chrome-stub";
+
+if (typeof window !== "undefined") {
+  const w = window as unknown as { chrome?: typeof chrome };
+  if (!w.chrome || !w.chrome.runtime?.id) {
+    w.chrome = buildMarketingChrome();
+    document.documentElement.dataset.marketing = "true";
+  }
+}

--- a/web/src/shared/marketing/marketing-devices.ts
+++ b/web/src/shared/marketing/marketing-devices.ts
@@ -1,0 +1,72 @@
+import type { StoredDevice } from "@/shared/storage/device-store";
+import { SyncState } from "@/shared/sync/sync-state";
+
+export interface MarketingDevice extends StoredDevice {
+  status: SyncState;
+}
+
+const ADDED_AT = Date.UTC(2026, 4, 1);
+
+const macDevice: MarketingDevice = {
+  targetAppInstanceId: "macos-marketing",
+  host: "192.168.1.10",
+  port: 13129,
+  trusted: true,
+  noteName: "My Macbook",
+  addedAt: ADDED_AT,
+  status: SyncState.CONNECTED,
+  syncInfo: {
+    appInfo: {
+      appInstanceId: "macos-marketing",
+      appVersion: "1.1.1",
+      appRevision: "0",
+      userName: "user",
+    },
+    endpointInfo: {
+      deviceId: "2",
+      deviceName: "device2",
+      platform: {
+        name: "Macos",
+        arch: "arm",
+        bitMode: 64,
+        version: "15.3.1",
+      },
+      hostInfoList: [{ networkPrefixLength: 24, hostAddress: "192.168.1.10" }],
+      port: 13129,
+    },
+  },
+};
+
+const winDevice: MarketingDevice = {
+  targetAppInstanceId: "windows-marketing",
+  host: "192.168.1.20",
+  port: 13129,
+  trusted: true,
+  noteName: "My Win",
+  addedAt: ADDED_AT,
+  status: SyncState.CONNECTED,
+  syncInfo: {
+    appInfo: {
+      appInstanceId: "windows-marketing",
+      appVersion: "1.1.1",
+      appRevision: "0",
+      userName: "user",
+    },
+    endpointInfo: {
+      deviceId: "1",
+      deviceName: "device1",
+      platform: {
+        name: "Windows",
+        arch: "x86",
+        bitMode: 64,
+        version: "11",
+      },
+      hostInfoList: [{ networkPrefixLength: 24, hostAddress: "192.168.1.20" }],
+      port: 13129,
+    },
+  },
+};
+
+export function getMarketingDevices(): MarketingDevice[] {
+  return [macDevice, winDevice];
+}

--- a/web/src/shared/marketing/marketing-fixtures.ts
+++ b/web/src/shared/marketing/marketing-fixtures.ts
@@ -1,0 +1,220 @@
+import type { PasteData, PasteCollection } from "@/shared/models/paste-data";
+import { PasteState } from "@/shared/models/paste-data";
+import {
+  PasteType,
+  PasteTypeInt,
+  type ColorPasteItem,
+  type FilesPasteItem,
+  type HtmlPasteItem,
+  type ImagesPasteItem,
+  type TextPasteItem,
+  type UrlPasteItem,
+} from "@/shared/models/paste-item";
+
+const MAC_INSTANCE = "macos-marketing";
+const LANGUAGE_STORAGE_KEY = "ui_language";
+
+const emptyCollection: PasteCollection = { pasteItems: [] };
+
+function normalizeLang(raw: string | undefined): "zh" | "en" {
+  return (raw ?? "").toLowerCase().startsWith("zh") ? "zh" : "en";
+}
+
+async function resolveLang(): Promise<"zh" | "en"> {
+  try {
+    const stored = await chrome.storage.local.get(LANGUAGE_STORAGE_KEY);
+    const persisted = stored[LANGUAGE_STORAGE_KEY] as string | undefined;
+    if (persisted) return normalizeLang(persisted);
+  } catch {
+    /* fall through to navigator */
+  }
+  return normalizeLang(navigator.language);
+}
+
+async function loadText(path: string): Promise<string> {
+  try {
+    const res = await fetch(path);
+    if (!res.ok) return "";
+    return await res.text();
+  } catch {
+    return "";
+  }
+}
+
+function colorFixture(): PasteData {
+  // #A6D6D6FF parsed as #RRGGBBAA → ARGB int32 (signed)
+  const argb = (0xff << 24) | (0xa6 << 16) | (0xd6 << 8) | 0xd6;
+  const item: ColorPasteItem = {
+    type: PasteType.COLOR,
+    identifiers: ["marketing-color"],
+    hash: "marketing-color",
+    size: 4,
+    color: argb,
+  };
+  return {
+    _id: 6,
+    id: 6,
+    appInstanceId: MAC_INSTANCE,
+    favorite: false,
+    pasteAppearItem: item,
+    pasteCollection: emptyCollection,
+    pasteType: PasteTypeInt.COLOR,
+    source: "Figma",
+    size: item.size,
+    hash: item.hash,
+    pasteState: PasteState.LOADED,
+  };
+}
+
+function urlFixture(): PasteData {
+  const url = "https://github.com";
+  const item: UrlPasteItem = {
+    type: PasteType.URL,
+    identifiers: ["marketing-url"],
+    hash: "marketing-url",
+    size: url.length,
+    url,
+  };
+  return {
+    _id: 5,
+    id: 5,
+    appInstanceId: MAC_INSTANCE,
+    favorite: false,
+    pasteAppearItem: item,
+    pasteCollection: emptyCollection,
+    pasteType: PasteTypeInt.URL,
+    source: "Google Chrome",
+    size: item.size,
+    hash: item.hash,
+    pasteState: PasteState.LOADED,
+  };
+}
+
+function fileFixture(): PasteData {
+  const fileName = "data.zip";
+  const item: FilesPasteItem = {
+    type: PasteType.FILE,
+    identifiers: ["marketing-file"],
+    hash: "marketing-file",
+    size: 1024 * 64,
+    count: 1,
+    relativePathList: [fileName],
+    fileInfoTreeMap: {},
+  };
+  return {
+    _id: 4,
+    id: 4,
+    appInstanceId: MAC_INSTANCE,
+    favorite: false,
+    pasteAppearItem: item,
+    pasteCollection: emptyCollection,
+    pasteType: PasteTypeInt.FILE,
+    source: "Finder",
+    size: item.size,
+    hash: item.hash,
+    pasteState: PasteState.LOADED,
+  };
+}
+
+function imageFixture(): PasteData {
+  const fileName = "sunflower.png";
+  const item: ImagesPasteItem = {
+    type: PasteType.IMAGE,
+    identifiers: ["marketing-image"],
+    hash: "marketing-image",
+    size: 1024 * 200,
+    count: 1,
+    relativePathList: [fileName],
+    fileInfoTreeMap: {},
+    dataUrl: `/marketing/${fileName}`,
+  };
+  return {
+    _id: 3,
+    id: 3,
+    appInstanceId: MAC_INSTANCE,
+    favorite: true,
+    pasteAppearItem: item,
+    pasteCollection: emptyCollection,
+    pasteType: PasteTypeInt.IMAGE,
+    source: "Photo Album",
+    size: item.size,
+    hash: item.hash,
+    pasteState: PasteState.LOADED,
+  };
+}
+
+function textFixture(text: string): PasteData {
+  const item: TextPasteItem = {
+    type: PasteType.TEXT,
+    identifiers: ["marketing-text"],
+    hash: "marketing-text",
+    size: text.length,
+    text,
+  };
+  return {
+    _id: 2,
+    id: 2,
+    appInstanceId: MAC_INSTANCE,
+    favorite: false,
+    pasteAppearItem: item,
+    pasteCollection: emptyCollection,
+    pasteType: PasteTypeInt.TEXT,
+    source: "Notes Archive",
+    size: item.size,
+    hash: item.hash,
+    pasteState: PasteState.LOADED,
+  };
+}
+
+function htmlFixture(html: string): PasteData {
+  const item: HtmlPasteItem = {
+    type: PasteType.HTML,
+    identifiers: ["marketing-html"],
+    hash: "marketing-html",
+    size: html.length,
+    html,
+    extraInfo: { background: 0xffffffff | 0 },
+  };
+  return {
+    _id: 1,
+    id: 1,
+    appInstanceId: MAC_INSTANCE,
+    favorite: false,
+    pasteAppearItem: item,
+    pasteCollection: emptyCollection,
+    pasteType: PasteTypeInt.HTML,
+    source: "Email",
+    size: item.size,
+    hash: item.hash,
+    pasteState: PasteState.LOADED,
+  };
+}
+
+const cachedByLang = new Map<string, Promise<PasteData[]>>();
+
+export function getMarketingPastes(): Promise<PasteData[]> {
+  return resolveLang().then((lang) => {
+    const existing = cachedByLang.get(lang);
+    if (existing) return existing;
+    const promise = (async () => {
+      const [text, html] = await Promise.all([
+        loadText(`/marketing/${lang}.txt`),
+        loadText(`/marketing/${lang}.html`),
+      ]);
+      return [
+        htmlFixture(html || "<p>HTML preview</p>"),
+        textFixture(text || "Marketing text"),
+        imageFixture(),
+        fileFixture(),
+        urlFixture(),
+        colorFixture(),
+      ];
+    })();
+    cachedByLang.set(lang, promise);
+    return promise;
+  });
+}
+
+export function invalidateMarketingCache(): void {
+  cachedByLang.clear();
+}

--- a/web/src/sidepanel/main.tsx
+++ b/web/src/sidepanel/main.tsx
@@ -3,8 +3,15 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import "../index.css";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+async function bootstrap() {
+  if (import.meta.env.VITE_MARKETING_MODE === "true") {
+    await import("@/shared/marketing/install");
+  }
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}
+
+void bootstrap();

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,30 +1,45 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { crx } from "@crxjs/vite-plugin";
 import manifest from "./manifest.json";
 import path from "path";
+import fs from "fs";
 
-export default defineConfig({
-  plugins: [react(), crx({ manifest })],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-    // Ensure Kotlin/JS library's deps resolve from web/node_modules
-    dedupe: ["@js-joda/core"],
+const stripMarketingFromDist = (): Plugin => ({
+  name: "strip-marketing-from-dist",
+  apply: "build",
+  closeBundle() {
+    const target = path.resolve(__dirname, "dist/marketing");
+    if (fs.existsSync(target)) fs.rmSync(target, { recursive: true, force: true });
   },
-  build: {
-    outDir: "dist",
-    emptyOutDir: true,
-    chunkSizeWarningLimit: 1024,
-    rollupOptions: {
-      input: {
-        sidepanel: path.resolve(__dirname, "src/sidepanel/index.html"),
-        offscreen: path.resolve(__dirname, "src/offscreen/offscreen.html"),
+});
+
+export default defineConfig(({ mode }) => {
+  const marketing = process.env.VITE_MARKETING_MODE === "true" || mode === "marketing";
+  return {
+    plugins: marketing
+      ? [react()]
+      : [react(), crx({ manifest }), stripMarketingFromDist()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+      // Ensure Kotlin/JS library's deps resolve from web/node_modules
+      dedupe: ["@js-joda/core"],
+    },
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      chunkSizeWarningLimit: 1024,
+      rollupOptions: {
+        input: {
+          sidepanel: path.resolve(__dirname, "src/sidepanel/index.html"),
+          offscreen: path.resolve(__dirname, "src/offscreen/offscreen.html"),
+        },
       },
     },
-  },
-  optimizeDeps: {
-    include: ["@js-joda/core"],
-  },
+    optimizeDeps: {
+      include: ["@js-joda/core"],
+    },
+  };
 });


### PR DESCRIPTION
Closes #4362

## Summary

- **`:web:packageExtension` Gradle task** — one-shot build + zip for Chrome Web Store. Manifest version auto-rewrites to `<base>.<git rev count>` (with `crosspaste-version.properties` revision taking precedence to match CI). Patches `dist/manifest.json` only, source files stay clean.
- **`npm run dev:marketing` preview mode** — sidepanel boots as a plain web page with mock data: 6 paste fixtures (HTML/text/image/file/URL/color) + 2 connected mock devices (Macbook + Windows), mirroring desktop `MarketingPasteData` / `MarketingSyncManager`. Used to capture Chrome Web Store screenshots without a real desktop peer.
- Marketing assets live under `web/public/marketing/` (gitignored). Vite `closeBundle` hook strips any leaked marketing files out of the production extension `dist/`.
- Live language switching: writes to `chrome.storage.local.ui_language` invalidate the fixture cache and broadcast `PASTE_UPDATED`, so EN ↔ ZH text/HTML reload immediately.

## Test plan

- [x] `cd web && npx tsc --noEmit` — passes
- [x] `cd web && npx vitest run` — 79/79 passing
- [x] `./gradlew :web:packageExtension` — produces `web/build/distributions/crosspaste-extension-2.0.0.<rev>.zip`; manifest inside has the bumped version; source `manifest.json` and `version.generated.ts` remain unmodified
- [x] `cd web && npm run build` — production extension builds; `dist/marketing/` is absent (assets stripped)
- [ ] `cd web && npm run dev:marketing` — sidepanel renders 6 mock paste cards + 2 connected mock devices; switching language in settings flips text/HTML between EN and ZH without page reload