### PR TITLE
:bug: harden network discovery: non-blocking mDNS teardown, debounced rebuild, offline gate

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -245,6 +245,20 @@ class SyncResolver(
      * to probing the full address list with a longer timeout.
      */
     private suspend fun SyncRuntimeInfo.discoverAndConnect(callback: ResolveCallback) {
+        // Gate discovery when the machine has no usable local interface (cold-start
+        // before the network is up, sleep/wake, cable pulled). Every telnet would fail
+        // with UnresolvedAddressException, and the per-poll "no reachable host" line
+        // turns into a log storm (#4509 / #4499: 700+ lines in one offline session).
+        // Skip probing entirely and stay DISCONNECTED; the NetworkStateMonitor re-emits
+        // interfaces the moment connectivity returns, and the next poll resolves cleanly.
+        if (networkInterfaceService.getCurrentUseNetworkInterfaces().isEmpty()) {
+            logger.debug { "$appInstanceId offline (no local interface), skipping discovery" }
+            if (connectState != SyncState.DISCONNECTED) {
+                updateConnectState(SyncState.DISCONNECTED)
+            }
+            return
+        }
+
         val result =
             discoverReachableHost() ?: run {
                 logger.info { "$appInstanceId no reachable host, hostInfoList: $hostInfoList" }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
@@ -49,7 +49,12 @@ class DesktopPasteBonjourService(
 
     private val logger = KotlinLogging.logger {}
 
-    private val actionChannel = Channel<List<NetworkInterfaceInfo>>(Channel.UNLIMITED)
+    // CONFLATED, not UNLIMITED: a single close()+setup() rebuild can take seconds
+    // (jmDNS teardown + re-registration), and the event-driven NetworkStateMonitor
+    // can emit several interface snapshots while one rebuild is in flight. We only
+    // ever need to converge on the *latest* snapshot, so collapse intermediate
+    // bursts instead of replaying every transient state (#4509 phase 2 debounce).
+    private val actionChannel = Channel<List<NetworkInterfaceInfo>>(Channel.CONFLATED)
 
     private val serviceListener = DesktopServiceListener(nearbyDeviceManager)
 
@@ -74,7 +79,11 @@ class DesktopPasteBonjourService(
     }
 
     suspend fun processNetworkChange(interfaces: List<NetworkInterfaceInfo>) {
-        close()
+        // Suspending teardown: the network-change consumer is a single coroutine, so
+        // a blocking close() (runBlocking) here would freeze the consumer's thread for
+        // the whole jmDNS shutdown. Drive it through the suspend path instead so the
+        // dispatcher stays free while interfaces tear down (#4509 phase 2).
+        closeServices()
 
         setup(interfaces)
     }
@@ -215,10 +224,17 @@ class DesktopPasteBonjourService(
         }
     }
 
-    override fun close() {
+    /**
+     * Suspending teardown of all registered jmDNS instances. Used on the network-change
+     * hot path ([processNetworkChange]) so a rebuild never blocks the consumer coroutine.
+     * jmDNS unregister/close are themselves blocking calls — they run on [scope]'s IO
+     * dispatcher inside [withTimeout] so a single misbehaving interface can't stall the
+     * rebuild past [CLOSE_TIMEOUT].
+     */
+    private suspend fun closeServices() {
         runCatching {
-            runBlocking {
-                withTimeout(CLOSE_TIMEOUT) {
+            withTimeout(CLOSE_TIMEOUT) {
+                coroutineScope {
                     jmdnsMap.values
                         .map { jmDNS ->
                             async {
@@ -233,6 +249,17 @@ class DesktopPasteBonjourService(
             deviceResolveThrottle.clear()
         }.onFailure { e ->
             logger.warn(e) { "Error closing Bonjour service" }
+        }
+    }
+
+    /**
+     * Lifecycle teardown (interface contract). Bridges the suspend [closeServices] to the
+     * synchronous shutdown path via [runBlocking]. This is a one-shot app-exit call, not
+     * the per-network-change hot path, so the brief block here is acceptable.
+     */
+    override fun close() {
+        runBlocking {
+            closeServices()
         }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -8,6 +8,7 @@ import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
 import com.crosspaste.exception.PasteException
 import com.crosspaste.exception.StandardErrorCode
+import com.crosspaste.net.NetworkInterfaceInfo
 import com.crosspaste.net.NetworkInterfaceService
 import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.net.SyncInfoFactory
@@ -51,7 +52,14 @@ class SyncResolverTest {
             mockk(relaxed = true) {
                 every { nearbySyncInfos } returns MutableStateFlow(emptyList())
             }
-        val networkInterfaceService: NetworkInterfaceService = mockk(relaxed = true)
+        val networkInterfaceService: NetworkInterfaceService =
+            mockk(relaxed = true) {
+                // Default to "online": discoverAndConnect now gates on having a usable
+                // local interface, so the resolver must see at least one by default.
+                // Tests covering the offline path override this to emptyList().
+                every { getCurrentUseNetworkInterfaces() } returns
+                    listOf(NetworkInterfaceInfo("en0", 24, "192.168.1.2"))
+            }
         val ratingPromptManager: RatingPromptManager = mockk(relaxed = true)
         val secureKeyPairSerializer: com.crosspaste.secure.SecureKeyPairSerializer = mockk(relaxed = true)
         val secureStore: SecureStore = mockk(relaxed = true)
@@ -286,6 +294,56 @@ class SyncResolverTest {
             coVerify { deps.telnetHelper.switchHost(emptyList(), any(), any(), any()) }
             // Already DISCONNECTED with no host → no redundant DB write.
             coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun discoverAndConnect_noLocalInterface_skipsProbingAndStaysDisconnected() =
+        runTest {
+            // #4509 phase 2: with no usable local interface, every telnet would fail and
+            // spam "no reachable host". The gate must skip discovery entirely — no telnet,
+            // no switchHost — and not re-persist an already-DISCONNECTED device.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo =
+                createSyncRuntimeInfo(
+                    connectState = SyncState.DISCONNECTED,
+                    hostInfoList = listOf(HostInfo(24, "192.168.1.100")),
+                )
+
+            deps.stubDbRead(syncRuntimeInfo)
+            every { deps.networkInterfaceService.getCurrentUseNetworkInterfaces() } returns emptyList()
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            coVerify(exactly = 0) { deps.telnetHelper.telnet(any(), any(), any()) }
+            coVerify(exactly = 0) { deps.telnetHelper.switchHost(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun discoverAndConnect_noLocalInterface_fromNonDisconnected_persistsDisconnectedOnce() =
+        runTest {
+            // A device that was CONNECTED loses all local interfaces: the gate must still
+            // record the DISCONNECTED transition exactly once (so the UI reflects reality)
+            // without probing any host.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo =
+                createConnectedSyncRuntimeInfo(hostAddress = "192.168.1.108")
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            // Heartbeat on the current address fails → falls through to discoverAndConnect.
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns ConnectionRefused
+            every { deps.networkInterfaceService.getCurrentUseNetworkInterfaces() } returns emptyList()
+
+            val capturedInfo = slot<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
+            coVerify(exactly = 0) { deps.telnetHelper.switchHost(any(), any(), any(), any()) }
         }
 
     // ========== A2. Phase E: recency-first probing + active switch ==========


### PR DESCRIPTION
Closes #4514

Follow-up robustness hardening for network discovery. Independent of the discovery self-healing core (relates to #4509) and **does not change any protocol**.

## Changes

1. **Non-blocking mDNS teardown.** Extract a suspending `closeServices()` and call it from `DesktopPasteBonjourService.processNetworkChange()` so the single network-change consumer coroutine no longer freezes on jmDNS shutdown via `runBlocking`. The interface `close()` keeps its synchronous signature for the app-exit lifecycle path and bridges to the suspend version via `runBlocking` (a one-shot call).
2. **Debounced rebuild.** Switch the rebuild channel from `Channel.UNLIMITED` to `Channel.CONFLATED` so transient interface snapshots collapse to the latest while a multi-second rebuild is in flight, instead of replaying every transient state.
3. **Offline discovery gate.** Gate `SyncResolver.discoverAndConnect()` on having at least one usable local interface. When offline (cold start before the network is up, sleep/wake, cable pulled): log once at debug, persist `DISCONNECTED` only on a real state change, and skip all probing. This kills the per-poll `no reachable host` log storm (700+ lines in a single offline session, see #4499). Discovery resumes naturally on the next poll once interfaces return.

## Tests

- `SyncResolverTest`: 2 new offline-gate tests; the default test interface stub is set to "online" (the resolver now reads `getCurrentUseNetworkInterfaces()`).
- `SyncResolverTest` (52 tests) green, `net` package green, ktlint clean.