### PR TITLE
:bug: suppress shortcut recognition during simulated paste

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
@@ -66,7 +66,7 @@ fun desktopUiModule(): Module =
         single<AppWindowManager> { get<DesktopAppWindowManager>() }
         single<DesktopAppSize> { DesktopAppSize(get()) }
         single<DesktopAppWindowManager> {
-            getDesktopAppWindowManager(get(), get(), lazy { get() }, lazy { get() }, get(), get())
+            getDesktopAppWindowManager(get(), get(), lazy { get() }, lazy { get() }, lazy { get() }, get(), get())
         }
         single<DesktopIconColorExtractor> { DesktopIconColorExtractor(get()) }
         single<DesktopScreenProvider> { DesktopScreenProvider(get(), get(), get(), get(), get(), get()) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
 import com.crosspaste.listener.ShortcutKeys
 import com.crosspaste.listener.ShortcutKeysAction
+import com.crosspaste.listener.ShortcutKeysListener
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.platform.Platform
 import com.crosspaste.utils.GlobalCoroutineScope.mainCoroutineDispatcher
@@ -24,6 +25,7 @@ fun getDesktopAppWindowManager(
     appSize: DesktopAppSize,
     lazyShortcutKeys: Lazy<ShortcutKeys>,
     lazyShortcutKeysAction: Lazy<ShortcutKeysAction>,
+    lazyShortcutKeysListener: Lazy<ShortcutKeysListener>,
     platform: Platform,
     userDataPathProvider: UserDataPathProvider,
 ): DesktopAppWindowManager =
@@ -32,6 +34,7 @@ fun getDesktopAppWindowManager(
             appInfo,
             appSize,
             lazyShortcutKeys,
+            lazyShortcutKeysListener,
             userDataPathProvider,
         )
     } else if (platform.isWindows()) {
@@ -39,6 +42,7 @@ fun getDesktopAppWindowManager(
             appInfo,
             appSize,
             lazyShortcutKeys,
+            lazyShortcutKeysListener,
             userDataPathProvider,
         )
     } else if (platform.isLinux()) {
@@ -47,6 +51,7 @@ fun getDesktopAppWindowManager(
             appSize,
             lazyShortcutKeys,
             lazyShortcutKeysAction,
+            lazyShortcutKeysListener,
             userDataPathProvider,
         )
     } else {

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.awt.ComposeWindow
 import com.crosspaste.listener.DesktopShortcutKeys.Companion.PASTE
 import com.crosspaste.listener.ShortcutKeys
 import com.crosspaste.listener.ShortcutKeysAction
+import com.crosspaste.listener.ShortcutKeysListener
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.platform.linux.api.X11Api
 import com.crosspaste.platform.linux.api.X11Api.Companion.bringToBack
@@ -22,6 +23,7 @@ class LinuxAppWindowManager(
     appSize: DesktopAppSize,
     private val lazyShortcutKeys: Lazy<ShortcutKeys>,
     private val lazyShortcutKeysAction: Lazy<ShortcutKeysAction>,
+    private val lazyShortcutKeysListener: Lazy<ShortcutKeysListener>,
     private val userDataPathProvider: UserDataPathProvider,
 ) : DesktopAppWindowManager(appSize) {
 
@@ -180,6 +182,9 @@ class LinuxAppWindowManager(
             lazyShortcutKeys.value.shortcutKeysCore.value.keys[PASTE]?.let {
                 it.map { key -> key.rawCode }
             } ?: listOf()
+        lazyShortcutKeysListener.value.beginPasteSuppression(
+            ShortcutKeysListener.PASTE_INJECTION_SUPPRESS_TIMEOUT,
+        )
         X11Api.toPaste(keyCodes)
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/MacAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/MacAppWindowManager.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.app
 
 import com.crosspaste.listener.ShortcutKeys
+import com.crosspaste.listener.ShortcutKeysListener
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.platform.macos.MacAppUtils
 import com.crosspaste.platform.macos.MacPasteUtils
@@ -16,6 +17,7 @@ class MacAppWindowManager(
     private val appInfo: AppInfo,
     appSize: DesktopAppSize,
     lazyShortcutKeys: Lazy<ShortcutKeys>,
+    private val lazyShortcutKeysListener: Lazy<ShortcutKeysListener>,
     private val userDataPathProvider: UserDataPathProvider,
 ) : DesktopAppWindowManager(appSize) {
 
@@ -159,6 +161,9 @@ class MacAppWindowManager(
     }
 
     override suspend fun toPaste() {
+        lazyShortcutKeysListener.value.beginPasteSuppression(
+            ShortcutKeysListener.PASTE_INJECTION_SUPPRESS_TIMEOUT,
+        )
         macPasteUtils.simulatePasteCommand()
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/WinAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/WinAppWindowManager.kt
@@ -3,6 +3,7 @@ package com.crosspaste.app
 import androidx.compose.ui.awt.ComposeWindow
 import com.crosspaste.listener.DesktopShortcutKeys.Companion.PASTE
 import com.crosspaste.listener.ShortcutKeys
+import com.crosspaste.listener.ShortcutKeysListener
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.platform.windows.WinAppInfo
 import com.crosspaste.platform.windows.WinAppInfoCaches
@@ -22,6 +23,7 @@ class WinAppWindowManager(
     appInfo: AppInfo,
     appSize: DesktopAppSize,
     private val lazyShortcutKeys: Lazy<ShortcutKeys>,
+    private val lazyShortcutKeysListener: Lazy<ShortcutKeysListener>,
     userDataPathProvider: UserDataPathProvider,
 ) : DesktopAppWindowManager(appSize) {
 
@@ -176,6 +178,9 @@ class WinAppWindowManager(
                 it.map { key -> key.rawCode }
             } ?: listOf()
 
+        lazyShortcutKeysListener.value.beginPasteSuppression(
+            ShortcutKeysListener.PASTE_INJECTION_SUPPRESS_TIMEOUT,
+        )
         WindowsFocusUtils.paste(keyCodes)
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/listener/DesktopShortcutKeysListener.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/listener/DesktopShortcutKeysListener.kt
@@ -2,8 +2,10 @@ package com.crosspaste.listener
 
 import androidx.compose.runtime.mutableStateListOf
 import com.crosspaste.platform.Platform
+import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent
 import com.github.kwhat.jnativehook.keyboard.NativeKeyListener
+import kotlin.time.Duration
 
 class DesktopShortcutKeysListener(
     platform: Platform,
@@ -20,10 +22,38 @@ class DesktopShortcutKeysListener(
     @Volatile
     override var editShortcutKeysMode: Boolean = false
 
+    @Volatile
+    private var pasteSuppressing: Boolean = false
+
+    @Volatile
+    private var pasteSuppressDeadlineMillis: Long = 0L
+
     override var currentKeys: MutableList<KeyboardKey> = mutableStateListOf()
+
+    override fun beginPasteSuppression(timeout: Duration) {
+        pasteSuppressDeadlineMillis = nowEpochMilliseconds() + timeout.inWholeMilliseconds
+        pasteSuppressing = true
+    }
+
+    private fun isPasteSuppressed(): Boolean {
+        if (!pasteSuppressing) {
+            return false
+        }
+        // Safety net: stop suppressing if the injected key-release echo never arrived.
+        if (pasteSuppressDeadlineMillis - nowEpochMilliseconds() <= 0) {
+            pasteSuppressing = false
+            return false
+        }
+        return true
+    }
 
     override fun nativeKeyPressed(nativeEvent: NativeKeyEvent) {
         if (!editShortcutKeysMode) {
+            // Drop events while suppressed: this is CrossPaste's own injected paste
+            // keystroke coming back, which would otherwise loop (issue #4500).
+            if (isPasteSuppressed()) {
+                return
+            }
             shortcutKeys.shortcutKeysCore.value.eventConsumer
                 .accept(nativeEvent)
         } else {
@@ -42,6 +72,14 @@ class DesktopShortcutKeysListener(
 
             currentKeys.clear()
             currentKeys.addAll(list.sortedWith(comparator))
+        }
+    }
+
+    override fun nativeKeyReleased(nativeEvent: NativeKeyEvent) {
+        // The injected paste keystroke releasing marks the end of our own simulation:
+        // lift suppression now rather than waiting for the safety timeout (issue #4500).
+        if (pasteSuppressing) {
+            pasteSuppressing = false
         }
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/listener/ShortcutKeysListener.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/listener/ShortcutKeysListener.kt
@@ -1,8 +1,30 @@
 package com.crosspaste.listener
 
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
 interface ShortcutKeysListener {
+
+    companion object {
+        // Safety net only. Normally suppression is lifted the moment the injected paste
+        // keystroke is observed released; this timeout just guarantees recognition can't
+        // stay disabled forever if that echo is ever dropped by the OS.
+        val PASTE_INJECTION_SUPPRESS_TIMEOUT = 500.milliseconds
+    }
 
     var editShortcutKeysMode: Boolean
 
     var currentKeys: MutableList<KeyboardKey>
+
+    /**
+     * Begin ignoring global shortcuts because CrossPaste is about to inject the system
+     * paste keystroke (Cmd+V / Ctrl+V) to perform a paste.
+     *
+     * That synthetic keystroke is delivered back to this global listener; if a paste
+     * shortcut is bound to a colliding combination it would re-trigger the paste
+     * endlessly, causing an infinite paste loop (issue #4500). Suppression is lifted as
+     * soon as the injected keystroke is observed released (i.e. the simulation actually
+     * finished), or after [timeout] as a safety net.
+     */
+    fun beginPasteSuppression(timeout: Duration)
 }


### PR DESCRIPTION
Follow-up to #4501 for #4500.

## Problem

CrossPaste performs a paste by injecting the system paste keystroke (Cmd+V on macOS, Ctrl+V on Windows/Linux) via global input simulation. That synthetic keystroke is then delivered back to CrossPaste's own global keyboard listener. If a paste shortcut is bound to a combination the injected keystroke satisfies, the action re-triggers the paste, which injects again — an infinite loop that froze the reporter's machine.

#4501 only blocked the **exact** `Cmd+V` combination. That is not enough: shortcut matching is **subset-based** (a combo matches as long as its keys are present; extra modifiers are ignored), and the macOS injection uses `CGEventSource(stateID: .combinedSessionState)`, so a physically-held modifier (e.g. holding Ctrl for a `Ctrl+V` binding) merges into the injected event. The injected `V` plus the held `Ctrl` re-satisfies the `Ctrl+V` shortcut, so `Ctrl+V` (and `Opt+V`, etc.) still loop.

There is no universal non-simulation "paste into the focused app" OS API (paste is initiated by the receiving app; Linux/X11 only has XTEST), so the fix is to stop reacting to our **own** injected keystroke rather than to abandon simulation.

## Fix

The listener stops recognizing shortcuts while CrossPaste injects the paste keystroke:

- **Open** suppression right before injecting — each platform's `toPaste()` calls `beginPasteSuppression(timeout)`.
- **Close** it when the listener observes the injected keystroke **released** (`nativeKeyReleased`) — i.e. the simulation actually completed.
- The timeout is only a **safety net** so recognition can't stay disabled forever if that release echo is ever dropped by the OS.

Why close on the key-release echo instead of right after the native call returns: the injected events are delivered to the listener **asynchronously**, a few ms after the native call returns. Reopening as soon as `simulatePasteCommand()` / `SendInput` / `XTestFakeKeyEvent` returns would reopen *before* the echoed event arrives, and the loop would resume. Closing on the observed release ties the window to the actual end of the simulation rather than a blind estimate.

Behavior while a paste shortcut is held: the catastrophic hundreds-per-second self-amplifying loop is eliminated; holding the key now repeats at the OS key-repeat rate, the same as holding Cmd+V in any app.

The `#4501` guards (reject binding Cmd+V in the settings dialog, ignore colliding bindings at dispatch) remain as defense-in-depth.

## Changes

- `ShortcutKeysListener`: add `beginPasteSuppression(Duration)` + `PASTE_INJECTION_SUPPRESS_TIMEOUT` (safety-net timeout).
- `DesktopShortcutKeysListener`: drop key-pressed events while suppressed; lift suppression on the injected key-release echo (`nativeKeyReleased`), or after the timeout.
- `MacAppWindowManager` / `WinAppWindowManager` / `LinuxAppWindowManager`: open suppression before injecting in `toPaste()`.
- Thread `Lazy<ShortcutKeysListener>` through the window-manager factory and DI (lazy to preserve the existing dependency-cycle break).

## Testing

- `./gradlew ktlintFormat` — clean
- `./gradlew :app:compileKotlinDesktop` — compiles
