### PR TITLE
:hammer: drop /hyperframes-demo/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,5 @@ output*/
 /.claude/skills/ui-ux-pro-max/
 /docs/superpowers/
 web/dist/
-/hyperframes-demo/
 scheduled_tasks.lock
 skills-lock.json


### PR DESCRIPTION
Closes #4411

## Summary

Remove the obsolete `/hyperframes-demo/` entry from `.gitignore`. The directory has been extracted to its own standalone repository (`crosspaste-desktop-hyperframes`), so this entry is no longer needed.

## Test plan

- [x] `git status` no longer references hyperframes-demo
- [x] No code references in the Kotlin/Gradle build remain (it was always a sibling HTML/Node project)