### PR TITLE
:bug: push receive: pre-allocate file slots so the first chunk has somewhere to land

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
@@ -115,6 +115,8 @@ private suspend fun handleFilePushChunk(
     val writeFailed =
         runCatching {
             fileUtils.writeFilesChunk(filesChunk, call.receiveChannel())
+        }.onFailure { e ->
+            logger.error(e) { "failed to write files chunk" }
         }.isFailure
     if (writeFailed) {
         logger.error { "push chunk: write failed pasteId=${headers.pasteId} chunkIndex=${headers.chunkIndex}" }

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -11,7 +11,7 @@ import com.crosspaste.paste.item.bindItem
 import com.crosspaste.paste.plugin.process.PasteProcessPlugin
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FilesIndex
-import com.crosspaste.presist.buildFilesIndex
+import com.crosspaste.presist.buildFilesIndexForReceive
 import com.crosspaste.sync.FilePullService
 import com.crosspaste.task.TaskBuilder
 import com.crosspaste.task.TaskSubmitter
@@ -289,7 +289,8 @@ class PasteReleaseService(
                     }
                 val id = newPasteData.id
 
-                val filesIndex = buildFilesIndex(newPasteData, userDataPathProvider, FilePullService.CHUNK_SIZE)
+                val filesIndex =
+                    buildFilesIndexForReceive(newPasteData, userDataPathProvider, FilePullService.CHUNK_SIZE)
                 if (filesIndex.getChunkCount() <= 0) {
                     logger.warn { "releaseRemotePasteDataForPush: empty filesIndex for pasteId=$id" }
                     pasteDao.markDeletePasteData(id)

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
@@ -6,7 +6,9 @@ import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.paste.item.CreatePasteItemHelper.createFilesPasteItem
 import com.crosspaste.paste.item.PasteItemReader
+import com.crosspaste.path.PlatformUserDataPathProvider
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.presist.SingleFileInfoTree
 import com.crosspaste.task.TaskSubmitter
 import com.crosspaste.utils.getJsonUtils
 import io.mockk.coEvery
@@ -14,8 +16,14 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import okio.Path.Companion.toOkioPath
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class PasteReleaseServicePushTest {
 
@@ -47,6 +55,27 @@ class PasteReleaseServicePushTest {
         return configManager
     }
 
+    /**
+     * Build a real [UserDataPathProvider] rooted at [storageRoot]. Required for the
+     * happy-path test, which asserts side effects on the real filesystem.
+     */
+    private fun realPathProvider(storageRoot: File): UserDataPathProvider {
+        val appConfig =
+            mockk<AppConfig>(relaxed = true).also {
+                every { it.useDefaultStoragePath } returns true
+                every { it.maxBackupFileSize } returns 100L
+            }
+        val configManager =
+            mockk<CommonConfigManager>(relaxed = true).also {
+                every { it.getCurrentConfig() } returns appConfig
+            }
+        val platformProvider =
+            mockk<PlatformUserDataPathProvider>().also {
+                every { it.getUserDefaultStoragePath() } returns storageRoot.toOkioPath()
+            }
+        return UserDataPathProvider(configManager, platformProvider)
+    }
+
     @Test
     fun releaseRemotePasteDataForPush_markDeletesWhenFilesIndexEmpty() =
         runBlocking {
@@ -54,7 +83,7 @@ class PasteReleaseServicePushTest {
             coEvery { pasteDao.createPasteData(any(), any()) } returns 99L
             coEvery { pasteDao.markDeletePasteData(any()) } returns Result.success(Unit)
 
-            // userDataPathProvider.resolve is called by buildFilesIndex with the FilesPasteItem
+            // userDataPathProvider.resolve is called by buildFilesIndexForReceive with the FilesPasteItem
             // but relaxed=true makes it a no-op — builder stays empty → FilesIndex has 0 chunks
             // → triggers the empty-filesIndex cleanup branch in releaseRemotePasteDataForPush.
             val service = newService(pasteDao = pasteDao)
@@ -80,4 +109,78 @@ class PasteReleaseServicePushTest {
             assertNull(result, "empty filesIndex should yield null result")
             coVerify(exactly = 1) { pasteDao.markDeletePasteData(99L) }
         }
+
+    /**
+     * Regression: before the fix, `releaseRemotePasteDataForPush` built the FilesIndex
+     * via `buildFilesIndex` which passed `isPull = false` to `UserDataPathProvider.resolve`,
+     * so the parent directory and empty file slots were never created on disk.
+     * The very first `/sync/file/push` chunk then died with `FileNotFoundException`
+     * (`RandomAccessFile("rw")` does NOT create parent dirs).
+     *
+     * After the fix it uses `buildFilesIndexForReceive` which passes `isPull = true`,
+     * pre-allocating the destination file with the right length and creating its
+     * parent directory tree.
+     */
+    @Test
+    fun releaseRemotePasteDataForPush_preallocatesFileSlotsOnDisk(
+        @TempDir tempDir: File,
+    ) = runBlocking {
+        val storage = File(tempDir, "storage").also { it.mkdirs() }
+        val newPasteId = 99L
+        val fileSize = 128L
+        val fileName = "image_0.JPG"
+
+        val pasteDao =
+            mockk<PasteDao>(relaxed = true).also {
+                coEvery { it.createPasteData(any(), any()) } returns newPasteId
+            }
+
+        val service =
+            newService(
+                pasteDao = pasteDao,
+                userDataPathProvider = realPathProvider(storage),
+            )
+
+        val filesItem =
+            createFilesPasteItem(
+                relativePathList = listOf(fileName),
+                fileInfoTreeMap = mapOf(fileName to SingleFileInfoTree(size = fileSize, hash = "h")),
+            )
+        val pasteData =
+            PasteData(
+                appInstanceId = "test-mobile",
+                pasteAppearItem = filesItem,
+                pasteCollection = PasteCollection(emptyList()),
+                pasteType = PasteType.FILE_TYPE.type,
+                source = null,
+                size = fileSize,
+                hash = "h",
+            )
+
+        val result = service.releaseRemotePasteDataForPush(pasteData)
+
+        assertNotNull(result, "non-empty filesIndex should yield a PushPrepareResult")
+        assertEquals(newPasteId, result.pasteId)
+
+        // The receive path must have created the parent directory tree and pre-allocated
+        // an empty file slot at the destination — otherwise the first chunk write would
+        // fail with FileNotFoundException at runtime.
+        val ymd =
+            com.crosspaste.utils.getDateUtils().run {
+                getYMD(epochMillisecondsToLocalDateTime(pasteData.createTime))
+            }
+        val expectedFile =
+            storage
+                .toOkioPath()
+                .resolve("files")
+                .resolve("test-mobile")
+                .resolve(ymd)
+                .resolve(newPasteId.toString())
+                .resolve(fileName)
+                .toFile()
+
+        assertTrue(expectedFile.parentFile.isDirectory, "parent directory must exist")
+        assertTrue(expectedFile.isFile, "file slot must be pre-allocated")
+        assertEquals(fileSize, expectedFile.length(), "pre-allocated slot must have the expected length")
+    }
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/FilesIndexFactory.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/FilesIndexFactory.kt
@@ -9,15 +9,45 @@ import com.crosspaste.utils.getDateUtils
  * Canonical [PasteData] → [FilesIndex] mapping. Resolves each [PasteFiles] item
  * through [userDataPathProvider] to compute on-disk chunk slots.
  *
- * Used by both directions of file sync:
- * - Pull (serving `/pull/file`): build from a LOADED PasteData to read chunks out.
- * - Push (receiving `/sync/file/push`): build from a freshly-bound LOADING PasteData
- *   so incoming chunks land in the right slots.
+ * Use this on the **sender** side — pull-serving (`/pull/file`) and push-sending
+ * ([com.crosspaste.sync.FilePushService.pushFiles]) — where the on-disk files
+ * already exist and must only be indexed. For the **receiver** side of push,
+ * use [buildFilesIndexForReceive] so parent directories and empty file slots
+ * get created before incoming chunks try to write into them.
  */
 fun buildFilesIndex(
     pasteData: PasteData,
     userDataPathProvider: UserDataPathProvider,
     chunkSize: Long,
+): FilesIndex = buildFilesIndexInternal(pasteData, userDataPathProvider, chunkSize, prepareSlots = false)
+
+/**
+ * Receive-side counterpart of [buildFilesIndex] for the push protocol.
+ *
+ * In addition to building the [FilesIndex] over the paste's destination paths,
+ * this also creates the parent directories and pre-allocates empty files at
+ * each target path — so the subsequent `/sync/file/push` chunk uploads can
+ * `RandomAccessFile`-seek into them. Without this preparation, the very first
+ * chunk hits `FileNotFoundException` because `RandomAccessFile("rw")` does not
+ * create missing parent directories.
+ *
+ * The pull-receive path achieves the same effect by calling
+ * [com.crosspaste.path.UserDataPathProvider.resolve] with `isPull = true`
+ * inside `FilePullService`. Push-receive lives in a different code path
+ * ([com.crosspaste.paste.PasteReleaseService.releaseRemotePasteDataForPush]),
+ * which is why it needs an explicit entry point.
+ */
+fun buildFilesIndexForReceive(
+    pasteData: PasteData,
+    userDataPathProvider: UserDataPathProvider,
+    chunkSize: Long,
+): FilesIndex = buildFilesIndexInternal(pasteData, userDataPathProvider, chunkSize, prepareSlots = true)
+
+private fun buildFilesIndexInternal(
+    pasteData: PasteData,
+    userDataPathProvider: UserDataPathProvider,
+    chunkSize: Long,
+    prepareSlots: Boolean,
 ): FilesIndex {
     val dateUtils = getDateUtils()
     val dateString =
@@ -31,7 +61,7 @@ fun buildFilesIndex(
             dateString,
             pasteData.id,
             pasteFiles,
-            false,
+            prepareSlots,
             builder,
         )
     }


### PR DESCRIPTION
## Summary

Real-device push from iOS Share Extension was failing on the desktop receiver with:

```
ERROR PushRouting -- failed to write files chunk
java.io.FileNotFoundException: /Users/.../images/<appInstanceId>/<date>/<pasteId>/image_0.JPG (No such file or directory)
    at java.io.RandomAccessFile.<init>(RandomAccessFile.java:298)
    at com.crosspaste.utils.DesktopFileUtils.writeFilesChunk(FileUtils.desktop.kt:58)
    at com.crosspaste.net.routing.PushRoutingKt.handleFilePushChunk(PushRouting.kt:117)
```

### Root cause

`PasteReleaseService.releaseRemotePasteDataForPush` built the destination `FilesIndex` via `buildFilesIndex`, which always passes `isPull = false` to `UserDataPathProvider.resolve(...)`. That flag controls two receive-side side effects:

- `autoCreateDir(basePath)` — create the parent directory tree
- `createEmptyPasteFile(filePath, size)` — pre-allocate each file slot with the right length

When `isPull = false`, only the path index is built; nothing is touched on disk. So when the first chunk arrived, `PushRouting.handleFilePushChunk` → `FileUtils.writeFilesChunk` opened the target with `RandomAccessFile(file, "rw")`, which **does not create missing parent directories**, and threw `FileNotFoundException`.

The pull-receive path doesn't have this problem because `FilePullService` calls `userDataPathProvider.resolve(..., isPull = true, ...)` directly, getting both side effects.

`buildFilesIndex` already documented dual use (pull-serving and push-receiving), but the implementation hard-coded `isPull = false` — fine for pull-serving (the sender already has the files on disk) but wrong for push-receiving.

## Changes

- **`shared/src/commonMain/kotlin/com/crosspaste/presist/FilesIndexFactory.kt`** — split into:
  - `buildFilesIndex(...)` — unchanged behavior, used by the sender side (pull-serving in `PullClientApi`, push-sending in `FilePushService`)
  - `buildFilesIndexForReceive(...)` — new wrapper that passes `isPull = true`, creating parent dirs and pre-allocating empty files
  - Kept as two separate top-level functions (rather than one with a default arg) so `FilePushService`'s `::buildFilesIndex` function reference stays valid — Kotlin function references include defaulted params in their arity.
- **`app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt`** — `releaseRemotePasteDataForPush` now calls `buildFilesIndexForReceive`.
- **`app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt`** — surface the underlying exception in `handleFilePushChunk`'s failure log. Previously the catch site only emitted `"push chunk: write failed"` without the cause, which is exactly why this bug went undiagnosed until a stacktrace was captured by hand.

## Test

`app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt` — new case `releaseRemotePasteDataForPush_preallocatesFileSlotsOnDisk`:

- Builds a real `UserDataPathProvider` rooted at a JUnit `@TempDir`
- Feeds a `FilesPasteItem` carrying a `SingleFileInfoTree(size=128)`
- Calls `service.releaseRemotePasteDataForPush(pasteData)`
- Asserts the destination parent directory exists and the empty file slot was pre-allocated at the expected length

Before the fix this test fails because the parent dir is never created — exactly mirroring the real-device symptom.

## Backward compatibility

- No protocol or wire-format change.
- No DB schema change.
- No public API change (`buildFilesIndex` signature is unchanged; new `buildFilesIndexForReceive` is additive).

## Verification

- [x] `./gradlew ktlintFormat` — clean
- [x] `./gradlew :app:compileKotlinDesktop :app:compileTestKotlinDesktop` — clean
- [x] `./gradlew :app:desktopTest --tests "com.crosspaste.paste.PasteReleaseServicePushTest"` — 2/2 pass (existing empty-index case + new regression)
- [x] Wider regression: `./gradlew :app:desktopTest --tests "com.crosspaste.paste.*" --tests "com.crosspaste.sync.*" --tests "com.crosspaste.net.*" --tests "com.crosspaste.task.*"` — **539 tests, 0 failures, 0 errors, 15 skipped (pre-existing)**

## Follow-up

- On the mobile side, the iOS Share Extension's push retries should now succeed once this lands and `./gradlew syncDesktop` propagates the change.

Refs: PR #4456 (M1+M2 server push), PR #4457 (M4 client wiring), PR #4467 (push extracted into `SharePushOrchestrator`).