### PR TITLE
:bug: stop smoke-test from killing user's PROD CrossPaste and aborting on macOS bash 3.2

### DIFF
--- a/smoke-test.ps1
+++ b/smoke-test.ps1
@@ -110,8 +110,14 @@ if (-not $proc.HasExited) {
         ForEach-Object { try { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } catch {} }
 }
 # Best-effort: kill any java.exe whose command line references CrossPaste.
+# Narrow on `appEnv=DEVELOPMENT` so we never reach the user's locally
+# running PROD CrossPaste, which boots with `-DappEnv=PRODUCTION`.
 Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
-    Where-Object { $_.Name -match '^(java|javaw)\.exe$' -and $_.CommandLine -match 'com\.crosspaste\.CrossPaste' } |
+    Where-Object {
+        $_.Name -match '^(java|javaw)\.exe$' -and
+        $_.CommandLine -match 'com\.crosspaste\.CrossPaste' -and
+        $_.CommandLine -match 'appEnv=DEVELOPMENT'
+    } |
     ForEach-Object { try { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } catch {} }
 
 if (Test-Path "$LogFile.err") {

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -103,10 +103,13 @@ if [ "$OS" = "linux" ]; then
 fi
 
 echo "[smoke] os=$OS boot_timeout=${BOOT_TIMEOUT}s compose_wait=${COMPOSE_WAIT}s"
-echo "[smoke] launching: ${LAUNCHER[*]} $GRADLE --no-daemon app:run"
+# `${LAUNCHER[*]:-}` / `${LAUNCHER[@]+...}` keep an empty array safe under
+# `set -u`; macOS still ships bash 3.2 by default, where `${arr[@]}` on an
+# empty array trips "unbound variable" and aborts the script at line one.
+echo "[smoke] launching: ${LAUNCHER[*]:-} $GRADLE --no-daemon app:run"
 echo "[smoke] log file: $LOG_FILE"
 
-"${LAUNCHER[@]}" "$GRADLE" --no-daemon app:run >>"$LOG_FILE" 2>&1 &
+${LAUNCHER[@]+"${LAUNCHER[@]}"} "$GRADLE" --no-daemon app:run >>"$LOG_FILE" 2>&1 &
 APP_PID=$!
 echo "[smoke] launched, pid=$APP_PID"
 
@@ -144,7 +147,9 @@ fi
 pkill -KILL -P "$APP_PID" 2>/dev/null || true
 kill -KILL "$APP_PID" 2>/dev/null || true
 # Best-effort: clean any orphan JVM the Gradle wrapper may have spawned.
-pkill -KILL -f 'com\.crosspaste\.CrossPaste' 2>/dev/null || true
+# Narrow on `appEnv=DEVELOPMENT` so we never reach the user's locally
+# running PROD CrossPaste, which boots with `-DappEnv=PRODUCTION`.
+pkill -KILL -f 'appEnv=DEVELOPMENT.*com\.crosspaste\.CrossPaste' 2>/dev/null || true
 wait "$APP_PID" 2>/dev/null || true
 
 echo "----- smoke app log tail -----"


### PR DESCRIPTION
## Summary

Two regressions in the freshly-landed `smoke-test.sh` / `smoke-test.ps1` from #4442:

1. **Safety / cross-platform** — final `pkill -f 'com\.crosspaste\.CrossPaste'` (and the PowerShell `Get-CimInstance Win32_Process … -match 'com\.crosspaste\.CrossPaste'` equivalent) at teardown matches **any** running CrossPaste, including the user's normal PROD instance. The smoke-test is positioned as a local pre-dep-bump check, so the developer almost certainly has their daily-driver CrossPaste open — it gets silently `SIGKILL`'d, losing clipboard session and unflushed state. Narrowed the match to also require `appEnv=DEVELOPMENT` in the command line: `app:run` defaults to `appEnv=DEVELOPMENT` (`app/build.gradle.kts:259`), release packaging uses `-PappEnv=PRODUCTION` (`.github/workflows/build-release.yml:216`), so they're cleanly distinguishable.

2. **macOS bash 3.2** — `set -u` plus `LAUNCHER=()` trips `LAUNCHER[@]: unbound variable` on the default `/bin/bash` 3.2.57 that ships with macOS. The script crashes on line one of its macOS branch:
   ```
   $ /bin/bash -c 'set -u; LAUNCHER=(); echo "${LAUNCHER[*]}"'
   bash: LAUNCHER[*]: unbound variable
   ```
   Switched to `${LAUNCHER[*]:-}` for the echo and `${LAUNCHER[@]+"${LAUNCHER[@]}"}` for the exec. Both forms are safe in bash 3.2 and 5.x, with empty and non-empty arrays — verified locally on `GNU bash 3.2.57(1)-release (arm64-apple-darwin25)`.

## Test plan

- [x] Reproduce bash 3.2 unbound-variable abort on stock macOS `/bin/bash`.
- [x] Verify patched expansions work under bash 3.2 with both empty and non-empty `LAUNCHER`.
- [x] Verify the new pkill regex `appEnv=DEVELOPMENT.*com\.crosspaste\.CrossPaste` matches a DEV-launched JVM but rejects a PROD-launched one and unrelated `appEnv=DEVELOPMENT` processes.
- [ ] End-to-end run of `./smoke-test.sh` on macOS (Apple Silicon) with PROD CrossPaste running in parallel; confirm PROD survives teardown.
- [ ] End-to-end run of `smoke-test.ps1` on Windows with PROD CrossPaste running; confirm PROD survives teardown.