### PR TITLE
:bug: sort nvm node versions by parsed semver in web build

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -142,11 +142,21 @@ fun resolveNpmCommand(): String {
             add("/usr/local/bin/npm")
             add("/usr/bin/npm")
             val home = System.getProperty("user.home")
+            val semverRegex = Regex("""^v?(\d+)\.(\d+)\.(\d+)""")
             File("$home/.nvm/versions/node")
                 .takeIf { it.isDirectory }
                 ?.listFiles { f -> f.isDirectory }
-                ?.sortedByDescending { it.name }
-                ?.forEach { add("${it.absolutePath}/bin/npm") }
+                ?.mapNotNull { dir ->
+                    semverRegex.find(dir.name)?.destructured?.let { (maj, min, patch) ->
+                        Triple(maj.toInt(), min.toInt(), patch.toInt()) to dir
+                    }
+                }
+                ?.sortedWith(
+                    compareByDescending<Pair<Triple<Int, Int, Int>, File>> { it.first.first }
+                        .thenByDescending { it.first.second }
+                        .thenByDescending { it.first.third },
+                )
+                ?.forEach { add("${it.second.absolutePath}/bin/npm") }
         }
     candidatePaths.firstOrNull { File(it).canExecute() }?.let { return it }
 


### PR DESCRIPTION
Closes #4389

## Summary

`web/build.gradle.kts:resolveNpmCommand()` sorted `~/.nvm/versions/node/*` by lexicographic directory name, so `v20.2.0` ranked above `v20.10.0`. With both installed, the first executable npm in that list was the older one.

This change parses each directory name into a `(major, minor, patch)` integer triple via `^v?(\d+)\.(\d+)\.(\d+)` and sorts descending by each component in turn. Directories that don't match the regex (e.g. nvm aliases) are filtered out instead of mis-sorted.

The `io.github.z4kn4fein:semver` library was considered but it lives on the project classpath, not the buildscript classpath, so using it here would have required wiring it into `buildscript { dependencies { … } }` — more invasive than the 5-line parse it would replace.

## Test plan

- [ ] `./gradlew :web:npmInstall` on a machine with `v20.2.0` and `v20.10.0` both present under `~/.nvm/versions/node/` resolves npm from the `v20.10.0` directory
- [ ] On machines with a single nvm node version installed, behavior is unchanged
- [ ] Non-semver entries (e.g. nvm `lts/*` aliases) no longer appear in the candidate list