### PR TITLE
:sparkles: add PasteDao.filterExistingIds for stale-id filtering

### DIFF
--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -13,6 +13,8 @@ interface PasteDao : SearchPasteData {
 
     suspend fun getNoDeletePasteData(id: Long): PasteData?
 
+    suspend fun filterExistingIds(ids: List<Long>): List<Long>
+
     suspend fun getLoadingPasteData(id: Long): PasteData?
 
     fun getLoadedPasteDataBlock(id: Long): PasteData?

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
@@ -66,6 +66,13 @@ class SqlPasteDao(
             getNoDeletePasteDataBlock(id)
         }
 
+    override suspend fun filterExistingIds(ids: List<Long>): List<Long> {
+        if (ids.isEmpty()) return emptyList()
+        return withContext(ioDispatcher) {
+            pasteDatabaseQueries.filterExistingIds(ids).executeAsList()
+        }
+    }
+
     override suspend fun getLoadingPasteData(id: Long): PasteData? =
         withContext(ioDispatcher) {
             pasteDatabaseQueries

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
@@ -76,6 +76,10 @@ CASE WHEN :onlyTagged THEN EXISTS (SELECT 1 FROM PasteTagEntity WHERE PasteTagEn
 getPasteData:
 SELECT * FROM PasteDataEntity WHERE id = :id AND pasteState IN :states;
 
+filterExistingIds:
+SELECT id FROM PasteDataEntity
+WHERE id IN :ids AND pasteState != -1;
+
 getPasteDataListLimit:
 SELECT * FROM PasteDataEntity WHERE pasteState != -1 ORDER BY createTime DESC, id DESC LIMIT ?;
 


### PR DESCRIPTION
Closes #4427

## Summary
- New SQLDelight query `filterExistingIds`: `SELECT id FROM PasteDataEntity WHERE id IN :ids AND pasteState != -1`.
- New `PasteDao.filterExistingIds(ids: List<Long>): List<Long>` (suspend); empty input → `emptyList()`, otherwise runs on `ioDispatcher`.

Pairs with the bulk-tag DAO surface in #4426 so a UI selection can be cheaply pruned to live, non-soft-deleted pastes before applying tags or counting tag membership.

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `./gradlew shared:generateCommonMainDatabaseInterface app:compileKotlinDesktop`
- [x] `./gradlew app:desktopTest --tests "com.crosspaste.db.paste.PasteDaoTest"` — existing DAO tests still green
- [ ] Manual: exercise via the bulk-tag UI once it lands