### PR TITLE
:sparkles: add bulk tag operations to PasteTagDao

### DIFF
--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteTagDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteTagDao.kt
@@ -30,6 +30,13 @@ interface PasteTagDao : QueryPasteTag {
 
     fun getPasteTagsBlock(pasteDataId: Long): List<Long>
 
+    suspend fun addTagsToPastes(
+        pasteDataIds: List<Long>,
+        pasteTagIds: Set<Long>,
+    )
+
+    suspend fun countTagsForPastes(pasteDataIds: List<Long>): Map<Long, Int>
+
     fun deletePasteTagBlock(id: Long)
 
     fun getAllTagsBlock(): List<PasteTag>

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteTagDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteTagDao.kt
@@ -93,6 +93,32 @@ class SqlPasteTagDao(
     override fun getPasteTagsBlock(pasteDataId: Long): List<Long> =
         tagDatabaseQueries.getPasteTags(pasteDataId).executeAsList()
 
+    override suspend fun addTagsToPastes(
+        pasteDataIds: List<Long>,
+        pasteTagIds: Set<Long>,
+    ) {
+        if (pasteDataIds.isEmpty() || pasteTagIds.isEmpty()) return
+        withContext(ioDispatcher) {
+            database.transaction {
+                pasteDataIds.forEach { pasteId ->
+                    pasteTagIds.forEach { tagId ->
+                        tagDatabaseQueries.pinPasteTagIgnore(pasteId, tagId)
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun countTagsForPastes(pasteDataIds: List<Long>): Map<Long, Int> {
+        if (pasteDataIds.isEmpty()) return emptyMap()
+        return withContext(ioDispatcher) {
+            tagDatabaseQueries
+                .countTagsForPastes(pasteDataIds)
+                .executeAsList()
+                .associate { it.tagId to it.pasteCount.toInt() }
+        }
+    }
+
     override fun deletePasteTagBlock(id: Long) {
         tagDatabaseQueries.deleteTag(id)
     }

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/TagDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/TagDatabase.sq
@@ -21,11 +21,20 @@ INSERT INTO TagEntity(name, color, sortOrder) VALUES (?, ?, ?);
 pinPasteTag:
 INSERT INTO PasteTagEntity(pasteId, tagId) VALUES (?, ?);
 
+pinPasteTagIgnore:
+INSERT OR IGNORE INTO PasteTagEntity(pasteId, tagId) VALUES (?, ?);
+
 unPinPasteTag:
 DELETE FROM PasteTagEntity WHERE pasteId = ? AND tagId = ?;
 
 getPasteTags:
 SELECT tagId FROM PasteTagEntity WHERE pasteId = ?;
+
+countTagsForPastes:
+SELECT tagId, COUNT(*) AS pasteCount
+FROM PasteTagEntity
+WHERE pasteId IN ?
+GROUP BY tagId;
 
 isPinnedPasteTag:
 SELECT EXISTS(SELECT 1 FROM PasteTagEntity WHERE pasteId = ? AND tagId = ?);


### PR DESCRIPTION
Closes #4425

## Summary
- New SQLDelight query `pinPasteTagIgnore` (`INSERT OR IGNORE INTO PasteTagEntity`) so re-tagging an already-tagged paste is a no-op instead of failing on the unique constraint.
- New SQLDelight query `countTagsForPastes` — `SELECT tagId, COUNT(*) ... WHERE pasteId IN ? GROUP BY tagId` — to back tristate UI on a multi-select tag picker.
- New `PasteTagDao` surface:
  - `addTagsToPastes(pasteDataIds, pasteTagIds)` — N×M inserts inside a single `transaction { }` on `ioDispatcher`; early-returns on empty input.
  - `countTagsForPastes(pasteDataIds): Map<Long, Int>` — tagId → number of the selected pastes that carry it; empty input returns `emptyMap()`.

DAO layer only; the UI that consumes these lands separately.

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew shared:generateCommonMainDatabaseInterface app:compileKotlinDesktop` — clean (the two RichText warnings are addressed by #4424)
- [x] `./gradlew app:desktopTest --tests "com.crosspaste.db.paste.PasteDaoTest"` — existing DAO tests still green
- [ ] Manual: exercise both new methods once the bulk-tagging UI lands