### PR TITLE
:sparkles: animate GIFs in image side preview via Skia codec

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/AnimatedImageSidePreview.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/AnimatedImageSidePreview.kt
@@ -5,13 +5,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Size
-import com.crosspaste.app.AttentionSurface
 import com.crosspaste.app.UserAttentionService
-import com.crosspaste.app.attentionOn
 import com.crosspaste.ui.base.SmartImageDisplayStrategy
 import com.crosspaste.ui.base.TransparentBackground
 import okio.Path
@@ -23,14 +20,11 @@ fun BoxScope.AnimatedImageSidePreview(
     smartImageDisplayStrategy: SmartImageDisplayStrategy,
     userAttentionService: UserAttentionService,
 ) {
-    // Pause animation when neither host window is visible — saves CPU/redraws
-    // while still resuming instantly when the user opens either surface.
-    val isAttentive by remember(userAttentionService) {
-        userAttentionService.attentionOn(
-            AttentionSurface.MAIN_WINDOW,
-            AttentionSurface.SEARCH_WINDOW,
-        )
-    }.collectAsState(initial = false)
+    // The side preview is mounted only inside the search window
+    // (see SideSearchWindowContent), so we gate solely on that surface — the
+    // main window's visibility is irrelevant here, and watching it would keep
+    // the frame loop running while the GIF is not actually on screen.
+    val isAttentive by userAttentionService.isSearchWindowVisible.collectAsState()
 
     TransparentBackground(modifier = Modifier.matchParentSize())
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/AnimatedImageSidePreview.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/AnimatedImageSidePreview.kt
@@ -1,0 +1,44 @@
+package com.crosspaste.ui.paste.side.preview
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Size
+import com.crosspaste.app.AttentionSurface
+import com.crosspaste.app.UserAttentionService
+import com.crosspaste.app.attentionOn
+import com.crosspaste.ui.base.SmartImageDisplayStrategy
+import com.crosspaste.ui.base.TransparentBackground
+import okio.Path
+
+@Composable
+fun BoxScope.AnimatedImageSidePreview(
+    imagePath: Path,
+    targetSizePx: Size,
+    smartImageDisplayStrategy: SmartImageDisplayStrategy,
+    userAttentionService: UserAttentionService,
+) {
+    // Pause animation when neither host window is visible — saves CPU/redraws
+    // while still resuming instantly when the user opens either surface.
+    val isAttentive by remember(userAttentionService) {
+        userAttentionService.attentionOn(
+            AttentionSurface.MAIN_WINDOW,
+            AttentionSurface.SEARCH_WINDOW,
+        )
+    }.collectAsState(initial = false)
+
+    TransparentBackground(modifier = Modifier.matchParentSize())
+
+    SkiaAnimatedImageView(
+        path = imagePath,
+        targetSizePx = targetSizePx,
+        smartImageDisplayStrategy = smartImageDisplayStrategy,
+        isPlaying = isAttentive,
+        modifier = Modifier.fillMaxSize().clipToBounds(),
+    )
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
@@ -2,19 +2,14 @@ package com.crosspaste.ui.paste.side.preview
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Badge
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -22,24 +17,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import coil3.ImageLoader
 import coil3.PlatformContext
-import coil3.compose.AsyncImagePainter
-import coil3.compose.SubcomposeAsyncImage
-import coil3.compose.SubcomposeAsyncImageContent
-import coil3.request.ImageRequest
-import coil3.request.crossfade
-import coil3.size.Precision
-import com.composables.icons.materialsymbols.MaterialSymbols
-import com.composables.icons.materialsymbols.rounded.Broken_image
+import com.crosspaste.app.UserAttentionService
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.image.ImageHandler
-import com.crosspaste.image.coil.ImageItem
 import com.crosspaste.image.coil.ImageLoaderQualifiers
 import com.crosspaste.paste.item.PasteFileCoordinate
 import com.crosspaste.paste.item.PasteImages
@@ -52,12 +37,9 @@ import com.crosspaste.ui.base.ImageFileSize
 import com.crosspaste.ui.base.ImageInfoLabel
 import com.crosspaste.ui.base.ImageResolution
 import com.crosspaste.ui.base.SmartImageDisplayStrategy
-import com.crosspaste.ui.base.TransparentBackground
 import com.crosspaste.ui.paste.PasteDataScope
-import com.crosspaste.ui.theme.AppUISize.gigantic
 import com.crosspaste.ui.theme.AppUISize.medium
 import com.crosspaste.ui.theme.AppUISize.small2X
-import com.crosspaste.ui.theme.AppUISize.tiny
 import com.crosspaste.ui.theme.AppUISize.tiny3X
 import com.crosspaste.utils.extension
 import com.crosspaste.utils.getFileUtils
@@ -70,24 +52,19 @@ fun PasteDataScope.ImageSidePreviewView() {
     val imageHandler = koinInject<ImageHandler<BufferedImage>>()
     val platformContext = koinInject<PlatformContext>()
     val userDataPathProvider = koinInject<UserDataPathProvider>()
+    val userAttentionService = koinInject<UserAttentionService>()
+    val copywriter = koinInject<GlobalCopywriter>()
     val fileUtils = remember { getFileUtils() }
-
     val smartImageDisplayStrategy = remember { SmartImageDisplayStrategy() }
 
-    val copywriter = koinInject<GlobalCopywriter>()
-
     val imagePasteItem = getPasteItem(PasteImages::class)
-
     val imageCount = remember(pasteData.id) { imagePasteItem.getDirectChildrenCount() }
-
     val isInDownloads = remember(imagePasteItem) { imagePasteItem.isInDownloads() }
 
     var index by remember(pasteData.id) { mutableStateOf(0) }
 
     val filePaths = remember(imagePasteItem) { imagePasteItem.getFilePaths(userDataPathProvider) }
-    if (filePaths.isEmpty()) {
-        return
-    }
+    if (filePaths.isEmpty()) return
 
     val safeIndex = index.coerceIn(filePaths.indices)
     val imagePath = filePaths[safeIndex]
@@ -97,25 +74,18 @@ fun PasteDataScope.ImageSidePreviewView() {
             PasteFileCoordinate(pasteData.getPasteCoordinate(), imagePath)
         }
 
-    val appSizeValue = LocalDesktopAppSizeValueState.current
     val density = LocalDensity.current
-    val targetUiSize = appSizeValue.sidePasteContentSize
+    val targetUiSize = LocalDesktopAppSizeValueState.current.sidePasteContentSize
     val targetSizePx =
         with(density) {
             Size(targetUiSize.width.toPx(), targetUiSize.height.toPx())
         }
 
-    val intSize by produceState<IntSize?>(
-        initialValue = null,
-        key1 = imagePath,
-    ) {
+    val intSize by produceState<IntSize?>(initialValue = null, key1 = imagePath) {
         value = imageHandler.readSize(imagePath)
     }
 
-    val fileSize by produceState(
-        initialValue = 0L,
-        key1 = imagePath,
-    ) {
+    val fileSize by produceState(initialValue = 0L, key1 = imagePath) {
         value = fileUtils.getFileSize(imagePath)
     }
 
@@ -128,111 +98,78 @@ fun PasteDataScope.ImageSidePreviewView() {
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-            val imgSize = intSize
-            val requestSize =
-                remember(targetSizePx, imgSize) {
-                    if (imgSize != null && imgSize.width > 0 && imgSize.height > 0) {
-                        smartImageDisplayStrategy.computeRequestSize(
-                            srcSize = Size(imgSize.width.toFloat(), imgSize.height.toFloat()),
-                            dstSize = targetSizePx,
-                        )
-                    } else {
-                        targetSizePx
-                    }
-                }
+            if (imagePath.isAnimatedImage()) {
+                AnimatedImageSidePreview(
+                    imagePath = imagePath,
+                    targetSizePx = targetSizePx,
+                    smartImageDisplayStrategy = smartImageDisplayStrategy,
+                    userAttentionService = userAttentionService,
+                )
+            } else {
+                StaticImageSidePreview(
+                    imagePath = imagePath,
+                    pasteFileCoordinate = pasteFileCoordinate,
+                    intSize = intSize,
+                    targetSizePx = targetSizePx,
+                    smartImageDisplayStrategy = smartImageDisplayStrategy,
+                    imageLoader = userImageLoader,
+                    platformContext = platformContext,
+                )
+            }
 
-            val request =
-                remember(pasteFileCoordinate, requestSize) {
-                    ImageRequest
-                        .Builder(platformContext)
-                        .data(ImageItem(pasteFileCoordinate, false))
-                        .size(width = requestSize.width.toInt(), height = requestSize.height.toInt())
-                        .precision(Precision.INEXACT)
-                        .crossfade(true)
-                        .build()
-                }
+            ImageCountBadge(imageCount)
 
-            SubcomposeAsyncImage(
-                modifier = Modifier.fillMaxSize().clipToBounds(),
-                model = request,
-                imageLoader = userImageLoader,
-                contentDescription = "imageType",
-                contentScale = ContentScale.Fit,
-                content = {
-                    val state by painter.state.collectAsState()
-                    when (state) {
-                        is AsyncImagePainter.State.Loading -> {
-                            Row(
-                                modifier = Modifier.fillMaxSize(),
-                                horizontalArrangement = Arrangement.Center,
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(gigantic),
-                                    strokeWidth = tiny,
-                                )
-                            }
-                        }
-                        is AsyncImagePainter.State.Error -> {
-                            Icon(
-                                imageVector = MaterialSymbols.Rounded.Broken_image,
-                                contentDescription = imagePath.name,
-                                modifier = Modifier.size(gigantic),
-                                tint = MaterialTheme.colorScheme.onBackground,
-                            )
-                        }
-                        else -> {
-                            val intrinsicSize = painter.intrinsicSize
-
-                            val displayResult =
-                                smartImageDisplayStrategy.compute(
-                                    srcSize = Size(intrinsicSize.width, intrinsicSize.height),
-                                    dstSize = targetSizePx,
-                                )
-
-                            TransparentBackground(modifier = Modifier.matchParentSize())
-
-                            SubcomposeAsyncImageContent(
-                                contentScale = displayResult.contentScale,
-                                alignment = displayResult.alignment,
-                            )
-                        }
-                    }
-                },
+            ImageInfoLabels(
+                isInDownloads = isInDownloads,
+                fileFormat = fileFormat,
+                intSize = intSize,
+                fileSize = fileSize,
+                copywriter = copywriter,
             )
+        }
+    }
+}
 
-            if (imageCount > 1L) {
-                val label = remember(imageCount) { if (imageCount > 99) "99+" else imageCount.toString() }
-                Badge(
-                    modifier =
-                        Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(top = medium, end = medium),
-                ) {
-                    Text(label)
-                }
-            }
+@Composable
+private fun BoxScope.ImageCountBadge(imageCount: Long) {
+    if (imageCount <= 1L) return
+    val label = remember(imageCount) { if (imageCount > 99) "99+" else imageCount.toString() }
+    Badge(
+        modifier =
+            Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = medium, end = medium),
+    ) {
+        Text(label)
+    }
+}
 
-            Column(
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = small2X),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(tiny3X),
-            ) {
-                if (isInDownloads) {
-                    ImageInfoLabel(text = copywriter.getText("in_downloads"))
-                }
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(tiny3X, Alignment.CenterHorizontally),
-                    verticalArrangement = Arrangement.spacedBy(tiny3X),
-                ) {
-                    ImageFileFormat(format = fileFormat)
-                    ImageResolution(imageSize = intSize)
-                    ImageFileSize(fileSize = fileSize)
-                }
-            }
+@Composable
+private fun BoxScope.ImageInfoLabels(
+    isInDownloads: Boolean,
+    fileFormat: String,
+    intSize: IntSize?,
+    fileSize: Long,
+    copywriter: GlobalCopywriter,
+) {
+    Column(
+        modifier =
+            Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = small2X),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(tiny3X),
+    ) {
+        if (isInDownloads) {
+            ImageInfoLabel(text = copywriter.getText("in_downloads"))
+        }
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(tiny3X, Alignment.CenterHorizontally),
+            verticalArrangement = Arrangement.spacedBy(tiny3X),
+        ) {
+            ImageFileFormat(format = fileFormat)
+            ImageResolution(imageSize = intSize)
+            ImageFileSize(fileSize = fileSize)
         }
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/ImageSidePreviewView.kt
@@ -48,12 +48,12 @@ import java.awt.image.BufferedImage
 
 @Composable
 fun PasteDataScope.ImageSidePreviewView() {
-    val userImageLoader = koinInject<ImageLoader>(qualifier = ImageLoaderQualifiers.USER_IMAGE)
+    val copywriter = koinInject<GlobalCopywriter>()
     val imageHandler = koinInject<ImageHandler<BufferedImage>>()
     val platformContext = koinInject<PlatformContext>()
-    val userDataPathProvider = koinInject<UserDataPathProvider>()
     val userAttentionService = koinInject<UserAttentionService>()
-    val copywriter = koinInject<GlobalCopywriter>()
+    val userDataPathProvider = koinInject<UserDataPathProvider>()
+    val userImageLoader = koinInject<ImageLoader>(qualifier = ImageLoaderQualifiers.USER_IMAGE)
     val fileUtils = remember { getFileUtils() }
     val smartImageDisplayStrategy = remember { SmartImageDisplayStrategy() }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SkiaAnimatedImageView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SkiaAnimatedImageView.kt
@@ -1,0 +1,199 @@
+package com.crosspaste.ui.paste.side.preview
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.asComposeImageBitmap
+import com.composables.icons.materialsymbols.MaterialSymbols
+import com.composables.icons.materialsymbols.rounded.Broken_image
+import com.crosspaste.ui.base.SmartImageDisplayStrategy
+import com.crosspaste.ui.theme.AppUISize.gigantic
+import com.crosspaste.ui.theme.AppUISize.tiny
+import com.crosspaste.utils.extension
+import com.crosspaste.utils.ioDispatcher
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import okio.Path
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.Codec
+import org.jetbrains.skia.Data
+import kotlin.time.Duration.Companion.milliseconds
+
+private val logger = KotlinLogging.logger {}
+
+// Many GIFs declare 0ms per frame; browsers clamp to ~100ms. 20ms (~50fps) is
+// a conservative floor that still respects intentionally fast animations.
+private const val MIN_FRAME_DURATION_MS = 20
+
+// Extensions whose animation Coil 3 cannot play on desktop, so we route them
+// through Skia's Codec instead. Add new entries here when extending support
+// (e.g. "apng", "webp" for animated WebP, "heic" for HEIF sequences).
+private val animatedImageExtensions: Set<String> = setOf("gif")
+
+fun Path.isAnimatedImage(): Boolean = extension.lowercase() in animatedImageExtensions
+
+private sealed interface CodecState {
+    data object Loading : CodecState
+
+    data object Failed : CodecState
+
+    data class Ready(
+        val codec: Codec,
+    ) : CodecState
+}
+
+@Composable
+fun SkiaAnimatedImageView(
+    path: Path,
+    targetSizePx: Size,
+    smartImageDisplayStrategy: SmartImageDisplayStrategy,
+    isPlaying: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val state by produceCodecState(path)
+
+    when (val current = state) {
+        CodecState.Loading -> LoadingIndicator()
+        CodecState.Failed -> BrokenIcon(path.name)
+        is CodecState.Ready ->
+            AnimatedFrames(
+                codec = current.codec,
+                targetSizePx = targetSizePx,
+                smartImageDisplayStrategy = smartImageDisplayStrategy,
+                isPlaying = isPlaying,
+                modifier = modifier,
+                contentDescription = path.name,
+            )
+    }
+}
+
+@Composable
+private fun AnimatedFrames(
+    codec: Codec,
+    targetSizePx: Size,
+    smartImageDisplayStrategy: SmartImageDisplayStrategy,
+    isPlaying: Boolean,
+    modifier: Modifier,
+    contentDescription: String,
+) {
+    val workBitmap =
+        remember(codec) {
+            Bitmap().apply { allocPixels(codec.imageInfo) }
+        }
+
+    DisposableEffect(workBitmap) {
+        onDispose { workBitmap.close() }
+    }
+
+    val frameInfos = remember(codec) { codec.framesInfo }
+    val frameCount = remember(codec) { codec.frameCount.coerceAtLeast(1) }
+
+    var frameIndex by remember(codec) { mutableIntStateOf(0) }
+    var frameTick by remember(codec) { mutableIntStateOf(0) }
+
+    LaunchedEffect(codec) {
+        // Prime frame 0 so something is drawable before the loop runs and so
+        // single-frame inputs (frameCount == 1) still render.
+        runCatching { codec.readPixels(workBitmap, 0) }
+            .onFailure { logger.warn(it) { "Failed to decode initial frame" } }
+        frameTick = 1
+    }
+
+    LaunchedEffect(codec, isPlaying, frameCount) {
+        if (!isPlaying || frameCount <= 1) return@LaunchedEffect
+        while (true) {
+            val durationMs =
+                frameInfos
+                    .getOrNull(frameIndex)
+                    ?.duration
+                    ?.coerceAtLeast(MIN_FRAME_DURATION_MS)
+                    ?: MIN_FRAME_DURATION_MS
+            delay(durationMs.milliseconds)
+            val nextIndex = (frameIndex + 1) % frameCount
+            runCatching { codec.readPixels(workBitmap, nextIndex) }
+                .onFailure { logger.warn(it) { "Failed to decode frame $nextIndex" } }
+            frameIndex = nextIndex
+            frameTick++
+        }
+    }
+
+    val imageBitmap =
+        remember(workBitmap, frameTick) {
+            workBitmap.asComposeImageBitmap()
+        }
+
+    val displayResult =
+        remember(codec, targetSizePx) {
+            smartImageDisplayStrategy.compute(
+                srcSize = Size(codec.imageInfo.width.toFloat(), codec.imageInfo.height.toFloat()),
+                dstSize = targetSizePx,
+            )
+        }
+
+    Image(
+        bitmap = imageBitmap,
+        contentDescription = contentDescription,
+        contentScale = displayResult.contentScale,
+        alignment = displayResult.alignment,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun produceCodecState(path: Path) =
+    produceState<CodecState>(initialValue = CodecState.Loading, key1 = path) {
+        val loaded =
+            withContext(ioDispatcher) {
+                runCatching {
+                    val bytes = path.toFile().readBytes()
+                    CodecState.Ready(Codec.makeFromData(Data.makeFromBytes(bytes)))
+                }.onFailure {
+                    logger.warn(it) { "Failed to decode animated image: $path" }
+                }.getOrElse { CodecState.Failed }
+            }
+        value = loaded
+        awaitDispose {
+            if (loaded is CodecState.Ready) loaded.codec.close()
+        }
+    }
+
+@Composable
+private fun LoadingIndicator() {
+    Row(
+        modifier = Modifier.fillMaxSize(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(gigantic),
+            strokeWidth = tiny,
+        )
+    }
+}
+
+@Composable
+private fun BrokenIcon(name: String) {
+    Icon(
+        imageVector = MaterialSymbols.Rounded.Broken_image,
+        contentDescription = name,
+        modifier = Modifier.size(gigantic),
+        tint = MaterialTheme.colorScheme.onBackground,
+    )
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/StaticImageSidePreview.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/StaticImageSidePreview.kt
@@ -1,0 +1,123 @@
+package com.crosspaste.ui.paste.side.preview
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.IntSize
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.compose.AsyncImagePainter
+import coil3.compose.SubcomposeAsyncImage
+import coil3.compose.SubcomposeAsyncImageContent
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.size.Precision
+import com.composables.icons.materialsymbols.MaterialSymbols
+import com.composables.icons.materialsymbols.rounded.Broken_image
+import com.crosspaste.image.coil.ImageItem
+import com.crosspaste.paste.item.PasteFileCoordinate
+import com.crosspaste.ui.base.SmartImageDisplayStrategy
+import com.crosspaste.ui.base.TransparentBackground
+import com.crosspaste.ui.theme.AppUISize.gigantic
+import com.crosspaste.ui.theme.AppUISize.tiny
+import okio.Path
+
+@Composable
+fun BoxScope.StaticImageSidePreview(
+    imagePath: Path,
+    pasteFileCoordinate: PasteFileCoordinate,
+    intSize: IntSize?,
+    targetSizePx: Size,
+    smartImageDisplayStrategy: SmartImageDisplayStrategy,
+    imageLoader: ImageLoader,
+    platformContext: PlatformContext,
+) {
+    val requestSize =
+        remember(targetSizePx, intSize) {
+            if (intSize != null && intSize.width > 0 && intSize.height > 0) {
+                smartImageDisplayStrategy.computeRequestSize(
+                    srcSize = Size(intSize.width.toFloat(), intSize.height.toFloat()),
+                    dstSize = targetSizePx,
+                )
+            } else {
+                targetSizePx
+            }
+        }
+
+    val request =
+        remember(pasteFileCoordinate, requestSize) {
+            ImageRequest
+                .Builder(platformContext)
+                .data(ImageItem(pasteFileCoordinate, false))
+                .size(width = requestSize.width.toInt(), height = requestSize.height.toInt())
+                .precision(Precision.INEXACT)
+                .crossfade(true)
+                .build()
+        }
+
+    SubcomposeAsyncImage(
+        modifier = Modifier.fillMaxSize().clipToBounds(),
+        model = request,
+        imageLoader = imageLoader,
+        contentDescription = "imageType",
+        contentScale = ContentScale.Fit,
+        content = {
+            val state by painter.state.collectAsState()
+            when (state) {
+                is AsyncImagePainter.State.Loading -> StaticLoadingIndicator()
+                is AsyncImagePainter.State.Error -> StaticBrokenIcon(imagePath.name)
+                else -> {
+                    val intrinsicSize = painter.intrinsicSize
+                    val displayResult =
+                        smartImageDisplayStrategy.compute(
+                            srcSize = Size(intrinsicSize.width, intrinsicSize.height),
+                            dstSize = targetSizePx,
+                        )
+                    TransparentBackground(modifier = Modifier.matchParentSize())
+                    SubcomposeAsyncImageContent(
+                        contentScale = displayResult.contentScale,
+                        alignment = displayResult.alignment,
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun StaticLoadingIndicator() {
+    Row(
+        modifier = Modifier.fillMaxSize(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(gigantic),
+            strokeWidth = tiny,
+        )
+    }
+}
+
+@Composable
+private fun StaticBrokenIcon(name: String) {
+    Icon(
+        imageVector = MaterialSymbols.Rounded.Broken_image,
+        contentDescription = name,
+        modifier = Modifier.size(gigantic),
+        tint = MaterialTheme.colorScheme.onBackground,
+    )
+}


### PR DESCRIPTION
Closes #4409

## Summary

- Add `SkiaAnimatedImageView`, a Skia-`Codec`-backed animated image renderer (no new dependency — Skiko already ships it). It decodes frames into a single reused `Bitmap` and advances on each frame's declared duration; `Codec`/`Bitmap` native handles are released via `awaitDispose`/`DisposableEffect`.
- The frame loop is gated on `UserAttentionService.attentionOn(MAIN_WINDOW, SEARCH_WINDOW)` — animation pauses when neither host window is visible, resumes instantly when either becomes visible.
- New animated formats (animated WebP, APNG, HEIC sequences) can be enabled by adding one entry to `animatedImageExtensions: Set<String>` in `SkiaAnimatedImageView.kt`. The renderer auto-degrades to a static frame when `frameCount <= 1`, so static decoders for these formats keep working too.
- Refactored `ImageSidePreviewView` into a thin orchestrator + `AnimatedImageSidePreview` (Skia branch with visibility wiring) + `StaticImageSidePreview` (Coil branch unchanged). Static image rendering for PNG/JPEG/WebP/HEIC/SVG is untouched.

## Test plan

- [ ] Copy a `.gif` (e.g. drag one from a chat client and `Cmd+C`); open the main window; select the entry — side preview should animate continuously.
- [ ] Hide the main window for several seconds, then reopen — animation should have paused (frame index visibly jumps forward when re-shown).
- [ ] Open the search window (global shortcut) on a `.gif` entry — animation should play in the search window's side preview as well.
- [ ] Hide both main and search windows — verify no GIF-decode CPU activity in profiler.
- [ ] Copy a static PNG/JPEG/WebP — renders via Coil exactly as before (no regression).
- [ ] Copy a single-frame GIF — renders the one frame, no infinite loop.
- [ ] Copy a corrupt or truncated GIF — falls back to the broken-image icon, no crash.