### PR TITLE
:bug: fix LazyColumn duplicate-key crash on Devices screen with Compose 1.11

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -238,7 +238,7 @@ fun DevicesContentView(guideContent: (@Composable () -> Unit)? = null) {
                     SearchingNearbyDevices()
                 }
             } else if (nearbyDevicesList.isNotEmpty()) {
-                items(nearbyDevicesList, key = { item -> item.appInfo.appInstanceId }) { syncInfo ->
+                items(nearbyDevicesList, key = { item -> "nearby-${item.appInfo.appInstanceId}" }) { syncInfo ->
                     val currentSyncInfo by rememberUpdatedState(syncInfo)
                     val scope =
                         remember(currentSyncInfo) {


### PR DESCRIPTION
Closes #4469

## Summary

- After upgrading to Compose Multiplatform 1.11.0, the Devices screen crashes with `IllegalArgumentException: Key "<appInstanceId>" was already used` whenever a paired device briefly co-exists in both the "my devices" and "nearby devices" lists.
- Root cause: `DevicesContentView`'s `LazyColumn` had two dynamic `items` blocks (online + nearby) keyed on the raw `appInstanceId`. The two flows are subscribed independently via `collectAsState`, so a one-frame overlap can happen right after pairing — 1.10 tolerated it silently, 1.11 enforces uniqueness across `items` blocks and throws.
- Fix: prefix the nearby section's key with `"nearby-"`, matching the existing `"offline-"` convention, so all three sections (online / offline / nearby) live in fully disjoint key namespaces regardless of recomposition order.

## Scope check

Audited every Lazy container in the project (17 across `:app`; other modules have no Compose UI). This is the only place where multiple dynamic `items` blocks shared an overlapping key namespace.

## Test plan

- [ ] Launch the app, pair a device, then unpair — Devices screen no longer crashes during the pair/unpair transition
- [ ] Verify offline devices still render correctly when toggled
- [ ] Verify nearby device list updates without flicker