### PR TITLE
:sparkles: add UserAttentionService to gate background pollers on window visibility

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/UserAttentionService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/UserAttentionService.kt
@@ -1,0 +1,72 @@
+package com.crosspaste.app
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+
+// Exposes per-surface visibility signals so background services can gate work
+// on whether the user can actually see the result. Background pollers that
+// only surface warnings inside a specific window should subscribe to that
+// window's flow via `attentionOn(...)`; pollers that must run regardless of
+// UI state (clipboard sync, cleanup) should simply not subscribe.
+//
+// Bubble window is intentionally not exposed — it's a transient surface that
+// no current poller needs to react to. Add it here when a real consumer
+// arrives.
+interface UserAttentionService {
+    val isMainWindowVisible: StateFlow<Boolean>
+    val isSearchWindowVisible: StateFlow<Boolean>
+}
+
+enum class AttentionSurface {
+    MAIN_WINDOW,
+    SEARCH_WINDOW,
+}
+
+// Returns a flow that emits true whenever *any* of the requested surfaces is
+// visible. Distinct-only — re-emits only on transitions.
+fun UserAttentionService.attentionOn(vararg surfaces: AttentionSurface): Flow<Boolean> {
+    require(surfaces.isNotEmpty()) { "attentionOn requires at least one surface" }
+    val flows =
+        surfaces.toSet().map { surface ->
+            when (surface) {
+                AttentionSurface.MAIN_WINDOW -> isMainWindowVisible
+                AttentionSurface.SEARCH_WINDOW -> isSearchWindowVisible
+            }
+        }
+    return if (flows.size == 1) {
+        // StateFlow already deduplicates, so no distinctUntilChanged here.
+        flows.single()
+    } else {
+        combine(flows) { values -> values.any { it } }.distinctUntilChanged()
+    }
+}
+
+// Runs `block` on `interval` cadence only while `attention` emits true.
+// When attention flips false the inner loop is cancelled; when it flips true
+// the loop restarts (firing `block` immediately if `runOnResume` is set, so
+// the user sees fresh state the moment they open the relevant surface
+// instead of waiting one interval).
+fun CoroutineScope.launchWhileAttentive(
+    attention: Flow<Boolean>,
+    interval: Duration,
+    runOnResume: Boolean = true,
+    block: suspend () -> Unit,
+): Job =
+    launch {
+        attention.collectLatest { attentive ->
+            if (!attentive) return@collectLatest
+            if (runOnResume) block()
+            while (true) {
+                delay(interval)
+                block()
+            }
+        }
+    }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -73,7 +73,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
             }
         }
         single<NetworkInterfaceService> { DesktopNetworkInterfaceService(get()) }
-        single<NetworkProfileService> { DesktopNetworkProfileService(get(), get(), get()) }
+        single<NetworkProfileService> { DesktopNetworkProfileService(get(), get(), get(), get()) }
         single<ResourcesClient> { DesktopResourcesClient(get(), get()) }
         single<PasteBonjourService> { DesktopPasteBonjourService(get(), get(), get(), get()) }
         single<PendingKeyExchangeStore> { PendingKeyExchangeStore() }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
@@ -10,7 +10,9 @@ import com.crosspaste.app.DesktopAppSize
 import com.crosspaste.app.DesktopAppTokenService
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.app.DesktopRatingPromptManager
+import com.crosspaste.app.DesktopUserAttentionService
 import com.crosspaste.app.RatingPromptManager
+import com.crosspaste.app.UserAttentionService
 import com.crosspaste.app.getDesktopAppWindowManager
 import com.crosspaste.i18n.DesktopGlobalCopywriter
 import com.crosspaste.i18n.GlobalCopywriter
@@ -87,6 +89,7 @@ fun desktopUiModule(): Module =
         single<ShortcutKeysListener> { get<DesktopShortcutKeysListener>() }
         single<ShortcutKeysLoader> { DesktopShortcutKeysLoader(get(), get()) }
         single<SmartImageDisplayStrategy> { SmartImageDisplayStrategy() }
+        single<UserAttentionService> { DesktopUserAttentionService(get<DesktopAppWindowManager>()) }
         single<SoundService> { DesktopSoundService(get()) }
         single<StoragePathManager> { DesktopStoragePathManager() }
         single<SyncScopeFactory> { DesktopSyncScopeFactory() }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopUserAttentionService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopUserAttentionService.kt
@@ -1,0 +1,28 @@
+package com.crosspaste.app
+
+import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+// `WindowInfo.show` reflects the app's *logical* show state — it stays true
+// while minimized. If we later decide minimized should count as "not paying
+// attention", refine the mapping here; consumers don't need to change.
+class DesktopUserAttentionService(
+    appWindowManager: DesktopAppWindowManager,
+    scope: CoroutineScope = namedScope(ioDispatcher, "DesktopUserAttentionService"),
+) : UserAttentionService {
+
+    override val isMainWindowVisible: StateFlow<Boolean> =
+        appWindowManager.mainWindowInfo
+            .map { it.show }
+            .stateIn(scope, SharingStarted.Eagerly, appWindowManager.getCurrentMainWindowInfo().show)
+
+    override val isSearchWindowVisible: StateFlow<Boolean> =
+        appWindowManager.searchWindowInfo
+            .map { it.show }
+            .stateIn(scope, SharingStarted.Eagerly, appWindowManager.getCurrentSearchWindowInfo().show)
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessModule.kt
@@ -4,6 +4,7 @@ import com.crosspaste.app.AppTokenApi
 import com.crosspaste.app.AppWindowManager
 import com.crosspaste.app.DesktopRatingPromptManager
 import com.crosspaste.app.RatingPromptManager
+import com.crosspaste.app.UserAttentionService
 import com.crosspaste.i18n.DesktopGlobalCopywriter
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.notification.NotificationManager
@@ -23,6 +24,7 @@ fun headlessUiModule() =
         single<SoundService> { HeadlessSoundService() }
         single<TokenCacheApi> { TokenCache }
         single<UISupport> { HeadlessUISupport(get()) }
+        single<UserAttentionService> { HeadlessUserAttentionService() }
     }
 
 fun headlessViewModelModule() = module {}

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessUserAttentionService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessUserAttentionService.kt
@@ -1,0 +1,15 @@
+package com.crosspaste.headless
+
+import com.crosspaste.app.UserAttentionService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+// Headless mode has no user-facing windows — every attention signal is
+// permanently false. Pollers gated through `launchWhileAttentive` will
+// naturally never fire, which is the desired behaviour.
+class HeadlessUserAttentionService : UserAttentionService {
+    private val never = MutableStateFlow(false)
+    override val isMainWindowVisible: StateFlow<Boolean> = never.asStateFlow()
+    override val isSearchWindowVisible: StateFlow<Boolean> = never.asStateFlow()
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkProfileService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkProfileService.kt
@@ -1,5 +1,9 @@
 package com.crosspaste.net
 
+import com.crosspaste.app.AttentionSurface
+import com.crosspaste.app.UserAttentionService
+import com.crosspaste.app.attentionOn
+import com.crosspaste.app.launchWhileAttentive
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.notification.MessageType
 import com.crosspaste.notification.NotificationManager
@@ -20,7 +24,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.seconds
@@ -29,6 +32,7 @@ class DesktopNetworkProfileService(
     private val configManager: DesktopConfigManager,
     private val notificationManager: NotificationManager,
     private val platform: Platform,
+    private val userAttentionService: UserAttentionService,
     private val scope: CoroutineScope = namedScope(ioDispatcher, "DesktopNetworkProfileService"),
 ) : NetworkProfileService {
 
@@ -50,12 +54,18 @@ class DesktopNetworkProfileService(
 
     init {
         if (platform.isWindows()) {
+            // Gate polling on the main window — that's the only surface that
+            // can render the warning dialog (`NetworkWarningDialogHost`) or
+            // the menu-bar warning entry, so polling while no one can see
+            // the result wastes COM enumerations every 60s. The 3s startup
+            // delay is preserved so we don't race the rest of init even if
+            // the main window comes up immediately.
             scope.launch {
                 delay(STARTUP_DELAY)
-                while (isActive) {
-                    runDetection()
-                    delay(REFRESH_INTERVAL)
-                }
+                launchWhileAttentive(
+                    attention = userAttentionService.attentionOn(AttentionSurface.MAIN_WINDOW),
+                    interval = REFRESH_INTERVAL,
+                ) { runDetection() }
             }
         }
 


### PR DESCRIPTION
Closes #4405

## Summary

- New `UserAttentionService` (commonMain) exposes per-surface visibility as `StateFlow<Boolean>` — main window and search window. Comes with two helpers: `attentionOn(vararg AttentionSurface)` to combine surfaces, and `CoroutineScope.launchWhileAttentive(...)` to drive polling loops gated on attention.
- Desktop binds `DesktopUserAttentionService` (wraps `DesktopAppWindowManager`); headless binds `HeadlessUserAttentionService` (permanently false).
- `DesktopNetworkProfileService` is the first migration: the 60s Windows firewall scan now only runs while the main window is visible. On window-show the helper fires `runDetection()` immediately, so the user sees fresh diagnosis the moment they open the window — not after waiting a poll interval.

## Design notes

- **Opt-in per service.** `SyncPollingManager` / `CleanScheduler` are not migrated — they need to run regardless of UI state. The abstraction is here for the pollers that only matter when a user can see the result.
- **Per-surface granularity.** Future detectors can subscribe to `MAIN_WINDOW` only, `SEARCH_WINDOW` only, or both via `attentionOn(MAIN_WINDOW, SEARCH_WINDOW)`. Network detection only renders warnings in the main window so it gates on `MAIN_WINDOW`.
- **Bubble window is not exposed.** No consumer needs it; add when one does.
- **`WindowInfo.show` is the app's logical show state**, so minimized windows still count as visible. If we later decide minimized should suspend polling, change the mapping in `DesktopUserAttentionService` only — consumers don't need to change.
- **Headless wins a small efficiency for free**: the always-false flows mean `runDetection()` is never invoked in headless mode, without explicit `if (headless)` checks scattered through services.
- **`runOnResume = true`** is the default so a user opening the main window sees a fresh diagnosis immediately, not after a 60s wait.

## Files

- `app/src/commonMain/kotlin/com/crosspaste/app/UserAttentionService.kt` — new
- `app/src/desktopMain/kotlin/com/crosspaste/app/DesktopUserAttentionService.kt` — new
- `app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessUserAttentionService.kt` — new
- `app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt` — bind `UserAttentionService` to desktop impl
- `app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessModule.kt` — bind to headless impl
- `app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt` — pass new dep into `DesktopNetworkProfileService`
- `app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkProfileService.kt` — migrate to `launchWhileAttentive`

## Test plan

- [x] `./gradlew app:desktopTest` — all desktop tests pass.
- [ ] Manual on Windows: open main window → confirm firewall check fires once immediately, then every 60s; close window → confirm no further `runDetection` log lines until window reopens.
- [ ] Manual on Windows headless install: confirm no Windows firewall COM calls happen at all (no "queryProfile" / "queryMDnsAllowed" log lines).
- [ ] Visually confirm that on first launch (main window auto-shows), the diagnosis & menu-bar warning entry populate within ~3s of startup as before.