### PR TITLE
:bug: resolve npm absolute path in :web build to fix daemon Exec error 2

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -131,11 +131,50 @@ tasks.register("generateI18n") {
     }
 }
 
-val npmCmd = if (org.gradle.internal.os.OperatingSystem.current().isWindows) "npm.cmd" else "npm"
+fun resolveNpmCommand(): String {
+    val isWindows = org.gradle.internal.os.OperatingSystem.current().isWindows
+    val fallback = if (isWindows) "npm.cmd" else "npm"
+    if (isWindows) return fallback
+    val userShell = System.getenv("SHELL")?.takeIf { java.io.File(it).canExecute() } ?: "/bin/bash"
+    return sequenceOf(
+        listOf(userShell, "-ic", "command -v npm"),
+        listOf(userShell, "-lc", "command -v npm"),
+        listOf("/bin/bash", "-lc", "command -v npm"),
+    ).firstNotNullOfOrNull { cmd ->
+        runCatching {
+            val process =
+                ProcessBuilder(cmd)
+                    .redirectErrorStream(false)
+                    .start()
+            val output = process.inputStream.bufferedReader().use { it.readText() }
+            process.waitFor()
+            output.lineSequence()
+                .map { it.trim() }
+                .firstOrNull { it.isNotBlank() && java.io.File(it).canExecute() }
+        }.getOrNull()
+    } ?: fallback
+}
+
+val npmCmd = resolveNpmCommand()
+
+val npmBinDir: String? =
+    java.io.File(npmCmd)
+        .takeIf { it.isAbsolute && it.exists() }
+        ?.parentFile
+        ?.absolutePath
+
+fun org.gradle.process.ExecSpec.injectNpmBinDir() {
+    val dir = npmBinDir ?: return
+    val currentPath = System.getenv("PATH").orEmpty()
+    if (currentPath.split(java.io.File.pathSeparator).none { it == dir }) {
+        environment("PATH", "$dir${java.io.File.pathSeparator}$currentPath")
+    }
+}
 
 tasks.register<Exec>("npmInstall") {
     workingDir = projectDir
     commandLine(npmCmd, "install")
+    injectNpmBinDir()
     inputs.file("package.json")
     outputs.dir("node_modules")
 }
@@ -144,6 +183,7 @@ tasks.register<Exec>("npmBuild") {
     dependsOn("npmInstall", "generateVersion", "generateI18n", ":core:jsBrowserProductionLibraryDistribution")
     workingDir = projectDir
     commandLine(npmCmd, "run", "build")
+    injectNpmBinDir()
     inputs.dir("src")
     inputs.dir("public")
     inputs.file("manifest.json")


### PR DESCRIPTION
Closes #4364

## Summary

- The `npmInstall` / `npmBuild` Exec tasks in `web/build.gradle.kts` called bare `npm`, which fails with `Exec failed, error: 2 (No such file or directory)` whenever the Gradle daemon's `PATH` does not contain `npm` — typical when Node is installed via nvm (sourced only in `~/.zshrc`) and the daemon was launched by a GUI IDE that does not read shell rc files.
- Resolves `npm`'s absolute path at configuration time by probing `$SHELL` in interactive mode (`$SHELL -ic "command -v npm"`), with `$SHELL -lc` and `/bin/bash -lc` fallbacks. Each candidate is validated as an executable file before being accepted; falls back to bare `"npm"` if all probes fail.
- Prepends the resolved npm's parent directory onto each `Exec` task's `PATH` so npm's `#!/usr/bin/env node` shebang can also resolve `node` in the subprocess.

## Test plan

- [x] `./gradlew :web:build` works in a normal terminal.
- [x] `env -i HOME=$HOME SHELL=$SHELL PATH=/usr/bin:/bin ./gradlew --stop && env -i HOME=$HOME SHELL=$SHELL PATH=/usr/bin:/bin ./gradlew :web:build` succeeds end-to-end (simulates an IDE-launched daemon with no nvm in `PATH`).
- [x] `./gradlew --stop && ./gradlew :web:npmInstall --rerun-tasks` from terminal still works.
- [x] `./gradlew ktlintFormat` clean.
- [ ] Verify on Windows (`npm.cmd` fallback path) — falls back to current behavior, no regression expected.
- [ ] Verify in a fresh IntelliJ-launched daemon.