### PR TITLE
:sparkles: include all historical sponsors in README

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           token: ${{ secrets.SPONSORS_TOKEN }}
           organization: true
+          active-only: false
           file: 'README.md'
 
       - name: Update sponsors in README.zh-CN.md
@@ -26,6 +27,7 @@ jobs:
         with:
           token: ${{ secrets.SPONSORS_TOKEN }}
           organization: true
+          active-only: false
           file: 'README.zh-CN.md'
 
       - name: Commit and push changes


### PR DESCRIPTION
Closes #4462

## Summary
- Add `active-only: false` to both `JamesIves/github-sponsors-readme-action` steps so the README shows every sponsor in the project's history, not just those currently flagged `isActive` by the GitHub Sponsors API.

## Why
One-time sponsorships have a short "active" window (roughly one month). After that the GraphQL API returns `isActive: false` and the default `active-only: true` filter drops them. Supporters like @liaokaime (\$1 one-time on 2024-08-18) were no longer rendered even though their contribution remains part of the project's history.

## Trade-off
The Sponsors section will grow over time; acceptable at CrossPaste's current scale and worth it to keep every supporter permanently acknowledged.

## Test plan
- [ ] Merge
- [ ] Manually trigger "Update Sponsors" from the Actions tab
- [ ] Verify the bot commit includes both jaepil-choi and liaokaime in the README avatar list