### PR TITLE
:bug: stop surfacing CancellationException as refresh failure

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceActionButton.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceActionButton.kt
@@ -29,8 +29,12 @@ import com.crosspaste.notification.NotificationManager
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.ui.base.GeneralIconButton
 import com.crosspaste.utils.getControlUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+
+private val logger = KotlinLogging.logger {}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,20 +78,23 @@ fun DeviceScope.DeviceActionButton(
                     },
             ) {
                 scope.launch {
-                    runCatching {
+                    try {
                         updateRefreshing(true)
                         getControlUtils().ensureMinExecutionTimeForCallback(2000L) { proceed ->
                             syncManager.refresh(listOf(syncRuntimeInfo.appInstanceId)) {
                                 proceed()
                             }
                         }
-                        updateRefreshing(false)
-                    }.onFailure { e ->
-                        updateRefreshing(false)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.error(e) { "refresh failed: ${syncRuntimeInfo.appInstanceId}" }
                         notificationManager.sendNotification(
                             title = { it.getText("refresh_connection_failed") },
                             messageType = MessageType.Error,
                         )
+                    } finally {
+                        updateRefreshing(false)
                     }
                 }
             }


### PR DESCRIPTION
Closes #4372

## Summary
- Replace `runCatching` in `DeviceActionButton` with `try / catch (CancellationException) rethrow / catch (Exception) notify / finally updateRefreshing(false)` so coroutine cancellation no longer fires a "Refresh connection failed" toast.
- Add a file-level logger and log the real exception, restoring the diagnostic visibility lost when #4291 dropped `e.message` from the notification.

## Why this happens
`DevicesContentView` partitions devices into online/offline lists with **different LazyColumn keys** (`it.appInstanceId` vs `"offline-${it.appInstanceId}"`). When a refresh on an offline device actually succeeds, `connectState` flips off `DISCONNECTED`, the item moves to the online section, the key changes, and the offline row leaves composition. That cancels `DeviceActionButton`'s `rememberCoroutineScope()`, which then propagates a `CancellationException` out of the in-flight `delay(remainingDelay)` inside `ensureMinExecutionTimeForCallback`. `runCatching` treats it as failure → false notification.

Rethrowing `CancellationException` lets the `launch` finish in the cancelled state cleanly (no crash, no propagation) — that is the documented contract for structured concurrency.

## Test plan
- [ ] Click refresh on a DISCONNECTED device that comes back online → no error notification, spinner resets
- [ ] Click refresh on a DISCONNECTED device that stays offline → error notification still fires, exception is logged with `refresh failed: <appInstanceId>`
- [ ] Navigate away from the device list mid-refresh → no notification, no log spam