### PR TITLE
:bug: fix COM ref leak and false-positive warning in Windows network detection

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkProfileService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkProfileService.kt
@@ -108,7 +108,7 @@ class DesktopNetworkProfileService(
             _diagnosis.value = diagnosis
         }.onFailure { e ->
             logger.warn(e) { "Failed to run Windows network diagnosis" }
-            _diagnosis.value = NetworkDiagnosis(NetworkProfile.UNKNOWN, mDnsAllowed = false)
+            _diagnosis.value = NetworkDiagnosis(NetworkProfile.UNKNOWN, mDnsAllowed = null)
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/NetworkProfileService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/NetworkProfileService.kt
@@ -21,7 +21,10 @@ interface NetworkProfileService {
 
 data class NetworkDiagnosis(
     val profile: NetworkProfile,
-    val mDnsAllowed: Boolean,
+    // null = could not be determined. Only an explicit `false` (rules enumerated,
+    // no allowing rule found) is treated as blocking — null short-circuits to
+    // avoid false-positive warnings on accounts that can't read firewall rules.
+    val mDnsAllowed: Boolean?,
 ) {
 
     fun isLikelyBlocking(): Boolean =
@@ -29,7 +32,7 @@ data class NetworkDiagnosis(
             NetworkProfile.PUBLIC,
             NetworkProfile.PRIVATE,
             NetworkProfile.DOMAIN_AUTHENTICATED,
-            -> !mDnsAllowed
+            -> mDnsAllowed == false
             NetworkProfile.UNKNOWN,
             NetworkProfile.NOT_APPLICABLE,
             -> false
@@ -38,7 +41,7 @@ data class NetworkDiagnosis(
     fun fingerprint(): String = "${profile.name}|$mDnsAllowed"
 
     companion object {
-        val NOT_APPLICABLE = NetworkDiagnosis(NetworkProfile.NOT_APPLICABLE, mDnsAllowed = true)
+        val NOT_APPLICABLE = NetworkDiagnosis(NetworkProfile.NOT_APPLICABLE, mDnsAllowed = null)
     }
 }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/api/WindowsNetworkApi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/api/WindowsNetworkApi.kt
@@ -21,7 +21,11 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 
 data class WindowsNetworkSnapshot(
     val profile: NetworkProfile,
-    val mDnsAllowed: Boolean,
+    // null = could not be determined (NetFwPolicy2 unavailable, enumeration failed,
+    // insufficient privileges, ...). The caller must NOT treat null as "blocked" —
+    // false-positive warnings in restricted environments were the whole reason this
+    // is a tristate.
+    val mDnsAllowed: Boolean?,
 )
 
 object WindowsNetworkApi {
@@ -68,17 +72,17 @@ object WindowsNetworkApi {
         val ownsCoInit = COMUtils.SUCCEEDED(hr)
         if (!ownsCoInit && hr.toInt() != RPC_E_CHANGED_MODE) {
             logger.warn { "CoInitializeEx failed: 0x${Integer.toHexString(hr.toInt())}" }
-            return WindowsNetworkSnapshot(NetworkProfile.UNKNOWN, mDnsAllowed = false)
+            return WindowsNetworkSnapshot(NetworkProfile.UNKNOWN, mDnsAllowed = null)
         }
         try {
             val profile =
                 runCatching { queryProfile() }
                     .onFailure { logger.warn(it) { "queryProfile failed" } }
                     .getOrDefault(NetworkProfile.UNKNOWN)
-            val mDnsAllowed =
+            val mDnsAllowed: Boolean? =
                 runCatching { queryMDnsAllowed(profile) }
                     .onFailure { logger.warn(it) { "queryMDnsAllowed failed" } }
-                    .getOrDefault(false)
+                    .getOrNull()
             return WindowsNetworkSnapshot(profile, mDnsAllowed)
         } finally {
             if (ownsCoInit) {
@@ -153,8 +157,13 @@ object WindowsNetworkApi {
             else -> 0
         }
 
-    private fun queryMDnsAllowed(profile: NetworkProfile): Boolean {
-        val profileBit = profile.firewallBit() ?: return false
+    // Returns:
+    //   true  — successfully enumerated firewall rules AND found an allowing one
+    //   false — successfully enumerated firewall rules AND found no allowing one
+    //   null  — could not enumerate (NetFwPolicy2 unavailable, restricted account,
+    //           QueryInterface failed, ...). Callers must NOT treat this as "blocked".
+    private fun queryMDnsAllowed(profile: NetworkProfile): Boolean? {
+        val profileBit = profile.firewallBit() ?: return null
 
         val ppPolicy = PointerByReference()
         val hr =
@@ -167,24 +176,24 @@ object WindowsNetworkApi {
             )
         if (!COMUtils.SUCCEEDED(hr)) {
             logger.warn { "CoCreateInstance(NetFwPolicy2) failed: 0x${Integer.toHexString(hr.toInt())}" }
-            return false
+            return null
         }
 
         val policy = NetFwPolicy2(ppPolicy.value)
         try {
             val ppRules = PointerByReference()
-            if (!COMUtils.SUCCEEDED(policy.getRules(ppRules))) return false
+            if (!COMUtils.SUCCEEDED(policy.getRules(ppRules))) return null
             val rules = NetFwRules(ppRules.value)
             try {
                 val ppEnum = PointerByReference()
-                if (!COMUtils.SUCCEEDED(rules.getNewEnum(ppEnum))) return false
+                if (!COMUtils.SUCCEEDED(rules.getNewEnum(ppEnum))) return null
 
                 // _NewEnum hands back IUnknown — promote it to IEnumVARIANT.
                 val rawEnum = Unknown(ppEnum.value)
                 val ppEnumVariant = PointerByReference()
                 val qiHr = rawEnum.QueryInterface(REFIID(EnumVariant.IID), ppEnumVariant)
                 rawEnum.Release()
-                if (!COMUtils.SUCCEEDED(qiHr)) return false
+                if (!COMUtils.SUCCEEDED(qiHr)) return null
 
                 val enumVariant = EnumVariant(ppEnumVariant.value)
                 try {
@@ -207,13 +216,18 @@ object WindowsNetworkApi {
         while (true) {
             val batch = enumVariant.Next(BATCH_SIZE)
             if (batch.isEmpty()) break
-            for (variant in batch) {
-                try {
+            try {
+                for (variant in batch) {
                     if (variant.getVarType().toInt() != Variant.VT_DISPATCH) continue
                     val dispatch = variant.getValue() as? Dispatch ?: continue
                     if (ruleAllowsDiscovery(dispatch, profileBit)) return true
-                } finally {
-                    // VariantClear releases the contained IDispatch/IUnknown reference.
+                }
+            } finally {
+                // VariantClear releases the contained IDispatch/IUnknown reference.
+                // Must clear EVERY variant in the batch — including ones not yet
+                // visited when we return early — otherwise each unprocessed entry
+                // leaks an IDispatch ref to an INetFwRule COM object.
+                for (variant in batch) {
                     OleAuto.INSTANCE.VariantClear(variant)
                 }
             }


### PR DESCRIPTION
Closes #4403

## Summary

Two bugs in the Windows network detection added in #4402:

- **COM IDispatch ref leak in `scanForAllowingRule`** — when an allowing rule is found, the early `return true` skips `VariantClear` on the remaining (up to 31) entries in the current `IEnumVARIANT` batch. Each leaked variant pins an `INetFwRule` COM reference. With the 60s probe cadence, the leak compounds to ~1860/hour, ~45k/day.
- **False-positive "network discovery blocked" warning on restricted environments** — `queryMDnsAllowed` returned `false` indistinguishably for "enumerated and no allowing rule" vs "could not enumerate" (`CoCreateInstance(NetFwPolicy2)` failures, restricted accounts, group policy lockdowns). Combined with a successfully detected `PRIVATE` / `DOMAIN_AUTHENTICATED` profile, this fired the warning dialog spuriously every 60s.

## Changes

- `WindowsNetworkApi.scanForAllowingRule`: hoist the per-variant `VariantClear` into an outer `try/finally` over the entire batch so cleanup runs for every entry regardless of how the loop exits.
- `WindowsNetworkApi.queryMDnsAllowed`, `WindowsNetworkSnapshot.mDnsAllowed`, `NetworkDiagnosis.mDnsAllowed`: make `mDnsAllowed` a tristate `Boolean?`. All soft-failure paths (`CoCreateInstance`, `getRules`, `getNewEnum`, `QueryInterface`, `firewallBit == null`) now return `null`. `isLikelyBlocking()` only warns when `mDnsAllowed == false`. The catch-all `runDetection` failure path and the `CoInitializeEx` early-return now also use `null`.

## Test plan

- [ ] Verify on a standard Windows account that a genuine "Network Discovery off" state still produces the warning dialog (`PRIVATE` + `mDnsAllowed = false`).
- [ ] Verify on a restricted account (or with `NetFwPolicy2` mocked to fail `CoCreateInstance`) that the dialog does NOT appear, even when the profile resolves to `PRIVATE`.
- [ ] Run the detection at the 60s cadence for ~10 minutes and confirm in Process Explorer that the JVM's `INetFwRule` / IDispatch handle count stays flat instead of growing.
- [ ] Existing `app:desktopTest` suite still passes.