### PR TITLE
OCR settings: redesign language rows and support drag-to-reorder loaded languages

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -58,6 +58,7 @@ import com.crosspaste.utils.getAppEnvUtils
 import io.github.oshai.kotlinlogging.KLogger
 import org.koin.core.KoinApplication
 import org.koin.core.context.GlobalContext
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 class DesktopModule(
@@ -88,7 +89,7 @@ class DesktopModule(
 
     override fun extensionModule() =
         module {
-            single<OCRModule> { DesktopOCRModule(get(), get(), get(), get(), get()) }
+            single { DesktopOCRModule(get(), get(), get(), get(), get()) } bind OCRModule::class
         }
 
     // SqlDelight

--- a/app/src/desktopMain/kotlin/com/crosspaste/module/ocr/DesktopOCRModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/module/ocr/DesktopOCRModule.kt
@@ -174,6 +174,12 @@ class DesktopOCRModule(
         }
     }
 
+    suspend fun setLanguages(trainedDataNames: List<String>) {
+        mutex.withLock {
+            updateOrCreateApi(trainedDataNames.joinToString("+"))
+        }
+    }
+
     override suspend fun extractText(path: Path): Result<String> =
         mutex.withLock {
             val ocrLanguage = configManager.getCurrentConfig().ocrLanguage

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/ocr/OCRContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/ocr/OCRContentView.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -180,8 +182,8 @@ private fun LoadedLanguageSection(
 ) {
     val density = LocalDensity.current
     var draggedIndex by remember { mutableStateOf<Int?>(null) }
-    var dragOffsetY by remember { mutableStateOf(0f) }
-    var rowHeightPx by remember { mutableStateOf(0) }
+    var dragOffsetY by remember { mutableFloatStateOf(0f) }
+    var rowHeightPx by remember { mutableIntStateOf(0) }
     val gapPx = with(density) { small2X.toPx() }
     val rowStepPx = rowHeightPx + gapPx
 
@@ -212,7 +214,9 @@ private fun LoadedLanguageSection(
                 language = language,
                 translationY = translationY,
                 isDragging = index == source,
-                onMeasured = { rowHeightPx = it },
+                onMeasured = { measured ->
+                    if (rowHeightPx == 0) rowHeightPx = measured
+                },
                 onDragStart = {
                     draggedIndex = index
                     dragOffsetY = 0f

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/ocr/OCRContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/ocr/OCRContentView.kt
@@ -1,52 +1,73 @@
 package com.crosspaste.ui.extension.ocr
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults.buttonColors
-import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.zIndex
+import com.composables.icons.materialsymbols.MaterialSymbols
+import com.composables.icons.materialsymbols.rounded.Drag_indicator
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.i18n.Language
-import com.crosspaste.image.OCRModule
 import com.crosspaste.module.DownloadState
 import com.crosspaste.module.ModuleDownloadManager
+import com.crosspaste.module.ocr.DesktopOCRModule
 import com.crosspaste.module.ocr.DesktopOCRModule.Companion.getTrainedDataName
 import com.crosspaste.module.ocr.DesktopOCRModule.Companion.splitOcrLanguages
 import com.crosspaste.notification.MessageType
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.ui.base.AlertCard
 import com.crosspaste.ui.base.SectionHeader
-import com.crosspaste.ui.settings.SettingSectionCard
-import com.crosspaste.ui.theme.AppUISize.huge
+import com.crosspaste.ui.theme.AppUISize.large
 import com.crosspaste.ui.theme.AppUISize.large2X
 import com.crosspaste.ui.theme.AppUISize.medium
-import com.crosspaste.ui.theme.AppUISize.tiny
+import com.crosspaste.ui.theme.AppUISize.small
+import com.crosspaste.ui.theme.AppUISize.small2X
+import com.crosspaste.ui.theme.AppUISize.tiny2X
+import com.crosspaste.ui.theme.AppUISize.tiny3X
+import com.crosspaste.ui.theme.AppUISize.tinyRoundedCornerShape
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import kotlin.math.roundToInt
+
+private val LanguageRowShape = tinyRoundedCornerShape
+private val ActionPillShape = RoundedCornerShape(small)
+private val RowPadding = PaddingValues(horizontal = medium, vertical = tiny2X)
+private val PillPadding = PaddingValues(horizontal = small, vertical = tiny3X)
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -55,7 +76,7 @@ fun OCRContentView() {
     val copywriter = koinInject<GlobalCopywriter>()
     val moduleDownloadManager = koinInject<ModuleDownloadManager>()
     val notificationManager = koinInject<NotificationManager>()
-    val ocrModule = koinInject<OCRModule>()
+    val ocrModule = koinInject<DesktopOCRModule>()
     val allLanguages = copywriter.getAllLanguages()
 
     val config by configManager.config.collectAsState()
@@ -77,10 +98,8 @@ fun OCRContentView() {
     }
 
     LazyColumn(
-        modifier =
-            Modifier
-                .fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(tiny),
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(medium),
     ) {
         if (ocrLanguageList.isNotEmpty()) {
             item {
@@ -91,53 +110,42 @@ fun OCRContentView() {
             }
 
             item {
-                SectionHeader("language_module_loaded", topPadding = medium)
-            }
+                val loadedLanguages =
+                    ocrLanguageList.mapNotNull { trainedDataName ->
+                        allLanguages.find { getTrainedDataName(it.abridge) == trainedDataName }
+                    }
 
-            item {
-                SettingSectionCard {
-                    val languages =
-                        ocrLanguageList.mapNotNull { ocrLanguage ->
-                            allLanguages.find { getTrainedDataName(it.abridge) == ocrLanguage }
+                LoadedLanguageSection(
+                    languages = loadedLanguages,
+                    onRemove = { language ->
+                        scope.launch {
+                            ocrModule.removeLanguage(language.abridge)
                         }
-
-                    languages
-                        .withIndex()
-                        .forEach { (index, language) ->
-                            LoadedLanguageItem(
-                                index = index + 1,
-                                language = language,
-                            ) {
-                                scope.launch {
-                                    ocrModule.removeLanguage(language.abridge)
-                                }
-                            }
-                            if (index < ocrLanguageList.lastIndex) {
-                                HorizontalDivider()
-                            }
+                    },
+                    onReorder = { newOrder ->
+                        scope.launch {
+                            ocrModule.setLanguages(newOrder.mapNotNull { getTrainedDataName(it.abridge) })
                         }
-                }
+                    },
+                )
             }
         }
 
         item {
-            SectionHeader("language_module_not_loaded", topPadding = medium)
-        }
+            Column(verticalArrangement = Arrangement.spacedBy(small2X)) {
+                SectionHeader("language_module_not_loaded")
 
-        item {
-            SettingSectionCard {
                 val languages =
                     allLanguages.filter { language ->
                         val ocrLanguage = ocrLanguageList.find { it == getTrainedDataName(language.abridge) }
                         ocrLanguage == null
                     }
 
-                languages.withIndex().forEach { (index, language) ->
-
-                    val downloadState = downloadState.fileStates[language.abridge]
+                languages.forEach { language ->
+                    val itemDownloadState = downloadState.fileStates[language.abridge]
                     LanguageItem(
                         language = language,
-                        state = downloadState,
+                        state = itemDownloadState,
                         onDownloadClick = {
                             ocrModule.createDownloadTask(language.abridge)?.let { task ->
                                 moduleDownloadManager.downloadFile(task)
@@ -158,12 +166,120 @@ fun OCRContentView() {
                             }
                         },
                     )
-
-                    if (index < languages.lastIndex) {
-                        HorizontalDivider()
-                    }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun LoadedLanguageSection(
+    languages: List<Language>,
+    onRemove: (Language) -> Unit,
+    onReorder: (List<Language>) -> Unit,
+) {
+    val density = LocalDensity.current
+    var draggedIndex by remember { mutableStateOf<Int?>(null) }
+    var dragOffsetY by remember { mutableStateOf(0f) }
+    var rowHeightPx by remember { mutableStateOf(0) }
+    val gapPx = with(density) { small2X.toPx() }
+    val rowStepPx = rowHeightPx + gapPx
+
+    val source = draggedIndex
+    val target =
+        if (source != null && rowStepPx > 0f && languages.isNotEmpty()) {
+            val shift = (dragOffsetY / rowStepPx).roundToInt()
+            (source + shift).coerceIn(0, languages.lastIndex)
+        } else {
+            null
+        }
+
+    Column(verticalArrangement = Arrangement.spacedBy(small2X)) {
+        SectionHeader("language_module_loaded")
+
+        languages.forEachIndexed { index, language ->
+            val translationY =
+                when {
+                    source == null -> 0f
+                    index == source -> dragOffsetY
+                    target != null && source < target && index in (source + 1)..target -> -rowStepPx
+                    target != null && source > target && index in target..(source - 1) -> rowStepPx
+                    else -> 0f
+                }
+
+            LoadedLanguageItem(
+                index = index + 1,
+                language = language,
+                translationY = translationY,
+                isDragging = index == source,
+                onMeasured = { rowHeightPx = it },
+                onDragStart = {
+                    draggedIndex = index
+                    dragOffsetY = 0f
+                },
+                onDragDelta = { dragOffsetY += it },
+                onDragEnd = {
+                    val from = source
+                    val to = target
+                    if (from != null && to != null && from != to) {
+                        val newList =
+                            languages.toMutableList().apply {
+                                add(to, removeAt(from))
+                            }
+                        onReorder(newList)
+                    }
+                    draggedIndex = null
+                    dragOffsetY = 0f
+                },
+                onRemoveClick = { onRemove(language) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun LanguageRowCard(
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = LanguageRowShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(RowPadding),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun ActionPill(
+    text: String,
+    containerColor: Color,
+    contentColor: Color,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        shape = ActionPillShape,
+        color = containerColor,
+    ) {
+        Box(
+            modifier = Modifier.padding(PillPadding),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.labelMedium,
+                color = contentColor,
+            )
         }
     }
 }
@@ -172,38 +288,64 @@ fun OCRContentView() {
 fun LoadedLanguageItem(
     index: Int,
     language: Language,
+    translationY: Float = 0f,
+    isDragging: Boolean = false,
+    onMeasured: (Int) -> Unit = {},
+    onDragStart: () -> Unit = {},
+    onDragDelta: (Float) -> Unit = {},
+    onDragEnd: () -> Unit = {},
     onRemoveClick: () -> Unit,
 ) {
     val copywriter = koinInject<GlobalCopywriter>()
-    ListItem(
+    val latestOnDragStart by rememberUpdatedState(onDragStart)
+    val latestOnDragDelta by rememberUpdatedState(onDragDelta)
+    val latestOnDragEnd by rememberUpdatedState(onDragEnd)
+    LanguageRowCard(
         modifier =
-            Modifier.height(huge),
-        headlineContent = {
+            Modifier
+                .zIndex(if (isDragging) 1f else 0f)
+                .graphicsLayer { this.translationY = translationY }
+                .onGloballyPositioned { onMeasured(it.size.height) },
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(small2X),
+        ) {
+            Icon(
+                imageVector = MaterialSymbols.Rounded.Drag_indicator,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier =
+                    Modifier
+                        .size(large)
+                        .pointerInput(Unit) {
+                            detectDragGestures(
+                                onDragStart = { latestOnDragStart() },
+                                onDragEnd = { latestOnDragEnd() },
+                                onDragCancel = { latestOnDragEnd() },
+                                onDrag = { _, dragAmount -> latestOnDragDelta(dragAmount.y) },
+                            )
+                        },
+            )
+            Text(
+                text = index.toString(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
             Text(
                 text = language.name,
                 style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
             )
-        },
-        leadingContent = {
-            Text(
-                text = index.toString(),
-                style = MaterialTheme.typography.labelMedium,
-            )
-        },
-        trailingContent = {
-            Button(
-                onClick = onRemoveClick,
-                colors =
-                    buttonColors(
-                        containerColor = MaterialTheme.colorScheme.error,
-                        contentColor = MaterialTheme.colorScheme.onError,
-                    ),
-            ) {
-                Text(copywriter.getText("remove"))
-            }
-        },
-        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-    )
+        }
+        ActionPill(
+            text = copywriter.getText("remove"),
+            containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.2f),
+            contentColor = MaterialTheme.colorScheme.error,
+            onClick = onRemoveClick,
+        )
+    }
 }
 
 @Composable
@@ -216,102 +358,91 @@ fun LanguageItem(
     onLoadClick: () -> Unit,
 ) {
     val copywriter = koinInject<GlobalCopywriter>()
-
-    ListItem(
-        modifier =
-            Modifier.height(huge),
-        headlineContent = {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = medium),
-                contentAlignment = Alignment.Center,
-            ) {
-                if (state is DownloadState.Downloading) {
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        LinearProgressIndicator(
-                            progress = state.progress.progress,
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .height(large2X),
-                            strokeCap = StrokeCap.Round,
-                        )
-                        Text(
-                            text = "${(state.progress.progress * 100).toInt()}%",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            fontWeight = FontWeight.Bold,
-                        )
-                    }
-                }
-            }
-        },
-        leadingContent = {
+    LanguageRowCard {
+        Row(
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(small2X),
+        ) {
             Text(
                 text = language.name,
                 style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
             )
-        },
-        trailingContent = {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(tiny),
-            ) {
-                when (state) {
-                    null, is DownloadState.Idle, is DownloadState.Cancelled -> {
-                        FilledTonalButton(
-                            onClick = onDownloadClick,
-                        ) {
-                            Text(copywriter.getText("download"))
-                        }
-                    }
-
-                    is DownloadState.Downloading -> {
-                        TextButton(
-                            onClick = onCancelClick,
-                        ) {
-                            Text(copywriter.getText("cancel"))
-                        }
-                    }
-
-                    is DownloadState.Completed -> {
-                        Button(
-                            onClick = onDeleteClick,
-                            colors =
-                                buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.error,
-                                    contentColor = MaterialTheme.colorScheme.onError,
-                                ),
-                        ) {
-                            Text(copywriter.getText("delete"))
-                        }
-                        Button(
-                            onClick = onLoadClick,
-                        ) {
-                            Text(copywriter.getText("load"))
-                        }
-                    }
-
-                    is DownloadState.Failed -> {
-                        Button(
-                            onClick = onDownloadClick,
-                            colors =
-                                buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.error,
-                                    contentColor = MaterialTheme.colorScheme.onError,
-                                ),
-                        ) {
-                            Text(copywriter.getText("retry"))
-                        }
-                    }
+            if (state is DownloadState.Downloading) {
+                Box(
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .padding(end = small2X),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    LinearProgressIndicator(
+                        progress = state.progress.progress,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .height(large2X),
+                        strokeCap = StrokeCap.Round,
+                    )
+                    Text(
+                        text = "${(state.progress.progress * 100).toInt()}%",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.Bold,
+                    )
                 }
             }
-        },
-        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-    )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(tiny2X),
+        ) {
+            when (state) {
+                null, is DownloadState.Idle, is DownloadState.Cancelled -> {
+                    ActionPill(
+                        text = copywriter.getText("download"),
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        onClick = onDownloadClick,
+                    )
+                }
+
+                is DownloadState.Downloading -> {
+                    ActionPill(
+                        text = copywriter.getText("cancel"),
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                        onClick = onCancelClick,
+                    )
+                }
+
+                is DownloadState.Completed -> {
+                    ActionPill(
+                        text = copywriter.getText("delete"),
+                        containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.2f),
+                        contentColor = MaterialTheme.colorScheme.error,
+                        onClick = onDeleteClick,
+                    )
+                    ActionPill(
+                        text = copywriter.getText("load"),
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        onClick = onLoadClick,
+                    )
+                }
+
+                is DownloadState.Failed -> {
+                    ActionPill(
+                        text = copywriter.getText("retry"),
+                        containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.2f),
+                        contentColor = MaterialTheme.colorScheme.error,
+                        onClick = onDownloadClick,
+                    )
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #4472

## Summary

- Per-row rounded `surfaceContainerHigh` cards + pill-shaped action buttons replace the shared card + dividers layout, matching the design prototype and the rest of the settings screens.
- Loaded language rows now have a drag handle and can be reordered; releasing the drag persists the new order via `DesktopOCRModule.setLanguages`, which re-initializes Tesseract with the reordered language string.
- The drag interaction is hand-rolled (no new dependency); `rememberUpdatedState` keeps the gesture callbacks pointing at the latest section state, fixing an early bug where releasing reverted the order.
- Koin binding switched to `single { DesktopOCRModule(...) } bind OCRModule::class` so the UI can inject the concrete desktop type without touching the shared `OCRModule` interface — no commonMain change, no mobile impact.

## Test plan

- [ ] `./gradlew :app:compileKotlinDesktop` passes
- [ ] `./gradlew ktlintFormat` clean
- [ ] Launch app → Settings → OCR
  - [ ] Loaded section renders each language as its own rounded card with grip handle, order index, language name, and a red pill "remove" button
  - [ ] Unloaded section renders pill "download" buttons; downloading state shows progress bar with gap before the cancel pill
  - [ ] Drag a loaded language up/down: intermediate rows shift in real time; release commits the new order; switching screens and returning still shows the new order
  - [ ] After reorder, OCR continues to work and the first-listed language is the primary one (verify via a screenshot containing mixed scripts)
  - [ ] Restart app: new order persists