### PR TITLE
:construction_worker: commit sponsor README updates back to repo

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -27,3 +27,9 @@ jobs:
           token: ${{ secrets.SPONSORS_TOKEN }}
           organization: true
           file: 'README.zh-CN.md'
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: ":construction_worker: update sponsors in README"
+          file_pattern: 'README.md README.zh-CN.md'


### PR DESCRIPTION
Closes #4460

## Summary
- Add a `stefanzweifel/git-auto-commit-action@v5` step to the Update Sponsors workflow that commits and pushes README changes back to the branch.

## Why
`JamesIves/github-sponsors-readme-action` rewrites the README files in the runner's workspace but does not commit/push. After the merge of #4459 manual workflow runs reported success ("The data was successfully retrieved and saved!") yet `README.md` / `README.zh-CN.md` on `main` were never updated, because the workspace is discarded at job end.

The workflow already declares `permissions: contents: write`, so the default `GITHUB_TOKEN` is enough — no extra secret needed for the commit step. The auto-commit action no-ops when no files changed, so the daily cron is safe.

## Test plan
- [ ] Merge
- [ ] Manually trigger "Update Sponsors" from the Actions tab
- [ ] Verify a bot commit lands updating the READMEs with current sponsor avatars