### PR TITLE
:bug: fix CLI native build after appInstanceId moved out of AppConfig

### DIFF
--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CliAdapters.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CliAdapters.kt
@@ -4,7 +4,6 @@ import com.crosspaste.cli.platform.NativePlatformPathProvider
 import com.crosspaste.config.AppConfig
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.path.PlatformUserDataPathProvider
-import com.crosspaste.utils.DeviceUtils
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
@@ -21,7 +20,6 @@ import okio.Path
  */
 @Serializable
 data class CliReadOnlyAppConfig(
-    override val appInstanceId: String = "",
     override val language: String = "en",
     override val font: String = "",
     override val isFollowSystemTheme: Boolean = true,
@@ -84,15 +82,6 @@ class CliConfigManager(
         nativePathProvider.getDefaultUserDataPath().resolve("appConfig.json")
 
     private val _config = MutableStateFlow<AppConfig>(loadConfigFromFile())
-
-    override val deviceUtils: DeviceUtils =
-        object : DeviceUtils {
-            override fun createAppInstanceId(): String = _config.value.appInstanceId
-
-            override fun getDeviceId(): String = ""
-
-            override fun getDeviceName(): String = "CLI"
-        }
 
     override val config: StateFlow<AppConfig> = _config
 

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CliModule.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CliModule.kt
@@ -5,6 +5,7 @@ import com.crosspaste.app.AppInfo
 import com.crosspaste.cli.platform.CliConfigReader
 import com.crosspaste.cli.platform.NativePlatformPathProvider
 import com.crosspaste.cli.platform.createNativePlatformPathProvider
+import com.crosspaste.config.AppMetadata
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.DriverFactory
 import com.crosspaste.db.NativeDriverFactory
@@ -26,8 +27,12 @@ import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.path.PlatformUserDataPathProvider
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.task.TaskSubmitter
+import kotlinx.serialization.json.Json
+import okio.FileSystem
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+
+private val metadataJson = Json { ignoreUnknownKeys = true }
 
 val cliModule =
     module {
@@ -42,9 +47,15 @@ val cliDatabaseModule =
         single<PlatformUserDataPathProvider> { CliPlatformUserDataPathProvider(get()) }
         single<UserDataPathProvider> { UserDataPathProvider(get(), get()) }
         single<AppInfo> {
-            val configManager = get<CommonConfigManager>()
+            val metadataPath =
+                get<NativePlatformPathProvider>().getDefaultUserDataPath().resolve(".metadata")
+            val appInstanceId =
+                runCatching {
+                    val content = FileSystem.SYSTEM.read(metadataPath) { readUtf8() }
+                    metadataJson.decodeFromString<AppMetadata>(content).appInstanceId
+                }.getOrDefault("")
             AppInfo(
-                appInstanceId = configManager.getCurrentConfig().appInstanceId,
+                appInstanceId = appInstanceId,
                 appVersion = "cli",
                 appRevision = "Unknown",
                 userName = "",


### PR DESCRIPTION
Closes #4481

## Summary

- Drop the now-invalid `appInstanceId` / `deviceUtils` overrides from `CliReadOnlyAppConfig` and `CliConfigManager` (both were removed from the shared interfaces by #4313).
- In `CliModule`, read `appInstanceId` directly from `<userDataDir>/.metadata` (the same `AppMetadata` file the desktop app persists), falling back to an empty string when the file is not present.

## Test plan

- [x] `./gradlew :cli:compileKotlinCliNative` passes
- [x] `./gradlew :cli:ktlintFormat` clean