### PR TITLE
Fix SyncResolver infinite resolve loop caused by swallowed CancellationException

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
@@ -8,6 +8,7 @@ import io.ktor.client.statement.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
@@ -39,19 +40,30 @@ class TelnetHelper(
                 val result = CompletableDeferred<Pair<HostInfo, VersionRelation>?>()
                 val mutex = Mutex()
 
-                hostInfoList.forEach { hostInfo ->
-                    launch(CoroutineName("SwitchHost")) {
-                        runCatching {
-                            telnet(hostInfo.hostAddress, port, timeout)?.let {
-                                mutex.withLock {
-                                    if (!result.isCompleted) {
-                                        result.complete(Pair(hostInfo, it))
+                val probeJobs =
+                    hostInfoList.map { hostInfo ->
+                        launch(CoroutineName("SwitchHost")) {
+                            runCatching {
+                                telnet(hostInfo.hostAddress, port, timeout)?.let {
+                                    mutex.withLock {
+                                        if (!result.isCompleted) {
+                                            result.complete(Pair(hostInfo, it))
+                                        }
                                     }
                                 }
+                            }.onFailure { e ->
+                                logger.debug(e) { "switchHost telnet failed for ${hostInfo.hostAddress}:$port" }
                             }
-                        }.onFailure { e ->
-                            logger.debug(e) { "switchHost telnet failed for ${hostInfo.hostAddress}:$port" }
                         }
+                    }
+
+                // When every probe finishes without a success, complete with null so
+                // result.await() returns immediately instead of blocking until the
+                // outer withTimeoutOrNull expires.
+                launch {
+                    probeJobs.joinAll()
+                    if (!result.isCompleted) {
+                        result.complete(null)
                     }
                 }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncPollingManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncPollingManager.kt
@@ -73,13 +73,16 @@ class SyncPollingManager(
     fun startPollingResolve(action: suspend () -> Unit): Job =
         syncHandlerScope.launch {
             while (isActive) {
-                runCatching {
+                try {
                     waitForNextExecution()
                     action()
-                }.onFailure { e ->
-                    if (e !is CancellationException) {
-                        logger.error(e) { "polling error" }
-                    }
+                } catch (e: CancellationException) {
+                    // Honor cancellation: rethrow so the loop terminates
+                    // immediately instead of spinning and re-emitting Resolve
+                    // events into a cancelled scope.
+                    throw e
+                } catch (e: Throwable) {
+                    logger.error(e) { "polling error" }
                 }
             }
         }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -32,6 +32,7 @@ import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.StripedMutex
 import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.coroutines.cancellation.CancellationException
 
 class SyncResolver(
     private val appInfo: AppInfo,
@@ -77,13 +78,13 @@ class SyncResolver(
     }
 
     private suspend fun processEvent(event: SyncEvent) {
-        runCatching {
+        try {
             if (event is SyncEvent.SyncRunTimeInfoEvent) {
                 // Re-read from DB to avoid stale snapshots.
                 // Events are queued in a SharedFlow and may be processed after the DB has changed.
                 val syncRuntimeInfo =
                     syncRuntimeInfoDao.getSyncRuntimeInfo(event.syncRuntimeInfo.appInstanceId)
-                        ?: return@runCatching
+                        ?: return
 
                 when (event) {
                     is SyncEvent.Resolve -> {
@@ -146,9 +147,15 @@ class SyncResolver(
                     }
                 }
             }
-        }.onFailure { e ->
+        } catch (e: CancellationException) {
+            // Never swallow cancellation — rethrow so structured concurrency
+            // can tear down the resolve pipeline instead of re-processing
+            // buffered events in a cancelled scope (which previously produced
+            // an unbounded "Failed to process event" loop on shutdown/teardown).
+            throw e
+        } catch (e: Throwable) {
             logger.error(e) { "Failed to process event: $event" }
-        }.apply {
+        } finally {
             if (event is SyncEvent.CallbackEvent) {
                 event.callback.onComplete()
             }
@@ -241,7 +248,12 @@ class SyncResolver(
         val result =
             discoverReachableHost() ?: run {
                 logger.info { "$appInstanceId no reachable host, hostInfoList: $hostInfoList" }
-                updateConnectState(SyncState.DISCONNECTED)
+                // Only persist when the state actually changes. Re-writing
+                // DISCONNECTED on every poll bumps modifyTime, re-emits the
+                // DB flow, and churns the handler for no reason.
+                if (connectState != SyncState.DISCONNECTED) {
+                    updateConnectState(SyncState.DISCONNECTED)
+                }
                 return
             }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TelnetHelperTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TelnetHelperTest.kt
@@ -10,12 +10,14 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
 
 class TelnetHelperTest {
 
@@ -198,6 +200,32 @@ class TelnetHelperTest {
             val result = helper.switchHost(hostInfoList, 13129, 5000L)
 
             assertNotNull(result)
+        }
+
+    @Test
+    fun switchHost_allFail_returnsImmediatelyWithoutWaitingForTimeout() =
+        runBlocking {
+            // Regression guard: when every probe fails, switchHost must complete its
+            // result with null as soon as all probes finish, NOT block until the internal
+            // withTimeoutOrNull expires. The internal timeout is set very high (10s) and
+            // the whole call is wrapped in a 2s deadline — if it returned only on timeout,
+            // this would throw TimeoutCancellationException.
+            val pasteClient = createMockPasteClient()
+            coEvery { pasteClient.get(any(), any(), any()) } throws RuntimeException("connection failed")
+
+            val helper = createTelnetHelper(pasteClient)
+            val hostInfoList =
+                listOf(
+                    HostInfo(24, "192.168.1.100"),
+                    HostInfo(24, "192.168.1.101"),
+                )
+
+            val result =
+                withTimeout(2.seconds) {
+                    helper.switchHost(hostInfoList, 13129, 10_000L)
+                }
+
+            assertNull(result)
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncPollingManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncPollingManagerTest.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -201,6 +203,36 @@ class SyncPollingManagerTest {
 
             assertTrue(actionCount > firstCount, "Polling should continue after exception")
             job.cancel()
+            childScope.cancel()
+        }
+
+    @Test
+    fun startPollingResolve_actionCancellationException_stopsPolling() =
+        runBlocking {
+            // Regression guard: if the action raises CancellationException, the polling
+            // loop must terminate instead of swallowing it and spinning (which fed the
+            // resolver infinite-loop). The job should complete and the action must not
+            // run a second time.
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val manager = SyncPollingManager(childScope)
+            var actionCount = 0
+
+            manager.fail() // short backoff so the first run happens quickly
+
+            val job =
+                manager.startPollingResolve {
+                    actionCount++
+                    throw CancellationException("simulated cancellation")
+                }
+
+            // With the fix the cancellation propagates and the job completes promptly.
+            // Without it, join() would never return and this times out.
+            withTimeout(5.seconds) {
+                job.join()
+            }
+
+            assertTrue(job.isCompleted, "Polling job should complete after cancellation")
+            assertEquals(1, actionCount, "Action must not run again after cancellation")
             childScope.cancel()
         }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -36,8 +36,10 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class SyncResolverTest {
@@ -181,11 +183,32 @@ class SyncResolverTest {
         }
 
     @Test
-    fun resolveDisconnected_switchHostReturnsNull_staysDisconnected() =
+    fun resolveDisconnected_switchHostReturnsNull_alreadyDisconnected_doesNotRewriteDb() =
         runTest {
+            // Convergence guard: a device that is already DISCONNECTED and still has no
+            // reachable host must NOT be re-persisted. Re-writing DISCONNECTED on every
+            // poll bumps modifyTime, re-emits the DB flow, and churns the handler.
             val deps = TestDeps()
             val resolver = deps.createResolver()
-            val syncRuntimeInfo = createSyncRuntimeInfo()
+            val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
+
+            val callback = createTestCallback()
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
+
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun resolveDisconnected_switchHostReturnsNull_fromNonDisconnected_persistsDisconnected() =
+        runTest {
+            // When the device was NOT already DISCONNECTED, losing the host must still
+            // persist the DISCONNECTED transition exactly once.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.INCOMPATIBLE)
 
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
@@ -209,14 +232,12 @@ class SyncResolverTest {
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
 
-            val capturedInfo = slot<SyncRuntimeInfo>()
-            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
-
             val callback = createTestCallback()
             resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             coVerify { deps.telnetHelper.switchHost(emptyList(), any(), any()) }
-            assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
+            // Already DISCONNECTED with no host → no redundant DB write.
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
         }
 
     // ========== B. resolveConnecting ==========
@@ -883,6 +904,44 @@ class SyncResolverTest {
             resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             assertTrue(onCompleteCalled)
+        }
+
+    @Test
+    fun processEvent_cancellationException_propagatesNotSwallowed() =
+        runTest {
+            // Regression guard for the resolver infinite-loop: a CancellationException
+            // raised while resolving (e.g. scope teardown / shutdown) MUST propagate out
+            // of processEvent instead of being caught-and-logged. Swallowing it broke
+            // structured-concurrency cancellation and let buffered Resolve events
+            // re-process endlessly ("Failed to process event" flood).
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } throws
+                CancellationException("scope cancelled")
+
+            assertFailsWith<CancellationException> {
+                resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+            }
+        }
+
+    @Test
+    fun processEvent_nonCancellationException_swallowedAndLogged() =
+        runTest {
+            // Counterpart to the cancellation test: ordinary failures must still be
+            // caught (not propagated), so one bad device cannot tear down the pipeline.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } throws
+                RuntimeException("boom")
+
+            // Should NOT throw — the runtime exception is swallowed.
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
         }
 
     @Test


### PR DESCRIPTION
Closes #4503

## Problem

Device auto-resolution can enter an infinite loop and never converge. The same `DISCONNECTED` device is resolved hundreds of times per second:

```
SyncResolver -- Resolve <id> (state=2)
SyncResolver -- <id> fast probe failed, falling back to full list
SyncResolver -- Failed to process event: Resolve <id>
kotlinx.coroutines.JobCancellationException: Job was cancelled; job=SupervisorJobImpl{Cancelling}@...
```

## Root cause

`CancellationException` was swallowed, breaking structured-concurrency cancellation:

- `SyncResolver.processEvent` used `runCatching { ... }.onFailure { log }`, which catches `CancellationException` too. On scope cancellation it was logged as "Failed to process event" instead of propagating, so the resolve pipeline never tore down and the `UNLIMITED` event channel's buffered `Resolve` events kept re-processing.
- `SyncPollingManager.startPollingResolve` had the same antipattern in its `while (isActive) { runCatching { ... } }` loop.

Amplifiers:
- `TelnetHelper.switchHost` never completed its `result` when **all** hosts failed telnet, so `await()` blocked until the outer `withTimeoutOrNull` (~2s) expired.
- `SyncResolver.discoverAndConnect` re-wrote `DISCONNECTED` on every poll even when already disconnected, bumping `modifyTime` and churning the DB flow.

## Changes

1. `processEvent`: rethrow `CancellationException`; only swallow non-cancellation failures.
2. `startPollingResolve`: rethrow `CancellationException` so the loop terminates.
3. `switchHost`: complete the result with `null` once all probes finish without success, so `await()` returns promptly.
4. `discoverAndConnect`: only persist `DISCONNECTED` when the state actually changes.

## Tests

- `SyncResolverTest`: cancellation propagates out of `processEvent`; ordinary exceptions still swallowed; no redundant DB write when already `DISCONNECTED`; still persists `DISCONNECTED` from a non-disconnected state.
- `SyncPollingManagerTest`: a `CancellationException` from the action stops polling.
- `TelnetHelperTest`: `switchHost` with all hosts failing returns immediately, not on timeout.

All touched test classes pass (`SyncResolverTest`, `SyncPollingManagerTest`, `TelnetHelperTest`, `GeneralSyncHandlerTest`, `GeneralSyncManagerTest`); ktlint clean.

## Out of scope (follow-up)

Resolve-event de-duplication / back-pressure (per-device conflated channel or in-flight dropping of duplicate poll `Resolve` events) will be handled in a separate change.