### PR TITLE
:bug: bypass JVM system proxy for LAN sync traffic

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -32,6 +32,7 @@ import com.crosspaste.db.DriverFactory
 import com.crosspaste.listener.GlobalListener
 import com.crosspaste.log.DesktopCrossPasteLogger
 import com.crosspaste.mcp.McpServer
+import com.crosspaste.net.LanBypassProxySelector
 import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.net.PasteClient
 import com.crosspaste.net.ResourcesClient
@@ -319,6 +320,12 @@ class CrossPaste {
         @JvmStatic
         fun main(args: Array<String>) {
             headless = args.contains("--headless") || java.awt.GraphicsEnvironment.isHeadless()
+            // Must run before any HttpClient is constructed: Ktor CIO consults the JVM
+            // default ProxySelector when no engine.proxy is configured, and JBR mirrors
+            // OS proxy settings into the JVM with CIDR-based nonProxyHosts that Java's
+            // wildcard matcher cannot parse. Without this, LAN sync requests get routed
+            // through the user's system proxy and time out.
+            LanBypassProxySelector.install()
             initModule()
 
             System.setProperty("sun.awt.exception.handler", AwtExceptionHandler::class.java.name)

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/LanBypassProxySelector.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/LanBypassProxySelector.kt
@@ -1,0 +1,129 @@
+package com.crosspaste.net
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.IOException
+import java.net.InetAddress
+import java.net.Proxy
+import java.net.ProxySelector
+import java.net.SocketAddress
+import java.net.URI
+
+/**
+ * Forces DIRECT connection for LAN addresses while delegating all
+ * other URIs to the original system proxy selector.
+ *
+ * Why this exists: JBR mirrors macOS / Windows system proxy settings
+ * into JVM system properties (`http.proxyHost` etc.) at startup. Java's
+ * `http.nonProxyHosts` uses shell-style wildcards and does NOT understand
+ * CIDR entries (e.g. `192.168.0.0/16`). When macOS configures bypass
+ * rules with CIDR, the JVM treats them as literal strings, every LAN
+ * address falls through to the proxy, and peer-to-peer sync requests
+ * are routed to a proxy that cannot reach the LAN peer — so they hang
+ * until the per-request timeout fires.
+ *
+ * This selector explicitly classifies LAN traffic (loopback, link-local,
+ * RFC1918 site-local, CGNAT, IPv6 ULA, and `.local` mDNS names) and
+ * short-circuits it to DIRECT, leaving outbound internet traffic on the
+ * user's configured proxy.
+ */
+class LanBypassProxySelector(
+    private val delegate: ProxySelector,
+) : ProxySelector() {
+
+    override fun select(uri: URI): List<Proxy> {
+        if (isLanUri(uri)) {
+            return DIRECT
+        }
+        return delegate.select(uri)
+    }
+
+    override fun connectFailed(
+        uri: URI,
+        sa: SocketAddress,
+        ioe: IOException,
+    ) {
+        if (!isLanUri(uri)) {
+            delegate.connectFailed(uri, sa, ioe)
+        }
+    }
+
+    internal fun isLanUri(uri: URI): Boolean {
+        val rawHost = uri.host ?: return false
+        // URI.getHost() returns IPv6 literals without brackets, so just trim defensively.
+        val host = rawHost.trim('[', ']')
+
+        if (host.endsWith(".local", ignoreCase = true)) return true
+
+        if (!looksLikeIpLiteral(host)) return false
+
+        return runCatching {
+            // For IP literals (matched above) getByName never triggers DNS resolution.
+            // Strip the IPv6 zone id ("fe80::1%en0") before parsing — addresses with
+            // a zone are always link-local.
+            val parseable = host.substringBefore('%')
+            val addr = InetAddress.getByName(parseable)
+            addr.isLoopbackAddress ||
+                addr.isLinkLocalAddress ||
+                addr.isSiteLocalAddress ||
+                addr.isAnyLocalAddress ||
+                isCgnatV4(addr) ||
+                isUniqueLocalV6(addr)
+        }.getOrElse {
+            logger.debug(it) { "LanBypassProxySelector: failed to classify $host" }
+            false
+        }
+    }
+
+    private fun isCgnatV4(addr: InetAddress): Boolean {
+        val bytes = addr.address
+        if (bytes.size != 4) return false
+        val first = bytes[0].toInt() and 0xFF
+        val second = bytes[1].toInt() and 0xFF
+        return first == 100 && second in 64..127 // 100.64.0.0/10
+    }
+
+    private fun isUniqueLocalV6(addr: InetAddress): Boolean {
+        // Java's isSiteLocalAddress only recognises the deprecated fec0::/10 prefix,
+        // not modern ULA (fc00::/7). Treat both fc00::/8 and fd00::/8 as LAN.
+        val bytes = addr.address
+        if (bytes.size != 16) return false
+        val first = bytes[0].toInt() and 0xFF
+        return first == 0xFC || first == 0xFD
+    }
+
+    private fun looksLikeIpLiteral(host: String): Boolean {
+        if (host.isEmpty()) return false
+        if (host.contains(':')) {
+            // IPv6 literal (may carry a zone id like %en0)
+            return host.all {
+                it.isDigit() ||
+                    it in 'a'..'f' ||
+                    it in 'A'..'F' ||
+                    it == ':' ||
+                    it == '.' ||
+                    it == '%' ||
+                    it.isLetter() ||
+                    it.isDigit()
+            }
+        }
+        if (!host.contains('.')) return false
+        return host.all { it.isDigit() || it == '.' }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+
+        private val DIRECT = listOf(Proxy.NO_PROXY)
+
+        /**
+         * Wrap the current default ProxySelector with LAN bypass. Idempotent:
+         * calling more than once leaves a single wrapper in place.
+         */
+        fun install() {
+            val current = getDefault() ?: return
+            if (current is LanBypassProxySelector) return
+            setDefault(LanBypassProxySelector(current))
+            logger.info { "LanBypassProxySelector installed (delegate=${current::class.java.name})" }
+        }
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/LanBypassProxySelectorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/LanBypassProxySelectorTest.kt
@@ -1,0 +1,169 @@
+package com.crosspaste.net
+
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.ProxySelector
+import java.net.SocketAddress
+import java.net.URI
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class LanBypassProxySelectorTest {
+
+    private lateinit var fakeProxy: Proxy
+    private lateinit var fakeDelegate: RecordingProxySelector
+    private lateinit var selector: LanBypassProxySelector
+
+    @BeforeTest
+    fun setUp() {
+        fakeProxy = Proxy(Proxy.Type.HTTP, InetSocketAddress("127.0.0.1", 7890))
+        fakeDelegate = RecordingProxySelector(listOf(fakeProxy))
+        selector = LanBypassProxySelector(fakeDelegate)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        fakeDelegate.reset()
+    }
+
+    @Test
+    fun `bypasses RFC1918 192_168 addresses`() {
+        val proxies = selector.select(URI("http://192.168.0.111:38549/sync/telnet"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+        assertEquals(0, fakeDelegate.selectCount)
+    }
+
+    @Test
+    fun `bypasses RFC1918 10_0 addresses`() {
+        val proxies = selector.select(URI("http://10.20.30.40:8080/"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+    }
+
+    @Test
+    fun `bypasses RFC1918 172_16 addresses`() {
+        val proxies = selector.select(URI("http://172.20.5.1:8080/"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+    }
+
+    @Test
+    fun `bypasses loopback IPv4`() {
+        val proxies = selector.select(URI("http://127.0.0.1:9000/"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+    }
+
+    @Test
+    fun `bypasses link-local IPv4`() {
+        val proxies = selector.select(URI("http://169.254.1.1:80/"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+    }
+
+    @Test
+    fun `bypasses CGNAT range`() {
+        val proxies = selector.select(URI("http://100.96.1.1:1234/"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+    }
+
+    @Test
+    fun `bypasses IPv6 loopback`() {
+        val proxies = selector.select(URI("http://[::1]:9000/"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+    }
+
+    @Test
+    fun `bypasses IPv6 link-local`() {
+        val proxies = selector.select(URI("http://[fe80::1]:9000/"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+    }
+
+    @Test
+    fun `bypasses IPv6 unique-local`() {
+        val proxies = selector.select(URI("http://[fd00::1]:9000/"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+    }
+
+    @Test
+    fun `bypasses mDNS local hostnames`() {
+        val proxies = selector.select(URI("http://my-mac.local:9000/"))
+        assertEquals(listOf(Proxy.NO_PROXY), proxies)
+        assertEquals(0, fakeDelegate.selectCount)
+    }
+
+    @Test
+    fun `delegates public IPv4 to system selector`() {
+        val proxies = selector.select(URI("http://8.8.8.8/"))
+        assertEquals(listOf(fakeProxy), proxies)
+        assertEquals(1, fakeDelegate.selectCount)
+    }
+
+    @Test
+    fun `delegates external hostnames without DNS resolution`() {
+        val proxies = selector.select(URI("https://github.com/"))
+        assertEquals(listOf(fakeProxy), proxies)
+        assertEquals(1, fakeDelegate.selectCount)
+    }
+
+    @Test
+    fun `connectFailed delegates only for non-LAN`() {
+        val sa: SocketAddress = InetSocketAddress("8.8.8.8", 443)
+        selector.connectFailed(URI("https://github.com/"), sa, IOException("boom"))
+        assertEquals(1, fakeDelegate.connectFailedCount)
+
+        selector.connectFailed(URI("http://192.168.0.111:38549/"), sa, IOException("boom"))
+        assertEquals(1, fakeDelegate.connectFailedCount) // unchanged
+    }
+
+    @Test
+    fun `install wraps current default once`() {
+        val original = ProxySelector.getDefault()
+        try {
+            ProxySelector.setDefault(fakeDelegate)
+            LanBypassProxySelector.install()
+            val first = ProxySelector.getDefault()
+            assertTrue(first is LanBypassProxySelector)
+
+            LanBypassProxySelector.install() // idempotent
+            assertSame(first, ProxySelector.getDefault())
+        } finally {
+            ProxySelector.setDefault(original)
+        }
+    }
+
+    @Test
+    fun `null host is not classified as LAN`() {
+        // opaque URI: getHost() returns null
+        assertFalse(selector.isLanUri(URI("mailto:foo@example.com")))
+    }
+
+    private class RecordingProxySelector(
+        private val response: List<Proxy>,
+    ) : ProxySelector() {
+        var selectCount: Int = 0
+            private set
+        var connectFailedCount: Int = 0
+            private set
+
+        override fun select(uri: URI?): List<Proxy> {
+            selectCount++
+            return response
+        }
+
+        override fun connectFailed(
+            uri: URI?,
+            sa: SocketAddress?,
+            ioe: IOException?,
+        ) {
+            connectFailedCount++
+        }
+
+        fun reset() {
+            selectCount = 0
+            connectFailedCount = 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Install `LanBypassProxySelector` early in `CrossPaste.main()` to wrap `ProxySelector.getDefault()`. For LAN targets (loopback, link-local, RFC1918, CGNAT 100.64/10, IPv6 ULA fc00::/7, `.local` mDNS), it always returns `Proxy.NO_PROXY`; other URIs are delegated to the original selector, preserving the user's proxy configuration for external traffic.
- Add 15 test cases covering v4/v6, CGNAT, ULA, `.local`, external hostname delegation, `connectFailed` delegation, idempotent install, etc.

## Why
At startup, JBR mirrors the OS system proxy settings into JVM system properties (`http.proxyHost`, `http.nonProxyHosts`, etc.). Java's `nonProxyHosts` uses shell-style wildcard matching, treating CIDR entries from the macOS config (`192.168.0.0/16`, `10.0.0.0/8`, etc.) as literal strings — so all LAN addresses miss the bypass list. Ktor CIO 3.5 falls back to `ProxySelector.getDefault()` when `engine.proxy` is null, which means every LAN sync request (`/sync/telnet`, `/sync/heartbeat`, WebSocket) gets routed through the user's HTTP proxy. The proxy can't forward LAN traffic to the peer CrossPaste server, so requests hang until the per-request timeout (2-3s). Symptom: nearby devices are discovered via mDNS (UDP multicast bypasses the proxy), but clicking "Connect" immediately flips to "offline/unknown".

## Verification
- `./gradlew app:desktopTest --tests com.crosspaste.net.LanBypassProxySelectorTest` all green (15 cases)
- Local dev build startup log confirms install: `LanBypassProxySelector installed (delegate=sun.net.spi.DefaultProxySelector)`
- After install, `TelnetHelper` requests to LAN peers flip from timeout to 200:
  ```
  12:01:13 httpResponse.status = 200 192.168.0.112:13129
  12:01:15 httpResponse.status = 200 192.168.0.100:13129
  ```

## Test plan
- [x] Unit tests cover `LanBypassProxySelector` classification logic (v4/v6, CGNAT, ULA, `.local`, external delegation, `connectFailed`, idempotent install)
- [x] Manually verified LAN sync outbound requests connect directly while macOS system proxy is enabled
- [ ] Validate on peers running Linux / Windows builds once published (the same patch is shared across platforms via desktopMain)

## Notes
- Unrelated to mDNS (mDNS uses UDP multicast and never goes through the proxy).
- Ktor server inbound is unaffected (NIO bind does not consult `ProxySelector`, and the handler itself makes no outbound calls).
- The `main()` entry point is now crowded with bootstrap steps; the next PR will extract them into `bootstrap/DesktopBootstrap.kt`.