### PR TITLE
:hammer: extract push out of SyncPasteTaskExecutor into SharePushOrchestrator

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SharePushOrchestrator.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SharePushOrchestrator.kt
@@ -1,0 +1,103 @@
+package com.crosspaste.sync
+
+import com.crosspaste.db.sync.SyncRuntimeInfo
+import com.crosspaste.db.sync.SyncRuntimeInfoDao
+import com.crosspaste.db.sync.SyncState
+import com.crosspaste.exception.StandardErrorCode
+import com.crosspaste.net.clientapi.ClientApiResult
+import com.crosspaste.net.clientapi.PasteClientApi
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.net.clientapi.createFailureResult
+import com.crosspaste.paste.PasteData
+import com.crosspaste.utils.HostAndPort
+import com.crosspaste.utils.buildUrl
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.URLBuilder
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Top-level entry point for "I must complete this sync now" scenarios — i.e.
+ * the iOS Share Extension and any other short-lived sender. Fans out to all
+ * peers currently in CONNECTED state and pushes (file-type) or sends metadata
+ * (text / url / etc.) directly, bypassing the SyncTask pipeline.
+ *
+ * Why not run this through SyncPasteTaskExecutor + TaskExecutor like the
+ * clipboard-capture flow does? Because push is a fundamentally different sync
+ * model: synchronous, in-process, no retry across process boundaries. Burying
+ * it inside the task executor leaked task-system semantics (DB-persisted
+ * retries, NearbyDeviceManager wiring, SyncManager startup) into callers that
+ * cannot tolerate them.
+ *
+ * This service is intentionally state-free — it reads SyncRuntimeInfo
+ * snapshots from the DB and reuses the existing client APIs. It does NOT
+ * start SyncManager, does NOT depend on in-memory SyncHandler state, and does
+ * NOT write back to SyncRuntimeInfo. Safe to call from a sandboxed extension
+ * process without polluting the main app's state.
+ */
+class SharePushOrchestrator(
+    private val pasteClientApi: PasteClientApi,
+    private val filePushService: FilePushService,
+    private val syncRuntimeInfoDao: SyncRuntimeInfoDao,
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    suspend fun pushToConnectedPeers(pasteData: PasteData): SharePushResult =
+        coroutineScope {
+            val targets = eligibleTargets()
+            if (targets.isEmpty()) {
+                logger.info { "pushToConnectedPeers: no CONNECTED peers; pasteId=${pasteData.id}" }
+                return@coroutineScope SharePushResult(emptyMap())
+            }
+            val perTarget =
+                targets
+                    .map { target -> async { target.appInstanceId to pushOne(pasteData, target) } }
+                    .awaitAll()
+                    .toMap()
+            SharePushResult(perTarget)
+        }
+
+    /**
+     * `connectState == CONNECTED` implies `EQUAL_TO` — see
+     * `GeneralSyncHandler.handleValueChange`: a version-mismatch resolve
+     * transitions the handler to `INCOMPATIBLE`, not `CONNECTED`. So filtering
+     * on `CONNECTED` + `allowSend` is sufficient and works off persisted DB
+     * state alone, without needing in-memory `SyncHandler` / `versionRelation`.
+     */
+    private suspend fun eligibleTargets(): List<SyncRuntimeInfo> =
+        syncRuntimeInfoDao
+            .getAllSyncRuntimeInfos()
+            .filter { it.connectState == SyncState.CONNECTED && it.allowSend }
+
+    private suspend fun pushOne(
+        pasteData: PasteData,
+        target: SyncRuntimeInfo,
+    ): ClientApiResult {
+        val host =
+            target.connectHostAddress
+                ?: run {
+                    logger.warn {
+                        "pushToConnectedPeers: skipping ${target.appInstanceId} — no connectHostAddress"
+                    }
+                    return createFailureResult(
+                        StandardErrorCode.CANT_GET_SYNC_ADDRESS,
+                        "no connect host address for ${target.appInstanceId}",
+                    )
+                }
+        val toUrl: URLBuilder.() -> Unit = { buildUrl(HostAndPort(host, target.port)) }
+        return if (pasteData.isFileType()) {
+            filePushService.pushFiles(pasteData, target.appInstanceId, toUrl)
+        } else {
+            pasteClientApi.sendPaste(pasteData, target.appInstanceId, toUrl)
+        }
+    }
+}
+
+data class SharePushResult(
+    val perTarget: Map<String, ClientApiResult>,
+) {
+    val allSucceeded: Boolean = perTarget.isNotEmpty() && perTarget.values.all { it is SuccessResult }
+    val anySucceeded: Boolean = perTarget.values.any { it is SuccessResult }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -24,7 +24,6 @@ import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.secure.SecureStore
-import com.crosspaste.sync.FilePushService
 import com.crosspaste.sync.SyncHandler
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.utils.HostAndPort
@@ -44,7 +43,6 @@ class SyncPasteTaskExecutor(
     private val configManager: CommonConfigManager,
     private val pasteDao: PasteDao,
     private val pasteClientApi: PasteClientApi,
-    private val filePushService: FilePushService,
     private val secureStore: SecureStore,
     private val syncManager: SyncManager,
     private val wsSessionManager: WsSessionManager,
@@ -241,27 +239,6 @@ class SyncPasteTaskExecutor(
         val hostAddress = handler.getConnectHostAddress()
         if (hostAddress != null) {
             val hostAndPort = HostAndPort(hostAddress, port)
-            // 2a. File-type pastes to a same-version peer take the push path:
-            //     sender drives chunk uploads instead of waiting for the
-            //     receiver to pull. This keeps iOS Share Extension (and any
-            //     short-lived sender) reliable when the peer's PasteServer is
-            //     suspended. EQUAL_TO gating ensures the peer implements the
-            //     M1+M2 server endpoints (`/sync/paste` push mode, `/sync/file/push`,
-            //     `/sync/paste/push/complete`). Any failure falls through to
-            //     pull-mode metadata send so behavior is preserved end-to-end.
-            //     (Extension peers were already routed to WebSocket above.)
-            if (shouldUsePushPath(pasteData, handler)) {
-                val pushResult =
-                    filePushService.pushFiles(pasteData, targetAppInstanceId) {
-                        buildUrl(hostAndPort)
-                    }
-                if (pushResult is SuccessResult) {
-                    return pushResult
-                }
-                logger.warn {
-                    "push to $handlerKey failed ($pushResult), falling back to pull-mode metadata send"
-                }
-            }
             return pasteClientApi.sendPaste(
                 pasteData,
                 targetAppInstanceId,
@@ -277,16 +254,6 @@ class SyncPasteTaskExecutor(
                 "Failed to get connect host address by $handlerKey and WebSocket unavailable",
             )
     }
-
-    /**
-     * Should this paste use the M4 push path instead of pull-mode metadata send?
-     * Push requires (a) actual file payload to ship and (b) a peer that implements
-     * the M1+M2 server endpoints — gated by `EQUAL_TO` version match.
-     */
-    private fun shouldUsePushPath(
-        pasteData: PasteData,
-        handler: SyncHandler,
-    ): Boolean = pasteData.isFileType() && handler.currentVersionRelation == VersionRelation.EQUAL_TO
 
     private suspend fun trySendViaWebSocket(
         targetAppInstanceId: String,

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -43,6 +43,7 @@ import com.crosspaste.sync.MarketingSyncManager
 import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.PendingKeyExchangeStore
 import com.crosspaste.sync.PushSessionManager
+import com.crosspaste.sync.SharePushOrchestrator
 import com.crosspaste.sync.SyncDeviceManager
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.sync.SyncResolver
@@ -97,6 +98,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 userDataPathProvider = get(),
             )
         }
+        single<SharePushOrchestrator> { SharePushOrchestrator(get(), get(), get()) }
         single<Server> {
             DesktopPasteServer(
                 get(named("readWritePort")),

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
@@ -170,7 +170,7 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
                     PullFileTaskExecutor(get(), get(), get(), get(), get(), get()),
                     PullIconTaskExecutor(get(), get(), get(), get()),
                     SwitchLanguageTaskExecutor(get(), get()),
-                    SyncPasteTaskExecutor(get(), get(), get(), get(), get(), get(), get(), get(), get()),
+                    SyncPasteTaskExecutor(get(), get(), get(), get(), get(), get(), get(), get()),
                 ),
                 get(),
             )

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SharePushOrchestratorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SharePushOrchestratorTest.kt
@@ -1,0 +1,223 @@
+package com.crosspaste.sync
+
+import com.crosspaste.db.sync.SyncRuntimeInfoDao
+import com.crosspaste.db.sync.SyncState
+import com.crosspaste.exception.PasteException
+import com.crosspaste.exception.StandardErrorCode
+import com.crosspaste.net.clientapi.FailureResult
+import com.crosspaste.net.clientapi.PasteClientApi
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteType
+import com.crosspaste.sync.SyncTestFixtures.createConnectedSyncRuntimeInfo
+import com.crosspaste.sync.SyncTestFixtures.createSyncRuntimeInfo
+import com.crosspaste.utils.getJsonUtils
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SharePushOrchestratorTest {
+
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    private class TestDeps {
+        val pasteClientApi: PasteClientApi = mockk(relaxed = true)
+        val filePushService: FilePushService = mockk(relaxed = true)
+        val syncRuntimeInfoDao: SyncRuntimeInfoDao = mockk(relaxed = true)
+
+        fun create(): SharePushOrchestrator =
+            SharePushOrchestrator(
+                pasteClientApi = pasteClientApi,
+                filePushService = filePushService,
+                syncRuntimeInfoDao = syncRuntimeInfoDao,
+            )
+    }
+
+    private fun pasteOf(type: PasteType): PasteData {
+        val pasteData = mockk<PasteData>(relaxed = true)
+        every { pasteData.id } returns 1L
+        every { pasteData.getType() } returns type
+        every { pasteData.isFileType() } returns (type == PasteType.FILE_TYPE || type == PasteType.IMAGE_TYPE)
+        return pasteData
+    }
+
+    private fun retryableFailure(message: String): FailureResult =
+        FailureResult(
+            PasteException(
+                StandardErrorCode.SYNC_PASTE_ERROR.toErrorCode(),
+                message,
+            ),
+        )
+
+    @Test
+    fun `no eligible targets returns empty result`() =
+        runTest {
+            val deps = TestDeps()
+            coEvery { deps.syncRuntimeInfoDao.getAllSyncRuntimeInfos() } returns emptyList()
+
+            val result = deps.create().pushToConnectedPeers(pasteOf(PasteType.TEXT_TYPE))
+
+            assertTrue(result.perTarget.isEmpty())
+            assertFalse(result.allSucceeded, "empty fan-out is not 'all succeeded'")
+            assertFalse(result.anySucceeded)
+            coVerify(exactly = 0) { deps.pasteClientApi.sendPaste(any(), any(), any()) }
+            coVerify(exactly = 0) { deps.filePushService.pushFiles(any(), any(), any()) }
+        }
+
+    @Test
+    fun `filters out non-CONNECTED and disallowSend targets`() =
+        runTest {
+            val deps = TestDeps()
+            val connected = createConnectedSyncRuntimeInfo(appInstanceId = "remote-1")
+            val disconnected =
+                createSyncRuntimeInfo(
+                    appInstanceId = "remote-2",
+                    connectHostAddress = "192.168.1.101",
+                    connectState = SyncState.DISCONNECTED,
+                )
+            val connectedButDisallowed =
+                createConnectedSyncRuntimeInfo(appInstanceId = "remote-3").copy(allowSend = false)
+            val unverified =
+                createSyncRuntimeInfo(
+                    appInstanceId = "remote-4",
+                    connectHostAddress = "192.168.1.103",
+                    connectState = SyncState.UNVERIFIED,
+                )
+
+            coEvery { deps.syncRuntimeInfoDao.getAllSyncRuntimeInfos() } returns
+                listOf(connected, disconnected, connectedButDisallowed, unverified)
+            coEvery { deps.pasteClientApi.sendPaste(any(), any(), any()) } returns SuccessResult()
+
+            val result = deps.create().pushToConnectedPeers(pasteOf(PasteType.TEXT_TYPE))
+
+            assertEquals(setOf("remote-1"), result.perTarget.keys)
+            assertTrue(result.allSucceeded)
+            coVerify(exactly = 1) { deps.pasteClientApi.sendPaste(any(), eq("remote-1"), any()) }
+            coVerify(exactly = 0) { deps.pasteClientApi.sendPaste(any(), eq("remote-2"), any()) }
+            coVerify(exactly = 0) { deps.pasteClientApi.sendPaste(any(), eq("remote-3"), any()) }
+            coVerify(exactly = 0) { deps.pasteClientApi.sendPaste(any(), eq("remote-4"), any()) }
+        }
+
+    @Test
+    fun `file type routes to filePushService`() =
+        runTest {
+            val deps = TestDeps()
+            coEvery { deps.syncRuntimeInfoDao.getAllSyncRuntimeInfos() } returns
+                listOf(createConnectedSyncRuntimeInfo(appInstanceId = "remote-1"))
+            coEvery { deps.filePushService.pushFiles(any(), any(), any()) } returns SuccessResult()
+
+            val result = deps.create().pushToConnectedPeers(pasteOf(PasteType.FILE_TYPE))
+
+            assertTrue(result.allSucceeded)
+            coVerify(exactly = 1) { deps.filePushService.pushFiles(any(), eq("remote-1"), any()) }
+            coVerify(exactly = 0) { deps.pasteClientApi.sendPaste(any(), any(), any()) }
+        }
+
+    @Test
+    fun `text type routes to pasteClientApi sendPaste`() =
+        runTest {
+            val deps = TestDeps()
+            coEvery { deps.syncRuntimeInfoDao.getAllSyncRuntimeInfos() } returns
+                listOf(createConnectedSyncRuntimeInfo(appInstanceId = "remote-1"))
+            coEvery { deps.pasteClientApi.sendPaste(any(), any(), any()) } returns SuccessResult()
+
+            val result = deps.create().pushToConnectedPeers(pasteOf(PasteType.TEXT_TYPE))
+
+            assertTrue(result.allSucceeded)
+            coVerify(exactly = 1) { deps.pasteClientApi.sendPaste(any(), eq("remote-1"), any()) }
+            coVerify(exactly = 0) { deps.filePushService.pushFiles(any(), any(), any()) }
+        }
+
+    @Test
+    fun `multi-target fan-out all succeed`() =
+        runTest {
+            val deps = TestDeps()
+            coEvery { deps.syncRuntimeInfoDao.getAllSyncRuntimeInfos() } returns
+                listOf(
+                    createConnectedSyncRuntimeInfo(appInstanceId = "remote-1"),
+                    createConnectedSyncRuntimeInfo(appInstanceId = "remote-2", hostAddress = "192.168.1.101"),
+                    createConnectedSyncRuntimeInfo(appInstanceId = "remote-3", hostAddress = "192.168.1.102"),
+                )
+            coEvery { deps.filePushService.pushFiles(any(), any(), any()) } returns SuccessResult()
+
+            val result = deps.create().pushToConnectedPeers(pasteOf(PasteType.FILE_TYPE))
+
+            assertEquals(setOf("remote-1", "remote-2", "remote-3"), result.perTarget.keys)
+            assertTrue(result.allSucceeded)
+            assertTrue(result.anySucceeded)
+            coVerify(exactly = 3) { deps.filePushService.pushFiles(any(), any(), any()) }
+        }
+
+    @Test
+    fun `multi-target fan-out partial failure`() =
+        runTest {
+            val deps = TestDeps()
+            coEvery { deps.syncRuntimeInfoDao.getAllSyncRuntimeInfos() } returns
+                listOf(
+                    createConnectedSyncRuntimeInfo(appInstanceId = "remote-1"),
+                    createConnectedSyncRuntimeInfo(appInstanceId = "remote-2", hostAddress = "192.168.1.101"),
+                )
+            coEvery {
+                deps.filePushService.pushFiles(any(), eq("remote-1"), any())
+            } returns SuccessResult()
+            coEvery {
+                deps.filePushService.pushFiles(any(), eq("remote-2"), any())
+            } returns retryableFailure("chunk upload failed")
+
+            val result = deps.create().pushToConnectedPeers(pasteOf(PasteType.FILE_TYPE))
+
+            assertEquals(setOf("remote-1", "remote-2"), result.perTarget.keys)
+            assertFalse(result.allSucceeded)
+            assertTrue(result.anySucceeded)
+            assertTrue(result.perTarget["remote-1"] is SuccessResult)
+            assertTrue(result.perTarget["remote-2"] is FailureResult)
+        }
+
+    @Test
+    fun `multi-target fan-out all fail`() =
+        runTest {
+            val deps = TestDeps()
+            coEvery { deps.syncRuntimeInfoDao.getAllSyncRuntimeInfos() } returns
+                listOf(
+                    createConnectedSyncRuntimeInfo(appInstanceId = "remote-1"),
+                    createConnectedSyncRuntimeInfo(appInstanceId = "remote-2", hostAddress = "192.168.1.101"),
+                )
+            coEvery {
+                deps.filePushService.pushFiles(any(), any(), any())
+            } returns retryableFailure("network down")
+
+            val result = deps.create().pushToConnectedPeers(pasteOf(PasteType.FILE_TYPE))
+
+            assertFalse(result.allSucceeded)
+            assertFalse(result.anySucceeded)
+            assertTrue(result.perTarget.values.all { it is FailureResult })
+        }
+
+    @Test
+    fun `null connectHostAddress fails that target gracefully without affecting others`() =
+        runTest {
+            val deps = TestDeps()
+            val withHost = createConnectedSyncRuntimeInfo(appInstanceId = "remote-1")
+            // CONNECTED + allowSend but somehow connectHostAddress is null —
+            // shouldn't crash the whole fan-out.
+            val withoutHost = createConnectedSyncRuntimeInfo(appInstanceId = "remote-2").copy(connectHostAddress = null)
+
+            coEvery { deps.syncRuntimeInfoDao.getAllSyncRuntimeInfos() } returns listOf(withHost, withoutHost)
+            coEvery { deps.pasteClientApi.sendPaste(any(), any(), any()) } returns SuccessResult()
+
+            val result = deps.create().pushToConnectedPeers(pasteOf(PasteType.TEXT_TYPE))
+
+            assertEquals(setOf("remote-1", "remote-2"), result.perTarget.keys)
+            assertTrue(result.perTarget["remote-1"] is SuccessResult)
+            assertTrue(result.perTarget["remote-2"] is FailureResult)
+            assertFalse(result.allSucceeded)
+            assertTrue(result.anySucceeded)
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
@@ -18,7 +18,6 @@ import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteType
 import com.crosspaste.secure.SecureStore
-import com.crosspaste.sync.FilePushService
 import com.crosspaste.sync.SyncHandler
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.sync.SyncTestFixtures.createConnectedSyncRuntimeInfo
@@ -48,7 +47,6 @@ class SyncPasteTaskExecutorTest {
         val configManager: CommonConfigManager = mockk(relaxed = true)
         val pasteDao: PasteDao = mockk(relaxed = true)
         val pasteClientApi: PasteClientApi = mockk(relaxed = true)
-        val filePushService: FilePushService = mockk(relaxed = true)
         val secureStore: SecureStore = mockk(relaxed = true)
         val syncManager: SyncManager = mockk(relaxed = true)
         val wsSessionManager: WsSessionManager =
@@ -77,7 +75,6 @@ class SyncPasteTaskExecutorTest {
                 configManager = configManager,
                 pasteDao = pasteDao,
                 pasteClientApi = pasteClientApi,
-                filePushService = filePushService,
                 secureStore = secureStore,
                 syncManager = syncManager,
                 wsSessionManager = wsSessionManager,
@@ -387,82 +384,5 @@ class SyncPasteTaskExecutorTest {
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is SuccessPasteTaskResult)
-        }
-
-    // ========== E. Push branch (M4) ==========
-
-    @Test
-    fun doExecuteTask_fileTypeEqualToNonExtension_takesPushPath() =
-        runTest {
-            val deps = TestDeps()
-            val executor = deps.createExecutor()
-            val task = createPasteTask()
-            val pasteData = createMockPasteData(PasteType.FILE_TYPE)
-            every { pasteData.isFileType() } returns true
-
-            val handler = createMockSyncHandler("remote-1", versionRelation = VersionRelation.EQUAL_TO)
-
-            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
-            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
-            coEvery { deps.filePushService.pushFiles(any(), any(), any()) } returns SuccessResult()
-
-            val result = executor.doExecuteTask(task)
-
-            assertTrue(result is SuccessPasteTaskResult)
-            coVerify(exactly = 1) { deps.filePushService.pushFiles(any(), eq("remote-1"), any()) }
-            // Push succeeded → pull-mode metadata send must not run as a backup.
-            coVerify(exactly = 0) { deps.pasteClientApi.sendPaste(any(), any(), any()) }
-        }
-
-    @Test
-    fun doExecuteTask_pushFails_fallsBackToPullSend() =
-        runTest {
-            val deps = TestDeps()
-            val executor = deps.createExecutor()
-            val task = createPasteTask()
-            val pasteData = createMockPasteData(PasteType.FILE_TYPE)
-            every { pasteData.isFileType() } returns true
-
-            val handler = createMockSyncHandler("remote-1", versionRelation = VersionRelation.EQUAL_TO)
-
-            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
-            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
-            coEvery { deps.filePushService.pushFiles(any(), any(), any()) } returns
-                FailureResult(
-                    PasteException(
-                        StandardErrorCode.PUSH_PREPARE_FAIL.toErrorCode(),
-                        "prepare 500",
-                    ),
-                )
-            coEvery { deps.pasteClientApi.sendPaste(any(), any(), any()) } returns SuccessResult()
-
-            val result = executor.doExecuteTask(task)
-
-            // The fallback path returns success → overall task succeeds.
-            assertTrue(result is SuccessPasteTaskResult)
-            coVerify(exactly = 1) { deps.filePushService.pushFiles(any(), eq("remote-1"), any()) }
-            coVerify(exactly = 1) { deps.pasteClientApi.sendPaste(any(), eq("remote-1"), any()) }
-        }
-
-    @Test
-    fun doExecuteTask_nonFileType_doesNotInvokePush() =
-        runTest {
-            val deps = TestDeps()
-            val executor = deps.createExecutor()
-            val task = createPasteTask()
-            val pasteData = createMockPasteData(PasteType.TEXT_TYPE)
-            every { pasteData.isFileType() } returns false
-
-            val handler = createMockSyncHandler("remote-1", versionRelation = VersionRelation.EQUAL_TO)
-
-            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
-            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
-            coEvery { deps.pasteClientApi.sendPaste(any(), any(), any()) } returns SuccessResult()
-
-            val result = executor.doExecuteTask(task)
-
-            assertTrue(result is SuccessPasteTaskResult)
-            coVerify(exactly = 0) { deps.filePushService.pushFiles(any(), any(), any()) }
-            coVerify(exactly = 1) { deps.pasteClientApi.sendPaste(any(), any(), any()) }
         }
 }


### PR DESCRIPTION
## Summary

M4 (PR #4457) placed the push code path inside `SyncPasteTaskExecutor.syncPasteToTarget` as an if-branch. Real-device testing of the iOS Share Extension surfaced three bugs all rooted in the same architectural mistake: push and pull are fundamentally different sync models and don't belong in the same task-executor pipeline.

Full design rationale in `crosspaste-mobile/docs/push-protocol-issues.md`.

### Why M4's in-task-executor placement was the wrong abstraction

|                | Pull (existing)                                  | Push (M4)                                       |
| -------------- | ------------------------------------------------ | ----------------------------------------------- |
| Call mode      | async enqueue → TaskExecutor background          | synchronous blocking → result in-band           |
| Failure        | `failureTask(needRetry=true)` → next process run | sender's process about to die — no \"next time\" |
| Lifetime       | minutes / hours (cross-process)                  | sender's ~25s execution window                  |
| Persistence    | required (retry needs the DB row)                | not needed (return value)                       |
| Caller         | long-running app                                 | one-shot forced flush                           |
| Result channel | poll task status / DB                            | direct return value                             |

Burying push inside the task executor forced its callers (iOS Share Extension) to drag in `SyncManager.start()` → `NearbyDeviceManager` / Bonjour / resolver, which writes back to `SyncRuntimeInfo` and pollutes the main app's view from a sandboxed extension process.

### What the new SharePushOrchestrator does

Top-level service parallel to the Task system, not inside it. State-free: reads `SyncRuntimeInfoDao` snapshots, fans out in parallel via `coroutineScope { async }`, routes file types to `filePushService.pushFiles` and others to `pasteClientApi.sendPaste`. Returns `SharePushResult(perTarget: Map<String, ClientApiResult>)` with `allSucceeded` / `anySucceeded` helpers.

```kotlin
suspend fun pushToConnectedPeers(pasteData: PasteData): SharePushResult
```

Filter is `connectState == CONNECTED && allowSend == true`. Sufficient because `GeneralSyncHandler.handleValueChange` transitions handlers to `INCOMPATIBLE` on version mismatch — they never stay at `CONNECTED`. Persisted DB state alone is enough; no in-memory `SyncHandler` needed.

Currently only the iOS Share Extension is expected to call this; mobile-side wiring lands separately.

### Three bugs this implicitly fixes

1. **Double LOADING entries on the receiver.** The M4 push branch fell through to `pasteClientApi.sendPaste` when `filePushService.pushFiles` failed. That created a second LOADING row plus a doomed reverse `/pull/file` request. The fallback path is gone — push is no longer in the executor at all.
2. **Push auto-enabled too broadly.** `shouldUsePushPath` defaulted to taking push for every file-type paste between same-version peers, including main-app callers that can host reverse pulls. Push is now invoked only via explicit `SharePushOrchestrator` call; default paste flow stays on pull-mode metadata send.
3. **`SyncManager.start()` pollution from the iOS Share Extension** (mobile-side). With push out of the task executor, the share extension no longer needs the task pipeline running — the mobile follow-up can drop `SyncManager.start()` from `ShareExtensionKoin` and call `SharePushOrchestrator` directly. Tracked in the crosspaste-mobile repo.

## What stays unchanged

These M4 protocol-level pieces remain — only the call site was wrong:

- `app/src/commonMain/.../net/clientapi/PushClientApi.kt`
- `app/src/commonMain/.../sync/FilePushService.kt`
- `app/src/commonMain/.../net/PasteClient.kt::postBinary`
- `core/src/commonMain/.../dto/push/*` DTOs
- Push error codes in `StandardErrorCode`
- Server-side push routing: `PushRouting`, `PushSessionManager`, `PasteRouting` push branch — all untouched

## Diff at a glance

```
6 files changed, 329 insertions(+), 114 deletions(-)
 NEW    app/src/commonMain/kotlin/com/crosspaste/sync/SharePushOrchestrator.kt
 MOD    app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt    (M3 shape)
 MOD    app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt          (+ single<SharePushOrchestrator>)
 MOD    app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt   (- one get() arg)
 NEW    app/src/desktopTest/kotlin/com/crosspaste/sync/SharePushOrchestratorTest.kt
 MOD    app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt (- M4 push tests + fixture)
```

## Backward compatibility

- No DB schema change. No `SyncExtraInfo` change. No wire-format change.
- Existing pull-mode metadata send + reverse `/pull/file` flow works identically.
- Earlier `forcePush` field proposal is **dropped entirely** — no flag is threaded through `SyncExtraInfo` / `PasteSourceContext` / `addSyncTask`. Push is now invoked exclusively by direct call to `SharePushOrchestrator`; there's no \"which path?\" decision to gate. (Supersedes PR #4466.)

## Test plan

- [x] `./gradlew ktlintFormat` — clean
- [x] `./gradlew :app:compileKotlinDesktop :app:compileTestKotlinDesktop` — clean
- [x] `./gradlew :app:desktopTest --tests \"com.crosspaste.sync.SharePushOrchestratorTest\"` — **8/8 pass** (no eligible targets, filter non-CONNECTED + disallowSend, file → pushFiles, text → sendPaste, fan-out all-success / partial / all-fail, null connectHostAddress graceful)
- [x] `./gradlew :app:desktopTest --tests \"com.crosspaste.task.SyncPasteTaskExecutorTest\"` — **14/14 pass** (without the deleted M4 push-branch cases)
- [x] `./gradlew :app:desktopTest --tests \"com.crosspaste.sync.FilePushServiceTest\" --tests \"com.crosspaste.net.clientapi.PushClientApiTest\"` — pass (protocol layer unchanged)
- [x] Wider regression: `./gradlew :app:desktopTest --tests \"com.crosspaste.task.*\" --tests \"com.crosspaste.sync.*\" --tests \"com.crosspaste.net.*\" --tests \"com.crosspaste.paste.*\"` — **538 tests, 0 failures, 0 errors, 15 skipped (pre-existing)**

## Deviations from spec

- Design doc imports `com.crosspaste.dto.sync.HostAndPort`; the actual location in this repo is `com.crosspaste.utils.HostAndPort`. Used the real path.
- `SharePushResult.allSucceeded` returns `false` when `perTarget` is empty (no eligible peers) — a no-op fan-out shouldn't claim success. Documented in tests.
- Null `connectHostAddress` returns a `FailureResult` with `StandardErrorCode.CANT_GET_SYNC_ADDRESS` for that target; surrounding targets still complete. The design doc left the error code unspecified.

## Follow-ups

- Mobile-side migration in `crosspaste-mobile` repo:
  - `IOSShareInboxProcessor` sets `targetAppInstanceIds = emptySet()` to suppress `addSyncTask`
  - `ShareExtensionKoin` drops `SyncManager.start()` and calls `SharePushOrchestrator.pushToConnectedPeers` directly
  - Delete `IOSSyncTaskWaiter` (no longer needed — orchestrator is suspend)
  - Mobile Koin registers `single<SharePushOrchestrator>` and adjusts `SyncPasteTaskExecutor` wiring (drops one `get()`)
- PR #4466 (`forcePush` opt-in approach) is superseded by this PR and should be closed.

Refs: PR #4457 (M4 mobile push client), PR #4456 (M1+M2 server push), design doc `crosspaste-mobile/docs/push-protocol-issues.md`.