### PR TITLE
:hammer: consolidate MacAcrylicEffect and tidy small readability issues

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -118,13 +118,11 @@ class PasteReleaseService(
                 currentPaste.setPasteId(id)
                 taskSubmitter.submit {
                     addRenderingTask(id, pasteType)
-                    // Skip syncing for remote clipboard data (e.g., Apple Universal Clipboard / Handoff).
-                    // These items are already from another device, so re-syncing them would cause
-                    // unnecessary duplication or sync loops.
-                    // An empty target set means every paired peer was filtered out (e.g. all-Apple
-                    // peers for an Apple Universal Clipboard event) — skip the task instead of
-                    // creating one that can't sync anywhere.
-                    if (!pasteData.remote && targetAppInstanceIds?.isEmpty() != true) {
+                    // Skip syncing items already from another device (would cause sync loops).
+                    // Empty target set = every peer filtered out (e.g. Apple Universal Clipboard
+                    // items skip Apple peers).
+                    val hasValidSyncTargets = targetAppInstanceIds == null || targetAppInstanceIds.isNotEmpty()
+                    if (!pasteData.remote && hasValidSyncTargets) {
                         addSyncTask(id, maxFileSize, pasteData.appInstanceId, targetAppInstanceIds)
                     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/BubbleWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/BubbleWindow.kt
@@ -15,10 +15,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -43,7 +41,6 @@ import androidx.compose.ui.window.WindowState
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.paste.PasteData
-import com.crosspaste.platform.macos.MacAppUtils
 import com.crosspaste.ui.DesktopContext.BubbleWindowContext
 import com.crosspaste.ui.model.PasteSearchViewModel
 import com.crosspaste.ui.model.PasteSelectionViewModel
@@ -51,13 +48,9 @@ import com.crosspaste.ui.paste.PasteDataScope
 import com.crosspaste.ui.paste.createPasteDataScope
 import com.crosspaste.ui.paste.edit.PasteHtmlEditContentView
 import com.crosspaste.ui.paste.edit.PasteTextEditContentView
-import com.crosspaste.utils.cpuDispatcher
 import com.crosspaste.utils.getPlatformUtils
-import com.sun.jna.Pointer
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
@@ -367,21 +360,6 @@ private fun BubbleWindowContent(
                         }
                     }
                 }
-            }
-        }
-    }
-}
-
-@Composable
-fun MacAcrylicEffect(window: ComposeWindow) {
-    LaunchedEffect(window) {
-        snapshotFlow { window.isDisplayable }
-            .first { it }
-
-        withContext(cpuDispatcher) {
-            runCatching {
-                val pointer = Pointer(window.windowHandle)
-                MacAppUtils.setWindowLevelPopUpMenu(pointer)
             }
         }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
@@ -170,19 +170,23 @@ fun SearchWindow(windowIcon: Painter?) {
 @Composable
 fun MacAcrylicEffect(
     window: ComposeWindow,
-    isDark: Boolean,
+    isDark: Boolean? = null,
 ) {
     LaunchedEffect(window, isDark) {
         snapshotFlow { window.isDisplayable }
             .first { it }
 
-        window.background = java.awt.Color(0, 0, 0, 0)
+        if (isDark != null) {
+            window.background = java.awt.Color(0, 0, 0, 0)
+        }
 
         withContext(cpuDispatcher) {
             runCatching {
                 val pointer = Pointer(window.windowHandle)
                 MacAppUtils.setWindowLevelPopUpMenu(pointer)
-                MacAppUtils.applyAcrylicBackground(pointer, isDark)
+                if (isDark != null) {
+                    MacAppUtils.applyAcrylicBackground(pointer, isDark)
+                }
             }
         }
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/FilesSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/FilesSidePreviewView.kt
@@ -68,6 +68,7 @@ fun PasteDataScope.FilesSidePreviewView() {
     SidePasteLayoutView(
         pasteBottomContent = {
             FilesPreviewBottomBar(
+                copywriter = copywriter,
                 fileDisplayInfo = fileDisplayInfo,
                 isInDownloads = isInDownloads,
             )
@@ -94,18 +95,15 @@ private fun rememberSingleVideoPath(
 
 @Composable
 private fun FilesPreviewBottomBar(
+    copywriter: GlobalCopywriter,
     fileDisplayInfo: FileDisplayInfo?,
     isInDownloads: Boolean,
 ) {
-    val copywriter = koinInject<GlobalCopywriter>()
-    val baseSubtitle = fileDisplayInfo?.subtitle ?: ""
     val subtitle =
-        if (isInDownloads) {
-            val inDownloadsText = copywriter.getText("in_downloads")
-            if (baseSubtitle.isNotEmpty()) "$inDownloadsText · $baseSubtitle" else inDownloadsText
-        } else {
-            baseSubtitle
-        }
+        listOfNotNull(
+            if (isInDownloads) copywriter.getText("in_downloads") else null,
+            fileDisplayInfo?.subtitle?.takeIf { it.isNotEmpty() },
+        ).joinToString(" · ")
     FileBottomSolid(
         modifier =
             Modifier


### PR DESCRIPTION
Closes #4368

## Summary
Four scope-limited refactors surfaced during code review. All behavior-preserving.

- **`MacAcrylicEffect` consolidation** — `BubbleWindow.kt` and `SearchWindow.kt` each defined a near-identical `MacAcrylicEffect` composable. Merged into one in `SearchWindow.kt` with `isDark: Boolean? = null`. Bubble window resolves to the default (popup-menu level only); search window passes the theme to opt into the acrylic background. Same package, so no call-site import changes needed.
- **`FilesPreviewBottomBar` DI cleanup** — the inner private composable was calling `koinInject<GlobalCopywriter>()` even though the parent `FilesSidePreviewView` already injected the same instance. Now passed as a parameter — DI stays at the boundary.
- **`PasteReleaseService` boolean readability** — replaced the double-negative `targetAppInstanceIds?.isEmpty() != true` with a named `hasValidSyncTargets` local; trimmed the surrounding 6-line comment to 3 lines now that the name carries the intent (kept the non-obvious WHY about Apple Universal Clipboard target filtering).
- **Subtitle string-building** — replaced the nested `if` + intermediate `baseSubtitle` variable in `FilesPreviewBottomBar` with `listOfNotNull(...).joinToString(" · ")`. Same output for all four cases (both empty, only downloads, only subtitle, both).

Net: +18 / -40 lines across 4 files.

## Test plan
- [x] `./gradlew ktlintFormat` clean
- [x] `./gradlew app:compileKotlinDesktop` clean
- [ ] Manual smoke: open search window on macOS, confirm acrylic background still renders correctly
- [ ] Manual smoke: open bubble window on macOS, confirm popup-menu window level still applied
- [ ] Manual smoke: copy a file from `~/Downloads` and from another folder; confirm bottom-bar subtitle reads `"In Downloads · <details>"` vs `"<details>"` as before