### PR TITLE
:hammer: opt in to ExperimentalRichTextApi in HTML/RTF side previews

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
@@ -19,10 +19,12 @@ import com.crosspaste.ui.LocalThemeState
 import com.crosspaste.ui.paste.PasteDataScope
 import com.crosspaste.ui.theme.AppUISize.small2X
 import com.crosspaste.utils.ColorAccessibility
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 import org.koin.compose.koinInject
 
+@OptIn(ExperimentalRichTextApi::class)
 @Composable
 fun PasteDataScope.HtmlSidePreviewView() {
     val copywriter = koinInject<GlobalCopywriter>()

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
@@ -19,10 +19,12 @@ import com.crosspaste.ui.LocalThemeState
 import com.crosspaste.ui.paste.PasteDataScope
 import com.crosspaste.ui.theme.AppUISize.small2X
 import com.crosspaste.utils.ColorAccessibility
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 import org.koin.compose.koinInject
 
+@OptIn(ExperimentalRichTextApi::class)
 @Composable
 fun PasteDataScope.RtfSidePreviewView() {
     val copywriter = koinInject<GlobalCopywriter>()


### PR DESCRIPTION
Closes #4423

## Summary
- Add `@OptIn(ExperimentalRichTextApi::class)` to `HtmlSidePreviewView` and `RtfSidePreviewView`, plus the matching import.
- richeditor-compose 1.0.0-rc14 (#4419) marked the `RichText` / `rememberRichTextState` surface as `@ExperimentalRichTextApi`; both side-preview composables hit that opt-in requirement and currently emit a warning every build.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew app:compileKotlinDesktop`
- [ ] Manual: open an HTML clipboard item and an RTF clipboard item from the side panel and confirm both render correctly