### PR TITLE
:sparkles: desktop file push protocol (M1+M2)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -13,11 +13,13 @@ import com.crosspaste.net.plugin.ServerEncryptPluginFactory
 import com.crosspaste.net.routing.SyncRoutingApi
 import com.crosspaste.net.routing.pasteRouting
 import com.crosspaste.net.routing.pullRouting
+import com.crosspaste.net.routing.pushRouting
 import com.crosspaste.net.routing.syncRouting
 import com.crosspaste.net.routing.wsRouting
 import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.paste.CacheManager
+import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.secure.SecureKeyPairSerializer
@@ -25,6 +27,7 @@ import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.PastePullService
 import com.crosspaste.sync.PendingKeyExchangeStore
+import com.crosspaste.sync.PushSessionManager
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
@@ -52,6 +55,8 @@ open class DefaultServerModule(
     private val pasteboardService: PasteboardService,
     private val pasteDao: PasteDao,
     private val pastePullService: PastePullService,
+    private val pasteReleaseService: PasteReleaseService,
+    private val pushSessionManager: PushSessionManager,
     private val secureKeyPairSerializer: SecureKeyPairSerializer,
     private val secureStore: SecureStore,
     private val syncApi: SyncApi,
@@ -114,14 +119,22 @@ open class DefaultServerModule(
                 pasteRouting(
                     appControl,
                     pasteboardService,
+                    pasteReleaseService,
                     pastePullService,
                     pasteRoutingScope,
+                    pushSessionManager,
                     syncRoutingApi,
                 )
                 pullRouting(
                     appInfo,
                     cacheManager,
                     pasteDao,
+                    syncRoutingApi,
+                    userDataPathProvider,
+                )
+                pushRouting(
+                    appInfo,
+                    pushSessionManager,
                     syncRoutingApi,
                     userDataPathProvider,
                 )

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -14,11 +14,15 @@ import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
 import com.crosspaste.utils.requireSyncHandler
 import com.crosspaste.utils.successResponse
+import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+
+private val logger: KLogger = KotlinLogging.logger("PasteRouting")
 
 fun Routing.pasteRouting(
     appControl: AppControl,
@@ -29,98 +33,163 @@ fun Routing.pasteRouting(
     pushSessionManager: PushSessionManager,
     syncRoutingApi: SyncRoutingApi,
 ) {
-    val logger = KotlinLogging.logger {}
-
     post("/sync/paste") {
-        getAppInstanceId(call)?.let { appInstanceId ->
-            val syncHandler = requireSyncHandler(call, syncRoutingApi, appInstanceId) ?: return@let
-
-            if (!syncHandler.currentSyncRuntimeInfo.allowReceive) {
-                logger.debug { "sync handler ($appInstanceId), user not allow receive" }
-                failResponse(call, StandardErrorCode.SYNC_NOT_ALLOW_RECEIVE_BY_USER.toErrorCode())
-                return@let
-            }
-
-            if (!appControl.isReceiveEnabled()) {
-                logger.debug { "sync handler  $appInstanceId, app not allow receive" }
-                failResponse(call, StandardErrorCode.SYNC_NOT_ALLOW_RECEIVE_BY_APP.toErrorCode())
-                return@let
-            }
-
-            val mode = call.request.headers[PushHeaders.SYNC_MODE]
-            val pasteData =
-                runCatching {
-                    call.receive<PasteData>().copy(remote = true)
-                }.onFailure { e ->
-                    logger.error(e) { "sync handler ($appInstanceId) receive pasteData error" }
-                    if (e is PasteException && e.match(StandardErrorCode.DECRYPT_FAIL)) {
-                        failResponse(call, StandardErrorCode.DECRYPT_FAIL.toErrorCode())
-                    } else {
-                        failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
-                    }
-                }.getOrNull() ?: return@let
-
-            if (mode == PushHeaders.SYNC_MODE_PUSH) {
-                // Permission gating policy: this branch is the ONLY place we check
-                // appControl.isReceiveEnabled() + syncHandler.allowReceive for the
-                // push flow. The two checks already ran above before we got here.
-                // Subsequent /sync/file/push and /sync/paste/push/complete trust the
-                // session token issued in our prepare response — toggling permissions
-                // mid-session does NOT abort in-flight uploads. The sender learns
-                // our decision from this response (200 = go, 4xx = stop).
-                if (!pasteData.isFileType()) {
-                    logger.warn { "push sync: paste from $appInstanceId is not file/image type, rejecting" }
-                    failResponse(call, StandardErrorCode.PUSH_NOT_FILE_TYPE.toErrorCode())
-                    return@let
-                }
-
-                val prepared = pasteReleaseService.releaseRemotePasteDataForPush(pasteData)
-                if (prepared == null) {
-                    failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
-                    return@let
-                }
-
-                val session =
-                    pushSessionManager.create(
-                        pasteId = prepared.pasteId,
-                        fromAppInstanceId = appInstanceId,
-                        filesIndex = prepared.filesIndex,
-                    )
-                if (session == null) {
-                    logger.warn { "push sync: rejected pasteId=${prepared.pasteId} (capacity)" }
-                    failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
-                    return@let
-                }
-
-                pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
-                appControl.completeReceiveOperation()
-                logger.debug {
-                    "sync handler ($appInstanceId) push prepare ok: pasteId=${prepared.pasteId} " +
-                        "chunkCount=${prepared.chunkCount}"
-                }
-                successResponse(
-                    call,
-                    PushPrepareResponse(
-                        pasteId = prepared.pasteId,
-                        chunkCount = prepared.chunkCount,
-                        chunkSize = prepared.chunkSize,
-                        sessionToken = session.token,
-                        needIcon = prepared.needIcon,
-                    ),
-                )
-                return@let
-            }
-
-            pasteRoutingScope.launch {
-                pasteboardService
-                    .tryWriteRemotePasteboard(pasteData)
-                    .onSuccess {
-                        pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
-                    }
-            }
-            logger.debug { "sync handler ($appInstanceId) receive pasteData: $pasteData" }
-            appControl.completeReceiveOperation()
-            successResponse(call)
-        }
+        handleSyncPaste(
+            call,
+            appControl,
+            pasteboardService,
+            pasteReleaseService,
+            pastePullService,
+            pasteRoutingScope,
+            pushSessionManager,
+            syncRoutingApi,
+        )
     }
+}
+
+private suspend fun handleSyncPaste(
+    call: ApplicationCall,
+    appControl: AppControl,
+    pasteboardService: PasteboardService,
+    pasteReleaseService: PasteReleaseService,
+    pastePullService: PastePullService,
+    pasteRoutingScope: CoroutineScope,
+    pushSessionManager: PushSessionManager,
+    syncRoutingApi: SyncRoutingApi,
+) {
+    val appInstanceId = getAppInstanceId(call) ?: return
+    val syncHandler = requireSyncHandler(call, syncRoutingApi, appInstanceId) ?: return
+
+    if (!syncHandler.currentSyncRuntimeInfo.allowReceive) {
+        logger.debug { "sync handler ($appInstanceId), user not allow receive" }
+        failResponse(call, StandardErrorCode.SYNC_NOT_ALLOW_RECEIVE_BY_USER.toErrorCode())
+        return
+    }
+    if (!appControl.isReceiveEnabled()) {
+        logger.debug { "sync handler ($appInstanceId), app not allow receive" }
+        failResponse(call, StandardErrorCode.SYNC_NOT_ALLOW_RECEIVE_BY_APP.toErrorCode())
+        return
+    }
+
+    val mode = call.request.headers[PushHeaders.SYNC_MODE]
+    val pasteData = receiveRemotePasteData(call, appInstanceId) ?: return
+
+    if (mode == PushHeaders.SYNC_MODE_PUSH) {
+        handlePushPrepare(
+            call,
+            appInstanceId,
+            pasteData,
+            appControl,
+            pasteReleaseService,
+            pastePullService,
+            pushSessionManager,
+        )
+    } else {
+        handlePullSync(
+            call,
+            appInstanceId,
+            pasteData,
+            appControl,
+            pasteboardService,
+            pastePullService,
+            pasteRoutingScope,
+        )
+    }
+}
+
+private suspend fun receiveRemotePasteData(
+    call: ApplicationCall,
+    appInstanceId: String,
+): PasteData? =
+    runCatching {
+        call.receive<PasteData>().copy(remote = true)
+    }.onFailure { e ->
+        logger.error(e) { "sync handler ($appInstanceId) receive pasteData error" }
+        val code =
+            if (e is PasteException && e.match(StandardErrorCode.DECRYPT_FAIL)) {
+                StandardErrorCode.DECRYPT_FAIL
+            } else {
+                StandardErrorCode.UNKNOWN_ERROR
+            }
+        failResponse(call, code.toErrorCode())
+    }.getOrNull()
+
+/**
+ * Permission gating policy: the caller ([handleSyncPaste]) already ran
+ * `appControl.isReceiveEnabled()` + `syncHandler.allowReceive`. The push
+ * flow's subsequent /sync/file/push and /sync/paste/push/complete trust the
+ * session token issued here — toggling permissions mid-session does NOT
+ * abort in-flight uploads. The sender learns our decision from this response
+ * (200 = go, 4xx = stop).
+ */
+private suspend fun handlePushPrepare(
+    call: ApplicationCall,
+    appInstanceId: String,
+    pasteData: PasteData,
+    appControl: AppControl,
+    pasteReleaseService: PasteReleaseService,
+    pastePullService: PastePullService,
+    pushSessionManager: PushSessionManager,
+) {
+    if (!pasteData.isFileType()) {
+        logger.warn { "push sync: paste from $appInstanceId is not file/image type, rejecting" }
+        failResponse(call, StandardErrorCode.PUSH_NOT_FILE_TYPE.toErrorCode())
+        return
+    }
+
+    val prepared = pasteReleaseService.releaseRemotePasteDataForPush(pasteData)
+    if (prepared == null) {
+        failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
+        return
+    }
+
+    val session =
+        pushSessionManager.create(
+            pasteId = prepared.pasteId,
+            fromAppInstanceId = appInstanceId,
+            filesIndex = prepared.filesIndex,
+        )
+    if (session == null) {
+        logger.warn { "push sync: rejected pasteId=${prepared.pasteId} (capacity)" }
+        failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
+        return
+    }
+
+    pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
+    appControl.completeReceiveOperation()
+    logger.debug {
+        "sync handler ($appInstanceId) push prepare ok: pasteId=${prepared.pasteId} " +
+            "chunkCount=${prepared.chunkCount}"
+    }
+    successResponse(
+        call,
+        PushPrepareResponse(
+            pasteId = prepared.pasteId,
+            chunkCount = prepared.chunkCount,
+            chunkSize = prepared.chunkSize,
+            sessionToken = session.token,
+            needIcon = prepared.needIcon,
+        ),
+    )
+}
+
+private suspend fun handlePullSync(
+    call: ApplicationCall,
+    appInstanceId: String,
+    pasteData: PasteData,
+    appControl: AppControl,
+    pasteboardService: PasteboardService,
+    pastePullService: PastePullService,
+    pasteRoutingScope: CoroutineScope,
+) {
+    pasteRoutingScope.launch {
+        pasteboardService
+            .tryWriteRemotePasteboard(pasteData)
+            .onSuccess {
+                pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
+            }
+    }
+    logger.debug { "sync handler ($appInstanceId) receive pasteData: $pasteData" }
+    appControl.completeReceiveOperation()
+    successResponse(call)
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -1,13 +1,18 @@
 package com.crosspaste.net.routing
 
 import com.crosspaste.app.AppControl
+import com.crosspaste.dto.push.PushHeaders
+import com.crosspaste.dto.push.PushPrepareResponse
 import com.crosspaste.exception.PasteException
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.sync.PastePullService
+import com.crosspaste.sync.PushSessionManager
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
+import com.crosspaste.utils.requireSyncHandler
 import com.crosspaste.utils.successResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.request.*
@@ -18,20 +23,17 @@ import kotlinx.coroutines.launch
 fun Routing.pasteRouting(
     appControl: AppControl,
     pasteboardService: PasteboardService,
+    pasteReleaseService: PasteReleaseService,
     pastePullService: PastePullService,
     pasteRoutingScope: CoroutineScope,
+    pushSessionManager: PushSessionManager,
     syncRoutingApi: SyncRoutingApi,
 ) {
     val logger = KotlinLogging.logger {}
 
     post("/sync/paste") {
         getAppInstanceId(call)?.let { appInstanceId ->
-            val syncHandler =
-                syncRoutingApi.getSyncHandler(appInstanceId) ?: run {
-                    logger.error { "not found appInstance id: $appInstanceId" }
-                    failResponse(call, StandardErrorCode.NOT_FOUND_APP_INSTANCE_ID.toErrorCode())
-                    return@let
-                }
+            val syncHandler = requireSyncHandler(call, syncRoutingApi, appInstanceId) ?: return@let
 
             if (!syncHandler.currentSyncRuntimeInfo.allowReceive) {
                 logger.debug { "sync handler ($appInstanceId), user not allow receive" }
@@ -45,32 +47,80 @@ fun Routing.pasteRouting(
                 return@let
             }
 
-            runCatching {
-                val pasteData =
-                    call
-                        .receive<PasteData>()
-                        .copy(remote = true)
+            val mode = call.request.headers[PushHeaders.SYNC_MODE]
+            val pasteData =
+                runCatching {
+                    call.receive<PasteData>().copy(remote = true)
+                }.onFailure { e ->
+                    logger.error(e) { "sync handler ($appInstanceId) receive pasteData error" }
+                    if (e is PasteException && e.match(StandardErrorCode.DECRYPT_FAIL)) {
+                        failResponse(call, StandardErrorCode.DECRYPT_FAIL.toErrorCode())
+                    } else {
+                        failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
+                    }
+                }.getOrNull() ?: return@let
 
-                pasteRoutingScope.launch {
-                    pasteboardService
-                        .tryWriteRemotePasteboard(
-                            pasteData,
-                        ).onSuccess {
-                            pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
-                        }
+            if (mode == PushHeaders.SYNC_MODE_PUSH) {
+                // Permission gating policy: this branch is the ONLY place we check
+                // appControl.isReceiveEnabled() + syncHandler.allowReceive for the
+                // push flow. The two checks already ran above before we got here.
+                // Subsequent /sync/file/push and /sync/paste/push/complete trust the
+                // session token issued in our prepare response — toggling permissions
+                // mid-session does NOT abort in-flight uploads. The sender learns
+                // our decision from this response (200 = go, 4xx = stop).
+                if (!pasteData.isFileType()) {
+                    logger.warn { "push sync: paste from $appInstanceId is not file/image type, rejecting" }
+                    failResponse(call, StandardErrorCode.PUSH_NOT_FILE_TYPE.toErrorCode())
+                    return@let
                 }
-                logger.debug { "sync handler ($appInstanceId) receive pasteData: $pasteData" }
+
+                val prepared = pasteReleaseService.releaseRemotePasteDataForPush(pasteData)
+                if (prepared == null) {
+                    failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
+                    return@let
+                }
+
+                val session =
+                    pushSessionManager.create(
+                        pasteId = prepared.pasteId,
+                        fromAppInstanceId = appInstanceId,
+                        filesIndex = prepared.filesIndex,
+                    )
+                if (session == null) {
+                    logger.warn { "push sync: rejected pasteId=${prepared.pasteId} (capacity)" }
+                    failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
+                    return@let
+                }
+
+                pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
                 appControl.completeReceiveOperation()
-            }.onSuccess {
-                successResponse(call)
-            }.onFailure { e ->
-                logger.error(e) { "sync handler ($appInstanceId) receive pasteData error" }
-                if (e is PasteException && e.match(StandardErrorCode.DECRYPT_FAIL)) {
-                    failResponse(call, StandardErrorCode.DECRYPT_FAIL.toErrorCode())
-                } else {
-                    failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
+                logger.debug {
+                    "sync handler ($appInstanceId) push prepare ok: pasteId=${prepared.pasteId} " +
+                        "chunkCount=${prepared.chunkCount}"
                 }
+                successResponse(
+                    call,
+                    PushPrepareResponse(
+                        pasteId = prepared.pasteId,
+                        chunkCount = prepared.chunkCount,
+                        chunkSize = prepared.chunkSize,
+                        sessionToken = session.token,
+                        needIcon = prepared.needIcon,
+                    ),
+                )
+                return@let
             }
+
+            pasteRoutingScope.launch {
+                pasteboardService
+                    .tryWriteRemotePasteboard(pasteData)
+                    .onSuccess {
+                        pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
+                    }
+            }
+            logger.debug { "sync handler ($appInstanceId) receive pasteData: $pasteData" }
+            appControl.completeReceiveOperation()
+            successResponse(call)
         }
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
@@ -9,6 +9,8 @@ import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
 import com.crosspaste.utils.getFileUtils
+import com.crosspaste.utils.requireSyncHandler
+import com.crosspaste.utils.requireTargetAppInstance
 import com.crosspaste.utils.successResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.request.*
@@ -28,20 +30,10 @@ fun Routing.pullRouting(
 
     post("/pull/file") {
         getAppInstanceId(call)?.let { fromAppInstanceId ->
-            val targetAppInstanceId = call.request.headers["targetAppInstanceId"]
-            if (targetAppInstanceId != appInfo.appInstanceId) {
-                logger.debug { "pull file targetAppInstanceId $targetAppInstanceId not match ${appInfo.appInstanceId}" }
-                failResponse(call, StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID.toErrorCode())
-                return@let
-            }
+            if (!requireTargetAppInstance(call, appInfo)) return@let
             val pullFileRequest: PullFileRequest = call.receive()
 
-            val syncHandler =
-                syncRoutingApi.getSyncHandler(fromAppInstanceId) ?: run {
-                    logger.error { "not found appInstance id: $fromAppInstanceId" }
-                    failResponse(call, StandardErrorCode.NOT_FOUND_APP_INSTANCE_ID.toErrorCode())
-                    return@let
-                }
+            val syncHandler = requireSyncHandler(call, syncRoutingApi, fromAppInstanceId) ?: return@let
 
             if (!syncHandler.currentSyncRuntimeInfo.allowSend) {
                 logger.debug { "sync handler ($fromAppInstanceId) not allow send" }
@@ -51,7 +43,7 @@ fun Routing.pullRouting(
 
             val filesIndex =
                 cacheManager.getFilesIndex(pullFileRequest.id) ?: run {
-                    logger.error { "$fromAppInstanceId get $targetAppInstanceId filesIndex not found" }
+                    logger.error { "$fromAppInstanceId get ${appInfo.appInstanceId} filesIndex not found" }
                     failResponse(call, StandardErrorCode.NOT_FOUND_FILES_INDEX.toErrorCode())
                     return@let
                 }
@@ -59,7 +51,7 @@ fun Routing.pullRouting(
             val chunk =
                 filesIndex.getChunk(pullFileRequest.chunkIndex) ?: run {
                     logger.error {
-                        "$fromAppInstanceId get $targetAppInstanceId chunk out range: " +
+                        "$fromAppInstanceId get ${appInfo.appInstanceId} chunk out range: " +
                             "${pullFileRequest.chunkIndex}"
                     }
                     failResponse(
@@ -109,21 +101,9 @@ fun Routing.pullRouting(
 
     get("/pull/pasteBatch") {
         getAppInstanceId(call)?.let { fromAppInstanceId ->
-            val targetAppInstanceId = call.request.headers["targetAppInstanceId"]
-            if (targetAppInstanceId != appInfo.appInstanceId) {
-                logger.debug {
-                    "pull pasteBatch targetAppInstanceId $targetAppInstanceId not match ${appInfo.appInstanceId}"
-                }
-                failResponse(call, StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID.toErrorCode())
-                return@let
-            }
+            if (!requireTargetAppInstance(call, appInfo)) return@let
 
-            val syncHandler =
-                syncRoutingApi.getSyncHandler(fromAppInstanceId) ?: run {
-                    logger.error { "not found appInstance id: $fromAppInstanceId" }
-                    failResponse(call, StandardErrorCode.NOT_FOUND_APP_INSTANCE_ID.toErrorCode())
-                    return@let
-                }
+            val syncHandler = requireSyncHandler(call, syncRoutingApi, fromAppInstanceId) ?: return@let
 
             if (!syncHandler.currentSyncRuntimeInfo.allowSend) {
                 logger.debug { "sync handler ($fromAppInstanceId) not allow send" }
@@ -148,21 +128,9 @@ fun Routing.pullRouting(
 
     get("/pull/paste") {
         getAppInstanceId(call)?.let { fromAppInstanceId ->
-            val targetAppInstanceId = call.request.headers["targetAppInstanceId"]
-            if (targetAppInstanceId != appInfo.appInstanceId) {
-                logger.debug {
-                    "pull paste targetAppInstanceId $targetAppInstanceId not match ${appInfo.appInstanceId}"
-                }
-                failResponse(call, StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID.toErrorCode())
-                return@let
-            }
+            if (!requireTargetAppInstance(call, appInfo)) return@let
 
-            val syncHandler =
-                syncRoutingApi.getSyncHandler(fromAppInstanceId) ?: run {
-                    logger.error { "not found appInstance id: $fromAppInstanceId" }
-                    failResponse(call, StandardErrorCode.NOT_FOUND_APP_INSTANCE_ID.toErrorCode())
-                    return@let
-                }
+            val syncHandler = requireSyncHandler(call, syncRoutingApi, fromAppInstanceId) ?: return@let
 
             if (!syncHandler.currentSyncRuntimeInfo.allowSend) {
                 logger.debug { "sync handler ($fromAppInstanceId) not allow send" }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
@@ -1,0 +1,186 @@
+package com.crosspaste.net.routing
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.dto.push.PushCompleteResponse
+import com.crosspaste.dto.push.PushHeaders
+import com.crosspaste.exception.StandardErrorCode
+import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.sync.PushSession
+import com.crosspaste.sync.PushSessionManager
+import com.crosspaste.utils.failResponse
+import com.crosspaste.utils.getAppInstanceId
+import com.crosspaste.utils.getFileUtils
+import com.crosspaste.utils.requireSyncHandler
+import com.crosspaste.utils.requireTargetAppInstance
+import com.crosspaste.utils.successResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.request.*
+import io.ktor.server.routing.*
+import io.ktor.utils.io.*
+
+fun Routing.pushRouting(
+    appInfo: AppInfo,
+    pushSessionManager: PushSessionManager,
+    syncRoutingApi: SyncRoutingApi,
+    userDataPathProvider: UserDataPathProvider,
+) {
+    val logger = KotlinLogging.logger {}
+    val fileUtils = getFileUtils()
+
+    // Permission gating policy: /sync/paste (push mode) is the only place where
+    // we check `appControl.isReceiveEnabled` + `syncHandler.allowReceive`. Once
+    // a PushSession exists, subsequent chunk uploads and /complete trust the
+    // session token — toggling permissions mid-session does NOT tear down
+    // in-flight work. Sender already knows the answer from the prepare response.
+    // SyncHandler lookup is kept as a peer-existence sanity check (cheap),
+    // its allowReceive flag is intentionally not consulted here.
+    post("/sync/file/push") {
+        val fromAppInstanceId = getAppInstanceId(call) ?: return@post
+        if (!requireTargetAppInstance(call, appInfo)) return@post
+        requireSyncHandler(call, syncRoutingApi, fromAppInstanceId) ?: return@post
+
+        val pasteId = call.request.headers[PushHeaders.PASTE_ID]?.toLongOrNull()
+        val chunkIndex = call.request.headers[PushHeaders.CHUNK_INDEX]?.toIntOrNull()
+        val token = call.request.headers[PushHeaders.SESSION_TOKEN]
+        if (pasteId == null || chunkIndex == null || token == null) {
+            failResponse(call, StandardErrorCode.INVALID_PARAMETER.toErrorCode())
+            return@post
+        }
+
+        val session = pushSessionManager.get(pasteId, token, fromAppInstanceId)
+        if (session == null) {
+            logger.debug { "push chunk: session not found pasteId=$pasteId from=$fromAppInstanceId" }
+            failResponse(call, StandardErrorCode.NOT_FOUND_PUSH_SESSION.toErrorCode())
+            return@post
+        }
+
+        if (chunkIndex !in 0 until session.chunkCount) {
+            failResponse(
+                call,
+                StandardErrorCode.OUT_RANGE_CHUNK_INDEX.toErrorCode(),
+                "chunk index $chunkIndex out of range (chunkCount=${session.chunkCount})",
+            )
+            return@post
+        }
+
+        // Fast-path idempotency: drain the body and ack without writing.
+        if (session.isReceived(chunkIndex)) {
+            call.receiveChannel().discard()
+            successResponse(call)
+            return@post
+        }
+
+        val filesChunk =
+            session.filesIndex.getChunk(chunkIndex) ?: run {
+                failResponse(
+                    call,
+                    StandardErrorCode.OUT_RANGE_CHUNK_INDEX.toErrorCode(),
+                    "chunk index $chunkIndex out of range in filesIndex",
+                )
+                return@post
+            }
+
+        runCatching {
+            fileUtils.writeFilesChunk(filesChunk, call.receiveChannel())
+        }.onFailure { e ->
+            logger.error(e) { "push chunk: write failed pasteId=$pasteId chunkIndex=$chunkIndex" }
+            failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
+            return@post
+        }
+
+        val markResult = session.markReceived(chunkIndex)
+        if (markResult == PushSession.MarkResult.Accepted) {
+            // Auto-finalize the moment the last chunk lands — don't wait for
+            // /complete (the client may never send it, e.g. Share Extension
+            // crash) or for the sweep poll (90s of latency).
+            pushSessionManager.tryFinalizeIfComplete(pasteId)
+        }
+        when (markResult) {
+            PushSession.MarkResult.Accepted,
+            PushSession.MarkResult.AlreadyReceived,
+            -> successResponse(call)
+
+            PushSession.MarkResult.OutOfRange ->
+                failResponse(
+                    call,
+                    StandardErrorCode.OUT_RANGE_CHUNK_INDEX.toErrorCode(),
+                    "chunk index $chunkIndex out of range",
+                )
+        }
+    }
+
+    post("/sync/paste/push/complete") {
+        val fromAppInstanceId = getAppInstanceId(call) ?: return@post
+        if (!requireTargetAppInstance(call, appInfo)) return@post
+
+        val pasteId = call.request.headers[PushHeaders.PASTE_ID]?.toLongOrNull()
+        val token = call.request.headers[PushHeaders.SESSION_TOKEN]
+        if (pasteId == null || token == null) {
+            failResponse(call, StandardErrorCode.INVALID_PARAMETER.toErrorCode())
+            return@post
+        }
+
+        val session = pushSessionManager.get(pasteId, token, fromAppInstanceId)
+        if (session == null) {
+            // Session is gone — almost always because auto-finalize on the last
+            // chunk already ran. Return success so the client doesn't retry.
+            // Wrong pasteId/token leaks nothing exploitable (the peer is already
+            // authenticated via secureStore; pasteIds are not secret).
+            logger.debug { "push complete: pasteId=$pasteId session absent (likely auto-finalized)" }
+            successResponse(call, PushCompleteResponse(emptyList()))
+            return@post
+        }
+
+        val missing = session.missingChunks()
+        if (missing.isNotEmpty()) {
+            logger.debug {
+                "push complete: pasteId=$pasteId missing ${missing.size}/${session.chunkCount} chunks"
+            }
+            successResponse(call, PushCompleteResponse(missing))
+            return@post
+        }
+
+        // Defensive: auto-finalize should have caught this already, but races
+        // happen. tryFinalize is idempotent — returns false if someone got here first.
+        if (pushSessionManager.tryFinalize(pasteId)) {
+            logger.info { "push complete: pasteId=$pasteId finalized via /complete" }
+        } else {
+            logger.info { "push complete: pasteId=$pasteId already finalized" }
+        }
+        successResponse(call, PushCompleteResponse(emptyList()))
+    }
+
+    post("/sync/icon/push/{source}") {
+        val fromAppInstanceId = getAppInstanceId(call) ?: return@post
+        if (!requireTargetAppInstance(call, appInfo)) return@post
+        // Same meta-only permission gating as /sync/file/push: icons are a
+        // continuation of an already-authorized push, no re-check of allowReceive.
+        requireSyncHandler(call, syncRoutingApi, fromAppInstanceId) ?: return@post
+
+        val source =
+            call.parameters["source"] ?: run {
+                failResponse(call, StandardErrorCode.NOT_FOUND_SOURCE.toErrorCode())
+                return@post
+            }
+
+        val iconPath =
+            runCatching {
+                userDataPathProvider.resolveIconPath(fromAppInstanceId, source)
+            }.getOrElse {
+                logger.warn { "push icon: invalid source from=$fromAppInstanceId source=$source" }
+                failResponse(call, StandardErrorCode.NOT_FOUND_SOURCE.toErrorCode())
+                return@post
+            }
+
+        runCatching {
+            fileUtils.writeFile(iconPath, call.receiveChannel())
+        }.onFailure { e ->
+            logger.error(e) { "push icon: write failed source=$source from=$fromAppInstanceId" }
+            failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
+            return@post
+        }
+
+        logger.info { "push icon: stored source=$source from=$fromAppInstanceId" }
+        successResponse(call)
+    }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
@@ -7,180 +7,233 @@ import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.sync.PushSession
 import com.crosspaste.sync.PushSessionManager
+import com.crosspaste.utils.FileUtils
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.requireSyncHandler
 import com.crosspaste.utils.requireTargetAppInstance
 import com.crosspaste.utils.successResponse
+import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
 import io.ktor.utils.io.*
 
+private val logger: KLogger = KotlinLogging.logger("PushRouting")
+private val fileUtils: FileUtils = getFileUtils()
+
+/**
+ * Permission gating policy: /sync/paste (push mode) is the only place where
+ * we check `appControl.isReceiveEnabled` + `syncHandler.allowReceive`. Once
+ * a PushSession exists, subsequent chunk uploads and /complete trust the
+ * session token — toggling permissions mid-session does NOT tear down
+ * in-flight work. Sender already knows the answer from the prepare response.
+ * SyncHandler lookup is kept as a peer-existence sanity check (cheap),
+ * its allowReceive flag is intentionally not consulted here.
+ */
 fun Routing.pushRouting(
     appInfo: AppInfo,
     pushSessionManager: PushSessionManager,
     syncRoutingApi: SyncRoutingApi,
     userDataPathProvider: UserDataPathProvider,
 ) {
-    val logger = KotlinLogging.logger {}
-    val fileUtils = getFileUtils()
-
-    // Permission gating policy: /sync/paste (push mode) is the only place where
-    // we check `appControl.isReceiveEnabled` + `syncHandler.allowReceive`. Once
-    // a PushSession exists, subsequent chunk uploads and /complete trust the
-    // session token — toggling permissions mid-session does NOT tear down
-    // in-flight work. Sender already knows the answer from the prepare response.
-    // SyncHandler lookup is kept as a peer-existence sanity check (cheap),
-    // its allowReceive flag is intentionally not consulted here.
     post("/sync/file/push") {
-        val fromAppInstanceId = getAppInstanceId(call) ?: return@post
-        if (!requireTargetAppInstance(call, appInfo)) return@post
-        requireSyncHandler(call, syncRoutingApi, fromAppInstanceId) ?: return@post
+        handleFilePushChunk(call, appInfo, pushSessionManager, syncRoutingApi)
+    }
+    post("/sync/paste/push/complete") {
+        handleCompletePush(call, appInfo, pushSessionManager)
+    }
+    post("/sync/icon/push/{source}") {
+        handleIconPush(call, appInfo, syncRoutingApi, userDataPathProvider)
+    }
+}
 
-        val pasteId = call.request.headers[PushHeaders.PASTE_ID]?.toLongOrNull()
-        val chunkIndex = call.request.headers[PushHeaders.CHUNK_INDEX]?.toIntOrNull()
-        val token = call.request.headers[PushHeaders.SESSION_TOKEN]
-        if (pasteId == null || chunkIndex == null || token == null) {
-            failResponse(call, StandardErrorCode.INVALID_PARAMETER.toErrorCode())
-            return@post
-        }
+private data class PushChunkHeaders(
+    val pasteId: Long,
+    val chunkIndex: Int,
+    val token: String,
+)
 
-        val session = pushSessionManager.get(pasteId, token, fromAppInstanceId)
-        if (session == null) {
-            logger.debug { "push chunk: session not found pasteId=$pasteId from=$fromAppInstanceId" }
-            failResponse(call, StandardErrorCode.NOT_FOUND_PUSH_SESSION.toErrorCode())
-            return@post
-        }
+private suspend fun parsePushChunkHeaders(call: ApplicationCall): PushChunkHeaders? {
+    val pasteId = call.request.headers[PushHeaders.PASTE_ID]?.toLongOrNull()
+    val chunkIndex = call.request.headers[PushHeaders.CHUNK_INDEX]?.toIntOrNull()
+    val token = call.request.headers[PushHeaders.SESSION_TOKEN]
+    if (pasteId == null || chunkIndex == null || token == null) {
+        failResponse(call, StandardErrorCode.INVALID_PARAMETER.toErrorCode())
+        return null
+    }
+    return PushChunkHeaders(pasteId, chunkIndex, token)
+}
 
-        if (chunkIndex !in 0 until session.chunkCount) {
+private suspend fun handleFilePushChunk(
+    call: ApplicationCall,
+    appInfo: AppInfo,
+    pushSessionManager: PushSessionManager,
+    syncRoutingApi: SyncRoutingApi,
+) {
+    val fromAppInstanceId = getAppInstanceId(call) ?: return
+    if (!requireTargetAppInstance(call, appInfo)) return
+    requireSyncHandler(call, syncRoutingApi, fromAppInstanceId) ?: return
+
+    val headers = parsePushChunkHeaders(call) ?: return
+
+    val session = pushSessionManager.get(headers.pasteId, headers.token, fromAppInstanceId)
+    if (session == null) {
+        logger.debug { "push chunk: session not found pasteId=${headers.pasteId} from=$fromAppInstanceId" }
+        failResponse(call, StandardErrorCode.NOT_FOUND_PUSH_SESSION.toErrorCode())
+        return
+    }
+
+    if (headers.chunkIndex !in 0 until session.chunkCount) {
+        failResponse(
+            call,
+            StandardErrorCode.OUT_RANGE_CHUNK_INDEX.toErrorCode(),
+            "chunk index ${headers.chunkIndex} out of range (chunkCount=${session.chunkCount})",
+        )
+        return
+    }
+
+    // Fast-path idempotency: drain the body and ack without writing.
+    if (session.isReceived(headers.chunkIndex)) {
+        call.receiveChannel().discard()
+        successResponse(call)
+        return
+    }
+
+    val filesChunk =
+        session.filesIndex.getChunk(headers.chunkIndex) ?: run {
             failResponse(
                 call,
                 StandardErrorCode.OUT_RANGE_CHUNK_INDEX.toErrorCode(),
-                "chunk index $chunkIndex out of range (chunkCount=${session.chunkCount})",
+                "chunk index ${headers.chunkIndex} out of range in filesIndex",
             )
-            return@post
+            return
         }
 
-        // Fast-path idempotency: drain the body and ack without writing.
-        if (session.isReceived(chunkIndex)) {
-            call.receiveChannel().discard()
-            successResponse(call)
-            return@post
-        }
-
-        val filesChunk =
-            session.filesIndex.getChunk(chunkIndex) ?: run {
-                failResponse(
-                    call,
-                    StandardErrorCode.OUT_RANGE_CHUNK_INDEX.toErrorCode(),
-                    "chunk index $chunkIndex out of range in filesIndex",
-                )
-                return@post
-            }
-
+    val writeFailed =
         runCatching {
             fileUtils.writeFilesChunk(filesChunk, call.receiveChannel())
-        }.onFailure { e ->
-            logger.error(e) { "push chunk: write failed pasteId=$pasteId chunkIndex=$chunkIndex" }
-            failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
-            return@post
-        }
-
-        val markResult = session.markReceived(chunkIndex)
-        if (markResult == PushSession.MarkResult.Accepted) {
-            // Auto-finalize the moment the last chunk lands — don't wait for
-            // /complete (the client may never send it, e.g. Share Extension
-            // crash) or for the sweep poll (90s of latency).
-            pushSessionManager.tryFinalizeIfComplete(pasteId)
-        }
-        when (markResult) {
-            PushSession.MarkResult.Accepted,
-            PushSession.MarkResult.AlreadyReceived,
-            -> successResponse(call)
-
-            PushSession.MarkResult.OutOfRange ->
-                failResponse(
-                    call,
-                    StandardErrorCode.OUT_RANGE_CHUNK_INDEX.toErrorCode(),
-                    "chunk index $chunkIndex out of range",
-                )
-        }
+        }.isFailure
+    if (writeFailed) {
+        logger.error { "push chunk: write failed pasteId=${headers.pasteId} chunkIndex=${headers.chunkIndex}" }
+        failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
+        return
     }
 
-    post("/sync/paste/push/complete") {
-        val fromAppInstanceId = getAppInstanceId(call) ?: return@post
-        if (!requireTargetAppInstance(call, appInfo)) return@post
+    finishChunkPush(call, pushSessionManager, session, headers)
+}
 
-        val pasteId = call.request.headers[PushHeaders.PASTE_ID]?.toLongOrNull()
-        val token = call.request.headers[PushHeaders.SESSION_TOKEN]
-        if (pasteId == null || token == null) {
-            failResponse(call, StandardErrorCode.INVALID_PARAMETER.toErrorCode())
-            return@post
-        }
+private suspend fun finishChunkPush(
+    call: ApplicationCall,
+    pushSessionManager: PushSessionManager,
+    session: PushSession,
+    headers: PushChunkHeaders,
+) {
+    val markResult = session.markReceived(headers.chunkIndex)
+    if (markResult == PushSession.MarkResult.Accepted) {
+        // Auto-finalize the moment the last chunk lands — don't wait for
+        // /complete (the client may never send it, e.g. Share Extension
+        // crash) or for the sweep poll (90s of latency).
+        pushSessionManager.tryFinalizeIfComplete(headers.pasteId)
+    }
+    when (markResult) {
+        PushSession.MarkResult.Accepted,
+        PushSession.MarkResult.AlreadyReceived,
+        -> successResponse(call)
 
-        val session = pushSessionManager.get(pasteId, token, fromAppInstanceId)
-        if (session == null) {
-            // Session is gone — almost always because auto-finalize on the last
-            // chunk already ran. Return success so the client doesn't retry.
-            // Wrong pasteId/token leaks nothing exploitable (the peer is already
-            // authenticated via secureStore; pasteIds are not secret).
-            logger.debug { "push complete: pasteId=$pasteId session absent (likely auto-finalized)" }
-            successResponse(call, PushCompleteResponse(emptyList()))
-            return@post
-        }
+        PushSession.MarkResult.OutOfRange ->
+            failResponse(
+                call,
+                StandardErrorCode.OUT_RANGE_CHUNK_INDEX.toErrorCode(),
+                "chunk index ${headers.chunkIndex} out of range",
+            )
+    }
+}
 
-        val missing = session.missingChunks()
-        if (missing.isNotEmpty()) {
-            logger.debug {
-                "push complete: pasteId=$pasteId missing ${missing.size}/${session.chunkCount} chunks"
-            }
-            successResponse(call, PushCompleteResponse(missing))
-            return@post
-        }
+private suspend fun handleCompletePush(
+    call: ApplicationCall,
+    appInfo: AppInfo,
+    pushSessionManager: PushSessionManager,
+) {
+    val fromAppInstanceId = getAppInstanceId(call) ?: return
+    if (!requireTargetAppInstance(call, appInfo)) return
 
-        // Defensive: auto-finalize should have caught this already, but races
-        // happen. tryFinalize is idempotent — returns false if someone got here first.
-        if (pushSessionManager.tryFinalize(pasteId)) {
-            logger.info { "push complete: pasteId=$pasteId finalized via /complete" }
-        } else {
-            logger.info { "push complete: pasteId=$pasteId already finalized" }
-        }
+    val pasteId = call.request.headers[PushHeaders.PASTE_ID]?.toLongOrNull()
+    val token = call.request.headers[PushHeaders.SESSION_TOKEN]
+    if (pasteId == null || token == null) {
+        failResponse(call, StandardErrorCode.INVALID_PARAMETER.toErrorCode())
+        return
+    }
+
+    val session = pushSessionManager.get(pasteId, token, fromAppInstanceId)
+    if (session == null) {
+        // Session is gone — almost always because auto-finalize on the last
+        // chunk already ran. Return success so the client doesn't retry.
+        // Wrong pasteId/token leaks nothing exploitable (the peer is already
+        // authenticated via secureStore; pasteIds are not secret).
+        logger.debug { "push complete: pasteId=$pasteId session absent (likely auto-finalized)" }
         successResponse(call, PushCompleteResponse(emptyList()))
+        return
     }
 
-    post("/sync/icon/push/{source}") {
-        val fromAppInstanceId = getAppInstanceId(call) ?: return@post
-        if (!requireTargetAppInstance(call, appInfo)) return@post
-        // Same meta-only permission gating as /sync/file/push: icons are a
-        // continuation of an already-authorized push, no re-check of allowReceive.
-        requireSyncHandler(call, syncRoutingApi, fromAppInstanceId) ?: return@post
+    val missing = session.missingChunks()
+    if (missing.isNotEmpty()) {
+        logger.debug {
+            "push complete: pasteId=$pasteId missing ${missing.size}/${session.chunkCount} chunks"
+        }
+        successResponse(call, PushCompleteResponse(missing))
+        return
+    }
 
-        val source =
-            call.parameters["source"] ?: run {
-                failResponse(call, StandardErrorCode.NOT_FOUND_SOURCE.toErrorCode())
-                return@post
-            }
+    // Defensive: auto-finalize should have caught this already, but races
+    // happen. tryFinalize is idempotent — returns false if someone got here first.
+    if (pushSessionManager.tryFinalize(pasteId)) {
+        logger.info { "push complete: pasteId=$pasteId finalized via /complete" }
+    } else {
+        logger.info { "push complete: pasteId=$pasteId already finalized" }
+    }
+    successResponse(call, PushCompleteResponse(emptyList()))
+}
 
-        val iconPath =
-            runCatching {
-                userDataPathProvider.resolveIconPath(fromAppInstanceId, source)
-            }.getOrElse {
-                logger.warn { "push icon: invalid source from=$fromAppInstanceId source=$source" }
-                failResponse(call, StandardErrorCode.NOT_FOUND_SOURCE.toErrorCode())
-                return@post
-            }
+private suspend fun handleIconPush(
+    call: ApplicationCall,
+    appInfo: AppInfo,
+    syncRoutingApi: SyncRoutingApi,
+    userDataPathProvider: UserDataPathProvider,
+) {
+    val fromAppInstanceId = getAppInstanceId(call) ?: return
+    if (!requireTargetAppInstance(call, appInfo)) return
+    // Same meta-only permission gating as /sync/file/push: icons are a
+    // continuation of an already-authorized push, no re-check of allowReceive.
+    requireSyncHandler(call, syncRoutingApi, fromAppInstanceId) ?: return
 
+    val source =
+        call.parameters["source"] ?: run {
+            failResponse(call, StandardErrorCode.NOT_FOUND_SOURCE.toErrorCode())
+            return
+        }
+
+    val iconPath =
+        runCatching {
+            userDataPathProvider.resolveIconPath(fromAppInstanceId, source)
+        }.getOrElse {
+            logger.warn { "push icon: invalid source from=$fromAppInstanceId source=$source" }
+            failResponse(call, StandardErrorCode.NOT_FOUND_SOURCE.toErrorCode())
+            return
+        }
+
+    val writeFailed =
         runCatching {
             fileUtils.writeFile(iconPath, call.receiveChannel())
-        }.onFailure { e ->
-            logger.error(e) { "push icon: write failed source=$source from=$fromAppInstanceId" }
-            failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
-            return@post
-        }
-
-        logger.info { "push icon: stored source=$source from=$fromAppInstanceId" }
-        successResponse(call)
+        }.isFailure
+    if (writeFailed) {
+        logger.error { "push icon: write failed source=$source from=$fromAppInstanceId" }
+        failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
+        return
     }
+
+    logger.info { "push icon: stored source=$source from=$fromAppInstanceId" }
+    successResponse(call)
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/CacheManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/CacheManager.kt
@@ -1,16 +1,12 @@
 package com.crosspaste.paste
 
 import com.crosspaste.db.paste.PasteDao
-import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FilesIndex
-import com.crosspaste.presist.FilesIndexBuilder
+import com.crosspaste.presist.buildFilesIndex
 import com.crosspaste.sync.FilePullService
-import com.crosspaste.utils.DateUtils
 
 interface CacheManager {
-
-    val dateUtils: DateUtils
 
     val pasteDao: PasteDao
 
@@ -20,25 +16,6 @@ interface CacheManager {
 
     fun loadKey(id: Long): FilesIndex? =
         pasteDao.getLoadedPasteDataBlock(id)?.let { pasteData ->
-            val dateString =
-                dateUtils.getYMD(
-                    dateUtils.epochMillisecondsToLocalDateTime(pasteData.createTime),
-                )
-            val filesIndexBuilder = FilesIndexBuilder(FilePullService.CHUNK_SIZE)
-            val fileItems = pasteData.getPasteAppearItems().filter { it is PasteFiles }
-            val pasteDataId = pasteData.id
-            val appInstanceId = pasteData.appInstanceId
-            for (pasteAppearItem in fileItems) {
-                val pasteFiles = pasteAppearItem as PasteFiles
-                userDataPathProvider.resolve(
-                    appInstanceId,
-                    dateString,
-                    pasteDataId,
-                    pasteFiles,
-                    false,
-                    filesIndexBuilder,
-                )
-            }
-            filesIndexBuilder.build()
+            buildFilesIndex(pasteData, userDataPathProvider, FilePullService.CHUNK_SIZE)
         }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -10,6 +10,9 @@ import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.paste.item.bindItem
 import com.crosspaste.paste.plugin.process.PasteProcessPlugin
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.presist.FilesIndex
+import com.crosspaste.presist.buildFilesIndex
+import com.crosspaste.sync.FilePullService
 import com.crosspaste.task.TaskBuilder
 import com.crosspaste.task.TaskSubmitter
 import com.crosspaste.utils.getFileUtils
@@ -19,6 +22,15 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.time.ExperimentalTime
+
+data class PushPrepareResult(
+    val pasteId: Long,
+    val filesIndex: FilesIndex,
+    val needIcon: Boolean,
+    val chunkSize: Long = FilePullService.CHUNK_SIZE,
+) {
+    val chunkCount: Int get() = filesIndex.getChunkCount()
+}
 
 class PasteReleaseService(
     private val commonConfigManager: CommonConfigManager,
@@ -138,6 +150,50 @@ class PasteReleaseService(
         }
     }
 
+    /**
+     * Shared file-paste landing pad for both directions of remote receive:
+     * pull ([releaseRemotePasteData]) and push ([releaseRemotePasteDataForPush]).
+     *
+     * Creates the LOADING row, computes `syncToDownload`, rebinds the items to the
+     * new PasteCoordinate, and writes the storage paths. Returns the bound
+     * PasteData (with the freshly-assigned id) or null when the input has no
+     * [PasteFiles] item — defensive guard, file-type pastes should always carry one.
+     */
+    private suspend fun bindFilePasteForReceive(pasteData: PasteData): PasteData? {
+        val pasteFiles = pasteData.getPasteItem(PasteFiles::class) ?: return null
+
+        val id = pasteDao.createPasteData(pasteData, PasteState.LOADING)
+
+        val fileSize = pasteFiles.size
+        val maxBackupFileSize =
+            fileUtils.bytesSize(
+                commonConfigManager.getCurrentConfig().maxBackupFileSize,
+            )
+
+        val syncToDownload =
+            fileSize > maxBackupFileSize ||
+                pasteData.pasteAppearItem
+                    ?.extraInfo
+                    ?.get(PasteItemProperties.SYNC_TO_DOWNLOAD)
+                    ?.jsonPrimitive
+                    ?.booleanOrNull == true
+
+        val pasteCoordinate = pasteData.getPasteCoordinate(id)
+        val newPasteAppearItem =
+            pasteData.pasteAppearItem?.bindItem(pasteCoordinate, syncToDownload)
+        val newPasteCollection =
+            pasteData.pasteCollection.bindItems(pasteCoordinate, syncToDownload)
+        val newPasteData =
+            pasteData.copy(
+                id = id,
+                pasteAppearItem = newPasteAppearItem,
+                pasteCollection = newPasteCollection,
+            )
+
+        pasteDao.updateFilePath(newPasteData)
+        return newPasteData
+    }
+
     suspend fun releaseRemotePasteData(
         pasteData: PasteData,
         tryWritePasteboard: (PasteData) -> Unit,
@@ -150,61 +206,26 @@ class PasteReleaseService(
                     fileUtils.existFile(userDataPathProvider.resolveIconPath(pasteData.appInstanceId, it))
                 }
 
-            val pasteState =
-                if (isFileType) {
-                    PasteState.LOADING
-                } else {
-                    PasteState.LOADED
-                }
-
-            val id = pasteDao.createPasteData(pasteData, pasteState)
-
             taskSubmitter.submit {
-                if (!isFileType) {
-                    markDeleteSameHash(id, pasteData.pasteType, pasteData.hash)
-                    addRenderingTask(id, pasteData.getType())
-                    tryWritePasteboard(pasteData)
-                } else {
-                    val pasteFiles = pasteData.getPasteItem(PasteFiles::class)
-
-                    if (pasteFiles == null) {
-                        logger.warn { "File-type paste $id has no PasteFiles item, skipping" }
-                        return@submit
+                val id: Long =
+                    if (!isFileType) {
+                        val newId = pasteDao.createPasteData(pasteData, PasteState.LOADED)
+                        markDeleteSameHash(newId, pasteData.pasteType, pasteData.hash)
+                        addRenderingTask(newId, pasteData.getType())
+                        tryWritePasteboard(pasteData)
+                        newId
+                    } else {
+                        val newPasteData =
+                            bindFilePasteForReceive(pasteData) ?: run {
+                                logger.warn {
+                                    "File-type paste from ${pasteData.appInstanceId} has no PasteFiles item, skipping"
+                                }
+                                return@submit
+                            }
+                        addPullFileTask(newPasteData.id, remotePasteDataId)
+                        addRelaySyncTask(newPasteData.id, newPasteData.appInstanceId)
+                        newPasteData.id
                     }
-
-                    val fileSize = pasteFiles.size
-                    val maxBackupFileSize =
-                        fileUtils.bytesSize(
-                            commonConfigManager.getCurrentConfig().maxBackupFileSize,
-                        )
-
-                    val syncToDownload =
-                        fileSize > maxBackupFileSize ||
-                            pasteData.pasteAppearItem
-                                ?.extraInfo
-                                ?.get(PasteItemProperties.SYNC_TO_DOWNLOAD)
-                                ?.jsonPrimitive
-                                ?.booleanOrNull == true
-
-                    val pasteCoordinate = pasteData.getPasteCoordinate(id)
-                    val pasteAppearItem = pasteData.pasteAppearItem
-                    val pasteCollection = pasteData.pasteCollection
-
-                    val newPasteAppearItem = pasteAppearItem?.bindItem(pasteCoordinate, syncToDownload)
-                    val newPasteCollection = pasteCollection.bindItems(pasteCoordinate, syncToDownload)
-
-                    val newPasteData =
-                        pasteData.copy(
-                            id = id,
-                            pasteAppearItem = newPasteAppearItem,
-                            pasteCollection = newPasteCollection,
-                        )
-
-                    pasteDao.updateFilePath(newPasteData)
-
-                    addPullFileTask(id, remotePasteDataId)
-                    addRelaySyncTask(id, newPasteData.appInstanceId)
-                }
 
                 existIconFile?.let {
                     addPullIconTask(id, it)
@@ -235,5 +256,58 @@ class PasteReleaseService(
             }.onFailure { e ->
                 logger.error(e) { "Release remote paste data with file failed" }
             }
+        }
+
+    /**
+     * Push-mode counterpart of [releaseRemotePasteData] for file-type pastes.
+     *
+     * Synchronously creates a LOADING PasteData, binds destination paths and builds
+     * the FilesIndex describing the slots that incoming chunk uploads will fill. The
+     * caller is expected to attach the FilesIndex to a push session so chunk lookups
+     * go through the session. Side effects mirror the file-type branch of
+     * [releaseRemotePasteData]: a relay-sync task is scheduled so other peers will
+     * eventually receive the paste, and a pull-icon task is queued when the source
+     * app icon isn't already cached locally. Returns null when the paste is not a
+     * file type or storage binding fails — callers should treat that as a rejection.
+     */
+    suspend fun releaseRemotePasteDataForPush(pasteData: PasteData): PushPrepareResult? =
+        withContext(ioDispatcher) {
+            if (!pasteData.isFileType()) {
+                logger.warn { "releaseRemotePasteDataForPush: paste is not a file type (${pasteData.getType()})" }
+                return@withContext null
+            }
+            runCatching {
+                val existIconFile: Boolean? =
+                    pasteData.source?.let {
+                        fileUtils.existFile(userDataPathProvider.resolveIconPath(pasteData.appInstanceId, it))
+                    }
+
+                val newPasteData =
+                    bindFilePasteForReceive(pasteData) ?: run {
+                        logger.warn { "releaseRemotePasteDataForPush: paste has no PasteFiles item" }
+                        return@runCatching null
+                    }
+                val id = newPasteData.id
+
+                val filesIndex = buildFilesIndex(newPasteData, userDataPathProvider, FilePullService.CHUNK_SIZE)
+                if (filesIndex.getChunkCount() <= 0) {
+                    logger.warn { "releaseRemotePasteDataForPush: empty filesIndex for pasteId=$id" }
+                    pasteDao.markDeletePasteData(id)
+                    return@runCatching null
+                }
+
+                taskSubmitter.submit {
+                    addRelaySyncTask(id, newPasteData.appInstanceId)
+                    existIconFile?.let { addPullIconTask(id, it) }
+                }
+
+                PushPrepareResult(
+                    pasteId = id,
+                    filesIndex = filesIndex,
+                    needIcon = existIconFile == false,
+                )
+            }.onFailure { e ->
+                logger.error(e) { "releaseRemotePasteDataForPush failed" }
+            }.getOrNull()
         }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteboardService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteboardService.kt
@@ -53,5 +53,5 @@ interface PasteboardService : PasteboardMonitor {
 
     suspend fun tryWriteRemotePasteboardList(pasteDataList: List<PasteData>): Result<Unit?>
 
-    suspend fun tryWriteRemotePasteboardWithFile(pasteData: PasteData): Result<Unit?>
+    suspend fun tryWriteRemotePasteboardWithFile(pasteId: Long): Result<Unit?>
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
@@ -1,0 +1,221 @@
+package com.crosspaste.sync
+
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.PasteboardService
+import com.crosspaste.presist.FilesIndex
+import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
+import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.util.collections.ConcurrentMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Concurrency model: writes (markReceived) go through [lock] so the
+ * "check-then-set" on `received[i]` and the count increment stay paired.
+ * Reads ([isReceived], [missingChunks], [receivedCount], [isComplete],
+ * [lastActivity]) are lockless on purpose — they may observe a slightly stale
+ * value while a concurrent markReceived is in flight. The acceptable failure
+ * modes are:
+ *   - chunk fast-path idempotency may miss a just-set bit → second write of the
+ *     same chunk to the same offset (same bytes, harmless redundancy);
+ *   - sweep may see isComplete=false right after the last chunk lands → session
+ *     gets discarded a sweep cycle later than the optimal moment.
+ * The win is no contention between the chunk hot path and sweep / status reads.
+ */
+class PushSession(
+    val pasteId: Long,
+    val fromAppInstanceId: String,
+    val token: String,
+    val filesIndex: FilesIndex,
+    createdAt: Long,
+) {
+    val chunkCount: Int = filesIndex.getChunkCount()
+    private val received: BooleanArray = BooleanArray(chunkCount)
+
+    // Mutated only inside `lock`. Read without lock — staleness tolerated, see class kdoc.
+    @Volatile private var receivedCountBacking: Int = 0
+
+    @Volatile private var lastActivityBacking: Long = createdAt
+    private val lock = Mutex()
+
+    val receivedCount: Int get() = receivedCountBacking
+    val lastActivity: Long get() = lastActivityBacking
+    val isComplete: Boolean get() = receivedCountBacking >= chunkCount
+
+    suspend fun markReceived(chunkIndex: Int): MarkResult {
+        if (chunkIndex !in 0 until chunkCount) {
+            return MarkResult.OutOfRange
+        }
+        lock.withLock {
+            if (received[chunkIndex]) {
+                lastActivityBacking = nowEpochMilliseconds()
+                return MarkResult.AlreadyReceived
+            }
+            received[chunkIndex] = true
+            receivedCountBacking += 1
+            lastActivityBacking = nowEpochMilliseconds()
+            return MarkResult.Accepted
+        }
+    }
+
+    // Lockless read — may briefly miss a just-set bit; second write is harmless (same bytes).
+    fun isReceived(chunkIndex: Int): Boolean = chunkIndex in 0 until chunkCount && received[chunkIndex]
+
+    // Lockless read — snapshot may include a chunk that's about to be marked received.
+    fun missingChunks(): List<Int> = (0 until chunkCount).filter { !received[it] }
+
+    enum class MarkResult {
+        Accepted,
+        AlreadyReceived,
+        OutOfRange,
+    }
+}
+
+class PushSessionManager(
+    private val pasteDao: PasteDao,
+    private val pasteboardService: PasteboardService,
+    private val maxActive: Int = DEFAULT_MAX_ACTIVE,
+    private val sessionTtl: Duration = DEFAULT_SESSION_TTL,
+    private val sweepInterval: Duration = DEFAULT_SWEEP_INTERVAL,
+    private val scope: CoroutineScope = namedScope(ioDispatcher, "PushSessionManager"),
+) {
+
+    companion object {
+        const val DEFAULT_MAX_ACTIVE: Int = 16
+        val DEFAULT_SESSION_TTL: Duration = 90.seconds
+        val DEFAULT_SWEEP_INTERVAL: Duration = 15.seconds
+    }
+
+    private val logger = KotlinLogging.logger {}
+
+    private val sessions = ConcurrentMap<Long, PushSession>()
+
+    init {
+        scope.launch {
+            while (isActive) {
+                delay(sweepInterval)
+                sweepExpired()
+            }
+        }
+    }
+
+    fun activeCount(): Int = sessions.size
+
+    @OptIn(ExperimentalUuidApi::class)
+    fun create(
+        pasteId: Long,
+        fromAppInstanceId: String,
+        filesIndex: FilesIndex,
+    ): PushSession? {
+        if (filesIndex.getChunkCount() <= 0) {
+            logger.warn { "PushSession create rejected: empty filesIndex for pasteId=$pasteId" }
+            return null
+        }
+        if (sessions.size >= maxActive) {
+            logger.warn { "PushSession create rejected: maxActive=$maxActive reached" }
+            return null
+        }
+        val session =
+            PushSession(
+                pasteId = pasteId,
+                fromAppInstanceId = fromAppInstanceId,
+                token = Uuid.random().toString(),
+                filesIndex = filesIndex,
+                createdAt = nowEpochMilliseconds(),
+            )
+        sessions[pasteId] = session
+        return session
+    }
+
+    fun get(
+        pasteId: Long,
+        token: String,
+        fromAppInstanceId: String,
+    ): PushSession? = sessions[pasteId]?.takeIf { it.token == token && it.fromAppInstanceId == fromAppInstanceId }
+
+    fun peek(pasteId: Long): PushSession? = sessions[pasteId]
+
+    /**
+     * Atomically claims and finalizes the session. Returns true when this caller
+     * owned the claim — caller can treat the finalize as scheduled. Returns
+     * false when the session is already gone (auto-finalize on last chunk, a
+     * concurrent /complete, or sweep). Idempotent across paths.
+     *
+     * Finalize is fire-and-forget on the manager's [scope]: file state flips
+     * LOADING → LOADED and a write to the local pasteboard is queued.
+     */
+    fun tryFinalize(pasteId: Long): Boolean {
+        if (sessions.remove(pasteId) == null) return false
+        scope.launch {
+            runCatching {
+                pasteboardService.tryWriteRemotePasteboardWithFile(pasteId)
+            }.onFailure { e ->
+                logger.warn(e) { "PushSession finalize failed: pasteId=$pasteId" }
+            }
+        }
+        return true
+    }
+
+    /**
+     * Primary finalization trigger — called by the chunk handler right after
+     * [PushSession.markReceived]. When the chunk just landed completes the set,
+     * the file is ready for the pasteboard NOW, not 90s later when sweep runs.
+     */
+    fun tryFinalizeIfComplete(pasteId: Long): Boolean {
+        val session = sessions[pasteId] ?: return false
+        if (!session.isComplete) return false
+        return tryFinalize(pasteId)
+    }
+
+    /**
+     * Visible for testing. Last-resort cleanup for sessions that timed out.
+     * The orphan-complete branch (all chunks arrived but no finalize ran) is a
+     * safety net — [tryFinalizeIfComplete] normally handles it the moment the
+     * last chunk arrives. Sweep only catches it if that path failed (e.g.
+     * scope cancelled during shutdown, finalize launch dropped).
+     */
+    suspend fun sweepExpired() {
+        val now = nowEpochMilliseconds()
+        val ttlMs = sessionTtl.inWholeMilliseconds
+        val expiredIds =
+            sessions.entries
+                .filter { (_, session) -> now - session.lastActivity > ttlMs }
+                .map { it.key }
+        for (id in expiredIds) {
+            val session = sessions[id] ?: continue
+            if (session.isComplete) {
+                if (tryFinalize(id)) {
+                    logger.info { "PushSession sweep salvaged orphan-complete: pasteId=$id" }
+                }
+            } else {
+                val removed = sessions.remove(id) ?: continue
+                runCatching {
+                    pasteDao.markDeletePasteData(id)
+                }.onFailure { e ->
+                    logger.warn(e) { "PushSession expire: markDeletePasteData($id) failed" }
+                }
+                logger.info {
+                    "PushSession expired and discarded: pasteId=$id " +
+                        "(${removed.receivedCount}/${removed.chunkCount} chunks received)"
+                }
+            }
+        }
+    }
+
+    fun close() {
+        scope.cancel()
+        sessions.clear()
+    }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/PullFileTaskExecutor.kt
@@ -112,7 +112,7 @@ class PullFileTaskExecutor(
                     val updatedPasteData = applyRenameMapToPasteData(pasteData, result.renameMap)
                     pasteDao.updateFilePath(updatedPasteData)
                 }
-                pasteboardService.tryWriteRemotePasteboardWithFile(pasteData)
+                pasteboardService.tryWriteRemotePasteboardWithFile(pasteData.id)
                 soundService.successSound()
                 SuccessPasteTaskResult()
             }

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/ResponseUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/ResponseUtils.kt
@@ -1,14 +1,20 @@
 package com.crosspaste.utils
 
+import com.crosspaste.app.AppInfo
 import com.crosspaste.exception.ErrorCode
 import com.crosspaste.exception.ErrorType
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.clientapi.FailResponse
+import com.crosspaste.net.routing.SyncRoutingApi
+import com.crosspaste.sync.SyncHandler
 import io.ktor.http.*
 import io.ktor.http.ContentType.Application.OctetStream
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.utils.io.*
+
+const val HEADER_APP_INSTANCE_ID: String = "appInstanceId"
+const val HEADER_TARGET_APP_INSTANCE_ID: String = "targetAppInstanceId"
 
 suspend inline fun successResponse(call: ApplicationCall) {
     call.respond(status = HttpStatusCode.OK, message = "")
@@ -54,9 +60,42 @@ suspend inline fun failResponse(
 }
 
 suspend inline fun getAppInstanceId(call: ApplicationCall): String? {
-    val appInstanceId = call.request.headers["appInstanceId"]
+    val appInstanceId = call.request.headers[HEADER_APP_INSTANCE_ID]
     if (appInstanceId == null) {
         failResponse(call, StandardErrorCode.NOT_FOUND_APP_INSTANCE_ID.toErrorCode())
     }
     return appInstanceId
 }
+
+/**
+ * Verifies the `targetAppInstanceId` header on the inbound call matches this
+ * instance. Writes a [StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID] 4xx and
+ * returns false on mismatch.
+ */
+suspend fun requireTargetAppInstance(
+    call: ApplicationCall,
+    appInfo: AppInfo,
+): Boolean {
+    val target = call.request.headers[HEADER_TARGET_APP_INSTANCE_ID]
+    if (target != appInfo.appInstanceId) {
+        failResponse(call, StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID.toErrorCode())
+        return false
+    }
+    return true
+}
+
+/**
+ * Resolves the [SyncHandler] for [fromAppInstanceId]. Writes a
+ * [StandardErrorCode.NOT_FOUND_APP_INSTANCE_ID] 4xx and returns null when the
+ * peer is unknown (e.g. removed mid-session). Callers should consult its
+ * `allowReceive`/`allowSend` flags themselves where applicable.
+ */
+suspend fun requireSyncHandler(
+    call: ApplicationCall,
+    syncRoutingApi: SyncRoutingApi,
+    fromAppInstanceId: String,
+): SyncHandler? =
+    syncRoutingApi.getSyncHandler(fromAppInstanceId) ?: run {
+        failResponse(call, StandardErrorCode.NOT_FOUND_APP_INSTANCE_ID.toErrorCode())
+        null
+    }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -40,6 +40,7 @@ import com.crosspaste.sync.MarketingNearbyDeviceManager
 import com.crosspaste.sync.MarketingSyncManager
 import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.PendingKeyExchangeStore
+import com.crosspaste.sync.PushSessionManager
 import com.crosspaste.sync.SyncDeviceManager
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.sync.SyncResolver
@@ -77,6 +78,12 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
         single<ResourcesClient> { DesktopResourcesClient(get(), get()) }
         single<PasteBonjourService> { DesktopPasteBonjourService(get(), get(), get(), get()) }
         single<PendingKeyExchangeStore> { PendingKeyExchangeStore() }
+        single<PushSessionManager> {
+            PushSessionManager(
+                pasteDao = get(),
+                pasteboardService = get(),
+            )
+        }
         single<PasteClient> { PasteClient(get(), get(), get()) }
         single<PullClientApi> { PullClientApi(get(), get(), get()) }
         single<PasteClientApi> { PasteClientApi(get(), get()) }
@@ -138,6 +145,8 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 pasteboardService = get(),
                 pasteDao = get(),
                 pastePullService = get(),
+                pasteReleaseService = get(),
+                pushSessionManager = get(),
                 secureKeyPairSerializer = get(),
                 secureStore = get(),
                 syncApi = get(),

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessPasteboardService.kt
@@ -81,8 +81,8 @@ class HeadlessPasteboardService(
         return tryWriteRemotePasteboard(pasteDataList.last())
     }
 
-    override suspend fun tryWriteRemotePasteboardWithFile(pasteData: PasteData): Result<Unit?> =
-        pasteReleaseService.releaseRemotePasteDataWithFile(pasteData.id) {
+    override suspend fun tryWriteRemotePasteboardWithFile(pasteId: Long): Result<Unit?> =
+        pasteReleaseService.releaseRemotePasteDataWithFile(pasteId) {
             remotePasteboardChannel.trySend {
                 tryWritePasteboard(pasteData = it, localOnly = true)
             }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopServerModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopServerModule.kt
@@ -12,6 +12,7 @@ import com.crosspaste.net.routing.SyncRoutingApi
 import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.paste.CacheManager
+import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.secure.SecureKeyPairSerializer
@@ -19,6 +20,7 @@ import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.PastePullService
 import com.crosspaste.sync.PendingKeyExchangeStore
+import com.crosspaste.sync.PushSessionManager
 import io.ktor.server.application.*
 import io.ktor.server.plugins.compression.*
 
@@ -35,6 +37,8 @@ class DesktopServerModule(
     pasteboardService: PasteboardService,
     pasteDao: PasteDao,
     pastePullService: PastePullService,
+    pasteReleaseService: PasteReleaseService,
+    pushSessionManager: PushSessionManager,
     secureKeyPairSerializer: SecureKeyPairSerializer,
     secureStore: SecureStore,
     syncApi: SyncApi,
@@ -58,6 +62,8 @@ class DesktopServerModule(
         pasteboardService,
         pasteDao,
         pastePullService,
+        pasteReleaseService,
+        pushSessionManager,
         secureKeyPairSerializer,
         secureStore,
         syncApi,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/AbstractPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/AbstractPasteboardService.kt
@@ -129,8 +129,8 @@ abstract class AbstractPasteboardService :
         return tryWriteRemotePasteboard(pasteDataList.last())
     }
 
-    override suspend fun tryWriteRemotePasteboardWithFile(pasteData: PasteData): Result<Unit?> =
-        pasteReleaseService.releaseRemotePasteDataWithFile(pasteData.id) { storePasteData ->
+    override suspend fun tryWriteRemotePasteboardWithFile(pasteId: Long): Result<Unit?> =
+        pasteReleaseService.releaseRemotePasteDataWithFile(pasteId) { storePasteData ->
             remotePasteboardChannel
                 .trySend {
                     tryWritePasteboard(

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopCacheManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopCacheManager.kt
@@ -3,8 +3,6 @@ package com.crosspaste.paste
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FilesIndex
-import com.crosspaste.utils.DateUtils
-import com.crosspaste.utils.getDateUtils
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.LoadingCache
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -16,8 +14,6 @@ class DesktopCacheManager(
 ) : CacheManager {
 
     private val logger = KotlinLogging.logger {}
-
-    override val dateUtils: DateUtils = getDateUtils()
 
     private val filesIndexCache: LoadingCache<Long, FilesIndex?> =
         Caffeine

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
@@ -1,0 +1,83 @@
+package com.crosspaste.paste
+
+import com.crosspaste.Database
+import com.crosspaste.config.AppConfig
+import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.item.CreatePasteItemHelper.createFilesPasteItem
+import com.crosspaste.paste.item.PasteItemReader
+import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.task.TaskSubmitter
+import com.crosspaste.utils.getJsonUtils
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class PasteReleaseServicePushTest {
+
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    private fun newService(
+        pasteDao: PasteDao = mockk(relaxed = true),
+        commonConfigManager: CommonConfigManager = defaultConfigManager(),
+        userDataPathProvider: UserDataPathProvider = mockk(relaxed = true),
+    ): PasteReleaseService =
+        PasteReleaseService(
+            commonConfigManager = commonConfigManager,
+            currentPaste = mockk(relaxed = true),
+            database = mockk<Database>(relaxed = true),
+            pasteDao = pasteDao,
+            pasteItemReader = mockk<PasteItemReader>(relaxed = true),
+            pasteProcessPlugins = emptyList(),
+            searchContentService = mockk(relaxed = true),
+            taskSubmitter = mockk<TaskSubmitter>(relaxed = true),
+            userDataPathProvider = userDataPathProvider,
+        )
+
+    private fun defaultConfigManager(): CommonConfigManager {
+        val appConfig = mockk<AppConfig>(relaxed = true)
+        every { appConfig.maxBackupFileSize } returns 100L // 100 MB after bytesSize() multiply
+        val configManager = mockk<CommonConfigManager>(relaxed = true)
+        every { configManager.getCurrentConfig() } returns appConfig
+        return configManager
+    }
+
+    @Test
+    fun releaseRemotePasteDataForPush_markDeletesWhenFilesIndexEmpty() =
+        runBlocking {
+            val pasteDao = mockk<PasteDao>(relaxed = true)
+            coEvery { pasteDao.createPasteData(any(), any()) } returns 99L
+            coEvery { pasteDao.markDeletePasteData(any()) } returns Result.success(Unit)
+
+            // userDataPathProvider.resolve is called by buildFilesIndex with the FilesPasteItem
+            // but relaxed=true makes it a no-op — builder stays empty → FilesIndex has 0 chunks
+            // → triggers the empty-filesIndex cleanup branch in releaseRemotePasteDataForPush.
+            val service = newService(pasteDao = pasteDao)
+
+            val emptyFilesItem =
+                createFilesPasteItem(
+                    relativePathList = emptyList(),
+                    fileInfoTreeMap = emptyMap(),
+                )
+            val pasteData =
+                PasteData(
+                    appInstanceId = "test-mobile",
+                    pasteAppearItem = emptyFilesItem,
+                    pasteCollection = PasteCollection(emptyList()),
+                    pasteType = PasteType.FILE_TYPE.type,
+                    source = null,
+                    size = 0L,
+                    hash = "",
+                )
+
+            val result = service.releaseRemotePasteDataForPush(pasteData)
+
+            assertNull(result, "empty filesIndex should yield null result")
+            coVerify(exactly = 1) { pasteDao.markDeletePasteData(99L) }
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
@@ -1,0 +1,255 @@
+package com.crosspaste.sync
+
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.PasteboardService
+import com.crosspaste.presist.FilesIndex
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class PushSessionManagerTest {
+
+    private fun fakeFilesIndex(chunkCount: Int): FilesIndex =
+        mockk<FilesIndex>().also { every { it.getChunkCount() } returns chunkCount }
+
+    private fun newManager(
+        maxActive: Int = 16,
+        sessionTtl: Duration = 90_000L.milliseconds,
+        sweepInterval: Duration = 60_000L.milliseconds,
+        scope: CoroutineScope = CoroutineScope(Job()),
+        pasteDao: PasteDao = mockk(relaxed = true),
+        pasteboardService: PasteboardService = mockk(relaxed = true),
+    ): Triple<PushSessionManager, PasteDao, PasteboardService> {
+        val mgr =
+            PushSessionManager(
+                pasteDao = pasteDao,
+                pasteboardService = pasteboardService,
+                maxActive = maxActive,
+                sessionTtl = sessionTtl,
+                sweepInterval = sweepInterval,
+                scope = scope,
+            )
+        return Triple(mgr, pasteDao, pasteboardService)
+    }
+
+    @Test
+    fun create_returnsSessionWithUniqueTokenAndFilesIndex() {
+        val (mgr) = newManager()
+        val indexA = fakeFilesIndex(3)
+        val indexB = fakeFilesIndex(5)
+        val a = mgr.create(pasteId = 1L, fromAppInstanceId = "mobile-a", filesIndex = indexA)
+        val b = mgr.create(pasteId = 2L, fromAppInstanceId = "mobile-b", filesIndex = indexB)
+        assertNotNull(a)
+        assertNotNull(b)
+        assertEquals(1L, a.pasteId)
+        assertEquals(3, a.chunkCount)
+        assertSame(indexA, a.filesIndex)
+        assertEquals("mobile-a", a.fromAppInstanceId)
+        assertEquals(2, mgr.activeCount())
+        assertNotEquals(a.token, b.token)
+        mgr.close()
+    }
+
+    @Test
+    fun create_rejectsWhenChunkCountInvalid() {
+        val (mgr) = newManager()
+        assertNull(mgr.create(pasteId = 1L, fromAppInstanceId = "mobile", filesIndex = fakeFilesIndex(0)))
+        assertNull(mgr.create(pasteId = 2L, fromAppInstanceId = "mobile", filesIndex = fakeFilesIndex(-1)))
+        assertEquals(0, mgr.activeCount())
+        mgr.close()
+    }
+
+    @Test
+    fun create_rejectsWhenMaxActiveReached() {
+        val (mgr) = newManager(maxActive = 2)
+        assertNotNull(mgr.create(1L, "mobile", fakeFilesIndex(1)))
+        assertNotNull(mgr.create(2L, "mobile", fakeFilesIndex(1)))
+        assertNull(mgr.create(3L, "mobile", fakeFilesIndex(1)))
+        assertEquals(2, mgr.activeCount())
+        mgr.close()
+    }
+
+    @Test
+    fun get_requiresMatchingTokenAndAppInstance() {
+        val (mgr) = newManager()
+        val session = mgr.create(1L, "mobile-a", fakeFilesIndex(2))!!
+        assertNotNull(mgr.get(1L, session.token, "mobile-a"))
+        assertNull(mgr.get(1L, "wrong-token", "mobile-a"))
+        assertNull(mgr.get(1L, session.token, "mobile-b"))
+        assertNull(mgr.get(2L, session.token, "mobile-a"))
+        mgr.close()
+    }
+
+    @Test
+    fun markReceived_isIdempotentAndCounts() =
+        runBlocking {
+            val (mgr) = newManager()
+            val session = mgr.create(1L, "mobile", fakeFilesIndex(3))!!
+            assertEquals(PushSession.MarkResult.Accepted, session.markReceived(0))
+            assertEquals(PushSession.MarkResult.Accepted, session.markReceived(2))
+            assertEquals(PushSession.MarkResult.AlreadyReceived, session.markReceived(0))
+            assertEquals(2, session.receivedCount)
+            assertFalse(session.isComplete)
+            assertEquals(listOf(1), session.missingChunks())
+
+            assertEquals(PushSession.MarkResult.Accepted, session.markReceived(1))
+            assertTrue(session.isComplete)
+            assertEquals(emptyList(), session.missingChunks())
+            mgr.close()
+        }
+
+    @Test
+    fun markReceived_outOfRange() =
+        runBlocking {
+            val (mgr) = newManager()
+            val session = mgr.create(1L, "mobile", fakeFilesIndex(3))!!
+            assertEquals(PushSession.MarkResult.OutOfRange, session.markReceived(-1))
+            assertEquals(PushSession.MarkResult.OutOfRange, session.markReceived(3))
+            assertEquals(0, session.receivedCount)
+            mgr.close()
+        }
+
+    @Test
+    fun tryFinalize_removesSessionAndQueuesPasteboardWrite() =
+        runBlocking {
+            val pasteboardService = mockk<PasteboardService>(relaxed = true)
+            coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(any()) } returns Result.success(Unit)
+            val (mgr) = newManager(pasteboardService = pasteboardService)
+            mgr.create(1L, "mobile", fakeFilesIndex(2))!!
+            assertEquals(1, mgr.activeCount())
+
+            assertTrue(mgr.tryFinalize(1L), "tryFinalize returns true when caller claims removal")
+            assertEquals(0, mgr.activeCount())
+            assertNull(mgr.peek(1L))
+            assertFalse(mgr.tryFinalize(1L), "second call returns false — session already gone")
+
+            // Finalize is launched on the manager's scope; let it run.
+            delay(50.milliseconds)
+            coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(1L) }
+            mgr.close()
+        }
+
+    @Test
+    fun tryFinalizeIfComplete_triggersOnLastChunk() =
+        runBlocking {
+            val pasteboardService = mockk<PasteboardService>(relaxed = true)
+            coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(any()) } returns Result.success(Unit)
+            val (mgr) = newManager(pasteboardService = pasteboardService)
+            val session = mgr.create(5L, "mobile", fakeFilesIndex(2))!!
+
+            // First chunk: not yet complete — tryFinalizeIfComplete is a no-op.
+            assertEquals(PushSession.MarkResult.Accepted, session.markReceived(0))
+            assertFalse(mgr.tryFinalizeIfComplete(5L))
+            assertEquals(1, mgr.activeCount())
+
+            // Last chunk: session becomes complete — tryFinalizeIfComplete fires.
+            assertEquals(PushSession.MarkResult.Accepted, session.markReceived(1))
+            assertTrue(mgr.tryFinalizeIfComplete(5L))
+            assertEquals(0, mgr.activeCount())
+
+            delay(50.milliseconds)
+            coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(5L) }
+            mgr.close()
+        }
+
+    @Test
+    fun tryFinalizeIfComplete_isNoopForIncompleteOrAbsent() =
+        runBlocking {
+            val pasteboardService = mockk<PasteboardService>(relaxed = true)
+            val (mgr) = newManager(pasteboardService = pasteboardService)
+            val session = mgr.create(9L, "mobile", fakeFilesIndex(3))!!
+            session.markReceived(0)
+
+            assertFalse(mgr.tryFinalizeIfComplete(9L), "not complete yet")
+            assertFalse(mgr.tryFinalizeIfComplete(404L), "no session for this id")
+            assertEquals(1, mgr.activeCount())
+            coVerify(exactly = 0) { pasteboardService.tryWriteRemotePasteboardWithFile(any()) }
+            mgr.close()
+        }
+
+    @Test
+    fun sweepExpired_removesStaleAndMarksDeleted() =
+        runBlocking {
+            val pasteDao = mockk<PasteDao>(relaxed = true)
+            coEvery { pasteDao.markDeletePasteData(any()) } returns Result.success(Unit)
+            val pasteboardService = mockk<PasteboardService>(relaxed = true)
+            val (mgr) =
+                newManager(
+                    sessionTtl = 10.milliseconds,
+                    pasteDao = pasteDao,
+                    pasteboardService = pasteboardService,
+                )
+            mgr.create(42L, "mobile", fakeFilesIndex(2))!!
+            assertEquals(1, mgr.activeCount())
+
+            delay(50.milliseconds)
+            mgr.sweepExpired()
+
+            assertEquals(0, mgr.activeCount())
+            val capturedId = slot<Long>()
+            coVerify(exactly = 1) { pasteDao.markDeletePasteData(capture(capturedId)) }
+            assertEquals(42L, capturedId.captured)
+            coVerify(exactly = 0) { pasteboardService.tryWriteRemotePasteboardWithFile(any()) }
+            mgr.close()
+        }
+
+    @Test
+    fun sweepExpired_finalizesOrphanCompleteSession() =
+        runBlocking {
+            val pasteDao = mockk<PasteDao>(relaxed = true)
+            val pasteboardService = mockk<PasteboardService>(relaxed = true)
+            coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(any()) } returns Result.success(Unit)
+            val (mgr) =
+                newManager(
+                    sessionTtl = 10.milliseconds,
+                    pasteDao = pasteDao,
+                    pasteboardService = pasteboardService,
+                )
+            val session = mgr.create(77L, "mobile", fakeFilesIndex(2))!!
+            // Simulate the corner case: all chunks landed AND auto-finalize was
+            // somehow skipped (scope cancelled mid-flight, etc.). Session is
+            // still in the map when sweep TTL expires.
+            assertEquals(PushSession.MarkResult.Accepted, session.markReceived(0))
+            assertEquals(PushSession.MarkResult.Accepted, session.markReceived(1))
+            assertTrue(session.isComplete)
+
+            delay(50.milliseconds)
+            mgr.sweepExpired()
+            // Finalize is fire-and-forget on the manager scope; wait for it.
+            delay(50.milliseconds)
+
+            assertEquals(0, mgr.activeCount())
+            val finalizedId = slot<Long>()
+            coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(capture(finalizedId)) }
+            assertEquals(77L, finalizedId.captured)
+            coVerify(exactly = 0) { pasteDao.markDeletePasteData(any()) }
+            mgr.close()
+        }
+
+    @Test
+    fun sweepExpired_keepsActiveSessions() =
+        runBlocking {
+            val (mgr) = newManager(sessionTtl = 5.seconds)
+            mgr.create(1L, "mobile", fakeFilesIndex(1))!!
+            mgr.sweepExpired()
+            assertEquals(1, mgr.activeCount())
+            mgr.close()
+        }
+}

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/push/PushCompleteResponse.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/push/PushCompleteResponse.kt
@@ -1,0 +1,10 @@
+package com.crosspaste.dto.push
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PushCompleteResponse(
+    val missingChunks: List<Int>,
+) {
+    val isComplete: Boolean get() = missingChunks.isEmpty()
+}

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/push/PushHeaders.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/push/PushHeaders.kt
@@ -1,0 +1,10 @@
+package com.crosspaste.dto.push
+
+object PushHeaders {
+    const val SYNC_MODE: String = "X-Sync-Mode"
+    const val SYNC_MODE_PUSH: String = "push"
+
+    const val PASTE_ID: String = "X-Paste-Id"
+    const val CHUNK_INDEX: String = "X-Chunk-Index"
+    const val SESSION_TOKEN: String = "X-Session-Token"
+}

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/push/PushPrepareResponse.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/push/PushPrepareResponse.kt
@@ -1,0 +1,17 @@
+package com.crosspaste.dto.push
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PushPrepareResponse(
+    val pasteId: Long,
+    val chunkCount: Int,
+    val chunkSize: Long,
+    val sessionToken: String,
+    /**
+     * True when the desktop has a `source` for this paste but no cached icon
+     * for the sender — mobile should follow up with `POST /sync/icon/push/{source}`.
+     * Always false when `source` is null or the icon is already cached.
+     */
+    val needIcon: Boolean = false,
+)

--- a/shared/src/commonMain/kotlin/com/crosspaste/exception/StandardErrorCode.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/exception/StandardErrorCode.kt
@@ -58,6 +58,10 @@ enum class StandardErrorCode(
     CLI_FORBIDDEN(6000, ErrorType.EXTERNAL_ERROR),
     CLI_NOT_FOUND(6001, ErrorType.EXTERNAL_ERROR),
     CLI_INVALID_REQUEST(6002, ErrorType.EXTERNAL_ERROR),
+
+    NOT_FOUND_PUSH_SESSION(7000, ErrorType.EXTERNAL_ERROR),
+    PUSH_SESSION_REJECTED(7001, ErrorType.EXTERNAL_ERROR),
+    PUSH_NOT_FILE_TYPE(7002, ErrorType.EXTERNAL_ERROR),
     ;
 
     private val errorCode: ErrorCode = ErrorCode(code, name, errorType)

--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/FilesIndexFactory.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/FilesIndexFactory.kt
@@ -1,0 +1,39 @@
+package com.crosspaste.presist
+
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.item.PasteFiles
+import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.utils.getDateUtils
+
+/**
+ * Canonical [PasteData] → [FilesIndex] mapping. Resolves each [PasteFiles] item
+ * through [userDataPathProvider] to compute on-disk chunk slots.
+ *
+ * Used by both directions of file sync:
+ * - Pull (serving `/pull/file`): build from a LOADED PasteData to read chunks out.
+ * - Push (receiving `/sync/file/push`): build from a freshly-bound LOADING PasteData
+ *   so incoming chunks land in the right slots.
+ */
+fun buildFilesIndex(
+    pasteData: PasteData,
+    userDataPathProvider: UserDataPathProvider,
+    chunkSize: Long,
+): FilesIndex {
+    val dateUtils = getDateUtils()
+    val dateString =
+        dateUtils.getYMD(
+            dateUtils.epochMillisecondsToLocalDateTime(pasteData.createTime),
+        )
+    val builder = FilesIndexBuilder(chunkSize)
+    pasteData.getPasteAppearItems().filterIsInstance<PasteFiles>().forEach { pasteFiles ->
+        userDataPathProvider.resolve(
+            pasteData.appInstanceId,
+            dateString,
+            pasteData.id,
+            pasteFiles,
+            false,
+            builder,
+        )
+    }
+    return builder.build()
+}


### PR DESCRIPTION
Closes #4455

## Summary

Desktop side of mobile→desktop active file push, enabling iOS Share
Extension and other short-lived mobile contexts to deliver files
reliably even after the host app is suspended.

## Changes

- **New routes** (`PushRouting.kt`):
  - `POST /sync/file/push` — chunk receive, auto-finalize on last chunk
  - `POST /sync/paste/push/complete` — idempotent ack (missing-chunks
    list or success)
  - `POST /sync/icon/push/{source}` — session-free icon push (mirrors
    `/pull/icon/{source}`)
- **`POST /sync/paste` branch** (`PasteRouting.kt`):
  - Reads `X-Sync-Mode: push`; on push, returns
    `PushPrepareResponse(pasteId, chunkCount, chunkSize, sessionToken,
    needIcon)`
- **`PushSessionManager`** — session store with 90s TTL sweep, max 16
  active. `tryFinalize` is the single race-safe finalize entry shared by
  the chunk handler (auto-finalize on last chunk), `/complete`, and
  sweep. Reads on the BooleanArray / count are lockless by design (see
  `PushSession` kdoc).
- **`PasteReleaseService.releaseRemotePasteDataForPush`** — synchronous
  prep: creates LOADING row, binds storage paths, builds FilesIndex,
  schedules relay-sync + pull-icon tasks (the same side-effects as the
  pull path's file branch). Empty FilesIndex → `markDeletePasteData`.
  Shared `bindFilePasteForReceive` helper consolidates 30 lines of
  duplication between pull and push prep.
- **Routing helpers** — `requireTargetAppInstance` and
  `requireSyncHandler` extracted into `ResponseUtils.kt`; used at all
  pull + push routes.
- **Shared `buildFilesIndex`** factory in `shared/presist/` —
  `CacheManager.loadKey` and `releaseRemotePasteDataForPush` both call
  it; eliminates duplicate index-construction logic.
- **`PasteboardService.tryWriteRemotePasteboardWithFile`** refactored to
  take `pasteId: Long` (both callers only used `.id`).
- **DTOs + constants** live together in `core/dto/push/`:
  `PushPrepareResponse`, `PushCompleteResponse`, `PushHeaders`.
- **3 new error codes** in `StandardErrorCode`:
  `NOT_FOUND_PUSH_SESSION`, `PUSH_SESSION_REJECTED`,
  `PUSH_NOT_FILE_TYPE`.

## Design highlights

- **Permission gating is meta-only.** `/sync/paste` checks
  `allowReceive` + `isReceiveEnabled`; chunk/complete/icon routes trust
  the session token. Once allowed, the session runs to completion even
  if the user toggles permission mid-flight.
- **Auto-finalize on last chunk.** When `markReceived` flips a session
  to complete, finalize launches immediately on the manager scope —
  user sees the paste on the clipboard with no sweep latency. `/complete`
  becomes an idempotent ack (lenient when session is already gone).
- **Sweep is the rare safety net** for the corner case where
  auto-finalize was dropped (scope cancelled during shutdown). Genuine
  incomplete sessions get `markDeletePasteData` after the 90s TTL.
- **Encryption is transparent** — the existing `secure: 1` header +
  `ServerDecryptionPlugin` auto-decrypt the body. No push-specific
  crypto handling.

## Test plan

- [x] `./gradlew :app:desktopTest --tests com.crosspaste.sync.PushSessionManagerTest` — 13 cases pass
- [x] `./gradlew :app:desktopTest --tests com.crosspaste.paste.PasteReleaseServicePushTest` — empty-filesIndex cleanup branch verified
- [x] `./gradlew :app:desktopTest --tests "com.crosspaste.sync.*" --tests "com.crosspaste.paste.*" --tests "com.crosspaste.net.*"` — 476 tests, 0 failures
- [x] `./gradlew ktlintFormat` clean
- [ ] Manual curl flow against a running desktop after `app:run` (deferred to QA)
- [ ] Mobile end-to-end (separate PR in `crosspaste-mobile`)

## Follow-ups (not in this PR)

- Mobile client (`PushClientApi`, `FilePushService`, `SyncPasteTaskExecutor`
  push branch, Share Extension integration)
- Version-gated rollout (only enable push when
  `versionRelation == EQUAL_TO`)
- Clean up LOADING orphan when push session capacity rejects
  (1-line `pasteDao.markDeletePasteData(prepared.pasteId)` in the
  rejection branch — tracked separately)