### PR TITLE
:bug: Fix HTML/RTF preview bottom gradient darker than content area

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.paste.item.HtmlPasteItem
 import com.crosspaste.paste.item.PasteItemReader
@@ -32,11 +33,12 @@ fun PasteDataScope.HtmlSidePreviewView() {
         mutableStateOf(Color(htmlPasteItem.getBackgroundColor()))
     }
 
+    val themeBackground = MaterialTheme.colorScheme.background
     val htmlBackground =
         if (backgroundColor == Color.Transparent) {
-            MaterialTheme.colorScheme.background
+            themeBackground
         } else {
-            backgroundColor
+            backgroundColor.compositeOver(themeBackground)
         }
     val isDark by remember(pasteData.id) { mutableStateOf(ColorAccessibility.isDarkColor(htmlBackground)) }
     val richTextColor =

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.paste.item.RtfPasteItem
@@ -32,11 +33,12 @@ fun PasteDataScope.RtfSidePreviewView() {
         mutableStateOf(Color(rtfPasteItem.getBackgroundColor()))
     }
 
+    val themeBackground = MaterialTheme.colorScheme.background
     val rtfBackground =
         if (backgroundColor == Color.Transparent) {
-            MaterialTheme.colorScheme.background
+            themeBackground
         } else {
-            backgroundColor
+            backgroundColor.compositeOver(themeBackground)
         }
     val isDark by remember(pasteData.id) { mutableStateOf(ColorAccessibility.isDarkColor(rtfBackground)) }
     val richTextColor =


### PR DESCRIPTION
Closes #4399

## Summary
- When the extracted HTML/RTF background color is translucent (e.g. `rgba(30, 58, 138, 0.2)` from a copied `<span style="background-color: rgba(...)">`), the bottom gradient strip in the side preview rendered noticeably darker than the content area above it.
- Root cause: the low-alpha color got alpha-blended over `pasteBackground` twice — once via `RichText.background(htmlBackground)` covering the whole preview, then again via `BottomGradient`'s stops on top of that already-blended area.
- Fix: composite the extracted color over the theme background once via `Color.compositeOver`, producing an opaque color. Stacking an opaque color twice is visually identical to stacking it once, so the two layers paint the same final pixel. Opaque extracted colors are unaffected (source-over no-op). Same fix applied to `RtfSidePreviewView`.

## Test plan
- [ ] Open side preview for an HTML paste whose body/span uses an `rgba()` background with low alpha (e.g. a Tailwind highlighted snippet) — content area and bottom gradient strip should now be the same shade.
- [ ] Open side preview for an HTML paste with an opaque dark background (e.g. a code editor screenshot) — gradient should still smoothly fade into the dark background as before, no harsh edge.
- [ ] Open side preview for an HTML paste with no extracted background color — falls back to theme background, looks identical to before.
- [ ] Repeat for an RTF paste to verify `RtfSidePreviewView` behaves the same.
- [ ] Toggle light/dark theme and re-check; the composite uses the current theme background so both modes should look consistent.