### PR TITLE
:bug: stop ClientEncryptPlugin throwing on bodyless GET and harden pull error handling

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/ClientApiResult.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/ClientApiResult.kt
@@ -57,24 +57,13 @@ fun createFailureResult(
     throwable: Throwable,
 ): FailureResult = FailureResult(PasteException(errorCodeSupplier.toErrorCode(), throwable))
 
-suspend inline fun <T> request(
+suspend inline fun safeApiCall(
     logger: KLogger,
     exceptionHandler: ExceptionHandler,
-    request: () -> HttpResponse,
-    transformData: (HttpResponse) -> T,
+    block: () -> ClientApiResult,
 ): ClientApiResult =
     try {
-        val response = request()
-        logger.debug { "response status: ${response.call.request.url} ${response.status}" }
-        if (response.status.value == 404) {
-            createFailureResult(StandardErrorCode.NOT_FOUND_API, "Not found Api")
-        } else if (response.status.value != 200) {
-            val failResponse = response.body<FailResponse>()
-            logger.error { "request error: $failResponse" }
-            createFailureResult(failResponse)
-        } else {
-            SuccessResult(transformData(response))
-        }
+        block()
     } catch (e: HttpRequestTimeoutException) {
         logger.warn(e) { "request timeout" }
         RequestTimeout
@@ -90,6 +79,26 @@ suspend inline fun <T> request(
             DecryptFail
         } else {
             UnknownError
+        }
+    }
+
+suspend inline fun <T> request(
+    logger: KLogger,
+    exceptionHandler: ExceptionHandler,
+    request: () -> HttpResponse,
+    transformData: (HttpResponse) -> T,
+): ClientApiResult =
+    safeApiCall(logger, exceptionHandler) {
+        val response = request()
+        logger.debug { "response status: ${response.call.request.url} ${response.status}" }
+        if (response.status.value == 404) {
+            createFailureResult(StandardErrorCode.NOT_FOUND_API, "Not found Api")
+        } else if (response.status.value != 200) {
+            val failResponse = response.body<FailResponse>()
+            logger.error { "request error: $failResponse" }
+            createFailureResult(failResponse)
+        } else {
+            SuccessResult(transformData(response))
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PullClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PullClientApi.kt
@@ -81,9 +81,9 @@ class PullClientApi(
                     buildUrl("pull", "paste")
                 },
             )
-        }, transformData = { response ->
+        }) { response ->
             response.body<PasteData>().copy(remote = true)
-        })
+        }
 
     suspend fun pullPasteBatch(
         targetAppInstanceId: String,
@@ -108,9 +108,9 @@ class PullClientApi(
                     parameters.append("limit", limit.toString())
                 },
             )
-        }, transformData = { response ->
+        }) { response ->
             response.body<List<PasteData>>().map { it.copy(remote = true) }
-        })
+        }
 
     private suspend fun result(
         response: HttpResponse,

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PullClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PullClientApi.kt
@@ -4,6 +4,7 @@ import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.dto.pull.PullFileRequest
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.PasteClient
+import com.crosspaste.net.exception.ExceptionHandler
 import com.crosspaste.paste.PasteData
 import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -15,6 +16,7 @@ import io.ktor.util.reflect.*
 class PullClientApi(
     private val pasteClient: PasteClient,
     private val configManager: CommonConfigManager,
+    private val exceptionHandler: ExceptionHandler,
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -23,50 +25,50 @@ class PullClientApi(
         pullFileRequest: PullFileRequest,
         targetAppInstanceId: String,
         toUrl: URLBuilder.() -> Unit,
-    ): ClientApiResult {
-        val response =
-            pasteClient.post(
-                message = pullFileRequest,
-                messageType = typeInfo<PullFileRequest>(),
-                timeout = 50000L,
-                headersBuilder = {
-                    append("targetAppInstanceId", targetAppInstanceId)
-                    if (configManager.getCurrentConfig().enableEncryptSync) {
-                        append("secure", "1")
-                    }
-                },
-                // pull file timeout is 50s
-                urlBuilder = {
-                    toUrl()
-                    buildUrl("pull", "file")
-                },
-            )
-
-        return result(response, "file", pullFileRequest)
-    }
+    ): ClientApiResult =
+        safeApiCall(logger, exceptionHandler) {
+            val response =
+                pasteClient.post(
+                    message = pullFileRequest,
+                    messageType = typeInfo<PullFileRequest>(),
+                    timeout = 50000L,
+                    headersBuilder = {
+                        append("targetAppInstanceId", targetAppInstanceId)
+                        if (configManager.getCurrentConfig().enableEncryptSync) {
+                            append("secure", "1")
+                        }
+                    },
+                    // pull file timeout is 50s
+                    urlBuilder = {
+                        toUrl()
+                        buildUrl("pull", "file")
+                    },
+                )
+            result(response, "file", pullFileRequest)
+        }
 
     suspend fun pullIcon(
         source: String,
         toUrl: URLBuilder.() -> Unit,
-    ): ClientApiResult {
-        val response =
-            pasteClient.get(
-                timeout = 50000L,
-                urlBuilder = {
-                    toUrl()
-                    buildUrl("pull", "icon", source)
-                },
-            )
-
-        return result(response, "icon", response.request.url)
-    }
+    ): ClientApiResult =
+        safeApiCall(logger, exceptionHandler) {
+            val response =
+                pasteClient.get(
+                    timeout = 50000L,
+                    urlBuilder = {
+                        toUrl()
+                        buildUrl("pull", "icon", source)
+                    },
+                )
+            result(response, "icon", response.request.url)
+        }
 
     @Suppress("unused")
     suspend fun pullLatestPaste(
         targetAppInstanceId: String,
         toUrl: URLBuilder.() -> Unit,
-    ): ClientApiResult {
-        val response =
+    ): ClientApiResult =
+        request(logger, exceptionHandler, request = {
             pasteClient.get(
                 headersBuilder = {
                     append("targetAppInstanceId", targetAppInstanceId)
@@ -79,33 +81,17 @@ class PullClientApi(
                     buildUrl("pull", "paste")
                 },
             )
-
-        return if (response.status.value == 200) {
-            logger.debug { "Success to pull latest paste" }
-            SuccessResult(response.body<PasteData>().copy(remote = true))
-        } else {
-            runCatching {
-                val failResponse = response.body<FailResponse>()
-                createFailureResult(
-                    StandardErrorCode.SYNC_PASTE_ERROR,
-                    "Fail to pull latest paste from $targetAppInstanceId: ${response.status.value} $failResponse",
-                )
-            }.getOrElse {
-                createFailureResult(
-                    StandardErrorCode.SYNC_PASTE_ERROR,
-                    "Fail to pull latest paste from $targetAppInstanceId: ${response.status.value}",
-                )
-            }
-        }
-    }
+        }, transformData = { response ->
+            response.body<PasteData>().copy(remote = true)
+        })
 
     suspend fun pullPasteBatch(
         targetAppInstanceId: String,
         createTime: Long?,
         limit: Long,
         toUrl: URLBuilder.() -> Unit,
-    ): ClientApiResult {
-        val response =
+    ): ClientApiResult =
+        request(logger, exceptionHandler, request = {
             pasteClient.get(
                 headersBuilder = {
                     append("targetAppInstanceId", targetAppInstanceId)
@@ -122,25 +108,9 @@ class PullClientApi(
                     parameters.append("limit", limit.toString())
                 },
             )
-
-        return if (response.status.value == 200) {
-            logger.debug { "Success to pull paste batch from $targetAppInstanceId" }
-            SuccessResult(response.body<List<PasteData>>().map { it.copy(remote = true) })
-        } else {
-            runCatching {
-                val failResponse = response.body<FailResponse>()
-                createFailureResult(
-                    StandardErrorCode.SYNC_PASTE_ERROR,
-                    "Fail to pull paste batch from $targetAppInstanceId: ${response.status.value} $failResponse",
-                )
-            }.getOrElse {
-                createFailureResult(
-                    StandardErrorCode.SYNC_PASTE_ERROR,
-                    "Fail to pull paste batch from $targetAppInstanceId: ${response.status.value}",
-                )
-            }
-        }
-    }
+        }, transformData = { response ->
+            response.body<List<PasteData>>().map { it.copy(remote = true) }
+        })
 
     private suspend fun result(
         response: HttpResponse,

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
@@ -72,7 +72,7 @@ class SyncClientApi(
                     },
                 )
             }
-        }, transformData = {
+        }) {
             val result = it.bodyAsText()
             result.toIntOrNull()?.let { connectedVersion ->
                 syncApi.compareVersion(connectedVersion)
@@ -80,7 +80,7 @@ class SyncClientApi(
                 logger.warn { "heartbeat response is not a valid version int: '$result'" }
                 null
             }
-        })
+        }
 
     suspend fun trust(
         targetAppInstanceId: String,
@@ -119,7 +119,7 @@ class SyncClientApi(
                     buildUrl("sync", "trust")
                 },
             )
-        }, transformData = {
+        }) {
             val trustResponse = it.body<TrustResponse>()
 
             val receiveSignPublicKey =
@@ -140,7 +140,7 @@ class SyncClientApi(
                 logger.warn { "verifyResult is false" }
                 false
             }
-        })
+        }
 
     suspend fun exchangeKeys(
         targetAppInstanceId: String,
@@ -172,7 +172,7 @@ class SyncClientApi(
                     buildUrl("sync", "trust", "v2", "exchange")
                 },
             )
-        }, transformData = {
+        }) {
             val response = it.body<KeyExchangeResponse>()
 
             val receiveSignPublicKey =
@@ -189,7 +189,7 @@ class SyncClientApi(
                 logger.warn { "exchangeKeys: signature verification failed" }
                 null
             }
-        })
+        }
 
     suspend fun trustV2Confirm(
         targetAppInstanceId: String,
@@ -219,12 +219,12 @@ class SyncClientApi(
                     buildUrl("sync", "trust", "v2", "confirm")
                 },
             )
-        }, transformData = {
+        }) {
             val response = it.body<TrustConfirmResponse>()
             // Save remote crypt public key is done in the server-side confirm handler
             // Here we just verify the response signature
             true
-        })
+        }
 
     suspend fun showToken(toUrl: URLBuilder.() -> Unit): ClientApiResult =
         request(logger, exceptionHandler, request = {
@@ -232,7 +232,7 @@ class SyncClientApi(
                 toUrl()
                 buildUrl("sync", "showToken")
             })
-        }, transformData = { true })
+        }) { true }
 
     suspend fun showPairingCode(toUrl: URLBuilder.() -> Unit): ClientApiResult =
         request(logger, exceptionHandler, request = {
@@ -240,7 +240,7 @@ class SyncClientApi(
                 toUrl()
                 buildUrl("sync", "showPairingCode")
             })
-        }, transformData = { true })
+        }) { true }
 
     suspend fun notifyExit(toUrl: URLBuilder.() -> Unit) {
         request(logger, exceptionHandler, request = {
@@ -248,7 +248,7 @@ class SyncClientApi(
                 toUrl()
                 buildUrl("sync", "notifyExit")
             })
-        }, transformData = { true })
+        }) { true }
     }
 
     suspend fun notifyRemove(toUrl: URLBuilder.() -> Unit) {
@@ -257,6 +257,6 @@ class SyncClientApi(
                 toUrl()
                 buildUrl("sync", "notifyRemove")
             })
-        }, transformData = { true })
+        }) { true }
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientEncryptPlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientEncryptPlugin.kt
@@ -32,19 +32,27 @@ class ClientEncryptPlugin(
             context.headers["targetAppInstanceId"]?.let { targetAppInstanceId ->
                 context.headers["secure"]?.let {
                     logger.debug { "client encrypt $targetAppInstanceId" }
-                    when (context.body) {
+                    when (val body = context.body) {
                         is OutgoingContent.ByteArrayContent -> {
                             val processor = secureStore.getMessageProcessor(targetAppInstanceId)
-                            val originalContent = context.body as OutgoingContent.ByteArrayContent
-                            val bytes = originalContent.bytes()
+                            val bytes = body.bytes()
                             val ciphertextMessageBytes = processor.encrypt(bytes)
                             context.body =
                                 ByteArrayContent(ciphertextMessageBytes, contentType = ContentType.Application.Json)
                         }
+                        is OutgoingContent.NoContent -> {
+                            // GET / DELETE etc.: the `secure` header only tells the server to
+                            // encrypt its response (handled by ClientDecryptPlugin). There is no
+                            // request body to encrypt here, so this is a legal no-op.
+                        }
                         else -> {
+                            // Unknown body type. Fail loudly instead of silently sending plaintext
+                            // under a `secure: 1` header — the API layer wraps these calls in
+                            // safeApiCall, so this surfaces as ClientApiResult.EncryptFail to the
+                            // caller without aborting the coroutine.
                             throw PasteException(
                                 StandardErrorCode.ENCRYPT_FAIL.toErrorCode(),
-                                "Unsupported content type for encryption: ${context.body::class}",
+                                "Unsupported content type for encryption: ${body::class}",
                             )
                         }
                     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -75,7 +75,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
         single<PasteBonjourService> { DesktopPasteBonjourService(get(), get(), get(), get()) }
         single<PendingKeyExchangeStore> { PendingKeyExchangeStore() }
         single<PasteClient> { PasteClient(get(), get(), get()) }
-        single<PullClientApi> { PullClientApi(get(), get()) }
+        single<PullClientApi> { PullClientApi(get(), get(), get()) }
         single<PasteClientApi> { PasteClientApi(get(), get()) }
         single<Server> {
             DesktopPasteServer(

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/clientapi/SafeApiCallTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/clientapi/SafeApiCallTest.kt
@@ -1,0 +1,82 @@
+package com.crosspaste.net.clientapi
+
+import com.crosspaste.net.exception.DesktopExceptionHandler
+import com.crosspaste.net.exception.ExceptionHandler
+import com.crosspaste.net.plugin.ClientEncryptPlugin
+import com.crosspaste.secure.SecureMessageProcessor
+import com.crosspaste.secure.SecureStore
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.writeFully
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SafeApiCallTest {
+
+    private val logger = KotlinLogging.logger {}
+    private val exceptionHandler: ExceptionHandler = DesktopExceptionHandler()
+
+    private val mockProcessor =
+        mockk<SecureMessageProcessor> {
+            every { encrypt(any()) } answers { firstArg<ByteArray>().reversedArray() }
+        }
+    private val mockSecureStore =
+        mockk<SecureStore> {
+            coEvery { getMessageProcessor(any()) } returns mockProcessor
+        }
+
+    private fun createClient(): HttpClient {
+        val mockEngine =
+            MockEngine { _ ->
+                respond(content = "OK", status = HttpStatusCode.OK)
+            }
+        return HttpClient(mockEngine) {
+            install(ClientEncryptPlugin(mockSecureStore))
+        }
+    }
+
+    @Test
+    fun `ClientEncryptPlugin throw is converted to EncryptFail by safeApiCall`() =
+        runBlocking {
+            // Pins the cross-layer contract: when the encrypt plugin throws (here triggered
+            // by a non-ByteArrayContent / non-NoContent body under `secure: 1`), the API-layer
+            // safeApiCall must catch it and return ClientApiResult.EncryptFail rather than
+            // letting the throw escape the coroutine.
+            val client = createClient()
+            val streamingBody =
+                object : OutgoingContent.WriteChannelContent() {
+                    override val contentType: ContentType = ContentType.Application.OctetStream
+
+                    override suspend fun writeTo(channel: ByteWriteChannel) {
+                        channel.writeFully("payload".encodeToByteArray())
+                    }
+                }
+
+            val result =
+                safeApiCall(logger, exceptionHandler) {
+                    val response: HttpResponse =
+                        client.post("https://localhost/test") {
+                            header("targetAppInstanceId", "test-instance")
+                            header("secure", "1")
+                            setBody(streamingBody)
+                        }
+                    SuccessResult(response.status)
+                }
+
+            assertEquals(EncryptFail, result)
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/plugin/ClientEncryptPluginTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/plugin/ClientEncryptPluginTest.kt
@@ -13,7 +13,10 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
 import io.ktor.http.contentType
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.writeFully
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -110,17 +113,59 @@ class ClientEncryptPluginTest {
         }
 
     @Test
-    fun `throws PasteException for unsupported content type when secure header is set`() =
+    fun `bodyless GET with secure header passes through without invoking encryption`() =
         runBlocking {
-            val client = createClient()
+            // GET / DELETE etc. have no request body to encrypt — the secure header
+            // signals that the *response* should be encrypted (handled by
+            // ClientDecryptPlugin). The encrypt plugin must skip these instead of
+            // aborting the request, otherwise pull endpoints crash on K/N iOS where
+            // the throwing coroutine has no exception handler installed.
+            val neverCalledStore =
+                mockk<SecureStore> {
+                    coEvery { getMessageProcessor(any()) } throws
+                        AssertionError("Should not encrypt bodyless request")
+                }
+            val client = createClient(neverCalledStore)
+
+            val response =
+                client.get("https://localhost/test") {
+                    header("targetAppInstanceId", "test-instance")
+                    header("secure", "1")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `throws PasteException for unsupported body type when secure header is set`() =
+        runBlocking {
+            // Streaming bodies (WriteChannelContent) are neither ByteArrayContent nor
+            // NoContent. Reaching this branch means a request was added that the encrypt
+            // plugin doesn't know how to encrypt — fail loud rather than silently send
+            // plaintext under a `secure: 1` header. The API layer's safeApiCall converts
+            // this into ClientApiResult.EncryptFail for the caller.
+            val neverCalledStore =
+                mockk<SecureStore> {
+                    coEvery { getMessageProcessor(any()) } throws
+                        AssertionError("Should not reach encryption for unsupported body type")
+                }
+            val client = createClient(neverCalledStore)
+
+            val streamingBody =
+                object : OutgoingContent.WriteChannelContent() {
+                    override val contentType: ContentType = ContentType.Application.OctetStream
+
+                    override suspend fun writeTo(channel: ByteWriteChannel) {
+                        channel.writeFully("payload".encodeToByteArray())
+                    }
+                }
 
             val exception =
                 assertFailsWith<PasteException> {
-                    // GET request with secure headers produces a non-ByteArrayContent body,
-                    // which should throw PasteException instead of silently sending plaintext
-                    client.get("https://localhost/test") {
+                    client.post("https://localhost/test") {
                         header("targetAppInstanceId", "test-instance")
                         header("secure", "1")
+                        setBody(streamingBody)
                     }
                 }
 

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
@@ -71,7 +71,7 @@ class HeadlessPeer(
 
     val pasteClientApi: PasteClientApi = PasteClientApi(pasteClient, configManager)
 
-    val pullClientApi: PullClientApi = PullClientApi(pasteClient, configManager)
+    val pullClientApi: PullClientApi = PullClientApi(pasteClient, configManager, exceptionHandler)
 
     val bonjourAdvertiser: BonjourAdvertiser = BonjourAdvertiser(appInfo).also { it.start() }
 


### PR DESCRIPTION
Closes #4370

## Summary
- Fix `ClientEncryptPlugin` falsely treating `OutgoingContent.NoContent` (GET/DELETE bodies) as an error — root cause of the iOS SIGABRT in mobile build 87300 when batch pull runs with `enableEncryptSync = true`.
- Wrap every `PullClientApi` method in `request()` / a new `safeApiCall` helper so any client-side throw becomes a `ClientApiResult` sentinel instead of escaping the coroutine (Kotlin/Native default behavior for uncaught coroutine exceptions is to abort the process).
- Restore the throw on truly unknown body types — now safe to fail loud, since the API layer catches it and surfaces `ClientApiResult.EncryptFail`. Preserves the `secure: 1` contract (no silent plaintext fallback).

## Why three layers
| Layer | Responsibility |
|-------|---------------|
| **(a) Plugin** — `ClientEncryptPlugin` | Three branches: encrypt `ByteArrayContent`, no-op for `NoContent` (GET/DELETE), throw for unknown body types. Keeps the security contract honest. |
| **(b) API** — `PullClientApi` + `safeApiCall` | Catch every client-side exception (encrypt failure, network error, timeout, serialization) and translate to a `ClientApiResult` sentinel. |
| **(c) Coroutine root** — mobile-side `loggingExceptionHandler` | Already present on mobile after 87300; becomes a true last-resort safety net rather than a daily band-aid. |

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew :app:compileKotlinDesktop`
- [x] `./gradlew :app:desktopTest --tests "com.crosspaste.net.plugin.ClientEncryptPluginTest"` — 6 tests pass
  - `encrypt succeeds with ByteArrayContent body`
  - `no encryption when secure header is absent`
  - `no encryption when targetAppInstanceId header is absent`
  - `bodyless GET with secure header passes through without invoking encryption` (new)
  - `throws PasteException for unsupported body type when secure header is set` (new — uses `WriteChannelContent`)
  - `propagates PasteException when key not found`
- [x] `./gradlew :app:desktopTest --tests "com.crosspaste.sync.SyncResolverTest"` — confirms `request()` refactor preserves error classification (DecryptFail / UnknownError / etc.)
- [ ] Smoke-test on iOS via mobile checkout once this lands in `commonMain` snapshot