### PR TITLE
:arrow_up: upgrade GitHub Actions to Node.js 24 runtime

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,11 +12,11 @@ jobs:
       cache-hit-x86: ${{ steps.cache-check-x86.outputs.cache-hit }}
       cache-hit-aarch64: ${{ steps.cache-check-aarch64.outputs.cache-hit }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: check-dylib-cache-x86
         id: cache-check-x86
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./app/dylib/darwin-x86-64/libMacosApi.dylib
           key: mac-dylib-darwin-x86-64-${{ hashFiles('**/*.swift', '**/dylib-mini-sys.properties') }}
@@ -24,7 +24,7 @@ jobs:
 
       - name: check-dylib-cache-aarch64
         id: cache-check-aarch64
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./app/dylib/darwin-aarch64/libMacosApi.dylib
           key: mac-dylib-darwin-aarch64-${{ hashFiles('**/*.swift', '**/dylib-mini-sys.properties') }}
@@ -34,7 +34,7 @@ jobs:
     needs: [check-dylib-cache]
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Swift environment
         if: needs.check-dylib-cache.outputs.cache-hit-x86 != 'true' || needs.check-dylib-cache.outputs.cache-hit-aarch64 != 'true'
@@ -54,7 +54,7 @@ jobs:
 
       - name: Save dylib to cache for x86_64
         if: needs.check-dylib-cache.outputs.cache-hit-x86 != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ./app/dylib/darwin-x86-64/libMacosApi.dylib
           key: mac-dylib-darwin-x86-64-${{ hashFiles('**/*.swift', '**/dylib-mini-sys.properties') }}
@@ -62,21 +62,21 @@ jobs:
 
       - name: Save dylib to cache for arm64
         if: needs.check-dylib-cache.outputs.cache-hit-aarch64 != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ./app/dylib/darwin-aarch64/libMacosApi.dylib
           key: mac-dylib-darwin-aarch64-${{ hashFiles('**/*.swift', '**/dylib-mini-sys.properties') }}
           enableCrossOsArchive: true
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
           check-latest: true
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -107,7 +107,7 @@ jobs:
       WINDOWS_STORE_ID: ${{ secrets.WINDOWS_STORE_ID }}
       WINDOWS_TENANT_ID: ${{ secrets.WINDOWS_TENANT_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       # https://github.com/actions/runner-images/issues/2840
@@ -119,7 +119,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -144,7 +144,7 @@ jobs:
           fi
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -161,7 +161,7 @@ jobs:
           chmod +x appimagetool.AppImage
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -171,20 +171,20 @@ jobs:
             '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
 
       - name: Cache Jetbrains Runtime JDK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ./app/jbr
           key: jbr-${{ hashFiles('**/jbr.yaml') }}
 
       - name: Restore dylib cache for x86_64
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./app/dylib/darwin-x86-64/libMacosApi.dylib
           key: mac-dylib-darwin-x86-64-${{ hashFiles('**/*.swift', '**/dylib-mini-sys.properties') }}
           enableCrossOsArchive: true
 
       - name: Restore dylib cache for aarch64
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./app/dylib/darwin-aarch64/libMacosApi.dylib
           key: mac-dylib-darwin-aarch64-${{ hashFiles('**/*.swift', '**/dylib-mini-sys.properties') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       app: ${{ steps.filter.outputs.app }}
       web: ${{ steps.filter.outputs.web }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -48,16 +48,16 @@ jobs:
     env:
       BUILD_FULL_PLATFORM: YES
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
           check-latest: true
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -67,7 +67,7 @@ jobs:
             '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
 
       - name: Cache JetBrains Runtime JDK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ./app/jbr
           key: jbr-${{ hashFiles('**/jbr.yaml') }}
@@ -80,23 +80,23 @@ jobs:
     if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
           check-latest: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -107,7 +107,7 @@ jobs:
             core.setOutput('pr-body', pr.data.body || 'No description provided');
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ steps.pr-details.outputs.head-sha }}

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -12,7 +12,7 @@ jobs:
   sponsors:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Update sponsors in README.md
         uses: JamesIves/github-sponsors-readme-action@v1


### PR DESCRIPTION
Closes #4479

## Summary
- Upgrade `actions/checkout` v4 → v6 across all four workflows
- Upgrade `actions/cache` (including `cache/restore`, `cache/save`) v4 → v5
- Upgrade `actions/setup-java` v4 → v5
- Upgrade `actions/setup-node` v4 → v5

All v5/v6 releases run on the Node.js 24 runtime and require runner ≥ v2.327.1, which GitHub-hosted runners already satisfy. This eliminates the Node.js 20 deprecation warnings emitted on every CI run.

## Breaking-change notes considered
- `actions/checkout@v6` changes credential persistence to a separate file. Only `sponsors.yml` does a downstream `git push` (via `stefanzweifel/git-auto-commit-action@v5`), which uses the standard git credential helper and should remain compatible.
- `actions/setup-node@v5` introduces automatic package-manager detection. Our usage explicitly sets `cache: 'npm'`, so behavior is unchanged.

## Test plan
- [ ] CI workflow runs cleanly on this PR with no Node.js 20 deprecation warnings
- [ ] After merge, observe the next scheduled `sponsors` cron run to confirm the auto-commit step still pushes successfully
- [ ] Next release tag triggers `build-release.yml` without runtime issues