### PR TITLE
:art: render sponsor avatars as rounded with spacing

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -21,6 +21,7 @@ jobs:
           organization: true
           active-only: false
           file: 'README.md'
+          template: '<a href="https://github.com/{{{ login }}}"><img src="https://wsrv.nl/?url=github.com/{{{ login }}}.png&w=120&h=120&fit=cover&mask=circle" width="60" height="60" alt="{{{ name }}}" /></a>&nbsp;'
 
       - name: Update sponsors in README.zh-CN.md
         uses: JamesIves/github-sponsors-readme-action@v1
@@ -29,6 +30,7 @@ jobs:
           organization: true
           active-only: false
           file: 'README.zh-CN.md'
+          template: '<a href="https://github.com/{{{ login }}}"><img src="https://wsrv.nl/?url=github.com/{{{ login }}}.png&w=120&h=120&fit=cover&mask=circle" width="60" height="60" alt="{{{ name }}}" /></a>&nbsp;'
 
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
Closes #4464

## Summary
- Override the `template` parameter of both `JamesIves/github-sponsors-readme-action` steps so sponsor avatars render as circles with breathing room between them.

## How
- Route avatar through [`wsrv.nl`](https://wsrv.nl/) (formerly `images.weserv.nl`) with `mask=circle` for server-side circular cropping — necessary because GitHub's Markdown sanitizer strips `style` / `class` attributes, ruling out CSS `border-radius`.
- Request 120×120 source, display at 60×60 for retina sharpness.
- Append `&nbsp;` after each `</a>` so avatars no longer sit edge-to-edge.
- Use triple-brace mustache `{{{ login }}}` to disable HTML entity escaping (also cleans up the `https:&#x2F;&#x2F;...` look in raw markdown).

## Risk
`wsrv.nl` is a long-running free image proxy used by Vue / Vite / Nuxt and many OSS projects. If it goes down, README sponsor avatars would break — workflow itself keeps running, easy revert.

## Test plan
- [ ] Merge
- [ ] Manually trigger "Update Sponsors" from the Actions tab
- [ ] Verify the rendered README shows circular avatars with visible spacing between them