### PR TITLE
:sparkles: self-heal mDNS discovery on OS network changes (#4509)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/NetworkStateMonitor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/NetworkStateMonitor.kt
@@ -1,0 +1,38 @@
+package com.crosspaste.net
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+/**
+ * Observes real OS network state so the discovery layer can self-heal.
+ *
+ * The JVM exposes no callback for interface up/down, IP changes, or reachability,
+ * so platform implementations bridge native events (e.g. macOS `NWPathMonitor`,
+ * Windows IP Helper / Network List Manager, Linux RTNETLINK) into [networkChanges].
+ *
+ * Each emission means "something about the network changed" — it carries no payload;
+ * consumers re-read the current interface snapshot themselves. Emissions may be
+ * coalesced/debounced by the implementation or the consumer.
+ */
+interface NetworkStateMonitor {
+
+    val networkChanges: Flow<Unit>
+
+    fun start()
+
+    fun stop()
+}
+
+/**
+ * Fallback for platforms without a native monitor yet. Never emits, so the
+ * discovery layer behaves exactly as it did before [NetworkStateMonitor] existed
+ * (config-driven only).
+ */
+class NoopNetworkStateMonitor : NetworkStateMonitor {
+
+    override val networkChanges: Flow<Unit> = emptyFlow()
+
+    override fun start() {}
+
+    override fun stop() {}
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -14,8 +14,12 @@ import com.crosspaste.net.DesktopPasteServer
 import com.crosspaste.net.DesktopResourcesClient
 import com.crosspaste.net.DesktopServerFactory
 import com.crosspaste.net.DesktopServerModule
+import com.crosspaste.net.LinuxNetworkStateMonitor
+import com.crosspaste.net.MacosNetworkStateMonitor
 import com.crosspaste.net.NetworkInterfaceService
 import com.crosspaste.net.NetworkProfileService
+import com.crosspaste.net.NetworkStateMonitor
+import com.crosspaste.net.NoopNetworkStateMonitor
 import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.net.PasteClient
 import com.crosspaste.net.ResourcesClient
@@ -24,6 +28,7 @@ import com.crosspaste.net.ServerFactory
 import com.crosspaste.net.ServerModule
 import com.crosspaste.net.SyncApi
 import com.crosspaste.net.TelnetHelper
+import com.crosspaste.net.WindowsNetworkStateMonitor
 import com.crosspaste.net.clientapi.PasteClientApi
 import com.crosspaste.net.clientapi.PullClientApi
 import com.crosspaste.net.clientapi.PushClientApi
@@ -35,6 +40,7 @@ import com.crosspaste.net.ws.WsClientConnector
 import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsPendingRequests
 import com.crosspaste.net.ws.WsSessionManager
+import com.crosspaste.platform.Platform
 import com.crosspaste.sync.FilePushService
 import com.crosspaste.sync.GeneralNearbyDeviceManager
 import com.crosspaste.sync.GeneralSyncManager
@@ -76,7 +82,16 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 GeneralNearbyDeviceManager(get(), get(), get(), get())
             }
         }
-        single<NetworkInterfaceService> { DesktopNetworkInterfaceService(get()) }
+        single<NetworkStateMonitor> {
+            val platform = get<Platform>()
+            when {
+                platform.isMacos() -> MacosNetworkStateMonitor()
+                platform.isWindows() -> WindowsNetworkStateMonitor()
+                platform.isLinux() -> LinuxNetworkStateMonitor()
+                else -> NoopNetworkStateMonitor()
+            }
+        }
+        single<NetworkInterfaceService> { DesktopNetworkInterfaceService(get(), get()) }
         single<NetworkProfileService> { DesktopNetworkProfileService(get(), get(), get(), get()) }
         single<ResourcesClient> { DesktopResourcesClient(get(), get()) }
         single<PasteBonjourService> { DesktopPasteBonjourService(get(), get(), get(), get()) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkInterfaceService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkInterfaceService.kt
@@ -6,39 +6,72 @@ import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlin.time.Duration.Companion.milliseconds
 
-class DesktopNetworkInterfaceService(
+open class DesktopNetworkInterfaceService(
     private val configManager: DesktopConfigManager,
+    private val networkStateMonitor: NetworkStateMonitor,
     networkRefreshScope: CoroutineScope = namedScope(ioDispatcher, "DesktopNetworkInterfaceService"),
 ) : AbstractNetworkInterfaceService() {
 
     private val jsonUtils = getJsonUtils()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
     override val networkInterfaces: StateFlow<List<NetworkInterfaceInfo>> =
-        configManager.config
-            .map { it.useNetworkInterfaces }
-            .distinctUntilChanged()
+        combine(
+            // Re-resolve when the user changes the configured interfaces...
+            configManager.config
+                .map { it.useNetworkInterfaces }
+                .distinctUntilChanged(),
+            // ...or when the OS reports a real network state change. The leading
+            // emit drives the initial resolution; debounce collapses flap bursts.
+            networkStateMonitor.networkChanges
+                .onStart { emit(Unit) }
+                .debounce(NETWORK_CHANGE_DEBOUNCE),
+        ) { useNetworkInterfacesJson, _ -> useNetworkInterfacesJson }
             .mapLatest { useNetworkInterfacesJson ->
-                createNetworkInterfaceInfos(useNetworkInterfacesJson)
-            }.stateIn(
+                resolveNetworkInterfaceInfos(useNetworkInterfacesJson)
+            }
+            // Content-based: only rebuild mDNS when the interface set actually changes.
+            .distinctUntilChanged()
+            .stateIn(
                 scope = networkRefreshScope,
                 started = SharingStarted.Eagerly,
                 initialValue = initNetworkInterfaceInfos(),
             )
 
-    private fun initNetworkInterfaceInfos(): List<NetworkInterfaceInfo> {
+    init {
+        networkStateMonitor.start()
+    }
+
+    private fun initNetworkInterfaceInfos(): List<NetworkInterfaceInfo> =
+        resolveNetworkInterfaceInfos(configManager.getCurrentConfig().useNetworkInterfaces)
+
+    /**
+     * Reads a fresh snapshot of the live interfaces and resolves them against the
+     * configured selection. Auto-selects a preferred interface when discovery is on
+     * and either nothing is configured or none of the configured interfaces are
+     * currently present — this is what unsticks the cold-start empty state once the
+     * network comes up.
+     */
+    private fun resolveNetworkInterfaceInfos(useNetworkInterfacesJson: String): List<NetworkInterfaceInfo> {
+        // Drop cached provider values so auto-select reflects the current network.
+        clearProviderCache()
+
         val config = configManager.getCurrentConfig()
         val useNetworkInterfaces =
-            jsonUtils.JSON.decodeFromString<List<String>>(
-                config.useNetworkInterfaces,
-            )
+            jsonUtils.JSON.decodeFromString<List<String>>(useNetworkInterfacesJson)
+
         if (config.enableDiscovery && useNetworkInterfaces.isEmpty()) {
             autoSelectAndSavePreferredInterface()?.let { return it }
         }
@@ -63,14 +96,7 @@ class DesktopNetworkInterfaceService(
             listOf(it)
         }
 
-    private fun createNetworkInterfaceInfos(useNetworkInterfacesJson: String): List<NetworkInterfaceInfo> {
-        val useNetworkInterfaces =
-            jsonUtils.JSON.decodeFromString<List<String>>(
-                useNetworkInterfacesJson,
-            )
-
-        val allNetworkInterfaceInfos = getAllNetworkInterfaceInfo()
-
-        return allNetworkInterfaceInfos.filter { it.name in useNetworkInterfaces }
+    companion object {
+        private val NETWORK_CHANGE_DEBOUNCE = 500L.milliseconds
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkInterfaceService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkInterfaceService.kt
@@ -59,10 +59,18 @@ open class DesktopNetworkInterfaceService(
 
     /**
      * Reads a fresh snapshot of the live interfaces and resolves them against the
-     * configured selection. Auto-selects a preferred interface when discovery is on
-     * and either nothing is configured or none of the configured interfaces are
-     * currently present — this is what unsticks the cold-start empty state once the
-     * network comes up.
+     * configured selection.
+     *
+     * The persisted [DesktopAppConfig.useNetworkInterfaces] holds the user's
+     * *preference*; the value this returns is the *active* selection actually bound
+     * by discovery. They diverge only while the preferred interface is offline:
+     *
+     *  - Fresh install (discovery on, nothing chosen yet): auto-select a preferred
+     *    interface and persist it as the bootstrap default.
+     *  - Preferred interface(s) all offline but the machine is online via another
+     *    interface: bind to it in-memory so discovery keeps working, but do NOT
+     *    persist — the preference must survive the outage so we heal back to it once
+     *    it returns (which a later network event re-resolves).
      */
     private fun resolveNetworkInterfaceInfos(useNetworkInterfacesJson: String): List<NetworkInterfaceInfo> {
         // Drop cached provider values so auto-select reflects the current network.
@@ -73,7 +81,7 @@ open class DesktopNetworkInterfaceService(
             jsonUtils.JSON.decodeFromString<List<String>>(useNetworkInterfacesJson)
 
         if (config.enableDiscovery && useNetworkInterfaces.isEmpty()) {
-            autoSelectAndSavePreferredInterface()?.let { return it }
+            autoSelectPreferredInterface(persist = true)?.let { return it }
         }
 
         val allNetworkInterfaceInfos = getAllNetworkInterfaceInfo()
@@ -81,18 +89,19 @@ open class DesktopNetworkInterfaceService(
         val interfaceInfos = allNetworkInterfaceInfos.filter { it.name in useNetworkInterfaces }
 
         if (interfaceInfos.isEmpty() && allNetworkInterfaceInfos.isNotEmpty()) {
-            autoSelectAndSavePreferredInterface()?.let { return it }
+            autoSelectPreferredInterface(persist = false)?.let { return it }
         }
 
         return interfaceInfos
     }
 
-    private fun autoSelectAndSavePreferredInterface(): List<NetworkInterfaceInfo>? =
+    private fun autoSelectPreferredInterface(persist: Boolean): List<NetworkInterfaceInfo>? =
         getPreferredNetworkInterface()?.let {
-            val useNetworkInterfacesJson =
-                jsonUtils.JSON.encodeToString(listOf(it.name))
-            configManager.updateConfig("useNetworkInterfaces", useNetworkInterfacesJson)
-
+            if (persist) {
+                val useNetworkInterfacesJson =
+                    jsonUtils.JSON.encodeToString(listOf(it.name))
+                configManager.updateConfig("useNetworkInterfaces", useNetworkInterfacesJson)
+            }
             listOf(it)
         }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/LinuxNetworkStateMonitor.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/LinuxNetworkStateMonitor.kt
@@ -1,0 +1,112 @@
+package com.crosspaste.net
+
+import com.crosspaste.platform.linux.api.NetlinkLib
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Linux [NetworkStateMonitor] backed by an RTNETLINK (`NETLINK_ROUTE`) socket.
+ *
+ * A dedicated daemon thread blocks on `recv`; the kernel wakes it on any interface
+ * or address change (link up/down, IPv4/IPv6 address add/remove). Each wake emits a
+ * change signal. [stop] closes the socket, which unblocks the `recv` and ends the
+ * thread. Any failure to open/bind the socket leaves the flow silent — discovery
+ * falls back to config-driven behaviour rather than breaking.
+ */
+class LinuxNetworkStateMonitor : NetworkStateMonitor {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val _networkChanges =
+        MutableSharedFlow<Unit>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    override val networkChanges: Flow<Unit> = _networkChanges
+
+    private val running = AtomicBoolean(false)
+
+    @Volatile
+    private var fd: Int = -1
+
+    @Volatile
+    private var thread: Thread? = null
+
+    override fun start() {
+        if (!running.compareAndSet(false, true)) {
+            return
+        }
+        runCatching {
+            val lib = NetlinkLib.INSTANCE
+            val socketFd =
+                lib.socket(NetlinkLib.AF_NETLINK, NetlinkLib.SOCK_RAW, NetlinkLib.NETLINK_ROUTE)
+            if (socketFd < 0) {
+                logger.warn { "Failed to open RTNETLINK socket: $socketFd" }
+                running.set(false)
+                return
+            }
+
+            val addr =
+                NetlinkLib.SockAddrNetlink().apply {
+                    nlFamily = NetlinkLib.AF_NETLINK.toShort()
+                    nlGroups =
+                        NetlinkLib.RTMGRP_LINK or
+                        NetlinkLib.RTMGRP_IPV4_IFADDR or
+                        NetlinkLib.RTMGRP_IPV6_IFADDR
+                }
+
+            if (lib.bind(socketFd, addr, addr.size()) < 0) {
+                logger.warn { "Failed to bind RTNETLINK socket" }
+                lib.close(socketFd)
+                running.set(false)
+                return
+            }
+
+            fd = socketFd
+            thread =
+                Thread({ readLoop(lib, socketFd) }, "LinuxNetworkStateMonitor").apply {
+                    isDaemon = true
+                    start()
+                }
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to start RTNETLINK monitor" }
+            running.set(false)
+        }
+    }
+
+    private fun readLoop(
+        lib: NetlinkLib,
+        socketFd: Int,
+    ) {
+        val buf = ByteArray(8192)
+        while (running.get()) {
+            val n = runCatching { lib.recv(socketFd, buf, buf.size.toLong(), 0) }.getOrElse { -1L }
+            if (n > 0) {
+                _networkChanges.tryEmit(Unit)
+            } else {
+                // Socket closed by stop(), or an error — exit the loop.
+                break
+            }
+        }
+    }
+
+    override fun stop() {
+        if (!running.compareAndSet(true, false)) {
+            return
+        }
+        val socketFd = fd
+        fd = -1
+        if (socketFd >= 0) {
+            runCatching {
+                NetlinkLib.INSTANCE.close(socketFd)
+            }.onFailure { e ->
+                logger.warn(e) { "Failed to close RTNETLINK socket" }
+            }
+        }
+        thread = null
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/LinuxNetworkStateMonitor.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/LinuxNetworkStateMonitor.kt
@@ -10,11 +10,36 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Linux [NetworkStateMonitor] backed by an RTNETLINK (`NETLINK_ROUTE`) socket.
  *
- * A dedicated daemon thread blocks on `recv`; the kernel wakes it on any interface
- * or address change (link up/down, IPv4/IPv6 address add/remove). Each wake emits a
- * change signal. [stop] closes the socket, which unblocks the `recv` and ends the
- * thread. Any failure to open/bind the socket leaves the flow silent — discovery
- * falls back to config-driven behaviour rather than breaking.
+ * A dedicated daemon thread `poll`s the socket; the kernel marks it readable on any
+ * interface or address change (link up/down, IPv4/IPv6 address add/remove), and the
+ * thread `recv`s the message and emits a change signal. [stop] flips [running] and
+ * closes the socket; the poll loop observes the flag on its next timeout and exits.
+ *
+ * Why poll instead of a blocking `recv`: on Linux, closing the socket from another
+ * thread does NOT wake a `recv` blocked on it, and netlink sockets do not support
+ * `shutdown`, so a blocking `recv` could never be cancelled. The bounded poll timeout
+ * is the cancellation signal. Polling an idle socket is cheap and never enumerates
+ * interfaces — only a real event triggers the `recv` and the downstream re-resolve.
+ *
+ * Any failure to open/bind the socket leaves the flow silent — discovery falls back
+ * to config-driven behaviour rather than breaking.
+ *
+ * Two known, deliberately-unhandled trade-offs:
+ *
+ *  - `poll` returning < 0 ends the loop. The only realistic cause would be `EINTR`,
+ *    but a thread blocked in a native syscall is treated as safepoint-safe by the
+ *    JVM (so GC/safepoints never signal it) and nothing installs a POSIX handler on
+ *    this thread, so `EINTR` is effectively unreachable in normal operation. If that
+ *    ever changes, retry on `EINTR` (e.g. a bounded consecutive-error counter) so a
+ *    transient interrupt cannot permanently silence the monitor.
+ *  - [stop] closes the socket but does NOT join this thread. That is safe ONLY
+ *    because the monitor is started once at construction and never stopped during the
+ *    process lifetime, so a stop→start race cannot occur. Do not rely on the
+ *    `POLLNVAL`/`break` path as a guard against it: after `close`, the kernel reuses
+ *    the lowest free fd, so a restart's new socket can land on the SAME fd this
+ *    thread is still polling — `poll` then returns `POLLIN`, not `POLLNVAL`, and this
+ *    zombie loop would steal messages from the new one. If [stop]/restart ever
+ *    becomes a real code path, join the thread in [stop] before returning.
  */
 class LinuxNetworkStateMonitor : NetworkStateMonitor {
 
@@ -83,12 +108,28 @@ class LinuxNetworkStateMonitor : NetworkStateMonitor {
         socketFd: Int,
     ) {
         val buf = ByteArray(8192)
+        val pollFd =
+            NetlinkLib.PollFd().apply {
+                fd = socketFd
+                events = NetlinkLib.POLLIN
+            }
         while (running.get()) {
+            pollFd.revents = 0
+            val ready = runCatching { lib.poll(pollFd, 1L, POLL_TIMEOUT_MS) }.getOrElse { -1 }
+            if (!running.get() || ready < 0) {
+                break // stop() requested, or poll error.
+            }
+            if (ready == 0) {
+                continue // Timeout: re-check running, then poll again.
+            }
+            if (pollFd.revents.toInt() and NetlinkLib.POLLIN.toInt() == 0) {
+                break // POLLERR/POLLHUP/POLLNVAL — the socket is no longer usable.
+            }
+            // Readable: drain the message (we only need the "changed" signal).
             val n = runCatching { lib.recv(socketFd, buf, buf.size.toLong(), 0) }.getOrElse { -1L }
             if (n > 0) {
                 _networkChanges.tryEmit(Unit)
             } else {
-                // Socket closed by stop(), or an error — exit the loop.
                 break
             }
         }
@@ -108,5 +149,10 @@ class LinuxNetworkStateMonitor : NetworkStateMonitor {
             }
         }
         thread = null
+    }
+
+    companion object {
+        // Upper bound on how long stop() waits to be observed by the poll loop.
+        private const val POLL_TIMEOUT_MS = 1000
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/MacosNetworkStateMonitor.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/MacosNetworkStateMonitor.kt
@@ -1,0 +1,51 @@
+package com.crosspaste.net
+
+import com.crosspaste.platform.macos.api.MacosApi
+import com.crosspaste.platform.macos.api.NetworkChangeCallback
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+/**
+ * macOS [NetworkStateMonitor] backed by `Network.framework`'s `NWPathMonitor`
+ * (bridged through the MacosApi dylib).
+ *
+ * The native monitor fires an initial path update on [start] — a free cold-start
+ * signal — and again on every interface up/down, IP change, or reachability change.
+ */
+class MacosNetworkStateMonitor : NetworkStateMonitor {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val _networkChanges =
+        MutableSharedFlow<Unit>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    override val networkChanges: Flow<Unit> = _networkChanges
+
+    // Strong reference required: JNA does not retain the callback, so without this
+    // field the native side could invoke a garbage-collected closure.
+    private val callback =
+        NetworkChangeCallback {
+            _networkChanges.tryEmit(Unit)
+        }
+
+    override fun start() {
+        runCatching {
+            MacosApi.INSTANCE.startNetworkStateMonitor(callback)
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to start macOS network state monitor" }
+        }
+    }
+
+    override fun stop() {
+        runCatching {
+            MacosApi.INSTANCE.stopNetworkStateMonitor()
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to stop macOS network state monitor" }
+        }
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/WindowsNetworkStateMonitor.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/WindowsNetworkStateMonitor.kt
@@ -1,0 +1,105 @@
+package com.crosspaste.net
+
+import com.crosspaste.platform.windows.api.Iphlpapi
+import com.sun.jna.platform.win32.WinNT.HANDLEByReference
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+/**
+ * Windows [NetworkStateMonitor] backed by the IP Helper change-notification API
+ * (`NotifyIpInterfaceChange` + `NotifyUnicastIpAddressChange`).
+ *
+ * Event-driven, replacing the need to poll: the kernel calls back on interface
+ * up/down and on unicast address add/remove (e.g. a DHCP lease change). Any failure
+ * to register simply leaves the flow silent — discovery falls back to config-driven
+ * behaviour rather than breaking.
+ */
+class WindowsNetworkStateMonitor : NetworkStateMonitor {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val _networkChanges =
+        MutableSharedFlow<Unit>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    override val networkChanges: Flow<Unit> = _networkChanges
+
+    // Strong reference required: JNA does not retain the callback, so without this
+    // field the native thread pool could invoke a garbage-collected trampoline.
+    private val callback =
+        Iphlpapi.ChangeCallback { _, _, _ ->
+            _networkChanges.tryEmit(Unit)
+        }
+
+    private val interfaceHandle = HANDLEByReference()
+    private val addressHandle = HANDLEByReference()
+
+    @Volatile
+    private var interfaceRegistered = false
+
+    @Volatile
+    private var addressRegistered = false
+
+    override fun start() {
+        // Interface up/down + IP interface changes.
+        runCatching {
+            val ret =
+                Iphlpapi.INSTANCE.NotifyIpInterfaceChange(
+                    Iphlpapi.AF_UNSPEC,
+                    callback,
+                    null,
+                    false,
+                    interfaceHandle,
+                )
+            if (ret == 0) {
+                interfaceRegistered = true
+            } else {
+                logger.warn { "NotifyIpInterfaceChange failed: $ret" }
+            }
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to register NotifyIpInterfaceChange" }
+        }
+
+        // Unicast address add/remove (e.g. DHCP lease change).
+        runCatching {
+            val ret =
+                Iphlpapi.INSTANCE.NotifyUnicastIpAddressChange(
+                    Iphlpapi.AF_UNSPEC,
+                    callback,
+                    null,
+                    false,
+                    addressHandle,
+                )
+            if (ret == 0) {
+                addressRegistered = true
+            } else {
+                logger.warn { "NotifyUnicastIpAddressChange failed: $ret" }
+            }
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to register NotifyUnicastIpAddressChange" }
+        }
+    }
+
+    override fun stop() {
+        if (interfaceRegistered) {
+            runCatching {
+                Iphlpapi.INSTANCE.CancelMibChangeNotify2(interfaceHandle.value)
+            }.onFailure { e ->
+                logger.warn(e) { "Failed to cancel NotifyIpInterfaceChange" }
+            }
+            interfaceRegistered = false
+        }
+        if (addressRegistered) {
+            runCatching {
+                Iphlpapi.INSTANCE.CancelMibChangeNotify2(addressHandle.value)
+            }.onFailure { e ->
+                logger.warn(e) { "Failed to cancel NotifyUnicastIpAddressChange" }
+            }
+            addressRegistered = false
+        }
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/NetlinkLib.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/NetlinkLib.kt
@@ -1,0 +1,64 @@
+package com.crosspaste.platform.linux.api
+
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Structure
+
+/**
+ * Minimal JNA binding to libc for RTNETLINK (`NETLINK_ROUTE`) socket monitoring.
+ *
+ * Drives the event-driven [com.crosspaste.net.LinuxNetworkStateMonitor]: a blocking
+ * `recv` on a netlink socket bound to the link/address multicast groups wakes up
+ * whenever the kernel reports an interface or address change.
+ *
+ * Sizes assume a 64-bit (LP64) build: `size_t`/`ssize_t` are 8 bytes and map to
+ * Kotlin [Long]; `socklen_t` is 4 bytes and maps to [Int].
+ */
+interface NetlinkLib : Library {
+
+    fun socket(
+        domain: Int,
+        type: Int,
+        protocol: Int,
+    ): Int
+
+    fun bind(
+        fd: Int,
+        addr: SockAddrNetlink,
+        addrlen: Int,
+    ): Int
+
+    fun recv(
+        fd: Int,
+        buf: ByteArray,
+        len: Long,
+        flags: Int,
+    ): Long
+
+    fun close(fd: Int): Int
+
+    /** `struct sockaddr_nl` (12 bytes). */
+    @Structure.FieldOrder("nlFamily", "nlPad", "nlPid", "nlGroups")
+    class SockAddrNetlink : Structure() {
+        @JvmField var nlFamily: Short = 0
+
+        @JvmField var nlPad: Short = 0
+
+        @JvmField var nlPid: Int = 0
+
+        @JvmField var nlGroups: Int = 0
+    }
+
+    companion object {
+        val INSTANCE: NetlinkLib = Native.load("c", NetlinkLib::class.java)
+
+        const val AF_NETLINK = 16
+        const val SOCK_RAW = 3
+        const val NETLINK_ROUTE = 0
+
+        // Multicast groups: link state, plus IPv4/IPv6 address add/remove.
+        const val RTMGRP_LINK = 0x1
+        const val RTMGRP_IPV4_IFADDR = 0x10
+        const val RTMGRP_IPV6_IFADDR = 0x100
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/NetlinkLib.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/NetlinkLib.kt
@@ -7,12 +7,14 @@ import com.sun.jna.Structure
 /**
  * Minimal JNA binding to libc for RTNETLINK (`NETLINK_ROUTE`) socket monitoring.
  *
- * Drives the event-driven [com.crosspaste.net.LinuxNetworkStateMonitor]: a blocking
- * `recv` on a netlink socket bound to the link/address multicast groups wakes up
- * whenever the kernel reports an interface or address change.
+ * Drives the event-driven [com.crosspaste.net.LinuxNetworkStateMonitor]: a netlink
+ * socket bound to the link/address multicast groups becomes readable whenever the
+ * kernel reports an interface or address change. The monitor `poll`s the socket and
+ * `recv`s only when it is readable.
  *
  * Sizes assume a 64-bit (LP64) build: `size_t`/`ssize_t` are 8 bytes and map to
- * Kotlin [Long]; `socklen_t` is 4 bytes and maps to [Int].
+ * Kotlin [Long]; `socklen_t` is 4 bytes and maps to [Int]; `nfds_t` is 8 bytes and
+ * maps to [Long].
  */
 interface NetlinkLib : Library {
 
@@ -35,7 +37,28 @@ interface NetlinkLib : Library {
         flags: Int,
     ): Long
 
+    /**
+     * Waits up to [timeout] ms for events on [fds] (here a single socket). Returns the
+     * number of ready descriptors, 0 on timeout, or < 0 on error. The bounded timeout
+     * lets the monitor notice [com.crosspaste.net.LinuxNetworkStateMonitor.stop].
+     */
+    fun poll(
+        fds: PollFd,
+        nfds: Long,
+        timeout: Int,
+    ): Int
+
     fun close(fd: Int): Int
+
+    /** `struct pollfd` (8 bytes). */
+    @Structure.FieldOrder("fd", "events", "revents")
+    class PollFd : Structure() {
+        @JvmField var fd: Int = 0
+
+        @JvmField var events: Short = 0
+
+        @JvmField var revents: Short = 0
+    }
 
     /** `struct sockaddr_nl` (12 bytes). */
     @Structure.FieldOrder("nlFamily", "nlPad", "nlPid", "nlGroups")
@@ -60,5 +83,8 @@ interface NetlinkLib : Library {
         const val RTMGRP_LINK = 0x1
         const val RTMGRP_IPV4_IFADDR = 0x10
         const val RTMGRP_IPV6_IFADDR = 0x100
+
+        // poll() events: data available to read.
+        const val POLLIN: Short = 0x0001
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/macos/api/MacosApi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/macos/api/MacosApi.kt
@@ -131,6 +131,10 @@ interface MacosApi : Library {
 
     fun trayCleanup()
 
+    fun startNetworkStateMonitor(callback: NetworkChangeCallback)
+
+    fun stopNetworkStateMonitor()
+
     companion object {
         val INSTANCE: MacosApi = Native.load("MacosApi", MacosApi::class.java)
 
@@ -159,4 +163,8 @@ fun interface FileResolverCallback : Callback {
         buffer: Pointer,
         bufferSize: Int,
     ): Int
+}
+
+fun interface NetworkChangeCallback : Callback {
+    fun invoke()
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/api/Iphlpapi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/api/Iphlpapi.kt
@@ -1,0 +1,66 @@
+package com.crosspaste.platform.windows.api
+
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.platform.win32.WinNT.HANDLE
+import com.sun.jna.platform.win32.WinNT.HANDLEByReference
+import com.sun.jna.win32.StdCallLibrary
+import com.sun.jna.win32.StdCallLibrary.StdCallCallback
+import com.sun.jna.win32.W32APIOptions
+
+/**
+ * Minimal JNA binding to the Windows IP Helper change-notification API.
+ *
+ * Drives the event-driven [com.crosspaste.net.WindowsNetworkStateMonitor]: the kernel
+ * invokes the registered callback (on a system thread-pool thread) whenever an IP
+ * interface comes up/down or a unicast address is added/removed.
+ */
+interface Iphlpapi : StdCallLibrary {
+
+    /**
+     * Registers for IP interface change notifications (interface up/down, metric, etc.).
+     * Returns NO_ERROR (0) on success and writes the notification handle.
+     */
+    fun NotifyIpInterfaceChange(
+        family: Int,
+        callback: ChangeCallback,
+        callerContext: Pointer?,
+        initialNotification: Boolean,
+        notificationHandle: HANDLEByReference,
+    ): Int
+
+    /**
+     * Registers for unicast IP address change notifications (e.g. a DHCP lease change).
+     */
+    fun NotifyUnicastIpAddressChange(
+        family: Int,
+        callback: ChangeCallback,
+        callerContext: Pointer?,
+        initialNotification: Boolean,
+        notificationHandle: HANDLEByReference,
+    ): Int
+
+    /** Cancels a notification registered by one of the Notify*Change calls. */
+    fun CancelMibChangeNotify2(notificationHandle: HANDLE): Int
+
+    /**
+     * Shared shape for PIPINTERFACE_CHANGE_CALLBACK and PUNICAST_IPADDRESS_CHANGE_CALLBACK —
+     * both are `VOID(PVOID context, PMIB_*_ROW row, MIB_NOTIFICATION_TYPE type)`. We only
+     * need the "something changed" signal, so the row pointer is left opaque.
+     */
+    fun interface ChangeCallback : StdCallCallback {
+        fun callback(
+            callerContext: Pointer?,
+            row: Pointer?,
+            notificationType: Int,
+        )
+    }
+
+    companion object {
+        val INSTANCE: Iphlpapi =
+            Native.load("iphlpapi", Iphlpapi::class.java, W32APIOptions.DEFAULT_OPTIONS)
+
+        // AF_UNSPEC: notify for both IPv4 and IPv6.
+        const val AF_UNSPEC = 0
+    }
+}

--- a/app/src/desktopMain/swift/MacosApi.swift
+++ b/app/src/desktopMain/swift/MacosApi.swift
@@ -3,6 +3,7 @@ import ApplicationServices
 import Cocoa
 import CoreGraphics
 import ImageIO
+import Network
 import QuickLookThumbnailing
 import Security
 
@@ -854,4 +855,33 @@ public func trayCleanup() {
         handlers.removeAll()
         callbackPointer = nil
     }
+}
+
+// MARK: - Network state monitor
+
+private var networkPathMonitor: NWPathMonitor?
+private var networkStateCallback: (@convention(c) () -> Void)?
+private let networkMonitorQueue = DispatchQueue(label: "com.crosspaste.networkStateMonitor")
+
+@_cdecl("startNetworkStateMonitor")
+public func startNetworkStateMonitor(callback: @escaping @convention(c) () -> Void) {
+    // Replace any existing monitor so repeated start calls don't leak.
+    networkPathMonitor?.cancel()
+    networkStateCallback = callback
+
+    let monitor = NWPathMonitor()
+    monitor.pathUpdateHandler = { _ in
+        // NWPathMonitor fires an initial update on start (free cold-start signal)
+        // and again on every interface up/down, IP change, or reachability change.
+        networkStateCallback?()
+    }
+    monitor.start(queue: networkMonitorQueue)
+    networkPathMonitor = monitor
+}
+
+@_cdecl("stopNetworkStateMonitor")
+public func stopNetworkStateMonitor() {
+    networkPathMonitor?.cancel()
+    networkPathMonitor = nil
+    networkStateCallback = nil
 }

--- a/app/src/desktopMain/swift/MacosApi.swift
+++ b/app/src/desktopMain/swift/MacosApi.swift
@@ -865,23 +865,30 @@ private let networkMonitorQueue = DispatchQueue(label: "com.crosspaste.networkSt
 
 @_cdecl("startNetworkStateMonitor")
 public func startNetworkStateMonitor(callback: @escaping @convention(c) () -> Void) {
-    // Replace any existing monitor so repeated start calls don't leak.
-    networkPathMonitor?.cancel()
-    networkStateCallback = callback
+    // All access to the two globals is funnelled through networkMonitorQueue — the
+    // same queue NWPathMonitor delivers updates on — so the callback read in the
+    // update handler never races the writes from start/stop (called on JNA threads).
+    networkMonitorQueue.async {
+        // Replace any existing monitor so repeated start calls don't leak.
+        networkPathMonitor?.cancel()
+        networkStateCallback = callback
 
-    let monitor = NWPathMonitor()
-    monitor.pathUpdateHandler = { _ in
-        // NWPathMonitor fires an initial update on start (free cold-start signal)
-        // and again on every interface up/down, IP change, or reachability change.
-        networkStateCallback?()
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { _ in
+            // NWPathMonitor fires an initial update on start (free cold-start signal)
+            // and again on every interface up/down, IP change, or reachability change.
+            networkStateCallback?()
+        }
+        monitor.start(queue: networkMonitorQueue)
+        networkPathMonitor = monitor
     }
-    monitor.start(queue: networkMonitorQueue)
-    networkPathMonitor = monitor
 }
 
 @_cdecl("stopNetworkStateMonitor")
 public func stopNetworkStateMonitor() {
-    networkPathMonitor?.cancel()
-    networkPathMonitor = nil
-    networkStateCallback = nil
+    networkMonitorQueue.async {
+        networkPathMonitor?.cancel()
+        networkPathMonitor = nil
+        networkStateCallback = nil
+    }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkInterfaceServiceSelfHealingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkInterfaceServiceSelfHealingTest.kt
@@ -5,6 +5,7 @@ import com.crosspaste.presist.OneFilePersist
 import com.crosspaste.utils.DesktopLocaleUtils
 import com.crosspaste.utils.getJsonUtils
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
@@ -35,6 +36,7 @@ private object LiveSnapshot {
  * a real OS network change (delivered via [NetworkStateMonitor]) re-reads the
  * live interface snapshot and re-emits, even when the config never changes.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class DesktopNetworkInterfaceServiceSelfHealingTest {
 
     @Suppress("unused")
@@ -42,6 +44,7 @@ class DesktopNetworkInterfaceServiceSelfHealingTest {
 
     private val en0 = NetworkInterfaceInfo("en0", 24, "192.168.1.5")
     private val en0NewIp = NetworkInterfaceInfo("en0", 24, "192.168.1.9")
+    private val en5 = NetworkInterfaceInfo("en5", 24, "10.0.0.5")
 
     /** Pushes network-change signals on demand, like the native monitor would. */
     private class FakeNetworkStateMonitor : NetworkStateMonitor {
@@ -167,5 +170,44 @@ class DesktopNetworkInterfaceServiceSelfHealingTest {
             job.cancel()
 
             assertEquals(listOf(listOf(en0)), emissions)
+        }
+
+    @Test
+    fun `runtime loss of the chosen interface falls back in memory without clobbering the preference`() =
+        runTest {
+            val configManager = newConfigManager()
+            // The user explicitly picked en5 while several interfaces were available.
+            configManager.updateConfig(
+                "useNetworkInterfaces",
+                jsonUtils.JSON.encodeToString(listOf("en5")),
+            )
+
+            setLiveSnapshot(listOf(en5))
+            val monitor = FakeNetworkStateMonitor()
+            val job = Job()
+            val service = TestableService(configManager, monitor, CoroutineScope(coroutineContext + job))
+            advanceUntilIdle()
+            assertEquals(listOf(en5), service.networkInterfaces.value)
+
+            // en5 goes offline, only en0 remains: bind to en0 so discovery survives...
+            setLiveSnapshot(listOf(en0))
+            monitor.fireNetworkChange()
+            advanceUntilIdle()
+            assertEquals(listOf(en0), service.networkInterfaces.value)
+            // ...but the persisted preference must be left untouched.
+            assertEquals(
+                listOf("en5"),
+                jsonUtils.JSON.decodeFromString<List<String>>(
+                    configManager.getCurrentConfig().useNetworkInterfaces,
+                ),
+            )
+
+            // en5 returns: heal back to the user's actual choice.
+            setLiveSnapshot(listOf(en5))
+            monitor.fireNetworkChange()
+            advanceUntilIdle()
+            assertEquals(listOf(en5), service.networkInterfaces.value)
+
+            job.cancel()
         }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkInterfaceServiceSelfHealingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkInterfaceServiceSelfHealingTest.kt
@@ -1,0 +1,171 @@
+package com.crosspaste.net
+
+import com.crosspaste.config.DesktopConfigManager
+import com.crosspaste.presist.OneFilePersist
+import com.crosspaste.utils.DesktopLocaleUtils
+import com.crosspaste.utils.getJsonUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toOkioPath
+import java.nio.file.Files
+import kotlin.coroutines.coroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Holds the "live" interface snapshot the service reads. Declared at file scope so
+ * it is available even while the superclass constructor calls the overridden
+ * [DesktopNetworkInterfaceService.getAllNetworkInterfaceInfo] — subclass instance
+ * fields are not yet initialized at that point. Tests run sequentially and reset it.
+ * Volatile so the flow coroutine sees writes made from the test body.
+ */
+private object LiveSnapshot {
+    @Volatile
+    var value: List<NetworkInterfaceInfo> = emptyList()
+}
+
+/**
+ * Verifies the self-healing re-sourcing of [DesktopNetworkInterfaceService]:
+ * a real OS network change (delivered via [NetworkStateMonitor]) re-reads the
+ * live interface snapshot and re-emits, even when the config never changes.
+ */
+class DesktopNetworkInterfaceServiceSelfHealingTest {
+
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    private val en0 = NetworkInterfaceInfo("en0", 24, "192.168.1.5")
+    private val en0NewIp = NetworkInterfaceInfo("en0", 24, "192.168.1.9")
+
+    /** Pushes network-change signals on demand, like the native monitor would. */
+    private class FakeNetworkStateMonitor : NetworkStateMonitor {
+        private val flow =
+            MutableSharedFlow<Unit>(
+                extraBufferCapacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
+        override val networkChanges: Flow<Unit> = flow
+
+        var started = false
+            private set
+
+        override fun start() {
+            started = true
+        }
+
+        override fun stop() {
+            started = false
+        }
+
+        fun fireNetworkChange() {
+            flow.tryEmit(Unit)
+        }
+    }
+
+    private class TestableService(
+        configManager: DesktopConfigManager,
+        monitor: NetworkStateMonitor,
+        scope: CoroutineScope,
+    ) : DesktopNetworkInterfaceService(configManager, monitor, scope) {
+
+        override fun getAllNetworkInterfaceInfo(): List<NetworkInterfaceInfo> = LiveSnapshot.value
+    }
+
+    private fun setLiveSnapshot(interfaces: List<NetworkInterfaceInfo>) {
+        LiveSnapshot.value = interfaces
+    }
+
+    private fun newConfigManager(): DesktopConfigManager {
+        val configDir = Files.createTempDirectory("netSelfHealConfig").toOkioPath()
+        configDir.toFile().deleteOnExit()
+        return DesktopConfigManager(
+            OneFilePersist(configDir.resolve("appConfig.json")),
+            DesktopLocaleUtils,
+        )
+    }
+
+    @Test
+    fun `starts the monitor on construction`() =
+        runTest {
+            setLiveSnapshot(emptyList())
+            val monitor = FakeNetworkStateMonitor()
+            val job = Job()
+            TestableService(newConfigManager(), monitor, CoroutineScope(coroutineContext + job))
+            assertEquals(true, monitor.started)
+            job.cancel()
+        }
+
+    @Test
+    fun `cold start with no network heals once interfaces appear`() =
+        runTest {
+            setLiveSnapshot(emptyList())
+            val monitor = FakeNetworkStateMonitor()
+            val job = Job()
+            val service = TestableService(newConfigManager(), monitor, CoroutineScope(coroutineContext + job))
+
+            // No interfaces at construction: discovery on, config empty -> empty result.
+            advanceUntilIdle()
+            assertEquals(emptyList(), service.networkInterfaces.value)
+
+            // Network comes up; a single native event should heal discovery.
+            setLiveSnapshot(listOf(en0))
+            monitor.fireNetworkChange()
+            advanceUntilIdle()
+
+            assertEquals(listOf(en0), service.networkInterfaces.value)
+            job.cancel()
+        }
+
+    @Test
+    fun `runtime ip change re-emits the new address`() =
+        runTest {
+            setLiveSnapshot(emptyList())
+            val monitor = FakeNetworkStateMonitor()
+            val job = Job()
+            val service = TestableService(newConfigManager(), monitor, CoroutineScope(coroutineContext + job))
+
+            setLiveSnapshot(listOf(en0))
+            monitor.fireNetworkChange()
+            advanceUntilIdle()
+            assertEquals(listOf(en0), service.networkInterfaces.value)
+
+            // Same interface name, new DHCP address.
+            setLiveSnapshot(listOf(en0NewIp))
+            monitor.fireNetworkChange()
+            advanceUntilIdle()
+
+            assertEquals(listOf(en0NewIp), service.networkInterfaces.value)
+            job.cancel()
+        }
+
+    @Test
+    fun `unchanged snapshot does not re-emit on a flap burst`() =
+        runTest {
+            setLiveSnapshot(emptyList())
+            val monitor = FakeNetworkStateMonitor()
+            val job = Job()
+            val service = TestableService(newConfigManager(), monitor, CoroutineScope(coroutineContext + job))
+
+            setLiveSnapshot(listOf(en0))
+            monitor.fireNetworkChange()
+            advanceUntilIdle()
+
+            val emissions = mutableListOf<List<NetworkInterfaceInfo>>()
+            val collectJob = launch { service.networkInterfaces.collect { emissions.add(it) } }
+            advanceUntilIdle()
+
+            // A burst of identical-snapshot events must collapse to zero new emissions.
+            repeat(5) { monitor.fireNetworkChange() }
+            advanceUntilIdle()
+            collectJob.cancel()
+            job.cancel()
+
+            assertEquals(listOf(listOf(en0)), emissions)
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/NoopNetworkStateMonitorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/NoopNetworkStateMonitorTest.kt
@@ -1,0 +1,20 @@
+package com.crosspaste.net
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class NoopNetworkStateMonitorTest {
+
+    @Test
+    fun `never emits so discovery stays config-driven`() =
+        runTest {
+            val monitor = NoopNetworkStateMonitor()
+            monitor.start()
+            // emptyFlow completes immediately without emitting.
+            val emissions = monitor.networkChanges.toList()
+            monitor.stop()
+            assertTrue(emissions.isEmpty())
+        }
+}


### PR DESCRIPTION
## Why

Closes #4509.

Discovery's interface list was sourced **only** from config (`DesktopNetworkInterfaceService.networkInterfaces` ← `config.useNetworkInterfaces`). It never reacted to real OS network changes, and an empty cold-start value got locked in until the app was restarted. The mDNS service (`DesktopPasteBonjourService`) rebuilds off that flow, so when the flow went silent the whole discovery layer effectively died (the #4499 logs showed 0 interfaces / 0 mDNS resolves and 700+ `no reachable host` lines in a session).

This builds on #4506 (runtime IP-change reconnect): reconnection is only useful if discovery can actually obtain the peer's new address — which requires discovery to heal itself first.

## What

Introduce an event-driven `NetworkStateMonitor` that re-resolves interfaces (and therefore rebuilds mDNS) whenever the OS reports a network change.

- **`NetworkStateMonitor`** (commonMain) interface + **`NoopNetworkStateMonitor`** fallback — non-supported platforms behave exactly as before (config-driven).
- **macOS** — `NWPathMonitor` (`Network.framework`) bridged through the `MacosApi` dylib (`startNetworkStateMonitor`/`stopNetworkStateMonitor`).
- **Windows** — IP Helper `NotifyIpInterfaceChange` + `NotifyUnicastIpAddressChange` (covers interface up/down and DHCP address changes), event-driven via JNA (`platform/windows/api/Iphlpapi.kt`).
- **Linux** — RTNETLINK (`NETLINK_ROUTE`, groups `RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR`) on a daemon thread blocking in `recv` (`platform/linux/api/NetlinkLib.kt`).
- **`DesktopNetworkInterfaceService`** re-sources `networkInterfaces` = `combine(config, monitor.onStart{emit}.debounce(500ms))` → resolve → content `distinctUntilChanged` → `stateIn`. Each resolve clears the provider cache and re-runs auto-select, which unsticks the cold-start empty state once the network comes up.
- **Koin** selects the monitor by `Platform` (macOS / Windows / Linux / else→noop). Every native impl degrades to silent (≈ noop) on registration/socket failure, so a monitor fault can never take down discovery.

JNA callbacks are held by strong fields to avoid GC of the native trampoline.

## Tests

- `DesktopNetworkInterfaceServiceSelfHealingTest` — cold-start `[]→[en0]` heals on a single event, runtime IP change re-emits, a flap burst collapses to one rebuild, monitor starts on construction.
- `NoopNetworkStateMonitorTest` — never emits.
- Full `com.crosspaste.net.*` suite (19 classes) green; macOS Swift dylib compiles; ktlint clean (app module).

## Limitations

The Windows and Linux monitors require their target OS and system native libraries (`iphlpapi.dll` / RTNETLINK), so they are **not** covered by cross-platform unit tests — verified to compile and to be correctly isolated (no `Native.load` on other platforms), pending real-device / `:e2e` validation.

## Scope

This is the design's Phase 1 (cure) + Phase 5 (Windows/Linux native). Phase 2 hardening (`DesktopPasteBonjourService.close()` `runBlocking`, mDNS rebuild debounce, log-storm gating) is intentionally deferred to a follow-up.