### PR TITLE
:bug: push protocol: remove pull fallback + gate behind forcePush opt-in

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteCollector.kt
@@ -118,7 +118,7 @@ class PasteCollector(
                                 }
                             }
                     }
-                    pasteReleaseService.releaseLocalPasteData(id, pasteItems, sourceContext.targetAppInstanceIds)
+                    pasteReleaseService.releaseLocalPasteData(id, pasteItems, sourceContext)
                 }.onFailure { e ->
                     logger.error(e) { "Failed to complete paste $id" }
                     markDeletePasteData(id)

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -76,8 +76,9 @@ class PasteReleaseService(
     suspend fun releaseLocalPasteData(
         id: Long,
         pasteItems: List<PasteItem>,
-        targetAppInstanceIds: Set<String>?,
+        sourceContext: PasteSourceContext,
     ) = withContext(ioDispatcher) {
+        val targetAppInstanceIds = sourceContext.targetAppInstanceIds
         pasteDao.getLoadingPasteData(id)?.let { pasteData ->
             var pasteAppearItems = pasteItems
             for (pastePlugin in pasteProcessPlugins) {
@@ -135,7 +136,13 @@ class PasteReleaseService(
                     // items skip Apple peers).
                     val hasValidSyncTargets = targetAppInstanceIds == null || targetAppInstanceIds.isNotEmpty()
                     if (!pasteData.remote && hasValidSyncTargets) {
-                        addSyncTask(id, maxFileSize, pasteData.appInstanceId, targetAppInstanceIds)
+                        addSyncTask(
+                            id,
+                            maxFileSize,
+                            pasteData.appInstanceId,
+                            targetAppInstanceIds,
+                            forcePush = sourceContext.forcePush,
+                        )
                     }
 
                     if (pasteType.isFile() || pasteType.isImage()) {

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteSourceContext.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteSourceContext.kt
@@ -5,4 +5,5 @@ data class PasteSourceContext(
     val remote: Boolean,
     val dragAndDrop: Boolean = false,
     val targetAppInstanceIds: Set<String>? = null,
+    val forcePush: Boolean = false,
 )

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -112,7 +112,7 @@ class SyncPasteTaskExecutor(
         val deferredResults: MutableList<Deferred<Pair<String, ClientApiResult>>> = mutableListOf()
 
         for (handler in getEligibleSyncHandlers(syncExtraInfo)) {
-            val deferred = createSyncTask(handler.key, handler.value, pasteData)
+            val deferred = createSyncTask(handler.key, handler.value, pasteData, syncExtraInfo)
             deferredResults.add(deferred)
         }
 
@@ -159,10 +159,11 @@ class SyncPasteTaskExecutor(
         handlerKey: String,
         handler: SyncHandler,
         pasteData: PasteData,
+        syncExtraInfo: SyncExtraInfo,
     ): Deferred<Pair<String, ClientApiResult>> =
         ioScope.async {
             runCatching {
-                val result = syncPasteToTarget(handlerKey, handler, pasteData)
+                val result = syncPasteToTarget(handlerKey, handler, pasteData, syncExtraInfo)
 
                 if (result is SuccessResult) {
                     appControl.completeSendOperation()
@@ -195,6 +196,7 @@ class SyncPasteTaskExecutor(
         handlerKey: String,
         handler: SyncHandler,
         pasteData: PasteData,
+        syncExtraInfo: SyncExtraInfo,
     ): ClientApiResult {
         val syncRuntimeInfo = handler.currentSyncRuntimeInfo
         val port = syncRuntimeInfo.port
@@ -241,25 +243,19 @@ class SyncPasteTaskExecutor(
         val hostAddress = handler.getConnectHostAddress()
         if (hostAddress != null) {
             val hostAndPort = HostAndPort(hostAddress, port)
-            // 2a. File-type pastes to a same-version peer take the push path:
-            //     sender drives chunk uploads instead of waiting for the
-            //     receiver to pull. This keeps iOS Share Extension (and any
-            //     short-lived sender) reliable when the peer's PasteServer is
-            //     suspended. EQUAL_TO gating ensures the peer implements the
-            //     M1+M2 server endpoints (`/sync/paste` push mode, `/sync/file/push`,
-            //     `/sync/paste/push/complete`). Any failure falls through to
-            //     pull-mode metadata send so behavior is preserved end-to-end.
-            //     (Extension peers were already routed to WebSocket above.)
-            if (shouldUsePushPath(pasteData, handler)) {
-                val pushResult =
-                    filePushService.pushFiles(pasteData, targetAppInstanceId) {
-                        buildUrl(hostAndPort)
-                    }
-                if (pushResult is SuccessResult) {
-                    return pushResult
-                }
-                logger.warn {
-                    "push to $handlerKey failed ($pushResult), falling back to pull-mode metadata send"
+            // 2a. Push path is opt-in via SyncExtraInfo.forcePush. Sender drives
+            //     chunk uploads instead of waiting for the receiver to pull, which is
+            //     required when the sender cannot host a PasteServer for reverse pulls
+            //     (e.g. iOS Share Extension). EQUAL_TO gating ensures the peer
+            //     implements the M1+M2 server endpoints (`/sync/paste` push mode,
+            //     `/sync/file/push`, `/sync/paste/push/complete`). On failure we
+            //     return the FailureResult unchanged: same-version peers necessarily
+            //     implement push, and reverse-pull fallback was creating a doomed
+            //     second LOADING entry on the receiver. The SyncTask will retry on
+            //     the next executor pass when applicable.
+            if (shouldUsePushPath(pasteData, handler, syncExtraInfo)) {
+                return filePushService.pushFiles(pasteData, targetAppInstanceId) {
+                    buildUrl(hostAndPort)
                 }
             }
             return pasteClientApi.sendPaste(
@@ -280,13 +276,19 @@ class SyncPasteTaskExecutor(
 
     /**
      * Should this paste use the M4 push path instead of pull-mode metadata send?
-     * Push requires (a) actual file payload to ship and (b) a peer that implements
-     * the M1+M2 server endpoints — gated by `EQUAL_TO` version match.
+     * Push is opt-in (`forcePush`): callers that cannot host reverse-pull (iOS Share
+     * Extension) request it explicitly. We also require (a) actual file payload to
+     * ship and (b) a peer that implements the M1+M2 server endpoints — gated by
+     * `EQUAL_TO` version match.
      */
     private fun shouldUsePushPath(
         pasteData: PasteData,
         handler: SyncHandler,
-    ): Boolean = pasteData.isFileType() && handler.currentVersionRelation == VersionRelation.EQUAL_TO
+        syncExtraInfo: SyncExtraInfo,
+    ): Boolean =
+        syncExtraInfo.forcePush &&
+            pasteData.isFileType() &&
+            handler.currentVersionRelation == VersionRelation.EQUAL_TO
 
     private suspend fun trySendViaWebSocket(
         targetAppInstanceId: String,

--- a/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/task/DesktopTaskSubmitter.kt
@@ -77,13 +77,14 @@ class DesktopTaskBuilder(
         fileSize: Long,
         appInstanceId: String,
         targetAppInstanceIds: Set<String>?,
+        forcePush: Boolean,
     ): TaskBuilder {
         if (appControl.isFileSizeSyncEnabled(fileSize)) {
             taskIds.add(
                 taskDao.createTaskBlock(
                     id,
                     TaskType.SYNC_PASTE_TASK,
-                    SyncExtraInfo(appInstanceId, targetAppInstanceIds),
+                    SyncExtraInfo(appInstanceId, targetAppInstanceIds, forcePush),
                 ),
             )
         }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectorTest.kt
@@ -8,6 +8,7 @@ import com.crosspaste.utils.getJsonUtils
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -166,7 +167,7 @@ class PasteCollectorTest {
 
             collector.completeCollect(1L)
 
-            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any(), any()) }
+            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any(), any<PasteSourceContext>()) }
         }
 
     @Test
@@ -197,7 +198,32 @@ class PasteCollectorTest {
             collector.completeCollect(1L)
 
             // Should still release since not all active indices errored
-            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any(), any()) }
+            coVerify { pasteReleaseService.releaseLocalPasteData(1L, any(), any<PasteSourceContext>()) }
+        }
+
+    @Test
+    fun `completeCollect forwards forcePush in sourceContext to releaseLocalPasteData`() =
+        runTest {
+            val forcePushContext =
+                PasteSourceContext(
+                    source = null,
+                    remote = false,
+                    forcePush = true,
+                )
+            val collector =
+                PasteCollector(1, appInfo, pasteDao, pasteReleaseService, forcePushContext)
+            val item = createTextPasteItem(text = "test")
+            collector.preCollectItem(0, TestPasteTypePlugin::class, item)
+
+            val captured = slot<PasteSourceContext>()
+            coEvery {
+                pasteReleaseService.releaseLocalPasteData(any(), any(), capture(captured))
+            } returns Unit
+
+            collector.completeCollect(1L)
+
+            assertTrue(captured.isCaptured, "releaseLocalPasteData must be invoked")
+            assertTrue(captured.captured.forcePush, "forcePush must flow through sourceContext")
         }
 
     @Test
@@ -207,8 +233,9 @@ class PasteCollectorTest {
             val item = createTextPasteItem(text = "test")
             collector.preCollectItem(0, TestPasteTypePlugin::class, item)
 
-            coEvery { pasteReleaseService.releaseLocalPasteData(any(), any(), any()) } throws
-                RuntimeException("release error")
+            coEvery {
+                pasteReleaseService.releaseLocalPasteData(any(), any(), any<PasteSourceContext>())
+            } throws RuntimeException("release error")
 
             collector.completeCollect(1L)
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/DesktopTaskBuilderTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/DesktopTaskBuilderTest.kt
@@ -1,0 +1,105 @@
+package com.crosspaste.task
+
+import com.crosspaste.app.AppControl
+import com.crosspaste.config.DesktopConfigManager
+import com.crosspaste.db.task.PasteTaskExtraInfo
+import com.crosspaste.db.task.SyncExtraInfo
+import com.crosspaste.db.task.TaskDao
+import com.crosspaste.db.task.TaskType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DesktopTaskBuilderTest {
+
+    private fun newBuilder(): Triple<DesktopTaskBuilder, TaskDao, AppControl> {
+        val appControl = mockk<AppControl>(relaxed = true)
+        every { appControl.isFileSizeSyncEnabled(any()) } returns true
+        val configManager = mockk<DesktopConfigManager>(relaxed = true)
+        val taskDao = mockk<TaskDao>(relaxed = true)
+        every { taskDao.createTaskBlock(any(), any(), any()) } returns 42L
+        val builder = DesktopTaskBuilder(appControl, configManager, taskDao)
+        return Triple(builder, taskDao, appControl)
+    }
+
+    @Test
+    fun `addSyncTask defaults forcePush to false in SyncExtraInfo`() {
+        val (builder, taskDao, _) = newBuilder()
+        val captured = slot<PasteTaskExtraInfo>()
+
+        builder.addSyncTask(
+            id = 1L,
+            fileSize = 0L,
+            appInstanceId = "local-app",
+            targetAppInstanceIds = setOf("remote-1"),
+        )
+
+        verify {
+            taskDao.createTaskBlock(
+                pasteDataId = 1L,
+                taskType = TaskType.SYNC_PASTE_TASK,
+                extraInfo = capture(captured),
+            )
+        }
+
+        val syncExtra = captured.captured as SyncExtraInfo
+        assertEquals("local-app", syncExtra.appInstanceId)
+        assertEquals(setOf("remote-1"), syncExtra.targetAppInstanceIds)
+        assertFalse(syncExtra.forcePush, "default forcePush must be false")
+    }
+
+    @Test
+    fun `addSyncTask propagates forcePush=true to SyncExtraInfo`() {
+        val (builder, taskDao, _) = newBuilder()
+        val captured = slot<PasteTaskExtraInfo>()
+
+        builder.addSyncTask(
+            id = 2L,
+            fileSize = 1024L,
+            appInstanceId = "local-app",
+            targetAppInstanceIds = setOf("remote-1"),
+            forcePush = true,
+        )
+
+        verify {
+            taskDao.createTaskBlock(
+                pasteDataId = 2L,
+                taskType = TaskType.SYNC_PASTE_TASK,
+                extraInfo = capture(captured),
+            )
+        }
+
+        val syncExtra = captured.captured as SyncExtraInfo
+        assertTrue(syncExtra.forcePush, "forcePush=true must reach SyncExtraInfo")
+    }
+
+    @Test
+    fun `addSyncTask skips task when file size disallowed`() {
+        val appControl = mockk<AppControl>(relaxed = true)
+        every { appControl.isFileSizeSyncEnabled(any()) } returns false
+        val taskDao = mockk<TaskDao>(relaxed = true)
+        val builder =
+            DesktopTaskBuilder(
+                appControl,
+                mockk<DesktopConfigManager>(relaxed = true),
+                taskDao,
+            )
+
+        builder.addSyncTask(
+            id = 3L,
+            fileSize = 999_999_999L,
+            appInstanceId = "local-app",
+            forcePush = true,
+        )
+
+        verify(exactly = 0) {
+            taskDao.createTaskBlock(any(), eq(TaskType.SYNC_PASTE_TASK), any())
+        }
+        assertTrue(builder.getTasks().isEmpty())
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
@@ -389,14 +389,17 @@ class SyncPasteTaskExecutorTest {
             assertTrue(result is SuccessPasteTaskResult)
         }
 
-    // ========== E. Push branch (M4) ==========
+    // ========== E. Push branch (M4) — forcePush gating ==========
 
     @Test
-    fun doExecuteTask_fileTypeEqualToNonExtension_takesPushPath() =
+    fun doExecuteTask_forcePushTrue_fileTypeEqualToNonExtension_takesPushPath() =
         runTest {
             val deps = TestDeps()
             val executor = deps.createExecutor()
-            val task = createPasteTask()
+            val task =
+                createPasteTask(
+                    extraInfo = SyncExtraInfo(appInstanceId = "local-app-1", forcePush = true),
+                )
             val pasteData = createMockPasteData(PasteType.FILE_TYPE)
             every { pasteData.isFileType() } returns true
 
@@ -415,11 +418,14 @@ class SyncPasteTaskExecutorTest {
         }
 
     @Test
-    fun doExecuteTask_pushFails_fallsBackToPullSend() =
+    fun doExecuteTask_forcePushTrue_pushFails_returnsFailureNoFallback() =
         runTest {
             val deps = TestDeps()
             val executor = deps.createExecutor()
-            val task = createPasteTask()
+            val task =
+                createPasteTask(
+                    extraInfo = SyncExtraInfo(appInstanceId = "local-app-1", forcePush = true),
+                )
             val pasteData = createMockPasteData(PasteType.FILE_TYPE)
             every { pasteData.isFileType() } returns true
 
@@ -434,14 +440,63 @@ class SyncPasteTaskExecutorTest {
                         "prepare 500",
                     ),
                 )
+
+            val result = executor.doExecuteTask(task)
+
+            // Push failure must NOT fall back to sendPaste — that path created a
+            // second LOADING entry on the receiver and a doomed reverse pull.
+            assertTrue(result is FailurePasteTaskResult)
+            coVerify(exactly = 1) { deps.filePushService.pushFiles(any(), eq("remote-1"), any()) }
+            coVerify(exactly = 0) { deps.pasteClientApi.sendPaste(any(), any(), any()) }
+        }
+
+    @Test
+    fun doExecuteTask_forcePushFalse_fileTypeEqualTo_routesToSendPaste() =
+        runTest {
+            val deps = TestDeps()
+            val executor = deps.createExecutor()
+            // Default extraInfo has forcePush = false.
+            val task = createPasteTask()
+            val pasteData = createMockPasteData(PasteType.FILE_TYPE)
+            every { pasteData.isFileType() } returns true
+
+            val handler = createMockSyncHandler("remote-1", versionRelation = VersionRelation.EQUAL_TO)
+
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
             coEvery { deps.pasteClientApi.sendPaste(any(), any(), any()) } returns SuccessResult()
 
             val result = executor.doExecuteTask(task)
 
-            // The fallback path returns success → overall task succeeds.
             assertTrue(result is SuccessPasteTaskResult)
-            coVerify(exactly = 1) { deps.filePushService.pushFiles(any(), eq("remote-1"), any()) }
+            coVerify(exactly = 0) { deps.filePushService.pushFiles(any(), any(), any()) }
             coVerify(exactly = 1) { deps.pasteClientApi.sendPaste(any(), eq("remote-1"), any()) }
+        }
+
+    @Test
+    fun doExecuteTask_forcePushTrue_nonFileType_routesToSendPaste() =
+        runTest {
+            val deps = TestDeps()
+            val executor = deps.createExecutor()
+            val task =
+                createPasteTask(
+                    extraInfo = SyncExtraInfo(appInstanceId = "local-app-1", forcePush = true),
+                )
+            val pasteData = createMockPasteData(PasteType.TEXT_TYPE)
+            every { pasteData.isFileType() } returns false
+
+            val handler = createMockSyncHandler("remote-1", versionRelation = VersionRelation.EQUAL_TO)
+
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+            coEvery { deps.pasteClientApi.sendPaste(any(), any(), any()) } returns SuccessResult()
+
+            val result = executor.doExecuteTask(task)
+
+            // forcePush only meaningful for file types — non-file still uses pull-mode metadata send.
+            assertTrue(result is SuccessPasteTaskResult)
+            coVerify(exactly = 0) { deps.filePushService.pushFiles(any(), any(), any()) }
+            coVerify(exactly = 1) { deps.pasteClientApi.sendPaste(any(), any(), any()) }
         }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/task/SyncExtraInfo.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/task/SyncExtraInfo.kt
@@ -10,6 +10,8 @@ class SyncExtraInfo(
     val appInstanceId: String,
     @SerialName("targetAppInstanceIds")
     val targetAppInstanceIds: Set<String>? = null,
+    @SerialName("forcePush")
+    val forcePush: Boolean = false,
 ) : PasteTaskExtraInfo {
 
     @SerialName("executionHistories")

--- a/shared/src/commonMain/kotlin/com/crosspaste/task/TaskSubmitter.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/task/TaskSubmitter.kt
@@ -26,6 +26,7 @@ interface TaskBuilder {
         fileSize: Long,
         appInstanceId: String,
         targetAppInstanceIds: Set<String>? = null,
+        forcePush: Boolean = false,
     ): TaskBuilder
 
     fun addRelaySyncTask(


### PR DESCRIPTION
## Summary

Follow-up fixes to two bugs in the M4 push protocol surfaced during iOS Share Extension real-device testing. Both fixes are in `commonMain` so they sync to mobile via `./gradlew syncDesktop`.

Background design doc: `crosspaste-mobile/docs/push-protocol-issues.md` — full root-cause analysis, the `forcePush` field design, and the migration / compat story. This PR covers **problems 1 and 2** from that doc; problem 3 (mobile-only) is tracked separately.

### Bug 1 — push failure no longer falls back to pull-mode metadata send

`SyncPasteTaskExecutor.syncPasteToTarget` previously fell through to `pasteClientApi.sendPaste` when `filePushService.pushFiles` returned a `FailureResult`. For senders that cannot host reverse pulls (notably iOS Share Extension) this created a doomed second LOADING entry on the receiver plus a reverse `/pull/file` that always failed. Same-version peers always implement the M1+M2 server endpoints, so the fallback never helped. Push failure now returns the `FailureResult` unchanged and the SyncTask retries on the next executor pass.

### Bug 2 — push path is now opt-in via `SyncExtraInfo.forcePush`

Previously **any** file-type paste between same-version peers was forced through push, even for callers that can host a PasteServer (main iOS app, Android, desktop-to-desktop). Push has a longer failure surface (prepare → multi-chunk → complete) and is only required when the sender cannot host reverse pulls. Push is now opt-in: only callers that explicitly set `forcePush = true` take the push path.

Default behavior for all existing call sites is unchanged (pull-mode metadata send). The only legitimate caller for `forcePush = true` is iOS Share Extension, which will set it in the follow-up mobile PR.

## Wiring (all commonMain)

| Class / field | Change |
|---|---|
| `SyncExtraInfo` | new `val forcePush: Boolean = false` |
| `TaskBuilder.addSyncTask` | new `forcePush: Boolean = false` param |
| `DesktopTaskBuilder.addSyncTask` | implements new param, forwards into `SyncExtraInfo` |
| `PasteSourceContext` | new `val forcePush: Boolean = false` |
| `PasteReleaseService.releaseLocalPasteData` | signature widened to take the full `PasteSourceContext` (cleaner than threading two related fields); forwards `forcePush` into `addSyncTask` |
| `PasteCollector.completeCollect` | passes the captured `sourceContext` instead of just `targetAppInstanceIds` |
| `SyncPasteTaskExecutor.shouldUsePushPath` | now takes `SyncExtraInfo`; returns `syncExtraInfo.forcePush && pasteData.isFileType() && handler.currentVersionRelation == EQUAL_TO` |
| `SyncPasteTaskExecutor.syncPasteToTarget` | push branch no longer falls through to `sendPaste` on failure |

All existing desktop call sites continue to use the default `forcePush = false`.

## Backward compatibility

- Old DB-serialized `SyncExtraInfo` rows that don't have a `forcePush` field deserialize to `false` (the kotlinx-serialization default) → pull-mode behavior preserved.
- Old mobile clients that don't know about `forcePush` send tasks via pull mode → still works.
- No wire-format changes to `PushPrepareResponse`, `PushHeaders`, or other push protocol artifacts.

## Test plan

- [x] `./gradlew ktlintFormat` — clean
- [x] `./gradlew :app:compileKotlinDesktop :app:compileTestKotlinDesktop` — clean
- [x] `./gradlew :app:desktopTest --tests "com.crosspaste.task.SyncPasteTaskExecutorTest"` — 18/18 pass, including the 4 new forcePush cases:
  - `doExecuteTask_forcePushTrue_fileTypeEqualToNonExtension_takesPushPath`
  - `doExecuteTask_forcePushTrue_pushFails_returnsFailureNoFallback`
  - `doExecuteTask_forcePushFalse_fileTypeEqualTo_routesToSendPaste`
  - `doExecuteTask_forcePushTrue_nonFileType_routesToSendPaste`
- [x] New `DesktopTaskBuilderTest` (3 tests, all pass) verifies forcePush propagates from `TaskBuilder.addSyncTask` into the queued `SyncExtraInfo`.
- [x] `PasteCollectorTest` extended with a case capturing the forwarded `PasteSourceContext` and asserting `forcePush` flows through.
- [x] Wider regression: `./gradlew :app:desktopTest --tests "com.crosspaste.task.*" --tests "com.crosspaste.sync.*" --tests "com.crosspaste.net.*" --tests "com.crosspaste.paste.*"` — 539 tests, 0 failures, 0 errors, 15 skipped (pre-existing).

## Deviations from spec

- The spec mentions a `MobileTaskBuilder` implementation; none exists in this repo (mobile lives in a separate private repo and consumes synced commonMain). Only `DesktopTaskBuilder` was updated here.
- Replaced the existing `doExecuteTask_pushFails_fallsBackToPullSend` test (which now describes the removed behavior) rather than just renaming it — its assertion would be inverted otherwise.
- The pre-existing `doExecuteTask_fileTypeEqualToNonExtension_takesPushPath` case was renamed to `doExecuteTask_forcePushTrue_fileTypeEqualToNonExtension_takesPushPath` and now passes `forcePush = true` explicitly.

## Follow-up

- Mobile-side problem 3 (iOS Share Extension bypassing `SyncManager` / `SyncTask`) is tracked separately and will land in `crosspaste-mobile` after this PR syncs.

Refs: PR #4457 (M4 mobile push client), PR #4456 (M1+M2 server push).