### PR TITLE
:sparkles: add drag-and-drop reordering for search tags

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/EditableTagChip.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/EditableTagChip.kt
@@ -42,11 +42,13 @@ import com.crosspaste.ui.theme.AppUISize.xxLarge
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
-private const val DOUBLE_CLICK_TIMEOUT_MS = 300L
+private val DOUBLE_CLICK_TIMEOUT_MS = 300L.milliseconds
 
 @Composable
 fun PasteTagScope.TagChip(
+    modifier: Modifier = Modifier,
     isSelected: Boolean,
     onEdit: () -> Unit,
     onSelect: () -> Unit,
@@ -107,7 +109,7 @@ fun PasteTagScope.TagChip(
                 selectedLabelColor = MaterialTheme.colorScheme.primary,
             ),
         shape = CircleShape,
-        modifier = Modifier.height(xxLarge),
+        modifier = modifier.height(xxLarge),
     )
 }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/SearchTagsView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/SearchTagsView.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.ui.search.side
 
+import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListLayoutInfo
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -18,6 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -67,28 +70,14 @@ fun SearchTagsView() {
     val tagMenuService = koinInject<DesktopPasteTagMenuService>()
 
     val searchWindowInfo = LocalSearchWindowInfoState.current
-
     val searchBaseParams by pasteSearchViewModel.searchBaseParams.collectAsState()
-
     val tagList by pasteSearchViewModel.tagList.collectAsState()
-
-    var newTag by remember { mutableStateOf<PasteTag?>(null) }
-
     val editingMap by PasteTagScope.isEditingMap
 
+    var newTag by remember { mutableStateOf<PasteTag?>(null) }
     val scope = rememberCoroutineScope()
-
     val lazyListState = rememberLazyListState()
-
-    var draggingTagId by remember { mutableStateOf<Long?>(null) }
-    var dragOffsetX by remember { mutableStateOf(0f) }
-    var displayList by remember { mutableStateOf(tagList) }
-
-    LaunchedEffect(tagList) {
-        if (draggingTagId == null) {
-            displayList = tagList
-        }
-    }
+    val dragState = rememberTagDragState(tagList)
 
     LaunchedEffect(searchWindowInfo.show) {
         newTag = null
@@ -101,158 +90,50 @@ fun SearchTagsView() {
         horizontalArrangement = Arrangement.spacedBy(tiny),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        itemsIndexed(displayList, key = { _, item -> item.id }) { _, tag ->
-            val currentTag by rememberUpdatedState(tag)
-
-            val isSelected = currentTag.id == searchBaseParams.tag
-            val isDragging = draggingTagId == tag.id
-
-            val tagScope =
-                remember(
-                    currentTag.id,
-                    currentTag.name,
-                    currentTag.color,
-                ) {
-                    createPasteTagScope(currentTag)
-                }
-
-            // Outermost wrapper of each LazyRow item slot. zIndex/transform/background MUST live
-            // here so they layer the dragged item above its sibling lazy items — applying them
-            // deeper inside (e.g. inside PasteContextMenuView) only layers within that subtree.
-            Box(
-                modifier =
-                    Modifier
-                        .zIndex(if (isDragging) 1f else 0f)
-                        .graphicsLayer {
-                            translationX = if (isDragging) dragOffsetX else 0f
-                            if (isDragging) {
-                                scaleX = 1.05f
-                                scaleY = 1.05f
-                            }
-                        }.then(
-                            if (isDragging) {
-                                // Lift effect + solid background so the dragged chip clearly
-                                // highlights on long-press and occludes neighbors.
-                                Modifier
-                                    .shadow(elevation = tiny3X, shape = CircleShape)
-                                    .background(
-                                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                                        shape = CircleShape,
-                                    )
-                            } else {
-                                Modifier
-                            },
-                        ),
-            ) {
-                if (editingMap[tag.id] == true) {
-                    tagScope.EditableTagChip { name ->
-                        if (name.isBlank()) {
-                            pasteTagDao.deletePasteTagBlock(tag.id)
-                        } else {
-                            pasteTagDao.updatePasteTagName(tag.id, name)
-                        }
-                        tagScope.stopEditing()
+        itemsIndexed(dragState.displayList, key = { _, item -> item.id }) { _, tag ->
+            SearchTagItem(
+                tag = tag,
+                isSelected = tag.id == searchBaseParams.tag,
+                isDragging = dragState.isDragging(tag.id),
+                isEditing = editingMap[tag.id] == true,
+                dragOffsetX = dragState.dragOffsetX,
+                contextMenuItemsFor = tagMenuService::menuItemsProvider,
+                onTagClick = { pasteSearchViewModel.updateTag(tag.id) },
+                onSubmitName = { name ->
+                    if (name.isBlank()) {
+                        pasteTagDao.deletePasteTagBlock(tag.id)
+                    } else {
+                        pasteTagDao.updatePasteTagName(tag.id, name)
                     }
-                } else {
-                    PasteContextMenuView(
-                        items = tagMenuService.menuItemsProvider(tagScope),
-                    ) {
-                        tagScope.TagChip(
-                            modifier =
-                                Modifier.pointerInput(tag.id) {
-                                    detectReorderDragGestures(
-                                        onDragStart = { initialDrift ->
-                                            draggingTagId = tag.id
-                                            // Snap chip to the cursor's drift during the long press.
-                                            dragOffsetX = initialDrift.x
-                                        },
-                                        onDragEnd = {
-                                            val finalOrder = displayList.map { it.id }
-                                            if (finalOrder != tagList.map { it.id }) {
-                                                scope.launch {
-                                                    pasteTagDao.updatePasteTagsSortOrder(finalOrder)
-                                                }
-                                            }
-                                            draggingTagId = null
-                                            dragOffsetX = 0f
-                                        },
-                                        onDragCancel = {
-                                            // Revert any in-progress swap to the persisted order.
-                                            displayList = tagList
-                                            draggingTagId = null
-                                            dragOffsetX = 0f
-                                        },
-                                        onDrag = { _, dragAmount ->
-                                            dragOffsetX += dragAmount.x
-
-                                            val visibleItems = lazyListState.layoutInfo.visibleItemsInfo
-                                            val draggedItem =
-                                                visibleItems.firstOrNull { it.key == tag.id }
-                                                    ?: return@detectReorderDragGestures
-                                            val draggedCenter =
-                                                draggedItem.offset + draggedItem.size / 2f + dragOffsetX
-
-                                            // Center-crossed-center swap rule: swap only once the
-                                            // dragged center has moved past the neighbor's center.
-                                            // This builds hysteresis ≈ half a chip's width so a
-                                            // post-swap layout update can't re-trigger the opposite
-                                            // swap (preventing oscillation).
-                                            val target =
-                                                visibleItems.firstOrNull { other ->
-                                                    if (other.key == tag.id) return@firstOrNull false
-                                                    val otherCenter = other.offset + other.size / 2f
-                                                    when {
-                                                        other.offset > draggedItem.offset ->
-                                                            draggedCenter > otherCenter
-                                                        other.offset < draggedItem.offset ->
-                                                            draggedCenter < otherCenter
-                                                        else -> false
-                                                    }
-                                                } ?: return@detectReorderDragGestures
-
-                                            val from = displayList.indexOfFirst { it.id == tag.id }
-                                            val to = displayList.indexOfFirst { it.id == target.key }
-                                            if (from == -1 || to == -1 || from == to) {
-                                                return@detectReorderDragGestures
-                                            }
-
-                                            // Keep the chip visually under the cursor across the swap.
-                                            dragOffsetX += (draggedItem.offset - target.offset).toFloat()
-                                            displayList =
-                                                displayList.toMutableList().apply {
-                                                    add(to, removeAt(from))
-                                                }
-                                        },
-                                    )
-                                },
-                            isSelected = isSelected,
-                            onEdit = {
-                                pasteSearchViewModel.updateTag(tag.id)
-                            },
-                        ) {
-                            tagScope.startEditing()
-                        }
+                },
+                onDragStart = { initialDrift -> dragState.startDrag(tag.id, initialDrift.x) },
+                onDragMove = { deltaX -> dragState.handleDragMove(deltaX, lazyListState.layoutInfo) },
+                onDragEnd = {
+                    dragState.finalizeDrag(tagList)?.let { finalOrder ->
+                        scope.launch { pasteTagDao.updatePasteTagsSortOrder(finalOrder) }
                     }
-                }
-            }
+                },
+                onDragCancel = { dragState.cancelDrag(tagList) },
+            )
         }
 
         newTag?.let {
             item {
-                val scope = remember { createPasteTagScope(it) }
-
-                scope.EditableTagChip { name ->
-                    newTag = null
-                    if (!name.isBlank()) {
-                        pasteTagDao.createPasteTag(name, it.color)
-                    }
-                    PasteTagScope.resetEditing()
-                }
+                NewTagChip(
+                    tag = it,
+                    onSubmit = { name ->
+                        newTag = null
+                        if (!name.isBlank()) {
+                            pasteTagDao.createPasteTag(name, it.color)
+                        }
+                        PasteTagScope.resetEditing()
+                    },
+                )
             }
         }
 
         item {
-            AssistChip(
+            AddTagChip(
                 onClick = {
                     if (appControl.isCreateTagEnabled()) {
                         scope.launch {
@@ -265,20 +146,204 @@ fun SearchTagsView() {
                         }
                     }
                 },
-                label = {
-                    Icon(
-                        imageVector = MaterialSymbols.Rounded.Add,
-                        contentDescription = "Add",
-                        modifier = Modifier.size(medium),
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                },
-                modifier = Modifier.height(xxLarge),
-                border = null,
-                shape = CircleShape,
             )
         }
     }
+}
+
+@Composable
+private fun SearchTagItem(
+    tag: PasteTag,
+    isSelected: Boolean,
+    isDragging: Boolean,
+    isEditing: Boolean,
+    dragOffsetX: Float,
+    contextMenuItemsFor: (PasteTagScope) -> () -> List<ContextMenuItem>,
+    onTagClick: () -> Unit,
+    onSubmitName: suspend (String) -> Unit,
+    onDragStart: (initialDrift: Offset) -> Unit,
+    onDragMove: (deltaX: Float) -> Unit,
+    onDragEnd: () -> Unit,
+    onDragCancel: () -> Unit,
+) {
+    val currentTag by rememberUpdatedState(tag)
+    val tagScope =
+        remember(currentTag.id, currentTag.name, currentTag.color) {
+            createPasteTagScope(currentTag)
+        }
+
+    // zIndex/transform/background MUST live on the outermost LazyRow item slot so they
+    // can layer the dragged item above its sibling lazy items — applying them deeper
+    // inside (e.g. inside PasteContextMenuView) only layers within that subtree.
+    Box(
+        modifier = Modifier.tagDragVisuals(isDragging = isDragging, dragOffsetX = dragOffsetX),
+    ) {
+        if (isEditing) {
+            tagScope.EditableTagChip { name ->
+                onSubmitName(name)
+                tagScope.stopEditing()
+            }
+        } else {
+            PasteContextMenuView(items = contextMenuItemsFor(tagScope)) {
+                tagScope.TagChip(
+                    modifier =
+                        Modifier.pointerInput(tag.id) {
+                            detectReorderDragGestures(
+                                onDragStart = onDragStart,
+                                onDragEnd = onDragEnd,
+                                onDragCancel = onDragCancel,
+                                onDrag = { _, dragAmount -> onDragMove(dragAmount.x) },
+                            )
+                        },
+                    isSelected = isSelected,
+                    onEdit = onTagClick,
+                ) {
+                    tagScope.startEditing()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NewTagChip(
+    tag: PasteTag,
+    onSubmit: suspend (String) -> Unit,
+) {
+    val tagScope = remember { createPasteTagScope(tag) }
+    tagScope.EditableTagChip(onSubmit)
+}
+
+@Composable
+private fun AddTagChip(onClick: () -> Unit) {
+    AssistChip(
+        onClick = onClick,
+        label = {
+            Icon(
+                imageVector = MaterialSymbols.Rounded.Add,
+                contentDescription = "Add",
+                modifier = Modifier.size(medium),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        },
+        modifier = Modifier.height(xxLarge),
+        border = null,
+        shape = CircleShape,
+    )
+}
+
+@Composable
+private fun Modifier.tagDragVisuals(
+    isDragging: Boolean,
+    dragOffsetX: Float,
+): Modifier {
+    val backgroundColor = MaterialTheme.colorScheme.surfaceContainerHighest
+    return this
+        .zIndex(if (isDragging) 1f else 0f)
+        .graphicsLayer {
+            translationX = if (isDragging) dragOffsetX else 0f
+            if (isDragging) {
+                scaleX = 1.05f
+                scaleY = 1.05f
+            }
+        }.then(
+            if (isDragging) {
+                // Lift effect + solid background so the dragged chip clearly highlights
+                // on long-press and occludes neighbors.
+                Modifier
+                    .shadow(elevation = tiny3X, shape = CircleShape)
+                    .background(color = backgroundColor, shape = CircleShape)
+            } else {
+                Modifier
+            },
+        )
+}
+
+@Stable
+private class TagDragState(
+    initial: List<PasteTag>,
+) {
+    var displayList by mutableStateOf(initial)
+        private set
+
+    var draggingTagId by mutableStateOf<Long?>(null)
+        private set
+
+    var dragOffsetX by mutableStateOf(0f)
+        private set
+
+    fun isDragging(tagId: Long): Boolean = draggingTagId == tagId
+
+    fun syncFromSource(source: List<PasteTag>) {
+        // Don't clobber the user's optimistic order while a drag is in progress.
+        if (draggingTagId == null) displayList = source
+    }
+
+    fun startDrag(
+        tagId: Long,
+        initialDriftX: Float,
+    ) {
+        draggingTagId = tagId
+        dragOffsetX = initialDriftX
+    }
+
+    fun handleDragMove(
+        deltaX: Float,
+        layoutInfo: LazyListLayoutInfo,
+    ) {
+        dragOffsetX += deltaX
+        val draggingId = draggingTagId ?: return
+        val visibleItems = layoutInfo.visibleItemsInfo
+        val draggedItem = visibleItems.firstOrNull { it.key == draggingId } ?: return
+        val draggedCenter = draggedItem.offset + draggedItem.size / 2f + dragOffsetX
+
+        // Center-crossed-center swap rule: swap only once the dragged center has moved
+        // past the neighbor's center. Builds hysteresis ≈ half a chip's width so a
+        // post-swap layout update can't re-trigger the opposite swap (no oscillation).
+        val target =
+            visibleItems.firstOrNull { other ->
+                if (other.key == draggingId) return@firstOrNull false
+                val otherCenter = other.offset + other.size / 2f
+                when {
+                    other.offset > draggedItem.offset -> draggedCenter > otherCenter
+                    other.offset < draggedItem.offset -> draggedCenter < otherCenter
+                    else -> false
+                }
+            } ?: return
+
+        val from = displayList.indexOfFirst { it.id == draggingId }
+        val to = displayList.indexOfFirst { it.id == target.key }
+        if (from == -1 || to == -1 || from == to) return
+
+        // Keep the chip visually under the cursor across the swap.
+        dragOffsetX += (draggedItem.offset - target.offset).toFloat()
+        displayList = displayList.toMutableList().apply { add(to, removeAt(from)) }
+    }
+
+    /**
+     * Clears drag state and returns the new id order if it differs from [persisted],
+     * else null (caller can skip the DB write).
+     */
+    fun finalizeDrag(persisted: List<PasteTag>): List<Long>? {
+        val finalIds = displayList.map { it.id }
+        draggingTagId = null
+        dragOffsetX = 0f
+        return finalIds.takeIf { it != persisted.map { p -> p.id } }
+    }
+
+    fun cancelDrag(persisted: List<PasteTag>) {
+        // Revert any in-progress swap to the persisted order.
+        displayList = persisted
+        draggingTagId = null
+        dragOffsetX = 0f
+    }
+}
+
+@Composable
+private fun rememberTagDragState(source: List<PasteTag>): TagDragState {
+    val state = remember { TagDragState(source) }
+    LaunchedEffect(source) { state.syncFromSource(source) }
+    return state
 }
 
 // Press-and-hold-then-drag gesture that tolerates pointer movement during the long-press wait.

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/SearchTagsView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/SearchTagsView.kt
@@ -1,12 +1,17 @@
 package com.crosspaste.ui.search.side
 
-import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Icon
@@ -22,6 +27,14 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.zIndex
 import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Add
 import com.crosspaste.app.AppControl
@@ -37,11 +50,14 @@ import com.crosspaste.ui.paste.PasteTagScope
 import com.crosspaste.ui.paste.createPasteTagScope
 import com.crosspaste.ui.theme.AppUISize.medium
 import com.crosspaste.ui.theme.AppUISize.tiny
+import com.crosspaste.ui.theme.AppUISize.tiny3X
 import com.crosspaste.ui.theme.AppUISize.xxLarge
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import kotlin.time.Duration.Companion.milliseconds
 
-@OptIn(ExperimentalFoundationApi::class)
+private val LONG_PRESS_TIMEOUT = 200.milliseconds
+
 @Composable
 fun SearchTagsView() {
     val appControl = koinInject<AppControl>()
@@ -62,20 +78,34 @@ fun SearchTagsView() {
 
     val scope = rememberCoroutineScope()
 
+    val lazyListState = rememberLazyListState()
+
+    var draggingTagId by remember { mutableStateOf<Long?>(null) }
+    var dragOffsetX by remember { mutableStateOf(0f) }
+    var displayList by remember { mutableStateOf(tagList) }
+
+    LaunchedEffect(tagList) {
+        if (draggingTagId == null) {
+            displayList = tagList
+        }
+    }
+
     LaunchedEffect(searchWindowInfo.show) {
         newTag = null
         PasteTagScope.resetEditing()
     }
 
     LazyRow(
+        state = lazyListState,
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(tiny),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        itemsIndexed(tagList, key = { _, item -> item.id }) { _, tag ->
+        itemsIndexed(displayList, key = { _, item -> item.id }) { _, tag ->
             val currentTag by rememberUpdatedState(tag)
 
             val isSelected = currentTag.id == searchBaseParams.tag
+            val isDragging = draggingTagId == tag.id
 
             val tagScope =
                 remember(
@@ -86,26 +116,122 @@ fun SearchTagsView() {
                     createPasteTagScope(currentTag)
                 }
 
-            if (editingMap[tag.id] == true) {
-                tagScope.EditableTagChip { name ->
-                    if (name.isBlank()) {
-                        pasteTagDao.deletePasteTagBlock(tag.id)
-                    } else {
-                        pasteTagDao.updatePasteTagName(tag.id, name)
+            // Outermost wrapper of each LazyRow item slot. zIndex/transform/background MUST live
+            // here so they layer the dragged item above its sibling lazy items — applying them
+            // deeper inside (e.g. inside PasteContextMenuView) only layers within that subtree.
+            Box(
+                modifier =
+                    Modifier
+                        .zIndex(if (isDragging) 1f else 0f)
+                        .graphicsLayer {
+                            translationX = if (isDragging) dragOffsetX else 0f
+                            if (isDragging) {
+                                scaleX = 1.05f
+                                scaleY = 1.05f
+                            }
+                        }.then(
+                            if (isDragging) {
+                                // Lift effect + solid background so the dragged chip clearly
+                                // highlights on long-press and occludes neighbors.
+                                Modifier
+                                    .shadow(elevation = tiny3X, shape = CircleShape)
+                                    .background(
+                                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                        shape = CircleShape,
+                                    )
+                            } else {
+                                Modifier
+                            },
+                        ),
+            ) {
+                if (editingMap[tag.id] == true) {
+                    tagScope.EditableTagChip { name ->
+                        if (name.isBlank()) {
+                            pasteTagDao.deletePasteTagBlock(tag.id)
+                        } else {
+                            pasteTagDao.updatePasteTagName(tag.id, name)
+                        }
+                        tagScope.stopEditing()
                     }
-                    tagScope.stopEditing()
-                }
-            } else {
-                PasteContextMenuView(
-                    items = tagMenuService.menuItemsProvider(tagScope),
-                ) {
-                    tagScope.TagChip(
-                        isSelected = isSelected,
-                        onEdit = {
-                            pasteSearchViewModel.updateTag(tag.id)
-                        },
+                } else {
+                    PasteContextMenuView(
+                        items = tagMenuService.menuItemsProvider(tagScope),
                     ) {
-                        tagScope.startEditing()
+                        tagScope.TagChip(
+                            modifier =
+                                Modifier.pointerInput(tag.id) {
+                                    detectReorderDragGestures(
+                                        onDragStart = { initialDrift ->
+                                            draggingTagId = tag.id
+                                            // Snap chip to the cursor's drift during the long press.
+                                            dragOffsetX = initialDrift.x
+                                        },
+                                        onDragEnd = {
+                                            val finalOrder = displayList.map { it.id }
+                                            if (finalOrder != tagList.map { it.id }) {
+                                                scope.launch {
+                                                    pasteTagDao.updatePasteTagsSortOrder(finalOrder)
+                                                }
+                                            }
+                                            draggingTagId = null
+                                            dragOffsetX = 0f
+                                        },
+                                        onDragCancel = {
+                                            // Revert any in-progress swap to the persisted order.
+                                            displayList = tagList
+                                            draggingTagId = null
+                                            dragOffsetX = 0f
+                                        },
+                                        onDrag = { _, dragAmount ->
+                                            dragOffsetX += dragAmount.x
+
+                                            val visibleItems = lazyListState.layoutInfo.visibleItemsInfo
+                                            val draggedItem =
+                                                visibleItems.firstOrNull { it.key == tag.id }
+                                                    ?: return@detectReorderDragGestures
+                                            val draggedCenter =
+                                                draggedItem.offset + draggedItem.size / 2f + dragOffsetX
+
+                                            // Center-crossed-center swap rule: swap only once the
+                                            // dragged center has moved past the neighbor's center.
+                                            // This builds hysteresis ≈ half a chip's width so a
+                                            // post-swap layout update can't re-trigger the opposite
+                                            // swap (preventing oscillation).
+                                            val target =
+                                                visibleItems.firstOrNull { other ->
+                                                    if (other.key == tag.id) return@firstOrNull false
+                                                    val otherCenter = other.offset + other.size / 2f
+                                                    when {
+                                                        other.offset > draggedItem.offset ->
+                                                            draggedCenter > otherCenter
+                                                        other.offset < draggedItem.offset ->
+                                                            draggedCenter < otherCenter
+                                                        else -> false
+                                                    }
+                                                } ?: return@detectReorderDragGestures
+
+                                            val from = displayList.indexOfFirst { it.id == tag.id }
+                                            val to = displayList.indexOfFirst { it.id == target.key }
+                                            if (from == -1 || to == -1 || from == to) {
+                                                return@detectReorderDragGestures
+                                            }
+
+                                            // Keep the chip visually under the cursor across the swap.
+                                            dragOffsetX += (draggedItem.offset - target.offset).toFloat()
+                                            displayList =
+                                                displayList.toMutableList().apply {
+                                                    add(to, removeAt(from))
+                                                }
+                                        },
+                                    )
+                                },
+                            isSelected = isSelected,
+                            onEdit = {
+                                pasteSearchViewModel.updateTag(tag.id)
+                            },
+                        ) {
+                            tagScope.startEditing()
+                        }
                     }
                 }
             }
@@ -152,5 +278,51 @@ fun SearchTagsView() {
                 shape = CircleShape,
             )
         }
+    }
+}
+
+// Press-and-hold-then-drag gesture that tolerates pointer movement during the long-press wait.
+// Unlike `detectDragGesturesAfterLongPress`, motion within the timeout does not cancel the
+// gesture, so users can press-and-immediately-start-moving without having to be perfectly still.
+// The cursor's drift accumulated during the wait is reported via `onDragStart` so callers can
+// snap the dragged element to its current cursor position.
+private suspend fun PointerInputScope.detectReorderDragGestures(
+    onDragStart: (initialDrift: Offset) -> Unit,
+    onDragEnd: () -> Unit,
+    onDragCancel: () -> Unit,
+    onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit,
+) {
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false)
+        var lastChange: PointerInputChange = down
+
+        val pressedThroughTimeout =
+            withTimeoutOrNull(LONG_PRESS_TIMEOUT.inWholeMilliseconds) {
+                while (true) {
+                    val event = awaitPointerEvent()
+                    val change = event.changes.firstOrNull { it.id == down.id }
+                    if (change == null || !change.pressed) return@withTimeoutOrNull
+                    lastChange = change
+                }
+            } == null
+
+        if (!pressedThroughTimeout) return@awaitEachGesture
+
+        // Consume the in-flight pointer change so the underlying clickable doesn't
+        // see this gesture as a press-and-release tap.
+        lastChange.consume()
+        onDragStart(lastChange.position - down.position)
+
+        val dragSucceeded =
+            drag(down.id) { change ->
+                onDrag(change, change.positionChange())
+                change.consume()
+            }
+
+        // Consume the up/cancel event so a long-press-then-release (no actual drag)
+        // doesn't fall through to the chip's onClick.
+        currentEvent.changes.forEach { it.consume() }
+
+        if (dragSucceeded) onDragEnd() else onDragCancel()
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
@@ -430,6 +430,46 @@ class PasteDaoTest {
         assertTrue(afterSecond > afterFirst)
     }
 
+    @Test
+    fun `updatePasteTagsSortOrder reorders tags`() = runTest {
+        val id1 = pasteTagDao.createPasteTag("a", 0xFF0000L)
+        val id2 = pasteTagDao.createPasteTag("b", 0x00FF00L)
+        val id3 = pasteTagDao.createPasteTag("c", 0x0000FFL)
+
+        // Original order: a, b, c
+        pasteTagDao.getAllTagsFlow().test {
+            val initial = awaitItem()
+            assertEquals(listOf(id1, id2, id3), initial.map { it.id })
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Reorder to: c, a, b
+        pasteTagDao.updatePasteTagsSortOrder(listOf(id3, id1, id2))
+
+        pasteTagDao.getAllTagsFlow().test {
+            val reordered = awaitItem()
+            assertEquals(listOf(id3, id1, id2), reordered.map { it.id })
+            // Sort orders compact and 1-based so getMaxSortOrder still works for new tags.
+            assertEquals(3L, pasteTagDao.getMaxSortOrder())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `updatePasteTagsSortOrder with empty list is a no-op`() = runTest {
+        val id1 = pasteTagDao.createPasteTag("only", 0xFF0000L)
+        val before = pasteTagDao.getMaxSortOrder()
+
+        pasteTagDao.updatePasteTagsSortOrder(emptyList())
+
+        assertEquals(before, pasteTagDao.getMaxSortOrder())
+        pasteTagDao.getAllTagsFlow().test {
+            val tags = awaitItem()
+            assertEquals(listOf(id1), tags.map { it.id })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     // --- Flow ---
 
     @Test

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteTagDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteTagDao.kt
@@ -21,6 +21,8 @@ interface PasteTagDao : QueryPasteTag {
         color: Long,
     )
 
+    suspend fun updatePasteTagsSortOrder(orderedIds: List<Long>)
+
     fun switchPinPasteTagBlock(
         pasteDataId: Long,
         pasteTagId: Long,

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteTagDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteTagDao.kt
@@ -65,6 +65,17 @@ class SqlPasteTagDao(
         }
     }
 
+    override suspend fun updatePasteTagsSortOrder(orderedIds: List<Long>) {
+        if (orderedIds.isEmpty()) return
+        withContext(ioDispatcher) {
+            database.transaction {
+                orderedIds.forEachIndexed { index, id ->
+                    tagDatabaseQueries.updateTagSortOrder((index + 1).toLong(), id)
+                }
+            }
+        }
+    }
+
     override fun switchPinPasteTagBlock(
         pasteDataId: Long,
         pasteTagId: Long,

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/TagDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/TagDatabase.sq
@@ -39,6 +39,9 @@ UPDATE TagEntity SET name = ? WHERE id = ?;
 updateTagColor:
 UPDATE TagEntity SET color = ? WHERE id = ?;
 
+updateTagSortOrder:
+UPDATE TagEntity SET sortOrder = ? WHERE id = ?;
+
 deleteTag:
 DELETE FROM TagEntity WHERE id = ?;
 


### PR DESCRIPTION
Closes #4376

## Summary
- Long-press (~200ms) a tag chip in the search panel and drag it horizontally to reorder; new order is persisted via `TagEntity.sortOrder`.
- Adds `PasteTagDao.updatePasteTagsSortOrder(orderedIds)` (single transaction, assigns `1..N` in order) plus the matching `updateTagSortOrder` SQL.
- Optimistic local list with center-crossed-center swap rule: a swap only happens after the dragged chip's center moves past the neighbor's center, so the post-swap layout shift can't immediately re-trigger an opposite swap.

## Implementation notes
- Custom `detectReorderDragGestures` instead of `detectDragGesturesAfterLongPress`: tolerates pointer drift during the long-press wait, and reports the accumulated drift via `onDragStart` so the chip snaps under the cursor.
- `displayList` mirrors `tagList` while idle and is mutated locally during a drag; `LaunchedEffect(tagList)` re-syncs once the drag ends.
- `TagChip` now accepts an external `Modifier` so the drag wrapper can apply `zIndex` / `graphicsLayer` / `pointerInput`.

## Known follow-ups (not in this PR)
- `modifier` parameter in `TagChip` should be moved to follow the standard Compose ordering (after required params).
- `onDragEnd` could skip the DB write when the order didn't actually change.
- Cross-width swap compensation can still drift slightly when chips have very different widths.

## Test plan
- [x] `./gradlew ktlintFormat` clean.
- [x] `./gradlew :app:compileKotlinDesktop` clean rebuild succeeds.
- [x] New `PasteDaoTest` cases: `updatePasteTagsSortOrder reorders tags`, `updatePasteTagsSortOrder with empty list is a no-op`.
- [ ] Manual: long-press a tag and drag past a neighbor — order swaps and persists across restart.
- [ ] Manual: plain click still selects the tag (no regression).
- [ ] Manual: long-press without movement, then release — tag is not accidentally selected/deselected, no DB churn beyond a single no-op update.
- [ ] Manual: edit / create / delete tag still works while no drag is in progress.