### PR TITLE
:zap: decode GIF frames off the UI thread with double buffering

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SkiaAnimatedImageView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SkiaAnimatedImageView.kt
@@ -40,7 +40,7 @@ private val logger = KotlinLogging.logger {}
 
 // Many GIFs declare 0ms per frame; browsers clamp to ~100ms. 20ms (~50fps) is
 // a conservative floor that still respects intentionally fast animations.
-private const val MIN_FRAME_DURATION_MS = 20
+internal const val MIN_FRAME_DURATION_MS = 20
 
 // Extensions whose animation Coil 3 cannot play on desktop, so we route them
 // through Skia's Codec instead. Add new entries here when extending support
@@ -48,6 +48,9 @@ private const val MIN_FRAME_DURATION_MS = 20
 private val animatedImageExtensions: Set<String> = setOf("gif")
 
 fun Path.isAnimatedImage(): Boolean = extension.lowercase() in animatedImageExtensions
+
+internal fun frameDurationMs(rawDurationMs: Int?): Int =
+    (rawDurationMs ?: MIN_FRAME_DURATION_MS).coerceAtLeast(MIN_FRAME_DURATION_MS)
 
 private sealed interface CodecState {
     data object Loading : CodecState
@@ -93,50 +96,64 @@ private fun AnimatedFrames(
     modifier: Modifier,
     contentDescription: String,
 ) {
-    val workBitmap =
+    // Two bitmaps so the next frame can be decoded into the back buffer on IO
+    // while the front buffer keeps drawing. The swap publishes on the UI
+    // thread once readPixels returns.
+    val bitmaps =
         remember(codec) {
-            Bitmap().apply { allocPixels(codec.imageInfo) }
+            Array(2) { Bitmap().apply { allocPixels(codec.imageInfo) } }
         }
 
-    DisposableEffect(workBitmap) {
-        onDispose { workBitmap.close() }
+    DisposableEffect(bitmaps) {
+        onDispose { bitmaps.forEach { it.close() } }
     }
 
     val frameInfos = remember(codec) { codec.framesInfo }
     val frameCount = remember(codec) { codec.frameCount.coerceAtLeast(1) }
 
     var frameIndex by remember(codec) { mutableIntStateOf(0) }
+    var frontIndex by remember(codec) { mutableIntStateOf(0) }
     var frameTick by remember(codec) { mutableIntStateOf(0) }
 
-    LaunchedEffect(codec) {
-        // Prime frame 0 so something is drawable before the loop runs and so
-        // single-frame inputs (frameCount == 1) still render.
-        runCatching { codec.readPixels(workBitmap, 0) }
-            .onFailure { logger.warn(it) { "Failed to decode initial frame" } }
-        frameTick = 1
-    }
-
     LaunchedEffect(codec, isPlaying, frameCount) {
+        // Prime frame 0 once per codec so something is drawable before the
+        // loop runs and so single-frame inputs (frameCount == 1) still render.
+        // Skipping on re-launch keeps the current frame visible when
+        // isPlaying toggles mid-playback.
+        if (frameTick == 0) {
+            withContext(ioDispatcher) {
+                runCatching { codec.readPixels(bitmaps[0], 0) }
+                    .onFailure { logger.warn(it) { "Failed to decode initial frame" } }
+            }
+            frameTick = 1
+        }
+
         if (!isPlaying || frameCount <= 1) return@LaunchedEffect
+
         while (true) {
-            val durationMs =
-                frameInfos
-                    .getOrNull(frameIndex)
-                    ?.duration
-                    ?.coerceAtLeast(MIN_FRAME_DURATION_MS)
-                    ?: MIN_FRAME_DURATION_MS
+            val durationMs = frameDurationMs(frameInfos.getOrNull(frameIndex)?.duration)
             delay(durationMs.milliseconds)
             val nextIndex = (frameIndex + 1) % frameCount
-            runCatching { codec.readPixels(workBitmap, nextIndex) }
-                .onFailure { logger.warn(it) { "Failed to decode frame $nextIndex" } }
-            frameIndex = nextIndex
-            frameTick++
+            val backIndex = 1 - frontIndex
+            // Decode off the UI thread; LZW decompression on large frames
+            // can otherwise eat the next render window.
+            val success =
+                withContext(ioDispatcher) {
+                    runCatching { codec.readPixels(bitmaps[backIndex], nextIndex) }
+                        .onFailure { logger.warn(it) { "Failed to decode frame $nextIndex" } }
+                        .isSuccess
+                }
+            if (success) {
+                frameIndex = nextIndex
+                frontIndex = backIndex
+                frameTick++
+            }
         }
     }
 
     val imageBitmap =
-        remember(workBitmap, frameTick) {
-            workBitmap.asComposeImageBitmap()
+        remember(frontIndex, frameTick) {
+            bitmaps[frontIndex].asComposeImageBitmap()
         }
 
     val displayResult =

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/paste/side/preview/SkiaAnimatedImageViewTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/paste/side/preview/SkiaAnimatedImageViewTest.kt
@@ -1,0 +1,96 @@
+package com.crosspaste.ui.paste.side.preview
+
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SkiaAnimatedImageViewTest {
+
+    @Test
+    fun `isAnimatedImage returns true for lowercase gif`() {
+        assertTrue("anim.gif".toPath().isAnimatedImage())
+    }
+
+    @Test
+    fun `isAnimatedImage is case-insensitive`() {
+        assertTrue("anim.GIF".toPath().isAnimatedImage())
+        assertTrue("anim.Gif".toPath().isAnimatedImage())
+        assertTrue("ANIM.gIf".toPath().isAnimatedImage())
+    }
+
+    @Test
+    fun `isAnimatedImage handles nested directories`() {
+        assertTrue("/tmp/clips/anim.gif".toPath().isAnimatedImage())
+        assertTrue("nested/dir/anim.GIF".toPath().isAnimatedImage())
+    }
+
+    @Test
+    fun `isAnimatedImage returns false for non-animated image extensions`() {
+        assertFalse("photo.png".toPath().isAnimatedImage())
+        assertFalse("photo.jpg".toPath().isAnimatedImage())
+        assertFalse("photo.webp".toPath().isAnimatedImage())
+        assertFalse("photo.apng".toPath().isAnimatedImage())
+        assertFalse("photo.heic".toPath().isAnimatedImage())
+    }
+
+    @Test
+    fun `isAnimatedImage returns false for unknown extension`() {
+        assertFalse("file.xyz".toPath().isAnimatedImage())
+    }
+
+    @Test
+    fun `isAnimatedImage returns false when there is no extension`() {
+        assertFalse("README".toPath().isAnimatedImage())
+        assertFalse("noext".toPath().isAnimatedImage())
+    }
+
+    @Test
+    fun `isAnimatedImage returns false for trailing dot`() {
+        // Path.extension is "" when the filename ends with a dot, so this must not match.
+        assertFalse("trailing.".toPath().isAnimatedImage())
+    }
+
+    @Test
+    fun `isAnimatedImage matches only the final extension segment`() {
+        // ".gif.bak" has extension "bak", not "gif".
+        assertFalse("anim.gif.bak".toPath().isAnimatedImage())
+        // ".bak.gif" has extension "gif".
+        assertTrue("anim.bak.gif".toPath().isAnimatedImage())
+    }
+
+    @Test
+    fun `frameDurationMs clamps null duration to the minimum floor`() {
+        assertEquals(MIN_FRAME_DURATION_MS, frameDurationMs(null))
+    }
+
+    @Test
+    fun `frameDurationMs clamps zero to the minimum floor`() {
+        // Many GIFs declare 0ms per frame; we must not pass that to delay().
+        assertEquals(MIN_FRAME_DURATION_MS, frameDurationMs(0))
+    }
+
+    @Test
+    fun `frameDurationMs clamps negative duration to the minimum floor`() {
+        assertEquals(MIN_FRAME_DURATION_MS, frameDurationMs(-50))
+    }
+
+    @Test
+    fun `frameDurationMs clamps durations below the floor`() {
+        assertEquals(MIN_FRAME_DURATION_MS, frameDurationMs(MIN_FRAME_DURATION_MS - 1))
+        assertEquals(MIN_FRAME_DURATION_MS, frameDurationMs(1))
+    }
+
+    @Test
+    fun `frameDurationMs returns the floor when duration equals it`() {
+        assertEquals(MIN_FRAME_DURATION_MS, frameDurationMs(MIN_FRAME_DURATION_MS))
+    }
+
+    @Test
+    fun `frameDurationMs preserves durations above the floor`() {
+        assertEquals(40, frameDurationMs(40))
+        assertEquals(100, frameDurationMs(100))
+        assertEquals(1_000, frameDurationMs(1_000))
+    }
+}


### PR DESCRIPTION
Closes #4421

## Summary
- Move `Codec.readPixels(...)` in `SkiaAnimatedImageView` into `withContext(ioDispatcher) { ... }` so GIF LZW decompression no longer blocks the Compose render thread on large frames.
- Pre-allocate two bitmaps; decode writes the back buffer, then `frontIndex` and `frameTick` are published on the main thread after IO returns, so the renderer never reads a half-written frame.
- Merge the prime + playback `LaunchedEffect` into a single coroutine and guard priming with `frameTick == 0`, which avoids racing two coroutines on the same `Codec` (Skia codecs are not documented as thread-safe) without needing a mutex.
- Extract the per-frame floor into `internal fun frameDurationMs(rawDurationMs: Int?): Int` so the `MIN_FRAME_DURATION_MS` clamp is pure / unit-testable; promote the constant to `internal const`.
- Add `SkiaAnimatedImageViewTest` (14 cases) covering `isAnimatedImage()` (case, multi-dot, unknown / missing extension, trailing dot, nested paths) and `frameDurationMs(...)` (null, zero, negative, below / at / above the floor).

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew app:compileKotlinDesktop`
- [x] `./gradlew app:desktopTest --tests "com.crosspaste.ui.paste.side.preview.SkiaAnimatedImageViewTest"` — 14/14 pass
- [ ] Manual: open a high-resolution GIF in the clipboard preview and confirm playback is smoother, no torn / half-rendered frames during the back-buffer write window