### PR TITLE
:zap: defer dragOffsetX read to layer phase in SearchTagsView

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/SearchTagsView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/search/side/SearchTagsView.kt
@@ -96,7 +96,7 @@ fun SearchTagsView() {
                 isSelected = tag.id == searchBaseParams.tag,
                 isDragging = dragState.isDragging(tag.id),
                 isEditing = editingMap[tag.id] == true,
-                dragOffsetX = dragState.dragOffsetX,
+                dragOffsetX = { dragState.dragOffsetX },
                 contextMenuItemsFor = tagMenuService::menuItemsProvider,
                 onTagClick = { pasteSearchViewModel.updateTag(tag.id) },
                 onSubmitName = { name ->
@@ -157,7 +157,7 @@ private fun SearchTagItem(
     isSelected: Boolean,
     isDragging: Boolean,
     isEditing: Boolean,
-    dragOffsetX: Float,
+    dragOffsetX: () -> Float,
     contextMenuItemsFor: (PasteTagScope) -> () -> List<ContextMenuItem>,
     onTagClick: () -> Unit,
     onSubmitName: suspend (String) -> Unit,
@@ -235,13 +235,13 @@ private fun AddTagChip(onClick: () -> Unit) {
 @Composable
 private fun Modifier.tagDragVisuals(
     isDragging: Boolean,
-    dragOffsetX: Float,
+    dragOffsetX: () -> Float,
 ): Modifier {
     val backgroundColor = MaterialTheme.colorScheme.surfaceContainerHighest
     return this
         .zIndex(if (isDragging) 1f else 0f)
         .graphicsLayer {
-            translationX = if (isDragging) dragOffsetX else 0f
+            translationX = if (isDragging) dragOffsetX() else 0f
             if (isDragging) {
                 scaleX = 1.05f
                 scaleY = 1.05f


### PR DESCRIPTION
Closes #4387.

## Summary

Fix a Compose recomposition regression introduced by #4377. The "split SearchTagsView complexity into per-slot composables" refactor moved the `dragState.dragOffsetX` read from a per-item `Modifier.graphicsLayer { }` block (layer phase) up to `SearchTagsView`'s composition, then passed the snapshotted `Float` down through `SearchTagItem` → `Modifier.tagDragVisuals`.

Effect: every pointer tick during a drag invalidates `SearchTagsView` and re-runs `itemsIndexed`, recomposing every visible chip.

## Fix

- `SearchTagItem` and `Modifier.tagDragVisuals`: `dragOffsetX: Float` → `dragOffsetX: () -> Float`.
- Read happens inside `graphicsLayer { translationX = if (isDragging) dragOffsetX() else 0f }`, so the snapshot subscription is on the layer instead of the composition.
- Call site passes `dragOffsetX = { dragState.dragOffsetX }`.

`isDragging` stays a value `Boolean` — it flips at most twice per drag and gates a `then(...)` modifier branch that has to run at composition time anyway.

No behavior change.

## Test plan

- [x] `./gradlew app:compileKotlinDesktop` — passes.
- [x] `./gradlew ktlintFormat` — passes.
- [ ] Manual: long-press + drag a tag chip in the search panel, confirm visuals (translation, lift, swap) match `main`.