### PR TITLE
:bug: bring main window to front on every showMainWindow call

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.awt.Frame
 
 fun getDesktopAppWindowManager(
     appInfo: AppInfo,
@@ -176,16 +177,23 @@ abstract class DesktopAppWindowManager(
     }
 
     fun showMainWindow(windowTrigger: WindowTrigger) {
-        if (!_mainWindowInfo.value.show) {
-            _mainWindowInfo.value =
-                _mainWindowInfo.value.copy(
-                    show = true,
-                    trigger = windowTrigger,
-                )
-        } else {
-            mainCoroutineDispatcher.launch {
-                focusMainWindow(windowTrigger)
+        _mainWindowInfo.value =
+            _mainWindowInfo.value.copy(
+                show = true,
+                trigger = windowTrigger,
+            )
+        mainCoroutineDispatcher.launch {
+            // AWT-level bring-to-front handles the already-visible case via the JVM's
+            // platform window APIs; focusMainWindow then runs the platform-specific
+            // aggressive activation (handles tray-menu focus race / app activation policy).
+            mainComposeWindow?.let { window ->
+                if (window.state == Frame.ICONIFIED) {
+                    window.state = Frame.NORMAL
+                }
+                window.toFront()
+                window.requestFocus()
             }
+            focusMainWindow(windowTrigger)
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/MainWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/MainWindow.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,12 +59,6 @@ fun MainWindow(windowIcon: Painter?) {
     val appSizeValue = LocalDesktopAppSizeValueState.current
 
     val config by configManager.config.collectAsState()
-
-    LaunchedEffect(mainWindowInfo.show) {
-        if (mainWindowInfo.show) {
-            appWindowManager.focusMainWindow(mainWindowInfo.trigger)
-        }
-    }
 
     DecoratedWindow(
         onCloseRequest = {


### PR DESCRIPTION
Closes #4407

## Summary
- Tray-menu page selection now reliably brings the main window to the front on macOS, Windows, and Linux. Previously, switching pages from the tray while the window was already open in the background changed the route but left the window behind other apps.
- `DesktopAppWindowManager.showMainWindow` is unified so both the hidden→shown and already-shown paths always publish state and always launch the focus path.
- Added a portable AWT `Window.toFront()` + `requestFocus()` (with de-iconify) on the underlying `ComposeWindow` before the platform-specific bring-to-front, so the JVM does a first-pass front via `CPlatformWindow.orderAboveSiblings` (macOS) / `BringWindowToTop` (Windows) / `XRaiseWindow` (Linux), independent of tray-menu dismissal timing.
- Removed the now-redundant `LaunchedEffect(mainWindowInfo.show)` in `MainWindow.kt`.

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew :app:desktopTest --tests com.crosspaste.app.AppWindowManagerTest`
- [ ] Manual: with the main window open in the background on macOS, click the tray icon → select Devices / Settings / Extension / Import / Export / Shortcut Keys / About → window should come to the front.
- [ ] Manual: repeat the above on Windows.
- [ ] Manual: repeat the above on Linux.
- [ ] Manual: hidden → shown via tray menu still works on all three platforms.
- [ ] Manual: minimized main window is restored and fronted when the tray menu is used.