### PR TITLE
:bug: harden thumbnail extraction and fix .ts TypeScript misclassification

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopVideoThumbnailLoader.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopVideoThumbnailLoader.kt
@@ -44,6 +44,11 @@ class DesktopVideoThumbnailLoader(
                     ImageIO.write(image, "PNG", result.toNioPath().toFile())
                 }
             }
+            else -> {
+                logger.debug {
+                    "Video thumbnail generation not supported on ${platform.name}; falling back to file icon for: ${value.filePath}"
+                }
+            }
         }
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/JIconExtract.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/JIconExtract.kt
@@ -150,6 +150,12 @@ object JIconExtract {
 
             bitmapInfo.read()
 
+            // GetDIBits may return biSizeImage == 0 for BI_RGB bitmaps; allocating
+            // Memory(0) and writing into it on the second call would corrupt native memory.
+            if (bitmapInfo.bmiHeader.biSizeImage <= 0) {
+                return null
+            }
+
             val lpPixels = Memory(bitmapInfo.bmiHeader.biSizeImage.toLong())
 
             bitmapInfo.bmiHeader.biCompression = WinGDI.BI_RGB

--- a/app/src/desktopMain/swift/MacosApi.swift
+++ b/app/src/desktopMain/swift/MacosApi.swift
@@ -622,11 +622,13 @@ public func createVideoThumbnail(
     videoPath: UnsafePointer<CChar>,
     thumbnailPath: UnsafePointer<CChar>
 ) -> Bool {
-    let videoPathString = String(cString: videoPath)
-    let thumbnailPathString = String(cString: thumbnailPath)
-
-    let videoUrl = URL(fileURLWithPath: videoPathString)
-    let thumbnailUrl = URL(fileURLWithPath: thumbnailPathString)
+    let videoUrl = URL(fileURLWithPath: String(cString: videoPath))
+    let thumbnailUrl = URL(fileURLWithPath: String(cString: thumbnailPath))
+    // Write into a sibling temp file and atomically rename on success so concurrent
+    // readers never observe a partial PNG, and a callback that completes after our
+    // 10s timeout cannot leave an orphaned thumbnail at the final path.
+    let tempUrl = thumbnailUrl.deletingLastPathComponent()
+        .appendingPathComponent(".\(UUID().uuidString).tmp")
 
     let request = QLThumbnailGenerator.Request(
         fileAt: videoUrl,
@@ -642,7 +644,7 @@ public func createVideoThumbnail(
         defer { semaphore.signal() }
         guard let thumbnail = thumbnail, thumbnail.type == .thumbnail else { return }
         guard let destination = CGImageDestinationCreateWithURL(
-            thumbnailUrl as CFURL,
+            tempUrl as CFURL,
             "public.png" as CFString,
             1,
             nil
@@ -652,9 +654,29 @@ public func createVideoThumbnail(
     }
 
     if semaphore.wait(timeout: .now() + .seconds(10)) == .timedOut {
+        // Callback may still be writing tempUrl; clean it up after a generous grace period.
+        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(20)) {
+            try? FileManager.default.removeItem(at: tempUrl)
+        }
         return false
     }
-    return success
+
+    guard success else {
+        try? FileManager.default.removeItem(at: tempUrl)
+        return false
+    }
+
+    do {
+        if FileManager.default.fileExists(atPath: thumbnailUrl.path) {
+            _ = try FileManager.default.replaceItemAt(thumbnailUrl, withItemAt: tempUrl)
+        } else {
+            try FileManager.default.moveItem(at: tempUrl, to: thumbnailUrl)
+        }
+        return true
+    } catch {
+        try? FileManager.default.removeItem(at: tempUrl)
+        return false
+    }
 }
 
 var statusItem: NSStatusItem?

--- a/shared/src/commonMain/kotlin/com/crosspaste/utils/OkioPathExtension.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/utils/OkioPathExtension.kt
@@ -72,7 +72,9 @@ val videoExtensions =
         "avi",
         "wmv",
         "flv",
-        "ts",
+        // Intentionally omit "ts": for a developer-focused clipboard tool, .ts is
+        // overwhelmingly TypeScript source, not an MPEG transport stream. The
+        // MPEG-TS variants .mts and .m2ts are still recognized below.
         "mts",
         "m2ts",
         "3gp",


### PR DESCRIPTION
Closes #4366

## Summary

Four post-review hardening fixes from #4359.

| File | Fix |
| --- | --- |
| `JIconExtract.kt` | Guard `Memory(0)` when `GetDIBits` returns `biSizeImage == 0` for BI_RGB bitmaps — second `GetDIBits` would otherwise corrupt native memory on Windows. |
| `DesktopVideoThumbnailLoader.kt` | Add `else` branch logging at debug level so Linux failures are diagnosable instead of silent. |
| `MacosApi.swift` (`createVideoThumbnail`) | Callback writes to a sibling `.<uuid>.tmp` and we atomically rename on success. Timed-out callbacks can no longer leave an orphan at the final path; concurrent readers can no longer observe a partial PNG mid-`Finalize`. Temp is cleaned up on timeout (delayed) and on rename / success failure. |
| `OkioPathExtension.kt` | Remove `"ts"` from `videoExtensions`. For this audience `.ts` is overwhelmingly TypeScript source; `.mts` / `.m2ts` still cover MPEG-TS variants. |

## Test plan

- [ ] `./gradlew ktlintCheck` passes
- [ ] `./gradlew app:desktopTest` passes
- [ ] macOS: copy a video file and confirm thumbnail still appears in the side preview
- [ ] macOS: copy a `.ts` TypeScript file and confirm it shows the file icon (no play overlay) and opens in the default text editor on click
- [ ] Windows (manual): copy a folder/file with various icon sources; ensure no native crash
- [ ] Linux (manual): copy a video file and confirm a debug log appears, falls back to file icon