### PR TITLE
:white_check_mark: regression tests for MaterialContextMenu hover-index and submenu position

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/contextmenu/MaterialContextMenuRepresentation.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/contextmenu/MaterialContextMenuRepresentation.kt
@@ -476,7 +476,7 @@ internal fun rememberNestedDropdownPositionProvider(
  * internal vertical padding (`menuTopPadding` / `menuBottomPadding`) is canceled out so the
  * visible hover background lines up across the popup boundary instead of being inset by it.
  */
-private class NestedDropdownPositionProvider(
+internal class NestedDropdownPositionProvider(
     private val windowMarginPx: Int,
     private val menuTopPaddingPx: Int,
     private val menuBottomPaddingPx: Int,

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/contextmenu/HoveredIndexTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/contextmenu/HoveredIndexTest.kt
@@ -1,0 +1,163 @@
+package com.crosspaste.ui.contextmenu
+
+import androidx.compose.foundation.interaction.HoverInteraction
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression coverage for the sticky-hover index flow that drives nested submenu visibility in
+ * [MaterialContextMenuRepresentation]. The behaviors under test were a previous source of UAF-like
+ * bugs in the upstream `dzirbel` library: dropping the sticky "last hovered" behavior would make
+ * the submenu close as soon as the pointer crosses the gap between parent and child.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HoveredIndexTest {
+
+    @Test
+    fun `empty iterable emits -1 and nothing else`() =
+        runTest {
+            val result = emptyList<InteractionSource>().hoveredIndex().first()
+            assertEquals(-1, result)
+        }
+
+    @Test
+    fun `initial emission for non-empty iterable with no hovers is -1`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val sources = List(3) { MutableInteractionSource() }
+            val emissions = collectIndices(sources)
+            assertEquals(listOf(-1), emissions.distinct())
+        }
+
+    @Test
+    fun `hovering source 0 emits 0`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val sources = List(3) { MutableInteractionSource() }
+            val emissions =
+                collectIndices(sources) {
+                    sources[0].emit(HoverInteraction.Enter())
+                }
+            assertTrue(0 in emissions, "expected 0 in $emissions")
+        }
+
+    @Test
+    fun `hovering source 1 emits 1`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val sources = List(3) { MutableInteractionSource() }
+            val emissions =
+                collectIndices(sources) {
+                    sources[1].emit(HoverInteraction.Enter())
+                }
+            assertTrue(1 in emissions, "expected 1 in $emissions")
+        }
+
+    @Test
+    fun `exit after enter keeps last index sticky`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val sources = List(2) { MutableInteractionSource() }
+            val enter = HoverInteraction.Enter()
+            val emissions =
+                collectIndices(sources) {
+                    sources[1].emit(enter)
+                    sources[1].emit(HoverInteraction.Exit(enter))
+                }
+            assertEquals(1, emissions.last(), "after Exit the index must not fall back to -1")
+        }
+
+    @Test
+    fun `moving hover between items emits both indices in order`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val sources = List(3) { MutableInteractionSource() }
+            val enter0 = HoverInteraction.Enter()
+            val enter2 = HoverInteraction.Enter()
+            val emissions =
+                collectIndices(sources) {
+                    sources[0].emit(enter0)
+                    sources[0].emit(HoverInteraction.Exit(enter0))
+                    sources[2].emit(enter2)
+                }
+            val nonNegative = emissions.filter { it >= 0 }
+            assertTrue(
+                nonNegative.indexOf(0) < nonNegative.indexOf(2),
+                "expected 0 before 2 in $nonNegative",
+            )
+            assertEquals(2, emissions.last(), "last hovered index should stick")
+        }
+
+    @Test
+    fun `unbalanced exit before any enter does not crash and stays at -1`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val sources = List(2) { MutableInteractionSource() }
+            val ghostEnter = HoverInteraction.Enter()
+            val emissions =
+                collectIndices(sources) {
+                    // Emit Exit without a paired Enter — pushes runningFold counter to -1.
+                    sources[0].emit(HoverInteraction.Exit(ghostEnter))
+                }
+            assertEquals(-1, emissions.last())
+        }
+
+    @Test
+    fun `overlapping enters from one source stay hovered until all are exited`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Compose can deliver nested Enter/Enter/Exit when pointer events overlap (e.g. a
+            // child element generates its own pair). The runningFold counter must reflect the
+            // outstanding count, not flip to "not hovered" on the first Exit.
+            val sources = List(2) { MutableInteractionSource() }
+            val enterA = HoverInteraction.Enter()
+            val enterB = HoverInteraction.Enter()
+            val emissions =
+                collectIndices(sources) {
+                    sources[0].emit(enterA)
+                    sources[0].emit(enterB)
+                    sources[0].emit(HoverInteraction.Exit(enterA))
+                }
+            assertEquals(
+                0,
+                emissions.last(),
+                "source 0 still has an outstanding Enter (counter > 0) so index must remain 0",
+            )
+        }
+
+    @Test
+    fun `balanced exits drop hover off the source but leave the sticky index alone`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val sources = List(2) { MutableInteractionSource() }
+            val enterA = HoverInteraction.Enter()
+            val enterB = HoverInteraction.Enter()
+            val emissions =
+                collectIndices(sources) {
+                    sources[0].emit(enterA)
+                    sources[0].emit(enterB)
+                    sources[0].emit(HoverInteraction.Exit(enterA))
+                    sources[0].emit(HoverInteraction.Exit(enterB))
+                    // All Enters balanced — combine emits -1, scan keeps the last sticky index.
+                }
+            assertEquals(0, emissions.last())
+        }
+
+    private suspend fun TestScope.collectIndices(
+        sources: List<MutableInteractionSource>,
+        emit: suspend () -> Unit = {},
+    ): List<Int> {
+        val emissions = mutableListOf<Int>()
+        val job =
+            backgroundScope.launch {
+                sources.hoveredIndex().toList(emissions)
+            }
+        testScheduler.runCurrent()
+        emit()
+        testScheduler.advanceUntilIdle()
+        job.cancel()
+        return emissions
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/contextmenu/NestedDropdownPositionProviderTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/contextmenu/NestedDropdownPositionProviderTest.kt
@@ -1,0 +1,168 @@
+package com.crosspaste.ui.contextmenu
+
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression coverage for the submenu position math. Off-by-one in the flip-left or flip-up
+ * branches will silently render the submenu in the wrong corner or with hover backgrounds that
+ * don't line up across the popup boundary — the whole point of canceling [menuTopPadding] /
+ * [menuBottomPadding] is to make that hover band continuous.
+ */
+class NestedDropdownPositionProviderTest {
+
+    private val windowMarginPx = 8
+    private val menuTopPaddingPx = 12
+    private val menuBottomPaddingPx = 12
+
+    private val provider =
+        NestedDropdownPositionProvider(
+            windowMarginPx = windowMarginPx,
+            menuTopPaddingPx = menuTopPaddingPx,
+            menuBottomPaddingPx = menuBottomPaddingPx,
+        )
+
+    @Test
+    fun `places popup to the right of the anchor when there is room`() {
+        val anchor = IntRect(left = 400, top = 300, right = 500, bottom = 348)
+        val popup = IntSize(width = 200, height = 300)
+
+        val offset =
+            provider.calculatePosition(
+                anchorBounds = anchor,
+                windowSize = IntSize(1000, 800),
+                layoutDirection = LayoutDirection.Ltr,
+                popupContentSize = popup,
+            )
+
+        assertEquals(
+            IntOffset(anchor.right, anchor.top - menuTopPaddingPx),
+            offset,
+        )
+    }
+
+    @Test
+    fun `flips to the left when the right edge would overflow the window`() {
+        val anchor = IntRect(left = 400, top = 100, right = 500, bottom = 148)
+        val popup = IntSize(width = 300, height = 200)
+
+        val offset =
+            provider.calculatePosition(
+                anchorBounds = anchor,
+                windowSize = IntSize(600, 800),
+                layoutDirection = LayoutDirection.Ltr,
+                popupContentSize = popup,
+            )
+
+        assertEquals(
+            IntOffset(anchor.left - popup.width, anchor.top - menuTopPaddingPx),
+            offset,
+        )
+    }
+
+    @Test
+    fun `flips upward when the bottom edge would overflow the window`() {
+        val anchor = IntRect(left = 200, top = 600, right = 300, bottom = 648)
+        val popup = IntSize(width = 200, height = 300)
+
+        val offset =
+            provider.calculatePosition(
+                anchorBounds = anchor,
+                windowSize = IntSize(1000, 800),
+                layoutDirection = LayoutDirection.Ltr,
+                popupContentSize = popup,
+            )
+
+        assertEquals(
+            IntOffset(anchor.right, anchor.bottom - popup.height + menuBottomPaddingPx),
+            offset,
+        )
+    }
+
+    @Test
+    fun `flips both axes when the popup would overflow both edges`() {
+        val anchor = IntRect(left = 400, top = 600, right = 500, bottom = 648)
+        val popup = IntSize(width = 300, height = 300)
+
+        val offset =
+            provider.calculatePosition(
+                anchorBounds = anchor,
+                windowSize = IntSize(600, 800),
+                layoutDirection = LayoutDirection.Ltr,
+                popupContentSize = popup,
+            )
+
+        assertEquals(
+            IntOffset(
+                anchor.left - popup.width,
+                anchor.bottom - popup.height + menuBottomPaddingPx,
+            ),
+            offset,
+        )
+    }
+
+    @Test
+    fun `clamps to window margin when neither side of the anchor fits`() {
+        // Popup wider/taller than the window — both flips still leave the offset negative,
+        // so the window-margin clamp at the end of calculatePosition must save us.
+        val anchor = IntRect(left = 10, top = 10, right = 20, bottom = 20)
+        val popup = IntSize(width = 200, height = 200)
+
+        val offset =
+            provider.calculatePosition(
+                anchorBounds = anchor,
+                windowSize = IntSize(100, 100),
+                layoutDirection = LayoutDirection.Ltr,
+                popupContentSize = popup,
+            )
+
+        assertEquals(IntOffset(windowMarginPx, windowMarginPx), offset)
+    }
+
+    @Test
+    fun `ignores layout direction so submenu always opens to the right when room exists`() {
+        val anchor = IntRect(left = 400, top = 300, right = 500, bottom = 348)
+        val popup = IntSize(width = 200, height = 300)
+        val window = IntSize(1000, 800)
+
+        val ltr =
+            provider.calculatePosition(
+                anchor,
+                window,
+                LayoutDirection.Ltr,
+                popup,
+            )
+        val rtl =
+            provider.calculatePosition(
+                anchor,
+                window,
+                LayoutDirection.Rtl,
+                popup,
+            )
+
+        assertEquals(ltr, rtl)
+    }
+
+    @Test
+    fun `handles anchor wider than popup without changing the math`() {
+        val anchor = IntRect(left = 100, top = 100, right = 700, bottom = 148)
+        val popup = IntSize(width = 200, height = 300)
+
+        val offset =
+            provider.calculatePosition(
+                anchorBounds = anchor,
+                windowSize = IntSize(1000, 800),
+                layoutDirection = LayoutDirection.Ltr,
+                popupContentSize = popup,
+            )
+
+        assertEquals(
+            IntOffset(anchor.right, anchor.top - menuTopPaddingPx),
+            offset,
+        )
+    }
+}


### PR DESCRIPTION
Closes #4453

## Summary
- PR #4448 swapped `dzirbel/compose-material-context-menu` for an in-tree implementation but shipped zero unit tests. The next Compose Multiplatform upgrade could silently regress two pure-function pieces that have non-obvious behavior — the sticky-hover index that keeps nested submenus open across the parent/child gap, and the position math that flips the submenu around window edges while keeping hover backgrounds continuous across the popup boundary.
- Mirrors the seam-and-test pattern #4444 introduced for `SkiaAnimatedImageView` after the same kind of silent-regression risk.

## Changes
- `MaterialContextMenuRepresentation.kt`: promote `NestedDropdownPositionProvider` from `private` to `internal`. Only access change required; `hoveredIndex()` was already `internal`.
- `HoveredIndexTest` (9 cases): empty iterable, initial state with no hovers, hover at index 0 and 1, exit keeps sticky, navigation across items, unbalanced Exit without prior Enter, overlapping nested Enter/Enter/Exit (counter stays positive), balanced full exit keeps the sticky index.
- `NestedDropdownPositionProviderTest` (7 cases): no-flip path, right-edge overflow flips to left, bottom-edge overflow flips up, both-axis flip, window-margin clamp when neither side fits, `LayoutDirection`-invariant (submenu always opens right), anchor wider than popup.

## Test plan
- [x] `./gradlew ktlintFormat :app:desktopTest --tests "com.crosspaste.ui.contextmenu.*"` — 16 / 16 passing locally.
- [x] Sanity-check that one wrong assumption (about combine resolution when two sources hover simultaneously) was corrected in test code, not by changing production behavior.