### PR TITLE
:bug: make smoke-test orphan-JVM kill order-independent

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -148,8 +148,12 @@ pkill -KILL -P "$APP_PID" 2>/dev/null || true
 kill -KILL "$APP_PID" 2>/dev/null || true
 # Best-effort: clean any orphan JVM the Gradle wrapper may have spawned.
 # Narrow on `appEnv=DEVELOPMENT` so we never reach the user's locally
-# running PROD CrossPaste, which boots with `-DappEnv=PRODUCTION`.
-pkill -KILL -f 'appEnv=DEVELOPMENT.*com\.crosspaste\.CrossPaste' 2>/dev/null || true
+# running PROD CrossPaste, which boots with `-DappEnv=PRODUCTION`. Match the
+# two substrings independently (mirrors smoke-test.ps1) so the kill survives
+# any future launcher that reorders JVM args.
+pgrep -f 'com\.crosspaste\.CrossPaste' 2>/dev/null \
+  | xargs -I{} sh -c 'ps -p {} -o command= 2>/dev/null | grep -q "appEnv=DEVELOPMENT" && kill -KILL {}' \
+  2>/dev/null || true
 wait "$APP_PID" 2>/dev/null || true
 
 echo "----- smoke app log tail -----"


### PR DESCRIPTION
Closes #4451

## Summary
- `smoke-test.sh` teardown matched orphan JVMs with a single regex `appEnv=DEVELOPMENT.*com\.crosspaste\.CrossPaste` that requires `-DappEnv=DEVELOPMENT` to appear before the main class. `smoke-test.ps1:117-119` already matches the two substrings independently — the bash side now does the same via `pgrep -f` + `ps -o command= | grep -q`.
- Behavior is unchanged under today's Gradle launcher (which emits `-D` flags first); the change guards against a silent miss if any future launcher reorders JVM args. The PROD-CrossPaste safety from #4445 is preserved — both `com.crosspaste.CrossPaste` AND `appEnv=DEVELOPMENT` must be present before SIGKILL.

## Compatibility
- Bash 3.2 (macOS default) — no process substitution or `mapfile`.
- `pgrep` / `ps -o command=` / `xargs -I{}` are POSIX/BSD-compatible.
- macOS `ps` does not truncate when stdout is piped (per `man ps`), so `-ww` is not needed.
- `xargs -I{}` with no stdin input is a no-op on BSD xargs, so the empty-`pgrep` path stays clean under `set -u`.

## Test plan
- [x] Reproduce: spawn a sleeping process with a command line that places the main class before `-DappEnv=DEVELOPMENT` — old single-regex misses it, new logic kills it.
- [x] Empty `pgrep` input under `set -u` — exits 0, no error.
- [ ] Local `./smoke-test.sh` end-to-end on macOS confirms normal teardown still works (will be run before merge).