### PR TITLE
:bug: stop device list flicker when re-probing offline devices

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceGroups.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceGroups.kt
@@ -1,0 +1,53 @@
+package com.crosspaste.ui.devices
+
+import com.crosspaste.db.sync.SyncRuntimeInfo
+import com.crosspaste.db.sync.SyncState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.scan
+
+/**
+ * Online / offline split for the device list.
+ *
+ * [lastOnline] carries each device's previously resolved group so a CONNECTING
+ * transition inherits where the device was, instead of letting it jump between
+ * lists on every re-probe.
+ */
+data class DeviceGroups(
+    val online: List<SyncRuntimeInfo> = emptyList(),
+    val offline: List<SyncRuntimeInfo> = emptyList(),
+    val lastOnline: Map<String, Boolean> = emptyMap(),
+) {
+    val hasDevices: Boolean
+        get() = online.isNotEmpty() || offline.isNotEmpty()
+
+    /**
+     * Sticky grouping: a flaky device that polling re-probes flips
+     * DISCONNECTED -> CONNECTING -> DISCONNECTED every cycle. Bucketing on the raw
+     * connectState would make it jump between the online and offline lists (and
+     * flip the offline count) on each flip. CONNECTING is a transition, so its
+     * group is decided by where the device was last resolved to: a previously
+     * online device stays online while re-probing, a previously offline device
+     * stays offline. Only terminal states (CONNECTED / attention / DISCONNECTED)
+     * actually move a device. The raw connectState is left untouched so the device
+     * row can still show the live "reconnecting" indicator.
+     */
+    fun next(list: List<SyncRuntimeInfo>): DeviceGroups {
+        val nextLastOnline = HashMap<String, Boolean>(list.size)
+        val (online, offline) =
+            list.partition { info ->
+                val isOnline =
+                    when (info.connectState) {
+                        SyncState.DISCONNECTED -> false
+                        SyncState.CONNECTING -> lastOnline[info.appInstanceId] ?: false
+                        else -> true
+                    }
+                nextLastOnline[info.appInstanceId] = isOnline
+                isOnline
+            }
+        return DeviceGroups(online, offline, nextLastOnline)
+    }
+}
+
+/** Groups a stream of device lists into sticky online / offline buckets. */
+fun Flow<List<SyncRuntimeInfo>>.scanDeviceGroups(): Flow<DeviceGroups> =
+    scan(DeviceGroups()) { previous, list -> previous.next(list) }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -3,7 +3,6 @@ package com.crosspaste.ui.devices
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -16,7 +15,6 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -29,14 +27,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.text.font.FontWeight
 import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Add
 import com.composables.icons.materialsymbols.rounded.Devices
 import com.composables.icons.materialsymbols.rounded.Refresh
-import com.crosspaste.db.sync.SyncRuntimeInfo
-import com.crosspaste.db.sync.SyncState
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.sync.NearbyDeviceManager
@@ -69,18 +63,14 @@ fun DevicesContentView(guideContent: (@Composable () -> Unit)? = null) {
 
     val searching by nearbyDeviceManager.searching.collectAsState()
 
-    val syncRuntimeInfos by syncManager.realTimeSyncRuntimeInfos.collectAsState()
+    val deviceGroups = rememberDeviceGroups()
+    val hasDevices = deviceGroups.hasDevices
 
     val unverifiedSyncRuntimeInfo by syncManager.unverifiedSyncRuntimeInfo.collectAsState()
 
     var showAddDeviceDialog by remember { mutableStateOf(false) }
     var showCurrentDeviceDialog by remember { mutableStateOf(false) }
     var offlineExpanded by rememberSaveable { mutableStateOf(false) }
-
-    val (onlineDevices, offlineDevices) =
-        remember(syncRuntimeInfos) {
-            syncRuntimeInfos.partition { it.connectState != SyncState.DISCONNECTED }
-        }
 
     LaunchedEffect(Unit) {
         syncManager.refresh { }
@@ -175,42 +165,19 @@ fun DevicesContentView(guideContent: (@Composable () -> Unit)? = null) {
             contentPadding = PaddingValues(bottom = titanic),
             verticalArrangement = Arrangement.spacedBy(tiny),
         ) {
-            if (syncRuntimeInfos.isNotEmpty()) {
-                stickyHeader {
-                    SectionHeader(
-                        text = "my_devices",
-                        trailingContent =
-                            if (offlineDevices.isNotEmpty()) {
-                                {
-                                    OfflineToggle(
-                                        count = offlineDevices.size,
-                                        checked = offlineExpanded,
-                                        onCheckedChange = { offlineExpanded = it },
-                                    )
-                                }
-                            } else {
-                                null
-                            },
-                    )
-                }
-            }
-
-            items(onlineDevices, key = { it.appInstanceId }) { syncRuntimeInfo ->
-                SyncDeviceItem(deviceScopeFactory, syncRuntimeInfo)
-            }
-
-            if (offlineExpanded) {
-                items(offlineDevices, key = { "offline-${it.appInstanceId}" }) { syncRuntimeInfo ->
-                    SyncDeviceItem(deviceScopeFactory, syncRuntimeInfo)
-                }
-            }
+            myDevicesSection(
+                deviceGroups = deviceGroups,
+                offlineExpanded = offlineExpanded,
+                onOfflineExpandedChange = { offlineExpanded = it },
+                deviceScopeFactory = deviceScopeFactory,
+            )
 
             stickyHeader {
                 SectionHeader(
                     text = "nearby_devices",
                     backgroundColor = MaterialTheme.colorScheme.surface,
                     topPadding =
-                        if (syncRuntimeInfos.isNotEmpty()) {
+                        if (hasDevices) {
                             medium
                         } else {
                             zero
@@ -252,42 +219,5 @@ fun DevicesContentView(guideContent: (@Composable () -> Unit)? = null) {
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun SyncDeviceItem(
-    deviceScopeFactory: DeviceScopeFactory,
-    syncRuntimeInfo: SyncRuntimeInfo,
-) {
-    val scope =
-        remember(syncRuntimeInfo) {
-            deviceScopeFactory.createDeviceScope(syncRuntimeInfo)
-        }
-    scope.DeviceConnectView()
-}
-
-@Composable
-private fun OfflineToggle(
-    count: Int,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-) {
-    val copywriter = koinInject<GlobalCopywriter>()
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(tiny2X),
-    ) {
-        Switch(
-            modifier = Modifier.scale(0.7f),
-            checked = checked,
-            onCheckedChange = onCheckedChange,
-        )
-        Text(
-            text = "${copywriter.getText(if (checked) "hide_offline" else "show_offline")} ($count)",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontWeight = FontWeight.Medium,
-        )
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/MyDevicesSection.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/MyDevicesSection.kt
@@ -1,0 +1,123 @@
+package com.crosspaste.ui.devices
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import com.crosspaste.db.sync.SyncRuntimeInfo
+import com.crosspaste.i18n.GlobalCopywriter
+import com.crosspaste.sync.SyncManager
+import com.crosspaste.ui.base.SectionHeader
+import com.crosspaste.ui.theme.AppUISize.tiny2X
+import com.crosspaste.ui.theme.AppUISize.zero
+import org.koin.compose.koinInject
+
+/**
+ * Builds the sticky online / offline device groups from [SyncManager]. Shared by
+ * desktop and mobile so the flicker-free grouping lives in one place; only the
+ * surrounding layout differs per platform.
+ */
+@Composable
+fun rememberDeviceGroups(): DeviceGroups {
+    val syncManager = koinInject<SyncManager>()
+    val deviceGroups by remember {
+        syncManager.realTimeSyncRuntimeInfos.scanDeviceGroups()
+    }.collectAsState(DeviceGroups())
+    return deviceGroups
+}
+
+/**
+ * The shared "my devices" list: a header with the offline toggle, the online
+ * devices, and (when expanded) the offline devices. Platform screens supply their
+ * own scaffold, top bar and nearby-devices section around this.
+ */
+fun LazyListScope.myDevicesSection(
+    deviceGroups: DeviceGroups,
+    offlineExpanded: Boolean,
+    onOfflineExpandedChange: (Boolean) -> Unit,
+    deviceScopeFactory: DeviceScopeFactory,
+    headerTopPadding: Dp = zero,
+) {
+    val onlineDevices = deviceGroups.online
+    val offlineDevices = deviceGroups.offline
+
+    if (deviceGroups.hasDevices) {
+        stickyHeader {
+            SectionHeader(
+                text = "my_devices",
+                topPadding = headerTopPadding,
+                trailingContent =
+                    if (offlineDevices.isNotEmpty()) {
+                        {
+                            OfflineToggle(
+                                count = offlineDevices.size,
+                                checked = offlineExpanded,
+                                onCheckedChange = onOfflineExpandedChange,
+                            )
+                        }
+                    } else {
+                        null
+                    },
+            )
+        }
+    }
+
+    items(onlineDevices, key = { it.appInstanceId }) { syncRuntimeInfo ->
+        SyncDeviceItem(deviceScopeFactory, syncRuntimeInfo)
+    }
+
+    if (offlineExpanded) {
+        items(offlineDevices, key = { "offline-${it.appInstanceId}" }) { syncRuntimeInfo ->
+            SyncDeviceItem(deviceScopeFactory, syncRuntimeInfo)
+        }
+    }
+}
+
+@Composable
+private fun SyncDeviceItem(
+    deviceScopeFactory: DeviceScopeFactory,
+    syncRuntimeInfo: SyncRuntimeInfo,
+) {
+    val scope =
+        remember(syncRuntimeInfo) {
+            deviceScopeFactory.createDeviceScope(syncRuntimeInfo)
+        }
+    scope.DeviceConnectView()
+}
+
+@Composable
+private fun OfflineToggle(
+    count: Int,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    val copywriter = koinInject<GlobalCopywriter>()
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(tiny2X),
+    ) {
+        Switch(
+            modifier = Modifier.scale(0.7f),
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+        Text(
+            text = "${copywriter.getText(if (checked) "hide_offline" else "show_offline")} ($count)",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}


### PR DESCRIPTION
Closes #4507

## Problem
The device screen groups devices into online / offline buckets using the raw `connectState` (`!= DISCONNECTED` = online). When `SyncPollingManager` re-probes a flaky-but-discoverable offline device, `SyncResolver` flips it `DISCONNECTED → CONNECTING → DISCONNECTED` every poll cycle (~60s). During the brief `CONNECTING` window the device is classified as online, jumps into the always-visible online list (offline count decrements), then drops back — a periodic flicker of the row and the counter.

## Fix
Sticky grouping carried through `scan`'s accumulator: `CONNECTING` inherits the device's previously resolved group, so only terminal states move a device between lists.
- `DISCONNECTED` → offline
- `CONNECTED` / attention states (UNVERIFIED / UNMATCHED / INCOMPATIBLE) → online
- `CONNECTING` → keep the last resolved group

The raw `connectState` is left untouched, so the device row still shows the live "reconnecting" indicator.

## Reuse
- `DeviceGroups` + `scanDeviceGroups()` — pure grouping logic (unit-testable)
- `rememberDeviceGroups()` + `LazyListScope.myDevicesSection(...)` — shared device-display section

Both live in `commonMain`, so desktop (`DevicesContentView`) and mobile (`MobileDevicesContentView`) share one implementation; only the surrounding scaffold / nearby section / padding differ per platform. The matching mobile call-site change is handled in the mobile repo.

## Verification
- `./gradlew ktlintFormat` clean
- `./gradlew :app:compileKotlinDesktop` passes
- Mobile `:mobileShared:compileCommonMainKotlinMetadata` passes with the shared files