### PR TITLE
:bug: reset selected index when the search window opens

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
@@ -119,11 +119,13 @@ fun SidePasteboardContentView() {
         }
     }
 
-    // Reset key modifier state when the window opens.
+    // Reset key modifier state and selection when the window opens, so it matches
+    // the freshly recreated scroll state above.
     LaunchedEffect(searchWindowInfo.show) {
         if (searchWindowInfo.show) {
             isCtrlPressed = false
             isShiftPressed = false
+            pasteSelectionViewModel.initSelectIndex()
         }
     }
 


### PR DESCRIPTION
Closes #4381

## Summary

- In `SidePasteboardContentView`, the `LazyListState` is recreated every time the search window opens so the list always starts scrolled to position 0, but the selected index in `PasteSelectionViewModel` was not reset alongside it — leaving the highlighted row out of sync with the viewport.
- Call `pasteSelectionViewModel.initSelectIndex()` from the `LaunchedEffect(searchWindowInfo.show)` block alongside the existing modifier-key reset so the selection is realigned with the freshly recreated scroll state.

## Test plan

- [ ] Scroll partway down the search list, pick a non-top item, close the search window, reopen it — list scrolls to top and the first item is highlighted (not the previously selected row).
- [ ] Open the search window with no prior selection — first item is highlighted as before; no regression.