### PR TITLE
:hammer: harden launchWhileAttentive against unhandled exceptions in block

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/UserAttentionService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/UserAttentionService.kt
@@ -1,5 +1,7 @@
 package com.crosspaste.app
 
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -10,6 +12,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
+
+private val attentiveLogger = KotlinLogging.logger {}
 
 // Exposes per-surface visibility signals so background services can gate work
 // on whether the user can actually see the result. Background pollers that
@@ -54,6 +58,11 @@ fun UserAttentionService.attentionOn(vararg surfaces: AttentionSurface): Flow<Bo
 // the loop restarts (firing `block` immediately if `runOnResume` is set, so
 // the user sees fresh state the moment they open the relevant surface
 // instead of waiting one interval).
+//
+// Exceptions thrown by `block` are caught and logged so a single bad tick
+// doesn't terminate the polling Job and silently stop all future ticks.
+// CancellationException is always rethrown to keep structured concurrency
+// semantics intact.
 fun CoroutineScope.launchWhileAttentive(
     attention: Flow<Boolean>,
     interval: Duration,
@@ -63,10 +72,20 @@ fun CoroutineScope.launchWhileAttentive(
     launch {
         attention.collectLatest { attentive ->
             if (!attentive) return@collectLatest
-            if (runOnResume) block()
+            if (runOnResume) runTick(block)
             while (true) {
                 delay(interval)
-                block()
+                runTick(block)
             }
         }
     }
+
+private suspend fun runTick(block: suspend () -> Unit) {
+    try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        attentiveLogger.warn(e) { "launchWhileAttentive block threw; continuing on next tick" }
+    }
+}


### PR DESCRIPTION
Closes #4414

## Summary

- Wrap each `block()` invocation in `launchWhileAttentive` with a private `runTick` helper that catches `Throwable`, logs via `KotlinLogging`, and continues to the next tick.
- Rethrow `CancellationException` explicitly so flow / parent-scope cancellation still propagates (structured concurrency preserved).
- Update the helper's KDoc to document the exception contract.

The existing sole consumer (`DesktopNetworkProfileService.runDetection`) keeps its own `runCatching` — that wrapper sets `_diagnosis = UNKNOWN` on failure, which is business logic, not just exception eating.

## Why

`collectLatest` does not restart its lambda when it throws; the outer `launch` then enters `Cancelled` state and subsequent attention flips can no longer revive the poller. Today this is latent because the one consumer self-wraps; the next consumer that forgets will silently lose its poller. The helper's name implies "polling gated by attention", so single-tick failure tolerance belongs in the helper, not in every caller.

## Test plan

- [x] `./gradlew :app:ktlintCommonMainSourceSetFormat` passes
- [x] `./gradlew :app:compileKotlinDesktop` passes
- [ ] Manual: on Windows, restart the app and confirm the network-profile poller continues to tick after a `WindowsNetworkApi.query()` failure (existing `runCatching` still wins first, so no regression expected)