### PR TITLE
:bug: round drag preview corners on web paste cards

### DIFF
--- a/web/src/components/paste-grid/PasteCard.tsx
+++ b/web/src/components/paste-grid/PasteCard.tsx
@@ -20,7 +20,7 @@ import { isDarkColor } from "@/shared/utils/html-color";
 import { NotificationManager } from "@/shared/notification/notification-manager";
 import { useImageUrl } from "@/shared/hooks/use-image-url";
 import { useCopyWithNotification } from "@/shared/hooks/use-copy-with-notification";
-import { applyImageDragData, getDragText } from "@/shared/paste/paste-drag";
+import { applyImageDragData, getDragText, setRoundedDragImage } from "@/shared/paste/paste-drag";
 
 const MAX_SIZE = 5 * 1024 * 1024;
 
@@ -254,7 +254,7 @@ export function PasteCard({ data, onClick, onDelete }: Props) {
     }
   }, [data]);
 
-  const handleDragStart = useCallback((e: React.DragEvent) => {
+  const handleDragStart = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     if (data.pasteType === PasteTypeInt.FILE) {
       e.preventDefault();
       NotificationManager.warning(t("file_drag_not_supported"), undefined, 3000, {
@@ -269,6 +269,7 @@ export function PasteCard({ data, onClick, onDelete }: Props) {
         return;
       }
       applyImageDragData(e.dataTransfer, dragImageUrl, dragImageFileName);
+      setRoundedDragImage(e.currentTarget, e.dataTransfer, e.clientX, e.clientY);
       return;
     }
     if (!dragText) {
@@ -277,6 +278,7 @@ export function PasteCard({ data, onClick, onDelete }: Props) {
     }
     e.dataTransfer.setData("text/plain", dragText);
     e.dataTransfer.effectAllowed = "copy";
+    setRoundedDragImage(e.currentTarget, e.dataTransfer, e.clientX, e.clientY);
   }, [data.pasteType, dragText, dragImageUrl, dragImageFileName, t, handleDownload]);
 
   const canDrag =

--- a/web/src/shared/paste/paste-drag.ts
+++ b/web/src/shared/paste/paste-drag.ts
@@ -64,3 +64,51 @@ export function applyImageDragData(
   dataTransfer.setData("DownloadURL", `${mime}:${fileName}:${imageUrl}`);
   dataTransfer.effectAllowed = "copy";
 }
+
+/**
+ * Replace Chrome's default rectangular drag snapshot with a rounded one.
+ *
+ * Why: the card source has `border-radius` + `overflow: hidden`, but Chrome's
+ * default drag image rasterizes the bounding box and paints the corners
+ * opaque, so the ghost looks rectangular even though the card on screen is
+ * rounded. We render an off-screen clone (carrying the same styles) and feed
+ * it to `setDragImage` so the captured snapshot keeps the rounded corners.
+ *
+ * Iframes inside the clone (HTML preview) are swapped for placeholders — a
+ * reattached iframe re-fetches its srcdoc and would snapshot blank anyway.
+ */
+export function setRoundedDragImage(
+  source: HTMLElement,
+  dataTransfer: DataTransfer,
+  pointerX: number,
+  pointerY: number,
+): void {
+  const rect = source.getBoundingClientRect();
+  const clone = source.cloneNode(true) as HTMLElement;
+
+  clone.querySelectorAll("iframe").forEach((iframe) => {
+    const placeholder = document.createElement("div");
+    placeholder.className = iframe.className;
+    placeholder.style.cssText = iframe.style.cssText;
+    iframe.replaceWith(placeholder);
+  });
+
+  Object.assign(clone.style, {
+    position: "fixed",
+    top: "-10000px",
+    left: "-10000px",
+    width: `${rect.width}px`,
+    height: `${rect.height}px`,
+    margin: "0",
+    pointerEvents: "none",
+  });
+  document.body.appendChild(clone);
+
+  dataTransfer.setDragImage(
+    clone,
+    pointerX - rect.left,
+    pointerY - rect.top,
+  );
+
+  setTimeout(() => clone.remove(), 0);
+}


### PR DESCRIPTION
Closes #4484

## Summary
- Cards in the web / Chrome extension paste grid have `border-radius: 14px` + `overflow: hidden`, but Chrome's default drag snapshot rasterizes the bounding box and produces a rectangular ghost that doesn't match the on-screen card.
- Added `setRoundedDragImage` in `web/src/shared/paste/paste-drag.ts`: clones the source card off-screen (swapping iframes for placeholders to avoid blank re-fetches) and passes it to `dataTransfer.setDragImage`, so the captured snapshot preserves the rounded corners.
- Wired the helper into `PasteCard.tsx`'s `handleDragStart` for both the text and image drag paths. File-type cards still `preventDefault` and never start a drag.

## Test plan
- [x] `tsc --noEmit` passes.
- [ ] In the Chrome extension side panel, drag a text card — preview shows rounded corners.
- [ ] Drag an image card — preview shows rounded corners; drop into the OS desktop still downloads via `DownloadURL`; drop into Gmail still embeds `<img>`.
- [ ] Drag an HTML card — preview shows the rounded card frame (iframe contents may render as the placeholder background; the surrounding card chrome stays rounded).
- [ ] File-type cards remain non-draggable and surface the "drag not supported" toast.