### PR TITLE
:bug: decouple device identity from IP for reliable reconnection

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.net
 
 import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.utils.HEADER_APP_INSTANCE_ID
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -14,7 +15,30 @@ import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Outcome of a `/sync/telnet` probe: the peer's protocol [versionRelation] plus the
+ * [peerAppInstanceId] it advertised in the response header (null when the peer is an
+ * older build that does not send the header).
+ */
+data class TelnetResult(
+    val versionRelation: VersionRelation,
+    val peerAppInstanceId: String?,
+) {
+    /**
+     * Whether this peer may be admitted as a connection candidate for [expected].
+     *
+     * The telnet header identity is unauthenticated and used only to gate the
+     * "candidate" set — trust is still granted by the ECDH heartbeat. We admit a peer
+     * whose identity is unknown (old build, no header) and leave it to the encrypted
+     * heartbeat to vet; we reject only a positively *different* identity, which is a
+     * ghost occupying a historical IP (#4499). A null [expected] disables filtering.
+     */
+    fun identityAccepted(expected: String?): Boolean =
+        expected == null || peerAppInstanceId == null || peerAppInstanceId == expected
+}
 
 class TelnetHelper(
     private val pasteClient: PasteClient,
@@ -31,27 +55,41 @@ class TelnetHelper(
     suspend fun switchHost(
         hostInfoList: List<HostInfo>,
         port: Int,
+        expectedAppInstanceId: String? = null,
         timeout: Long = FAST_TIMEOUT,
-    ): Pair<HostInfo, VersionRelation>? {
+    ): Pair<HostInfo, TelnetResult>? {
         if (hostInfoList.isEmpty()) return null
 
         return withTimeoutOrNull(timeout.milliseconds) {
             supervisorScope {
-                val result = CompletableDeferred<Pair<HostInfo, VersionRelation>?>()
+                val result = CompletableDeferred<Pair<HostInfo, TelnetResult>?>()
                 val mutex = Mutex()
 
                 val probeJobs =
                     hostInfoList.map { hostInfo ->
                         launch(CoroutineName("SwitchHost")) {
                             runCatching {
-                                telnet(hostInfo.hostAddress, port, timeout)?.let {
-                                    mutex.withLock {
-                                        if (!result.isCompleted) {
-                                            result.complete(Pair(hostInfo, it))
+                                telnet(hostInfo.hostAddress, port, timeout)?.let { telnetResult ->
+                                    // Identity filtering happens here, inside the race: a
+                                    // reachable-but-mismatched ghost must not win and crowd
+                                    // out the real peer that advertised the right identity.
+                                    if (telnetResult.identityAccepted(expectedAppInstanceId)) {
+                                        mutex.withLock {
+                                            if (!result.isCompleted) {
+                                                result.complete(Pair(hostInfo, telnetResult))
+                                            }
+                                        }
+                                    } else {
+                                        logger.info {
+                                            "switchHost skip ${hostInfo.hostAddress}:$port " +
+                                                "identity mismatch (${telnetResult.peerAppInstanceId} != $expectedAppInstanceId)"
                                         }
                                     }
                                 }
                             }.onFailure { e ->
+                                // Never swallow cancellation — let structured concurrency
+                                // tear the probe down instead of marking it "completed".
+                                if (e is CancellationException) throw e
                                 logger.debug(e) { "switchHost telnet failed for ${hostInfo.hostAddress}:$port" }
                             }
                         }
@@ -76,7 +114,7 @@ class TelnetHelper(
         hostAddress: String,
         port: Int,
         timeout: Long = FAST_TIMEOUT,
-    ): VersionRelation? =
+    ): TelnetResult? =
         runCatching {
             val hostAndPort = HostAndPort(hostAddress, port)
             val httpResponse =
@@ -88,13 +126,23 @@ class TelnetHelper(
 
             if (httpResponse.status.value == 200) {
                 val result = httpResponse.bodyAsText()
-                result.toIntOrNull()?.let {
-                    syncApi.compareVersion(it)
+                result.toIntOrNull()?.let { version ->
+                    // Identity rides back on the same response (header), so version +
+                    // identity are obtained atomically with no extra round-trip. Older
+                    // peers omit the header -> peerAppInstanceId is null.
+                    TelnetResult(
+                        versionRelation = syncApi.compareVersion(version),
+                        peerAppInstanceId = httpResponse.headers[HEADER_APP_INSTANCE_ID],
+                    )
                 }
             } else {
                 null
             }
         }.onFailure {
+            // Don't convert a coroutine cancellation into a null "unreachable" result —
+            // rethrow so cancellation propagates (matches SyncResolver.processEvent and the
+            // #4503 fix). Other failures genuinely mean the host is unreachable.
+            if (it is CancellationException) throw it
             logger.debug(it) { "telnet $hostAddress fail" }
         }.getOrNull()
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -22,6 +22,7 @@ import com.crosspaste.sync.PendingKeyExchange
 import com.crosspaste.sync.PendingKeyExchangeStore
 import com.crosspaste.utils.CryptographyUtils
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
+import com.crosspaste.utils.HEADER_APP_INSTANCE_ID
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
 import com.crosspaste.utils.getJsonUtils
@@ -161,6 +162,10 @@ fun Routing.syncRouting(
     }
 
     get("/sync/telnet") {
+        // Advertise our identity alongside the version so discovery can vet the peer
+        // atomically. Unauthenticated, selection-only (trust is via ECDH); body is
+        // unchanged so older clients ignore the extra header. See #4499 / #4500.
+        call.response.headers.append(HEADER_APP_INSTANCE_ID, appInfo.appInstanceId)
         successResponse(call, syncApi.VERSION)
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
@@ -4,6 +4,7 @@ import com.crosspaste.app.AppInfo
 import com.crosspaste.app.RatingPromptManager
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
@@ -81,13 +82,12 @@ class GeneralNearbyDeviceManager(
         val appInstanceId = syncInfo.appInfo.appInstanceId
         if (!isSelf(appInstanceId)) {
             logger.info { "Service resolved: $syncInfo" }
+            val now = DateUtils.nowEpochMilliseconds()
             syncInfos.update { current ->
                 val existSyncInfo = current[appInstanceId]
-                if (existSyncInfo == null) {
-                    current + (appInstanceId to syncInfo)
-                } else {
-                    current + (appInstanceId to existSyncInfo.merge(syncInfo))
-                }
+                val merged =
+                    existSyncInfo?.merge(syncInfo, now) ?: syncInfo.withStampedHostInfo(now)
+                current + (appInstanceId to merged)
             }
 
             syncInfos.value[appInstanceId]?.let { mergedInfo ->

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -97,7 +97,15 @@ class GeneralSyncHandler(
             return
         }
 
-        if (previous.connectHostAddress != null &&
+        // A changed connect address only warrants an immediate re-resolve when the
+        // device is currently CONNECTED (e.g. mDNS advertised a new address for a
+        // live peer). For CONNECTING / DISCONNECTED / etc. we must NOT short-circuit
+        // here — let the connectState handling below run so SyncPollingManager applies
+        // exponential backoff. Otherwise a discover -> authenticate -> fail pass that
+        // thrashes the address (CONNECTING@new <-> DISCONNECTED@stale) re-emits Resolve
+        // on every DB write and bypasses backoff (#4499 / #4500 tight loop).
+        if (current.connectState == SyncState.CONNECTED &&
+            previous.connectHostAddress != null &&
             current.connectHostAddress != null &&
             previous.connectHostAddress != current.connectHostAddress
         ) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -304,7 +304,13 @@ class SyncResolver(
                 }
 
                 else -> {
-                    updateConnectState(SyncState.DISCONNECTED)
+                    // Persist DISCONNECTED at the address we actually tried, not the
+                    // stale snapshot's connectHostAddress. Reverting to the old address
+                    // here makes connectHostAddress oscillate (CONNECTING@new ->
+                    // DISCONNECTED@stale) within a single resolve pass, which the DB flow
+                    // reads as an address change and re-emits Resolve, bypassing backoff
+                    // (#4499 / #4500 tight loop).
+                    updateConnectState(SyncState.DISCONNECTED, host, networkPrefixLength)
                 }
             }
         } else {
@@ -327,7 +333,7 @@ class SyncResolver(
             ratingPromptManager.trackSignificantAction()
         } else {
             // Verify host is still reachable before showing UNVERIFIED to user
-            telnetHelper.telnet(host, port)?.let { versionRelation ->
+            telnetHelper.telnet(host, port)?.versionRelation?.let { versionRelation ->
                 if (versionRelation == VersionRelation.EQUAL_TO) {
                     logger.info { "$appInstanceId to unverified $host $port" }
                     updateConnectState(SyncState.UNVERIFIED, host, networkPrefixLength)
@@ -352,7 +358,7 @@ class SyncResolver(
                 return
             }
             // Verify host still reachable; only update DB if state changes
-            telnetHelper.telnet(host, port)?.let { versionRelation ->
+            telnetHelper.telnet(host, port)?.versionRelation?.let { versionRelation ->
                 callback.updateVersionRelation(versionRelation)
                 if (versionRelation != VersionRelation.EQUAL_TO) {
                     updateConnectState(SyncState.INCOMPATIBLE, host, connectNetworkPrefixLength)
@@ -373,6 +379,11 @@ class SyncResolver(
             return
         }
         connectHostAddress?.let { host ->
+            // Heartbeat the current address DIRECTLY — it need not be a member of
+            // hostInfoList. With Phase B's capacity cap, a still-alive connectHostAddress
+            // can be LRU-evicted from hostInfoList once the peer advertises newer ones;
+            // keeping liveness checks bound to the address (not list membership) is what
+            // makes that boundary safe. Do not change this to "only probe hostInfoList".
             val state = heartbeat(host, port, appInstanceId, callback)
             when (state) {
                 SyncState.CONNECTED -> {
@@ -390,10 +401,17 @@ class SyncResolver(
                 }
 
                 else -> {
-                    updateConnectState(SyncState.DISCONNECTED)
+                    // Active switch (#4499 weakness ①): the current address is unreachable.
+                    // Instead of dropping to DISCONNECTED (a visible disconnect, then a
+                    // separate reconnect pass), re-discover among the peer's advertised
+                    // addresses in the same pass. An IP move resolves as
+                    // CONNECTED -> CONNECTING -> CONNECTED with no gap; if nothing is
+                    // reachable, discoverAndConnect persists DISCONNECTED itself.
+                    logger.info { "$appInstanceId heartbeat failed on $host, switching via discovery" }
+                    discoverAndConnect(callback)
                 }
             }
-        } ?: updateConnectState(SyncState.DISCONNECTED)
+        } ?: discoverAndConnect(callback)
     }
 
     private suspend fun SyncRuntimeInfo.forceResolve(callback: ResolveCallback) {
@@ -403,25 +421,41 @@ class SyncResolver(
     }
 
     /**
-     * Fast-then-slow host discovery: try the last known address first
-     * with a short timeout, then fall back to probing all addresses
-     * with a longer timeout.
+     * Recency-first, fast-then-slow host discovery: probe the most-recently-advertised
+     * address first with a short timeout (the currently-connected address wins ties),
+     * then fall back to racing the full recency-ordered list with a longer timeout.
+     *
+     * Ordering by lastSeen means a peer that moved to a new IP is reached on the fresh
+     * address immediately, instead of wasting the fast timeout on a now-dead old one
+     * (#4499 weakness ②). switchHost admits only identity-matching (or identity-unknown)
+     * hosts so a ghost on a historical IP is never selected.
      */
     private suspend fun SyncRuntimeInfo.discoverReachableHost(): Pair<HostInfo, VersionRelation>? {
-        // Fast path: try the previously connected address first
-        connectHostAddress?.let { lastHost ->
-            val lastHostInfo = hostInfoList.firstOrNull { it.hostAddress == lastHost }
-            if (lastHostInfo != null) {
-                logger.info { "$appInstanceId fast probe $lastHost:$port" }
-                telnetHelper.telnet(lastHost, port, TelnetHelper.FAST_TIMEOUT)?.let { version ->
-                    return@discoverReachableHost Pair(lastHostInfo, version)
+        val ordered =
+            hostInfoList.sortedWith(
+                compareByDescending<HostInfo> { it.lastSeen }
+                    .thenByDescending { it.hostAddress == connectHostAddress },
+            )
+
+        // Fast path: probe the freshest address first (skipped when there are none).
+        ordered.firstOrNull()?.let { freshest ->
+            logger.info { "$appInstanceId fast probe ${freshest.hostAddress}:$port (lastSeen=${freshest.lastSeen})" }
+            telnetHelper.telnet(freshest.hostAddress, port, TelnetHelper.FAST_TIMEOUT)?.let { telnetResult ->
+                if (telnetResult.identityAccepted(appInstanceId)) {
+                    return@discoverReachableHost Pair(freshest, telnetResult.versionRelation)
                 }
-                logger.info { "$appInstanceId fast probe failed, falling back to full list" }
+                logger.info {
+                    "$appInstanceId fast probe identity mismatch " +
+                        "(${telnetResult.peerAppInstanceId}), skipping ${freshest.hostAddress}"
+                }
             }
+            logger.info { "$appInstanceId fast probe failed, falling back to full list" }
         }
 
-        // Slow path: try all addresses in parallel with a longer timeout
-        return telnetHelper.switchHost(hostInfoList, port, TelnetHelper.SLOW_TIMEOUT)
+        // Slow path: race the recency-ordered list in parallel with a longer timeout.
+        return telnetHelper
+            .switchHost(ordered, port, appInstanceId, TelnetHelper.SLOW_TIMEOUT)
+            ?.let { (hostInfo, telnetResult) -> Pair(hostInfo, telnetResult.versionRelation) }
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDaoTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.collections.listOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class SyncRuntimeInfoDaoTest {
@@ -147,5 +148,121 @@ class SyncRuntimeInfoDaoTest {
             // Cancel the test
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `insertOrUpdateSyncInfo caps stored hostInfoList at MAX_RECENT_HOST_INFO`() = runTest {
+        val manyHosts = (1..(HostInfo.MAX_RECENT_HOST_INFO + 4)).map { HostInfo(24, "10.0.0.$it") }
+        syncRuntimeInfoDao.insertOrUpdateSyncInfo(
+            testSyncInfo.copy(
+                endpointInfo = testSyncInfo.endpointInfo.copy(hostInfoList = manyHosts),
+            ),
+        )
+
+        val stored = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
+        assertNotNull(stored)
+        assertEquals(HostInfo.MAX_RECENT_HOST_INFO, stored.hostInfoList.size)
+    }
+
+    @Test
+    fun `insertOrUpdateSyncInfo re-advertising same address set does not write`() = runTest {
+        // "restamp doesn't churn": re-advertising the same address set (even with a
+        // different incoming lastSeen) must not produce a DB write, because
+        // hostInfoListEqual compares by address only. Verified via modifyTime stability.
+        syncRuntimeInfoDao.insertOrUpdateSyncInfo(testSyncInfo) // hostInfoList = [.100]
+        val before = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
+        assertNotNull(before)
+
+        val reAdvertised = testSyncInfo.copy(
+            endpointInfo = testSyncInfo.endpointInfo.copy(
+                // same address, deliberately different lastSeen on the wire
+                hostInfoList = listOf(HostInfo(32, "192.168.1.100", lastSeen = 999_999L)),
+            ),
+        )
+        syncRuntimeInfoDao.insertOrUpdateSyncInfo(reAdvertised)
+
+        val after = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
+        assertNotNull(after)
+        assertEquals(before.modifyTime, after.modifyTime)
+    }
+
+    @Test
+    fun `insertOrUpdateSyncInfo LRU-evicts connectHostAddress from list but preserves the column`() = runTest {
+        syncRuntimeInfoDao.insertOrUpdateSyncInfo(testSyncInfo)
+        val connected = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")!!.copy(
+            connectState = SyncState.CONNECTED,
+            connectHostAddress = "192.168.1.100", // == testSyncInfo's only address
+            connectNetworkPrefixLength = 32,
+        )
+        syncRuntimeInfoDao.updateConnectInfo(connected)
+
+        // The peer advertises MAX newer addresses, none of which is .100.
+        val newer = (1..HostInfo.MAX_RECENT_HOST_INFO).map { HostInfo(24, "10.0.0.$it") }
+        syncRuntimeInfoDao.insertOrUpdateSyncInfo(
+            testSyncInfo.copy(endpointInfo = testSyncInfo.endpointInfo.copy(hostInfoList = newer)),
+        )
+
+        val after = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
+        assertNotNull(after)
+        // .100 was LRU-evicted from the host list...
+        assertEquals(HostInfo.MAX_RECENT_HOST_INFO, after.hostInfoList.size)
+        assertTrue(after.hostInfoList.none { it.hostAddress == "192.168.1.100" })
+        // ...but the connect address column (and state) are still preserved.
+        assertEquals("192.168.1.100", after.connectHostAddress)
+        assertEquals(SyncState.CONNECTED, after.connectState)
+    }
+
+    @Test
+    fun `insertOrUpdateSyncInfo preserves connect address on mDNS-style update`() = runTest {
+        // Establish a CONNECTED device with a known connect address.
+        syncRuntimeInfoDao.insertOrUpdateSyncInfo(testSyncInfo)
+        val connected = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")!!.copy(
+            connectState = SyncState.CONNECTED,
+            connectHostAddress = "192.168.1.100",
+            connectNetworkPrefixLength = 32,
+        )
+        syncRuntimeInfoDao.updateConnectInfo(connected)
+
+        // An mDNS re-advertisement adds a new address and carries no connectInfo.
+        val advertised = testSyncInfo.copy(
+            endpointInfo = testSyncInfo.endpointInfo.copy(
+                hostInfoList = listOf(HostInfo(24, "192.168.1.200")),
+            ),
+        )
+        syncRuntimeInfoDao.insertOrUpdateSyncInfo(advertised)
+
+        val after = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
+        assertNotNull(after)
+        // connectState was already preserved via the -1 sentinel; the connect address
+        // must be preserved too (#4499 weakness ①) rather than nulled.
+        assertEquals(SyncState.CONNECTED, after.connectState)
+        assertEquals("192.168.1.100", after.connectHostAddress)
+        assertEquals(32.toShort(), after.connectNetworkPrefixLength)
+        // ...while the newly-advertised address is merged into the host list.
+        assertTrue(after.hostInfoList.any { it.hostAddress == "192.168.1.200" })
+    }
+
+    @Test
+    fun `insertOrUpdateSyncInfo evicts old ghost addresses as new ones arrive`() = runTest {
+        // #4499 ghost accumulation: a full set of old addresses, then a full set of new
+        // ones. Capacity-LRU must end with only the newly-advertised addresses.
+        val oldHosts = (1..HostInfo.MAX_RECENT_HOST_INFO).map { HostInfo(24, "10.0.0.$it") }
+        syncRuntimeInfoDao.insertOrUpdateSyncInfo(
+            testSyncInfo.copy(
+                endpointInfo = testSyncInfo.endpointInfo.copy(hostInfoList = oldHosts),
+            ),
+        )
+
+        val newHosts = (1..HostInfo.MAX_RECENT_HOST_INFO).map { HostInfo(24, "10.1.1.$it") }
+        syncRuntimeInfoDao.insertOrUpdateSyncInfo(
+            testSyncInfo.copy(
+                endpointInfo = testSyncInfo.endpointInfo.copy(hostInfoList = newHosts),
+            ),
+        )
+
+        val stored = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
+        assertNotNull(stored)
+        assertEquals(HostInfo.MAX_RECENT_HOST_INFO, stored.hostInfoList.size)
+        assertTrue(stored.hostInfoList.all { it.hostAddress.startsWith("10.1.1.") })
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
@@ -219,6 +219,155 @@ class DtoSerializationTest {
         assertEquals(1, merged.endpointInfo.hostInfoList.size)
     }
 
+    // --- HostInfo.mergeRecent (Phase B: recency-ordered, capacity-capped) ---
+
+    @Test
+    fun `mergeRecent orders incoming first and stamps now`() {
+        val existing = listOf(HostInfo(24, "192.168.1.1", lastSeen = 100L))
+        val incoming = listOf(HostInfo(24, "192.168.1.2"))
+
+        val merged = HostInfo.mergeRecent(existing, incoming, now = 5000L)
+
+        assertEquals(2, merged.size)
+        assertEquals("192.168.1.2", merged[0].hostAddress)
+        assertEquals(5000L, merged[0].lastSeen)
+        assertEquals("192.168.1.1", merged[1].hostAddress)
+        assertEquals(100L, merged[1].lastSeen)
+    }
+
+    @Test
+    fun `mergeRecent dedups by address keeping fresh lastSeen`() {
+        val existing = listOf(HostInfo(24, "192.168.1.1", lastSeen = 100L))
+        val incoming = listOf(HostInfo(24, "192.168.1.1"))
+
+        val merged = HostInfo.mergeRecent(existing, incoming, now = 5000L)
+
+        assertEquals(1, merged.size)
+        assertEquals("192.168.1.1", merged[0].hostAddress)
+        assertEquals(5000L, merged[0].lastSeen)
+    }
+
+    @Test
+    fun `mergeRecent caps at MAX_RECENT_HOST_INFO dropping oldest`() {
+        // Existing already at the cap, each older than the next.
+        val existing =
+            (1..HostInfo.MAX_RECENT_HOST_INFO).map { i ->
+                HostInfo(24, "10.0.0.$i", lastSeen = i.toLong())
+            }
+        // A brand-new address arrives.
+        val incoming = listOf(HostInfo(24, "10.0.0.99"))
+
+        val merged = HostInfo.mergeRecent(existing, incoming, now = 1_000L)
+
+        assertEquals(HostInfo.MAX_RECENT_HOST_INFO, merged.size)
+        // Newest is the incoming one.
+        assertEquals("10.0.0.99", merged[0].hostAddress)
+        // The oldest existing (lastSeen = 1, "10.0.0.1") was evicted.
+        assertTrue(merged.none { it.hostAddress == "10.0.0.1" })
+    }
+
+    @Test
+    fun `mergeRecent dedups incoming-internal duplicates`() {
+        // incoming = [a, a, b] -> result must not contain duplicate a.
+        val incoming =
+            listOf(
+                HostInfo(24, "10.0.0.1"),
+                HostInfo(24, "10.0.0.1"),
+                HostInfo(24, "10.0.0.2"),
+            )
+
+        val merged = HostInfo.mergeRecent(emptyList(), incoming, now = 100L)
+
+        assertEquals(2, merged.size)
+        assertEquals(1, merged.count { it.hostAddress == "10.0.0.1" })
+        assertTrue(merged.any { it.hostAddress == "10.0.0.2" })
+    }
+
+    @Test
+    fun `mergeRecent dedups duplicate addresses within incoming and does not crowd out history`() {
+        // A peer (or a buggy/hostile TXT record) advertises the same address many times.
+        // It must collapse to a single entry — not fill the cap and evict real history.
+        val existing = listOf(HostInfo(24, "10.0.0.1", lastSeen = 1L))
+        val incoming = List(HostInfo.MAX_RECENT_HOST_INFO) { HostInfo(24, "10.0.0.5") }
+
+        val merged = HostInfo.mergeRecent(existing, incoming, now = 100L)
+
+        assertEquals(2, merged.size)
+        assertEquals(1, merged.count { it.hostAddress == "10.0.0.5" })
+        assertTrue(merged.any { it.hostAddress == "10.0.0.1" })
+    }
+
+    @Test
+    fun `mergeRecent output has no duplicate addresses even from legacy existing`() {
+        // Legacy data could hold the same address twice (old .distinct() kept entries that
+        // differed only by prefix). The merged result must still be address-unique.
+        val existing =
+            listOf(
+                HostInfo(24, "10.0.0.7", lastSeen = 5L),
+                HostInfo(32, "10.0.0.7", lastSeen = 3L),
+            )
+        val incoming = listOf(HostInfo(24, "10.0.0.8"))
+
+        val merged = HostInfo.mergeRecent(existing, incoming, now = 100L)
+
+        assertEquals(1, merged.count { it.hostAddress == "10.0.0.7" })
+        assertEquals(merged.map { it.hostAddress }, merged.map { it.hostAddress }.distinct())
+    }
+
+    @Test
+    fun `mergeRecent is capacity-only and never time-prunes a stale-but-present address`() {
+        // An address with an ancient lastSeen survives as long as it fits in the cap —
+        // there is no clock-based TTL (a stable device must never be aged out).
+        val existing = listOf(HostInfo(24, "192.168.1.1", lastSeen = 1L))
+        val incoming = listOf(HostInfo(24, "192.168.1.2"))
+
+        val merged = HostInfo.mergeRecent(existing, incoming, now = 9_000_000L)
+
+        assertTrue(merged.any { it.hostAddress == "192.168.1.1" })
+    }
+
+    // --- HostInfo cross-version wire compatibility (Phase B: lastSeen field) ---
+
+    @Test
+    fun `HostInfo decode from old wire without lastSeen uses default`() {
+        // old build -> new build: a peer that predates the lastSeen field omits it.
+        val oldWire = """{"networkPrefixLength":24,"hostAddress":"192.168.1.4"}"""
+        val decoded = json.decodeFromString<HostInfo>(oldWire)
+        assertEquals("192.168.1.4", decoded.hostAddress)
+        assertEquals(24.toShort(), decoded.networkPrefixLength)
+        assertEquals(0L, decoded.lastSeen)
+    }
+
+    @Test
+    fun `HostInfo decode tolerates lastSeen plus unknown future keys`() {
+        // new build -> old build: the configured Json (ignoreUnknownKeys=true) must not
+        // throw on fields it doesn't know. This is the exact mechanism that lets an OLD
+        // peer (same config) ignore our new lastSeen — guarding cross-version wire compat.
+        val futureWire =
+            """{"networkPrefixLength":24,"hostAddress":"192.168.1.4","lastSeen":7,"futureX":1}"""
+        val decoded = json.decodeFromString<HostInfo>(futureWire)
+        assertEquals("192.168.1.4", decoded.hostAddress)
+        assertEquals(7L, decoded.lastSeen)
+    }
+
+    @Test
+    fun `SyncInfo decode tolerates unknown future key on nested HostInfo`() {
+        // Same tolerance must hold through the full SyncInfo envelope (the shape that
+        // actually crosses the wire), not just a bare HostInfo.
+        val wire =
+            """
+            {"appInfo":{"appInstanceId":"id","appVersion":"1.0.0","appRevision":"r","userName":"u"},
+             "endpointInfo":{"deviceId":"d","deviceName":"n",
+              "platform":{"name":"TestOS","arch":"x86_64","bitMode":64,"version":"1.0.0"},
+              "hostInfoList":[{"networkPrefixLength":24,"hostAddress":"10.0.0.1","lastSeen":5,"futureX":1}],
+              "port":13129}}
+            """.trimIndent()
+        val decoded = json.decodeFromString<SyncInfo>(wire)
+        assertEquals(1, decoded.endpointInfo.hostInfoList.size)
+        assertEquals("10.0.0.1", decoded.endpointInfo.hostInfoList[0].hostAddress)
+        assertEquals(5L, decoded.endpointInfo.hostInfoList[0].lastSeen)
+    }
+
     // --- PairingRequest ---
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
@@ -294,10 +294,12 @@ class SyncIntegrationTest {
             val b = createInstance("device-b")
             a.start()
 
-            val versionRelation = b.telnetHelper.telnet("localhost", a.getPort())
+            val result = b.telnetHelper.telnet("localhost", a.getPort())
 
-            assertNotNull(versionRelation)
-            assertEquals(VersionRelation.EQUAL_TO, versionRelation)
+            assertNotNull(result)
+            assertEquals(VersionRelation.EQUAL_TO, result.versionRelation)
+            // Phase A: the server advertises its identity in the telnet response header.
+            assertEquals(a.appInfo.appInstanceId, result.peerAppInstanceId)
         }
 
     // ---- Test 9: SwitchHost first responder wins ----
@@ -316,11 +318,13 @@ class SyncIntegrationTest {
                 )
 
             val b = createInstance("device-b")
-            val result = b.telnetHelper.switchHost(hostInfoList, a.getPort())
+            val result =
+                b.telnetHelper.switchHost(hostInfoList, a.getPort(), expectedAppInstanceId = a.appInfo.appInstanceId)
 
             assertNotNull(result)
             assertEquals("127.0.0.1", result.first.hostAddress)
-            assertEquals(VersionRelation.EQUAL_TO, result.second)
+            assertEquals(VersionRelation.EQUAL_TO, result.second.versionRelation)
+            assertEquals(a.appInfo.appInstanceId, result.second.peerAppInstanceId)
         }
 
     // ---- Test 10: Notify remove ----

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TelnetHelperTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TelnetHelperTest.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.net
 
 import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.utils.HEADER_APP_INSTANCE_ID
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.mockk.coEvery
@@ -11,10 +12,12 @@ import io.mockk.unmockkStatic
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.seconds
@@ -37,11 +40,18 @@ class TelnetHelperTest {
     private fun createMockResponse(
         statusCode: Int,
         body: String,
+        appInstanceId: String? = null,
     ): HttpResponse {
         val response = mockk<HttpResponse>(relaxed = true)
         val statusObj = HttpStatusCode.fromValue(statusCode)
         every { response.status } returns statusObj
         coEvery { response.bodyAsText(any()) } returns body
+        every { response.headers } returns
+            if (appInstanceId != null) {
+                headersOf(HEADER_APP_INSTANCE_ID, appInstanceId)
+            } else {
+                Headers.Empty
+            }
         return response
     }
 
@@ -63,7 +73,7 @@ class TelnetHelperTest {
             val result = helper.telnet("192.168.1.100", 13129)
 
             assertNotNull(result)
-            assertEquals(VersionRelation.EQUAL_TO, result)
+            assertEquals(VersionRelation.EQUAL_TO, result.versionRelation)
         }
 
     @Test
@@ -77,7 +87,7 @@ class TelnetHelperTest {
             val result = helper.telnet("192.168.1.100", 13129)
 
             assertNotNull(result)
-            assertEquals(VersionRelation.HIGHER_THAN, result)
+            assertEquals(VersionRelation.HIGHER_THAN, result.versionRelation)
         }
 
     @Test
@@ -91,7 +101,7 @@ class TelnetHelperTest {
             val result = helper.telnet("192.168.1.100", 13129)
 
             assertNotNull(result)
-            assertEquals(VersionRelation.LOWER_THAN, result)
+            assertEquals(VersionRelation.LOWER_THAN, result.versionRelation)
         }
 
     @Test
@@ -132,6 +142,20 @@ class TelnetHelperTest {
             assertNull(result)
         }
 
+    @Test
+    fun telnet_cancellationException_propagatesNotSwallowed() =
+        runTest {
+            // A coroutine cancellation must NOT be swallowed and turned into a null
+            // "unreachable" result — it must propagate (matches the #4503 convention).
+            val pasteClient = createMockPasteClient()
+            coEvery { pasteClient.get(any(), any(), any()) } throws CancellationException("cancelled")
+
+            val helper = createTelnetHelper(pasteClient)
+            assertFailsWith<CancellationException> {
+                helper.telnet("192.168.1.100", 13129)
+            }
+        }
+
     // ========== B. switchHost (parallel) ==========
     // switchHost uses CoroutineScope(ioDispatcher) internally so tests need real time
 
@@ -145,11 +169,11 @@ class TelnetHelperTest {
             val helper = createTelnetHelper(pasteClient)
             val hostInfoList = listOf(HostInfo(24, "192.168.1.100"))
 
-            val result = helper.switchHost(hostInfoList, 13129, 5000L)
+            val result = helper.switchHost(hostInfoList, 13129, timeout = 5000L)
 
             assertNotNull(result)
             assertEquals("192.168.1.100", result.first.hostAddress)
-            assertEquals(VersionRelation.EQUAL_TO, result.second)
+            assertEquals(VersionRelation.EQUAL_TO, result.second.versionRelation)
         }
 
     @Test
@@ -176,7 +200,7 @@ class TelnetHelperTest {
                     HostInfo(24, "192.168.1.101"),
                 )
 
-            val result = helper.switchHost(hostInfoList, 13129, 2000L)
+            val result = helper.switchHost(hostInfoList, 13129, timeout = 2000L)
 
             assertNull(result)
         }
@@ -197,7 +221,7 @@ class TelnetHelperTest {
                     HostInfo(24, "192.168.1.101"),
                 )
 
-            val result = helper.switchHost(hostInfoList, 13129, 5000L)
+            val result = helper.switchHost(hostInfoList, 13129, timeout = 5000L)
 
             assertNotNull(result)
         }
@@ -222,7 +246,7 @@ class TelnetHelperTest {
 
             val result =
                 withTimeout(2.seconds) {
-                    helper.switchHost(hostInfoList, 13129, 10_000L)
+                    helper.switchHost(hostInfoList, 13129, timeout = 10_000L)
                 }
 
             assertNull(result)
@@ -238,8 +262,91 @@ class TelnetHelperTest {
             val helper = createTelnetHelper(pasteClient)
             val hostInfoList = listOf(HostInfo(24, "192.168.1.100"))
 
-            val result = helper.switchHost(hostInfoList, 13129, 2000L)
+            val result = helper.switchHost(hostInfoList, 13129, timeout = 2000L)
 
             assertNull(result)
+        }
+
+    // ========== C. identity (Phase A: identity-aware discovery) ==========
+
+    @Test
+    fun telnet_readsPeerAppInstanceIdFromHeader() =
+        runTest {
+            val pasteClient = createMockPasteClient()
+            val response = createMockResponse(200, SyncApi.VERSION.toString(), appInstanceId = "peer-123")
+            coEvery { pasteClient.get(any(), any(), any()) } returns response
+
+            val helper = createTelnetHelper(pasteClient)
+            val result = helper.telnet("192.168.1.100", 13129)
+
+            assertNotNull(result)
+            assertEquals("peer-123", result.peerAppInstanceId)
+        }
+
+    @Test
+    fun telnet_oldPeerWithoutHeader_peerAppInstanceIdNull() =
+        runTest {
+            val pasteClient = createMockPasteClient()
+            val response = createMockResponse(200, SyncApi.VERSION.toString())
+            coEvery { pasteClient.get(any(), any(), any()) } returns response
+
+            val helper = createTelnetHelper(pasteClient)
+            val result = helper.telnet("192.168.1.100", 13129)
+
+            assertNotNull(result)
+            assertNull(result.peerAppInstanceId)
+        }
+
+    @Test
+    fun switchHost_identityMismatch_rejectsHost() =
+        runBlocking {
+            val pasteClient = createMockPasteClient()
+            // Reachable, but advertises a different identity (a ghost on a historical IP).
+            val response = createMockResponse(200, SyncApi.VERSION.toString(), appInstanceId = "ghost-999")
+            coEvery { pasteClient.get(any(), any(), any()) } returns response
+
+            val helper = createTelnetHelper(pasteClient)
+            val hostInfoList = listOf(HostInfo(24, "192.168.1.100"))
+
+            val result =
+                helper.switchHost(hostInfoList, 13129, expectedAppInstanceId = "real-1", timeout = 2000L)
+
+            assertNull(result)
+        }
+
+    @Test
+    fun switchHost_identityMatch_acceptsHost() =
+        runBlocking {
+            val pasteClient = createMockPasteClient()
+            val response = createMockResponse(200, SyncApi.VERSION.toString(), appInstanceId = "real-1")
+            coEvery { pasteClient.get(any(), any(), any()) } returns response
+
+            val helper = createTelnetHelper(pasteClient)
+            val hostInfoList = listOf(HostInfo(24, "192.168.1.100"))
+
+            val result =
+                helper.switchHost(hostInfoList, 13129, expectedAppInstanceId = "real-1", timeout = 5000L)
+
+            assertNotNull(result)
+            assertEquals("192.168.1.100", result.first.hostAddress)
+            assertEquals("real-1", result.second.peerAppInstanceId)
+        }
+
+    @Test
+    fun switchHost_oldPeerUnknownIdentity_admittedAsFallback() =
+        runBlocking {
+            val pasteClient = createMockPasteClient()
+            // Old peer: reachable, no identity header. Must still be admitted (heartbeat vets it).
+            val response = createMockResponse(200, SyncApi.VERSION.toString())
+            coEvery { pasteClient.get(any(), any(), any()) } returns response
+
+            val helper = createTelnetHelper(pasteClient)
+            val hostInfoList = listOf(HostInfo(24, "192.168.1.100"))
+
+            val result =
+                helper.switchHost(hostInfoList, 13129, expectedAppInstanceId = "real-1", timeout = 5000L)
+
+            assertNotNull(result)
+            assertNull(result.second.peerAppInstanceId)
         }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
@@ -247,6 +247,115 @@ class GeneralSyncHandlerTest {
             childScope.cancel()
         }
 
+    /**
+     * Regression for #4499 / #4500: within a single failing resolve pass the address
+     * thrashes (CONNECTING@new -> DISCONNECTED@stale). The DISCONNECTED write changes
+     * BOTH state and address. The address-change branch must NOT short-circuit with an
+     * immediate Resolve here — that bypassed SyncPollingManager's backoff and produced
+     * the ~530ms tight loop. Instead the DISCONNECTED handling must run: increment the
+     * fail count (backoff) and emit RefreshSyncInfo, but no Resolve (previous != CONNECTED).
+     */
+    @Test
+    fun handleValueChange_addressThrashOnFailure_appliesBackoffWithoutResolve() =
+        runTest {
+            val emitter = TestEmitter()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncRuntimeInfo =
+                createConnectingSyncRuntimeInfo(hostAddress = "192.168.1.109")
+
+            val handler = GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
+            advanceTimeBy(SMALL_ADVANCE_MS)
+            emitter.events.clear()
+            val failBefore = handler.syncPollingManager.currentFailCount
+
+            // Failure path reverted the address to a stale snapshot value while also
+            // dropping to DISCONNECTED — the exact write that used to bypass backoff.
+            handler.updateSyncRuntimeInfo(
+                syncRuntimeInfo.copy(
+                    connectState = SyncState.DISCONNECTED,
+                    connectHostAddress = "192.168.1.117",
+                ),
+            )
+            advanceTimeBy(SMALL_ADVANCE_MS)
+
+            assertTrue(emitter.events.none { it is SyncEvent.Resolve })
+            assertTrue(emitter.events.any { it is SyncEvent.RefreshSyncInfo })
+            assertEquals(failBefore + 1, handler.syncPollingManager.currentFailCount)
+            childScope.cancel()
+        }
+
+    /**
+     * A connect-address change while NOT connected (here: staying CONNECTING) must not
+     * trigger an immediate Resolve — only CONNECTED address changes do.
+     */
+    @Test
+    fun handleValueChange_addressChangeWhileConnecting_doesNotEmitResolve() =
+        runTest {
+            val emitter = TestEmitter()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncRuntimeInfo =
+                createConnectingSyncRuntimeInfo(hostAddress = "192.168.1.108")
+
+            val handler = GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
+            advanceTimeBy(SMALL_ADVANCE_MS)
+            emitter.events.clear()
+
+            handler.updateSyncRuntimeInfo(
+                syncRuntimeInfo.copy(connectHostAddress = "192.168.1.109"),
+            )
+            advanceTimeBy(SMALL_ADVANCE_MS)
+
+            assertTrue(emitter.events.none { it is SyncEvent.Resolve })
+            childScope.cancel()
+        }
+
+    /**
+     * Phase E + #4500 guard: an active switch makes the resolver write the sequence
+     * CONNECTED@old → CONNECTING@new → CONNECTED@new within one pass. Fed through the
+     * handler, this must stay bounded — the CONNECTING write (address changed but state
+     * != CONNECTED) must NOT re-emit Resolve (the old backoff-bypass), only the final
+     * CONNECTED transition emits exactly one verify Resolve, and no fail()/backoff fires.
+     *
+     * (The resolver half — that it produces this sequence with no DISCONNECTED — is
+     * covered by SyncResolverTest.verifyConnection_currentAddressDead_activeSwitches...;
+     * a single fully-wired live loop is impractical here because GeneralSyncHandler's
+     * polling loop reads wall-clock, so the two halves are asserted independently.)
+     */
+    @Test
+    fun handleValueChange_activeSwitchSequence_boundedResolvesNoBackoffBypass() =
+        runTest {
+            val emitter = TestEmitter()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val connectedOld = createConnectedSyncRuntimeInfo(hostAddress = "192.168.1.108")
+
+            val handler = GeneralSyncHandler(connectedOld, emitter.emitEvent, childScope)
+            advanceTimeBy(SMALL_ADVANCE_MS)
+            emitter.events.clear()
+            val failBefore = handler.syncPollingManager.currentFailCount
+
+            // The exact DB-write sequence an active switch produces in one resolve pass.
+            handler.updateSyncRuntimeInfo(
+                connectedOld.copy(
+                    connectState = SyncState.CONNECTING,
+                    connectHostAddress = "192.168.1.109",
+                ),
+            )
+            advanceTimeBy(SMALL_ADVANCE_MS)
+            handler.updateSyncRuntimeInfo(
+                connectedOld.copy(
+                    connectState = SyncState.CONNECTED,
+                    connectHostAddress = "192.168.1.109",
+                ),
+            )
+            advanceTimeBy(SMALL_ADVANCE_MS)
+
+            // Exactly one Resolve (the final CONNECTED verify); the CONNECTING address
+            // change did NOT bypass backoff with an extra Resolve.
+            assertEquals(1, emitter.events.count { it is SyncEvent.Resolve })
+            assertEquals(failBefore, handler.syncPollingManager.currentFailCount)
+            childScope.cancel()
+        }
+
     // ========== C. API delegation ==========
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -12,6 +12,7 @@ import com.crosspaste.net.NetworkInterfaceService
 import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.net.SyncInfoFactory
 import com.crosspaste.net.TelnetHelper
+import com.crosspaste.net.TelnetResult
 import com.crosspaste.net.VersionRelation
 import com.crosspaste.net.clientapi.ConnectionRefused
 import com.crosspaste.net.clientapi.DecryptFail
@@ -123,8 +124,8 @@ class SyncResolverTest {
             val hostInfo = HostInfo(24, "192.168.1.100")
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns
-                Pair(hostInfo, VersionRelation.EQUAL_TO)
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns
+                Pair(hostInfo, TelnetResult(VersionRelation.EQUAL_TO, null))
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns true
             coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
                 SuccessResult(VersionRelation.EQUAL_TO)
@@ -141,6 +142,53 @@ class SyncResolverTest {
         }
 
     @Test
+    fun resolveDisconnected_fastProbeIdentityMismatch_fallsThroughToCorrectHost() =
+        runTest {
+            // #4499 Phase A: a ghost squats on our last address (.108) advertising a
+            // different identity. The fast probe must reject it and fall through to the
+            // full-list probe, which finds the real peer that moved to .109.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo =
+                createSyncRuntimeInfo(
+                    connectState = SyncState.DISCONNECTED,
+                    connectHostAddress = "192.168.1.108",
+                    hostInfoList =
+                        listOf(
+                            HostInfo(24, "192.168.1.108"),
+                            HostInfo(24, "192.168.1.109"),
+                        ),
+                )
+
+            deps.stubDbRead(syncRuntimeInfo)
+            // Fast probe of .108 is reachable but returns a foreign identity.
+            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns
+                TelnetResult(VersionRelation.EQUAL_TO, "ghost-app-id")
+            // Full-list probe surfaces the real peer (identity-matched) at .109.
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns
+                Pair(
+                    HostInfo(24, "192.168.1.109"),
+                    TelnetResult(VersionRelation.EQUAL_TO, syncRuntimeInfo.appInstanceId),
+                )
+            coEvery { deps.secureStore.existCryptPublicKey(any()) } returns true
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
+                SuccessResult(VersionRelation.EQUAL_TO)
+
+            val capturedInfos = mutableListOf<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfos)) } returns "test-app-1"
+
+            val callback = createTestCallback()
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
+
+            // Never connected to the ghost .108; converged on the real .109.
+            assertEquals(SyncState.CONNECTING, capturedInfos[0].connectState)
+            assertEquals("192.168.1.109", capturedInfos[0].connectHostAddress)
+            assertEquals(SyncState.CONNECTED, capturedInfos[1].connectState)
+            assertEquals("192.168.1.109", capturedInfos[1].connectHostAddress)
+            coVerify { deps.telnetHelper.switchHost(any(), any(), any(), any()) }
+        }
+
+    @Test
     fun resolveDisconnected_switchHostReturnsLowerThan_setsIncompatible() =
         runTest {
             val deps = TestDeps()
@@ -149,8 +197,8 @@ class SyncResolverTest {
             val hostInfo = HostInfo(24, "192.168.1.100")
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns
-                Pair(hostInfo, VersionRelation.LOWER_THAN)
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns
+                Pair(hostInfo, TelnetResult(VersionRelation.LOWER_THAN, null))
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -170,8 +218,8 @@ class SyncResolverTest {
             val hostInfo = HostInfo(24, "192.168.1.100")
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns
-                Pair(hostInfo, VersionRelation.HIGHER_THAN)
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns
+                Pair(hostInfo, TelnetResult(VersionRelation.HIGHER_THAN, null))
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -193,7 +241,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
 
             val callback = createTestCallback()
             resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
@@ -211,7 +259,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.INCOMPATIBLE)
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -230,14 +278,148 @@ class SyncResolverTest {
             val syncRuntimeInfo = createSyncRuntimeInfo(hostInfoList = emptyList())
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
 
             val callback = createTestCallback()
             resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
-            coVerify { deps.telnetHelper.switchHost(emptyList(), any(), any()) }
+            coVerify { deps.telnetHelper.switchHost(emptyList(), any(), any(), any()) }
             // Already DISCONNECTED with no host → no redundant DB write.
             coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    // ========== A2. Phase E: recency-first probing + active switch ==========
+
+    @Test
+    fun discoverReachableHost_fastProbesFreshestAddressFirst() =
+        runTest {
+            // Two known addresses; .109 was advertised more recently than .108.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo =
+                createSyncRuntimeInfo(
+                    connectState = SyncState.DISCONNECTED,
+                    hostInfoList =
+                        listOf(
+                            HostInfo(24, "192.168.1.108", lastSeen = 1L),
+                            HostInfo(24, "192.168.1.109", lastSeen = 100L),
+                        ),
+                )
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns
+                TelnetResult(VersionRelation.EQUAL_TO, syncRuntimeInfo.appInstanceId)
+            coEvery { deps.secureStore.existCryptPublicKey(any()) } returns true
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
+                SuccessResult(VersionRelation.EQUAL_TO)
+
+            val capturedInfos = mutableListOf<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfos)) } returns "test-app-1"
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            // Fresh .109 is the fast-probe target and the address we connect on.
+            coVerify { deps.telnetHelper.telnet("192.168.1.109", any(), any()) }
+            assertEquals(SyncState.CONNECTING, capturedInfos[0].connectState)
+            assertEquals("192.168.1.109", capturedInfos[0].connectHostAddress)
+        }
+
+    @Test
+    fun verifyConnection_currentAddressDead_activeSwitchesWithoutDisconnect() =
+        runTest {
+            // CONNECTED on .108; heartbeat there fails, but the peer is reachable at the
+            // freshly-advertised .109. Must switch CONNECTED -> CONNECTING -> CONNECTED
+            // with NO intervening DISCONNECTED write (#4499 weakness ①).
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo =
+                createSyncRuntimeInfo(
+                    connectState = SyncState.CONNECTED,
+                    connectHostAddress = "192.168.1.108",
+                    connectNetworkPrefixLength = 24,
+                    hostInfoList =
+                        listOf(
+                            HostInfo(24, "192.168.1.108", lastSeen = 1L),
+                            HostInfo(24, "192.168.1.109", lastSeen = 100L),
+                        ),
+                )
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            coEvery { deps.secureStore.existCryptPublicKey(any()) } returns true
+            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns
+                TelnetResult(VersionRelation.EQUAL_TO, syncRuntimeInfo.appInstanceId)
+            // First heartbeat (verify .108) fails; second (authenticate .109) succeeds.
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returnsMany
+                listOf(ConnectionRefused, SuccessResult(VersionRelation.EQUAL_TO))
+
+            val capturedInfos = mutableListOf<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfos)) } returns "test-app-1"
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertTrue(capturedInfos.none { it.connectState == SyncState.DISCONNECTED })
+            assertEquals(SyncState.CONNECTING, capturedInfos[0].connectState)
+            assertEquals("192.168.1.109", capturedInfos[0].connectHostAddress)
+            assertEquals(SyncState.CONNECTED, capturedInfos.last().connectState)
+            assertEquals("192.168.1.109", capturedInfos.last().connectHostAddress)
+        }
+
+    @Test
+    fun verifyConnection_connectAddressNotInHostInfoList_butAlive_staysConnected() =
+        runTest {
+            // Intentional Phase E boundary: connectHostAddress may have been LRU-evicted
+            // from hostInfoList (the peer broadcast newer addresses) yet still be alive.
+            // verifyConnection must heartbeat it DIRECTLY and keep the connection — it must
+            // NOT require connectHostAddress to be a member of hostInfoList. This guards
+            // against a future refactor that only ever probes hostInfoList.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo =
+                createSyncRuntimeInfo(
+                    connectState = SyncState.CONNECTED,
+                    connectHostAddress = "192.168.1.5",
+                    connectNetworkPrefixLength = 24,
+                    // .5 is deliberately absent from the host list.
+                    hostInfoList =
+                        (1..HostInfo.MAX_RECENT_HOST_INFO).map { i ->
+                            HostInfo(24, "192.168.9.$i", lastSeen = i.toLong())
+                        },
+                )
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
+                SuccessResult(VersionRelation.EQUAL_TO)
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            // Heartbeat on the (off-list) connect address succeeded → still CONNECTED,
+            // no state write at all.
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun verifyConnection_currentAddressDeadAndNoReachableHost_setsDisconnected() =
+        runTest {
+            // CONNECTED, heartbeat fails, and re-discovery finds nothing reachable ->
+            // the active-switch path falls through to DISCONNECTED.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo(hostAddress = "192.168.1.108")
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns ConnectionRefused
+            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
+
+            val capturedInfo = slot<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
 
     // ========== B. resolveConnecting ==========
@@ -324,7 +506,8 @@ class SyncResolverTest {
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
             // No token cached -> telnet
-            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns VersionRelation.EQUAL_TO
+            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns
+                TelnetResult(VersionRelation.EQUAL_TO, null)
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -347,7 +530,7 @@ class SyncResolverTest {
                 )
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -616,7 +799,8 @@ class SyncResolverTest {
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
             coEvery { deps.syncClientApi.trust(any(), any(), any(), any()) } returns
                 FailureResult(PasteException(StandardErrorCode.TOKEN_INVALID.toErrorCode(), "invalid"))
-            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns VersionRelation.EQUAL_TO
+            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns
+                TelnetResult(VersionRelation.EQUAL_TO, null)
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -635,7 +819,8 @@ class SyncResolverTest {
 
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
-            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns VersionRelation.EQUAL_TO
+            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns
+                TelnetResult(VersionRelation.EQUAL_TO, null)
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -654,7 +839,8 @@ class SyncResolverTest {
 
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
-            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns VersionRelation.LOWER_THAN
+            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns
+                TelnetResult(VersionRelation.LOWER_THAN, null)
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -696,7 +882,7 @@ class SyncResolverTest {
 
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -802,7 +988,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -810,7 +996,7 @@ class SyncResolverTest {
             val callback = createTestCallback()
             resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
-            coVerify { deps.telnetHelper.switchHost(any(), any(), any()) }
+            coVerify { deps.telnetHelper.switchHost(any(), any(), any(), any()) }
         }
 
     @Test
@@ -821,7 +1007,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.INCOMPATIBLE)
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
 
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
@@ -829,7 +1015,7 @@ class SyncResolverTest {
             val callback = createTestCallback()
             resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
-            coVerify { deps.telnetHelper.switchHost(any(), any(), any()) }
+            coVerify { deps.telnetHelper.switchHost(any(), any(), any(), any()) }
         }
 
     @Test
@@ -850,7 +1036,7 @@ class SyncResolverTest {
             resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, callback))
 
             // resolveConnecting path is taken, which calls telnet (not switchHost)
-            coVerify(exactly = 0) { deps.telnetHelper.switchHost(any(), any(), any()) }
+            coVerify(exactly = 0) { deps.telnetHelper.switchHost(any(), any(), any(), any()) }
         }
 
     @Test
@@ -861,14 +1047,14 @@ class SyncResolverTest {
             val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(any()) } returns "test-app-1"
 
             val callback = createTestCallback()
             resolver.emitEvent(SyncEvent.ForceResolve(syncRuntimeInfo, callback))
 
             verify { deps.pasteBonjourService.refreshTarget(any(), any()) }
-            coVerify { deps.telnetHelper.switchHost(any(), any(), any()) }
+            coVerify { deps.telnetHelper.switchHost(any(), any(), any(), any()) }
         }
 
     @Test
@@ -891,7 +1077,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createSyncRuntimeInfo()
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } throws RuntimeException("test error")
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } throws RuntimeException("test error")
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(any()) } returns "test-app-1"
 
             var onCompleteCalled = false
@@ -919,7 +1105,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } throws
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } throws
                 CancellationException("scope cancelled")
 
             assertFailsWith<CancellationException> {
@@ -937,7 +1123,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } throws
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } throws
                 RuntimeException("boom")
 
             // Should NOT throw — the runtime exception is swallowed.
@@ -953,8 +1139,8 @@ class SyncResolverTest {
             val hostInfo = HostInfo(24, "192.168.1.100")
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.telnetHelper.switchHost(any(), any(), any()) } returns
-                Pair(hostInfo, VersionRelation.EQUAL_TO)
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns
+                Pair(hostInfo, TelnetResult(VersionRelation.EQUAL_TO, null))
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns true
             coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
                 SuccessResult(VersionRelation.EQUAL_TO)

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/TxtRecordUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/TxtRecordUtilsTest.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.utils
 
 import com.crosspaste.app.AppInfo
+import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.dto.sync.EndpointInfo
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.platform.Platform
@@ -31,6 +32,20 @@ class TxtRecordUtilsTest {
                     port = 13129,
                 ),
         )
+
+    // Encodes a raw JSON string into the same base64-chunked TXT dict shape that
+    // decodeFromTxtRecordDict consumes — lets a test feed hand-written wire payloads
+    // (e.g. older/future peers) through the real decode path.
+    private fun toTxtDict(
+        rawJson: String,
+        chunkSize: Int = 128,
+    ): Map<String, ByteArray> {
+        val base64 = getCodecsUtils().base64Encode(rawJson.encodeToByteArray())
+        return base64
+            .chunked(chunkSize)
+            .mapIndexed { index, chunk -> index.toString() to chunk.encodeToByteArray() }
+            .toMap()
+    }
 
     @Test
     fun `encode and decode round-trip preserves SyncInfo`() {
@@ -94,6 +109,94 @@ class TxtRecordUtilsTest {
         val encoded = TxtRecordUtils.encodeToTxtRecordDict(syncInfo)
         assertTrue(encoded.isNotEmpty())
         encoded.values.forEach { assertTrue(it.isNotEmpty(), "Each chunk should be non-empty") }
+    }
+
+    // --- Phase B: HostInfo.lastSeen crosses the real mDNS TXT path ---
+
+    @Test
+    fun `round-trip preserves multi-host hostInfoList with lastSeen`() {
+        val original =
+            createTestSyncInfo().let {
+                it.copy(
+                    endpointInfo =
+                        it.endpointInfo.copy(
+                            hostInfoList =
+                                listOf(
+                                    HostInfo(24, "192.168.1.1", lastSeen = 111L),
+                                    HostInfo(24, "192.168.1.2", lastSeen = 222L),
+                                ),
+                        ),
+                )
+            }
+        val encoded = TxtRecordUtils.encodeToTxtRecordDict(original)
+        val byteArrayMap = encoded.mapValues { (_, v) -> v.encodeToByteArray() }
+        val decoded = TxtRecordUtils.decodeFromTxtRecordDict<SyncInfo>(byteArrayMap)
+        assertEquals(original.endpointInfo.hostInfoList, decoded.endpointInfo.hostInfoList)
+        assertEquals(
+            222L,
+            decoded.endpointInfo.hostInfoList
+                .first { it.hostAddress == "192.168.1.2" }
+                .lastSeen,
+        )
+    }
+
+    @Test
+    fun `decodes TXT payload from an older peer that omits lastSeen`() {
+        // old build -> new build over the real mDNS TXT codec: hostInfoList entries
+        // without lastSeen must decode with the default rather than failing discovery.
+        val oldJson =
+            """
+            {"appInfo":{"appInstanceId":"id","appVersion":"1.0","appRevision":"r","userName":"u"},
+             "endpointInfo":{"deviceId":"d","deviceName":"n",
+              "platform":{"name":"macOS","arch":"aarch64","bitMode":64,"version":"14.0"},
+              "hostInfoList":[{"networkPrefixLength":24,"hostAddress":"10.0.0.5"}],"port":13129}}
+            """.trimIndent()
+        val txtDict = toTxtDict(oldJson)
+
+        val decoded = TxtRecordUtils.decodeFromTxtRecordDict<SyncInfo>(txtDict)
+
+        assertEquals(
+            "10.0.0.5",
+            decoded.endpointInfo.hostInfoList
+                .single()
+                .hostAddress,
+        )
+        assertEquals(
+            0L,
+            decoded.endpointInfo.hostInfoList
+                .single()
+                .lastSeen,
+        )
+    }
+
+    @Test
+    fun `decodes TXT payload carrying unknown future keys without throwing`() {
+        // new/future build -> this build over the real codec: unknown keys are tolerated,
+        // which is the same mechanism by which an OLD peer ignores our new lastSeen.
+        val futureJson =
+            """
+            {"appInfo":{"appInstanceId":"id","appVersion":"9.9","appRevision":"r","userName":"u","futureA":1},
+             "endpointInfo":{"deviceId":"d","deviceName":"n",
+              "platform":{"name":"macOS","arch":"aarch64","bitMode":64,"version":"14.0"},
+              "hostInfoList":[{"networkPrefixLength":24,"hostAddress":"10.0.0.6","lastSeen":42,"futureB":2}],
+              "port":13129,"futureC":3}}
+            """.trimIndent()
+        val txtDict = toTxtDict(futureJson)
+
+        val decoded = TxtRecordUtils.decodeFromTxtRecordDict<SyncInfo>(txtDict)
+
+        assertEquals(
+            "10.0.0.6",
+            decoded.endpointInfo.hostInfoList
+                .single()
+                .hostAddress,
+        )
+        assertEquals(
+            42L,
+            decoded.endpointInfo.hostInfoList
+                .single()
+                .lastSeen,
+        )
     }
 
     @Test

--- a/core/src/commonMain/kotlin/com/crosspaste/db/sync/HostInfo.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/db/sync/HostInfo.kt
@@ -6,4 +6,43 @@ import kotlinx.serialization.Serializable
 data class HostInfo(
     val networkPrefixLength: Short,
     var hostAddress: String,
-)
+    val lastSeen: Long = 0L,
+) {
+    companion object {
+        // Cap on retained addresses per peer. Bounds ghost accumulation (#4499) while
+        // keeping enough recent addresses to cover multiple interfaces (wifi/ethernet/VPN)
+        // plus a little IP history.
+        const val MAX_RECENT_HOST_INFO: Int = 8
+
+        /**
+         * Merge [incoming] advertised addresses into [existing], newest-first.
+         *
+         * Recency ([lastSeen]) is stamped on receipt with [now] — the value carried over
+         * the wire is meaningless across devices' clocks. Incoming addresses replace any
+         * same-address existing entry with a fresh [now]; the result is ordered by
+         * lastSeen descending and capped at [max] so a peer's address list can never grow
+         * unbounded. Eviction is purely capacity-based (LRU): a stable, still-connected
+         * device is never aged out by a clock, and ghost addresses that stop being
+         * advertised sink to the bottom and fall off as new addresses arrive.
+         */
+        fun mergeRecent(
+            existing: List<HostInfo>,
+            incoming: List<HostInfo>,
+            now: Long,
+            max: Int = MAX_RECENT_HOST_INFO,
+        ): List<HostInfo> {
+            // De-dup incoming by address (a peer / TXT record may advertise the same
+            // address more than once); stamp the survivors fresh.
+            val fresh = incoming.distinctBy { it.hostAddress }.map { it.copy(lastSeen = now) }
+            val incomingAddresses = fresh.mapTo(HashSet()) { it.hostAddress }
+            val retained = existing.filterNot { it.hostAddress in incomingAddresses }
+            // Sort newest-first, then collapse any remaining duplicate addresses (keeping
+            // the freshest — e.g. legacy `existing` rows that held the same address under
+            // different prefixes), and finally cap.
+            return (fresh + retained)
+                .sortedByDescending { it.lastSeen }
+                .distinctBy { it.hostAddress }
+                .take(max)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/sync/SyncInfo.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/sync/SyncInfo.kt
@@ -1,6 +1,8 @@
 package com.crosspaste.dto.sync
 
 import com.crosspaste.app.AppInfo
+import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.utils.DateUtils
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -9,13 +11,21 @@ data class SyncInfo(
     val appInfo: AppInfo,
     val endpointInfo: EndpointInfo,
 ) {
-    fun merge(other: SyncInfo): SyncInfo {
-        val hostInfoList = endpointInfo.hostInfoList
-        val otherHostInfoList = other.endpointInfo.hostInfoList
-
+    /**
+     * Merge [other]'s freshly-advertised endpoint into this one. [other] wins on metadata
+     * and its addresses are stamped newest; the host list is recency-ordered and capped
+     * via [HostInfo.mergeRecent] so accumulated addresses stay bounded (#4499).
+     */
+    fun merge(
+        other: SyncInfo,
+        now: Long = DateUtils.nowEpochMilliseconds(),
+    ): SyncInfo {
         val mergedList =
-            (hostInfoList + otherHostInfoList)
-                .distinctBy { it.hostAddress }
+            HostInfo.mergeRecent(
+                existing = endpointInfo.hostInfoList,
+                incoming = other.endpointInfo.hostInfoList,
+                now = now,
+            )
 
         val appInfo = other.appInfo
         val endpointInfo =
@@ -28,6 +38,23 @@ data class SyncInfo(
             )
         return SyncInfo(appInfo, endpointInfo)
     }
+
+    /**
+     * Stamp and bound this endpoint's host list on first sight (no prior entry to merge
+     * with). Keeps the wire-supplied addresses but applies recency + the capacity cap.
+     */
+    fun withStampedHostInfo(now: Long = DateUtils.nowEpochMilliseconds()): SyncInfo =
+        copy(
+            endpointInfo =
+                endpointInfo.copy(
+                    hostInfoList =
+                        HostInfo.mergeRecent(
+                            existing = emptyList(),
+                            incoming = endpointInfo.hostInfoList,
+                            now = now,
+                        ),
+                ),
+        )
 
     override fun toString(): String = Json.encodeToString(this)
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SqlSyncRuntimeInfoDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SqlSyncRuntimeInfoDao.kt
@@ -166,10 +166,27 @@ class SqlSyncRuntimeInfoDao(
                                 ).executeAsOneOrNull()
 
                         if (existing != null) {
-                            val hostInfoList = (existing.hostInfoList + syncInfo.endpointInfo.hostInfoList).distinct()
+                            // Recency-ordered, capacity-capped merge (LRU) instead of an
+                            // unbounded union — bounds ghost-address accumulation (#4499).
+                            val hostInfoList =
+                                HostInfo.mergeRecent(
+                                    existing = existing.hostInfoList,
+                                    incoming = syncInfo.endpointInfo.hostInfoList,
+                                    now = now,
+                                )
 
-                            val connectNetworkPrefixLength: Long? = connectInfo?.networkPrefixLength?.toLong()
-                            val connectHostAddress: String? = connectInfo?.hostAddress
+                            // When this update carries no connectInfo (e.g. an mDNS
+                            // re-advertisement), preserve the existing connect address /
+                            // prefix instead of nulling them. The connectState column is
+                            // already preserved via a CASE on the -1 sentinel; the address
+                            // must be preserved too, otherwise a peer's IP-change broadcast
+                            // wipes connectHostAddress and forces a visible disconnect
+                            // (#4499 weakness ①).
+                            val connectNetworkPrefixLength: Long? =
+                                connectInfo?.networkPrefixLength?.toLong()
+                                    ?: existing.connectNetworkPrefixLength?.toLong()
+                            val connectHostAddress: String? =
+                                connectInfo?.hostAddress ?: existing.connectHostAddress
                             val connectState: Long = if (connectInfo != null) SyncState.CONNECTED.toLong() else -1L
 
                             val hostInfoChanged =
@@ -225,7 +242,15 @@ class SqlSyncRuntimeInfoDao(
                                     SyncState.DISCONNECTED.toLong()
                                 }
 
-                            val hostInfoArrayJson = jsonUtils.JSON.encodeToString(syncInfo.endpointInfo.hostInfoList)
+                            // Stamp recency and apply the capacity cap on first insert too,
+                            // so a peer can't seed an unbounded address list.
+                            val hostInfoList =
+                                HostInfo.mergeRecent(
+                                    existing = emptyList(),
+                                    incoming = syncInfo.endpointInfo.hostInfoList,
+                                    now = now,
+                                )
+                            val hostInfoArrayJson = jsonUtils.JSON.encodeToString(hostInfoList)
                             syncRuntimeInfoDatabaseQueries.createSyncRuntimeInfo(
                                 syncInfo.appInfo.appInstanceId,
                                 syncInfo.appInfo.appVersion,


### PR DESCRIPTION
## Summary

Rework device (re)connection so a paired peer is located by **identity** (`appInstanceId` / ECDH key) rather than by IP. This fixes the non-converging reconnect loop and the unbounded address accumulation behind #4499, and lets peers survive DHCP IP changes without a visible disconnect.

The trust anchor was already identity-bound (ECDH shared secret keyed by `appInstanceId`); only **host selection** was coupled to IP. These changes move selection onto identity while keeping trust exactly where it was.

## What changed

**C — stop the tight loop (backoff bypass)**
- `GeneralSyncHandler`: a `connectHostAddress` change triggers an immediate re-resolve only when the device is `CONNECTED`; other states fall through to the connect-state path so `SyncPollingManager` exponential backoff applies.
- `SyncResolver.authenticate`: on failure, persists `DISCONNECTED` at the address actually tried instead of reverting to the stale snapshot address (which made the address oscillate and bypass backoff).

**A — identity-aware discovery**
- `/sync/telnet` returns the responder's `appInstanceId` in a response header (body unchanged → older clients are unaffected).
- `TelnetResult` carries `peerAppInstanceId`; discovery admits a host only when its advertised identity matches the expected peer. `switchHost` filters **inside** the parallel race so a ghost on a historical IP cannot crowd out the real peer.
- The header is **unauthenticated and selection-only** — unknown identity (older peers without the header) is still admitted and vetted by the ECDH heartbeat; only a positively different identity is rejected.

**B — bounded, recency-ordered address list**
- `HostInfo` gains `lastSeen`. `HostInfo.mergeRecent` replaces the unbounded union in both `SyncInfo.merge` and the DAO with a recency-ordered, capacity-capped merge (LRU, max 8), bounding ghost-address accumulation. Capacity-only (no time TTL) so a stable, still-connected device is never aged out.

**E — active switch on IP change**
- The DAO preserves `connectHostAddress` / prefix on an mDNS re-advertisement (previously nulled).
- `discoverReachableHost` probes the most-recently-advertised address first (recency-first).
- `verifyConnection` re-discovers in place on heartbeat failure (`CONNECTED → CONNECTING → CONNECTED`) instead of dropping to `DISCONNECTED`, removing the visible disconnect window on an IP change.

## Compatibility
- New `appInstanceId` telnet header: response body unchanged; older clients ignore it.
- New `HostInfo.lastSeen`: serialized with a default; tolerated in both directions thanks to `ignoreUnknownKeys=true` on the wire codecs (mDNS TXT record + `crosspaste-sync-info` header). **No DB schema migration.**

## Scope note (Phase D dropped)
The design's "ghost governance" phase (mark a record `stale` / "probably reinstalled, please re-pair") was **dropped**: an identity mismatch cannot distinguish a reinstall from a dual-boot machine booting its other OS, or from DHCP reassigning the IP to a different device — all of which are simply *offline*. Marking the record offline is the correct, honest behavior, and the C/A/B/E changes already make dual-boot switches show offline and auto-reconnect.

## Testing
`./gradlew app:desktopTest` is green. Added/updated tests cover:
- backoff-bypass regression (address thrash on failure) and the active-switch sequence staying bounded;
- identity admit/reject + old-peer (no header) fallback, inside `switchHost` and end-to-end over the real Ktor server;
- cross-version serialization (missing `lastSeen` → default; unknown future keys tolerated) including the real mDNS TXT path;
- `mergeRecent` dedup (incoming-internal + legacy), recency ordering, capacity eviction;
- DAO: re-advertise same address set → no write, LRU eviction of `connectHostAddress` while the column is preserved, connect-address preserved across mDNS update;
- recency-first probing, active switch without a `DISCONNECTED` flicker, and `CancellationException` propagation in `TelnetHelper`.

Closes #4499
