### PR TITLE
:sparkles: push subnet-matched address on /sync/telnet to cut mDNS reconnection latency

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -107,6 +107,7 @@ open class DefaultServerModule(
                     appTokenApi,
                     configManager,
                     exceptionHandler,
+                    nearbyDeviceManager,
                     networkInterfaceService,
                     pendingKeyExchangeStore,
                     secureKeyPairSerializer,

--- a/app/src/commonMain/kotlin/com/crosspaste/net/SyncInfoHeaderCodec.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/SyncInfoHeaderCodec.kt
@@ -1,0 +1,36 @@
+package com.crosspaste.net
+
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.utils.getJsonUtils
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * Wire codec for advertising a [SyncInfo] inside an HTTP header. The payload is the
+ * JSON encoding of the SyncInfo, Base64-wrapped so it survives as a single header value.
+ *
+ * Two sites must agree byte-for-byte on this format:
+ *  - clients attach [HEADER] on `/sync/telnet` to push their current (subnet-matched)
+ *    address so a peer learns it without waiting for the next mDNS round (#4509 phase 3),
+ *  - the server decodes it back in `SyncRouting` (also reused by the trust handshake).
+ *
+ * Keeping encode/decode in one object is what guarantees that symmetry.
+ */
+object SyncInfoHeaderCodec {
+
+    const val HEADER: String = "crosspaste-sync-info"
+
+    @OptIn(ExperimentalEncodingApi::class)
+    fun encode(syncInfo: SyncInfo): String =
+        Base64.encode(getJsonUtils().JSON.encodeToString(syncInfo).encodeToByteArray())
+
+    @OptIn(ExperimentalEncodingApi::class)
+    fun decode(encoded: String): SyncInfo? =
+        runCatching {
+            getJsonUtils().JSON.decodeFromString<SyncInfo>(
+                Base64.decode(encoded).decodeToString(),
+            )
+        }.getOrNull()
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/net/SyncInfoHeaderCodec.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/SyncInfoHeaderCodec.kt
@@ -11,12 +11,16 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * Wire codec for advertising a [SyncInfo] inside an HTTP header. The payload is the
  * JSON encoding of the SyncInfo, Base64-wrapped so it survives as a single header value.
  *
- * Two sites must agree byte-for-byte on this format:
- *  - clients attach [HEADER] on `/sync/telnet` to push their current (subnet-matched)
- *    address so a peer learns it without waiting for the next mDNS round (#4509 phase 3),
- *  - the server decodes it back in `SyncRouting` (also reused by the trust handshake).
+ * Three sites must agree byte-for-byte on this format:
+ *  - desktop/mobile clients attach [HEADER] on `/sync/telnet` to push their current
+ *    (subnet-matched) address so a peer learns it without waiting for the next mDNS round
+ *    (#4509 phase 3),
+ *  - the server decodes it back in `SyncRouting` (also reused by the trust handshake),
+ *  - the web client (`web/src/shared/api/sync.ts`) builds the same header via
+ *    `btoa(JSON.stringify(syncInfo))`.
  *
- * Keeping encode/decode in one object is what guarantees that symmetry.
+ * Keeping encode/decode in one object is what guarantees that symmetry on this side — any
+ * change to [HEADER] or the encoding must be mirrored in the web client.
  */
 object SyncInfoHeaderCodec {
 
@@ -26,11 +30,15 @@ object SyncInfoHeaderCodec {
     fun encode(syncInfo: SyncInfo): String =
         Base64.encode(getJsonUtils().JSON.encodeToString(syncInfo).encodeToByteArray())
 
+    /**
+     * Decode the header value, throwing on malformed input. Use when the caller wants to
+     * log *why* a header failed to parse; prefer [decode] when a null is enough.
+     */
     @OptIn(ExperimentalEncodingApi::class)
-    fun decode(encoded: String): SyncInfo? =
-        runCatching {
-            getJsonUtils().JSON.decodeFromString<SyncInfo>(
-                Base64.decode(encoded).decodeToString(),
-            )
-        }.getOrNull()
+    fun decodeOrThrow(encoded: String): SyncInfo =
+        getJsonUtils().JSON.decodeFromString<SyncInfo>(
+            Base64.decode(encoded).decodeToString(),
+        )
+
+    fun decode(encoded: String): SyncInfo? = runCatching { decodeOrThrow(encoded) }.getOrNull()
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
@@ -41,13 +41,21 @@ data class TelnetResult(
 }
 
 class TelnetHelper(
+    private val networkInterfaceService: NetworkInterfaceService,
     private val pasteClient: PasteClient,
     private val syncApi: SyncApi,
+    private val syncInfoFactory: SyncInfoFactory,
 ) {
 
     companion object {
         const val FAST_TIMEOUT = 500L
         const val SLOW_TIMEOUT = 2000L
+
+        // Building the advertise hint must never stall the probe. createSyncInfo waits
+        // for our own server port (portFlow.first { it > 0 }), which is instant once the
+        // server is up but blocks during the cold-start window before it is. Cap it so a
+        // not-yet-ready local server just means "no hint this round", not a delayed probe.
+        private val ADVERTISE_BUILD_TIMEOUT = 100.milliseconds
     }
 
     private val logger = KotlinLogging.logger {}
@@ -117,8 +125,19 @@ class TelnetHelper(
     ): TelnetResult? =
         runCatching {
             val hostAndPort = HostAndPort(hostAddress, port)
+            // Piggyback our current address onto the probe so the peer learns where to
+            // reach us back without waiting for the next mDNS round (#4509 phase 3). We
+            // advertise only the local interface(s) on the peer's subnet — that is the
+            // address it can actually route to. Best-effort: a failure here must never
+            // turn a reachable host into an "unreachable" result.
+            val advertiseHeader = buildAdvertiseHeader(hostAddress)
             val httpResponse =
-                pasteClient.get(timeout = timeout) {
+                pasteClient.get(
+                    timeout = timeout,
+                    headersBuilder = {
+                        advertiseHeader?.let { append(SyncInfoHeaderCodec.HEADER, it) }
+                    },
+                ) {
                     buildUrl(hostAndPort)
                     buildUrl("sync", "telnet")
                 }
@@ -144,5 +163,36 @@ class TelnetHelper(
             // #4503 fix). Other failures genuinely mean the host is unreachable.
             if (it is CancellationException) throw it
             logger.debug(it) { "telnet $hostAddress fail" }
+        }.getOrNull()
+
+    /**
+     * Build the value for [SyncInfoHeaderCodec.HEADER] advertising the local address the
+     * peer at [peerAddress] should use to reach us: our interface(s) on the peer's subnet
+     * (#4509 phase 3). Reuses [HostInfo.filter] — the same subnet match the trust flow uses
+     * to pick a reachable address. Returns null when no local interface shares the peer's
+     * subnet (cross-subnet / offline), in which case we advertise nothing and leave address
+     * recovery to mDNS / discovery self-healing. Best-effort: swallows non-cancellation
+     * failures so building the hint can never fail the probe itself.
+     */
+    private suspend fun buildAdvertiseHeader(peerAddress: String): String? =
+        runCatching {
+            val hostInfoList =
+                networkInterfaceService
+                    .getCurrentUseNetworkInterfaces()
+                    .map { it.toHostInfo() }
+                    .filter { it.filter(peerAddress) }
+            if (hostInfoList.isEmpty()) {
+                null
+            } else {
+                // withTimeoutOrNull returns null on its own timeout (no throw) but still
+                // propagates a real parent cancellation — exactly the best-effort semantics
+                // we want for the hint.
+                withTimeoutOrNull(ADVERTISE_BUILD_TIMEOUT) {
+                    SyncInfoHeaderCodec.encode(syncInfoFactory.createSyncInfo(hostInfoList))
+                }
+            }
+        }.onFailure {
+            if (it is CancellationException) throw it
+            logger.debug(it) { "failed to build advertise header for $peerAddress" }
         }.getOrNull()
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
@@ -66,6 +66,12 @@ class TelnetHelper(
     // changes — re-advertising on every probe would re-run the server-side addDevice (and
     // its trackSignificantAction) far more often than mDNS does. A real IP change recomputes
     // a different list here, so the next probe naturally re-advertises (#4518 review).
+    //
+    // Keyed by probed address (not peer identity, which we only learn from the response):
+    // switchHost racing a peer's N candidate addresses therefore advertises once per
+    // candidate on first contact (N <= MAX_RECENT_HOST_INFO, each correct for its own
+    // subnet), then never again until our address changes. That bounded, one-time fan-out
+    // is acceptable.
     private val lastAdvertised: MutableMap<String, List<HostInfo>> = ConcurrentMap()
 
     suspend fun switchHost(

--- a/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
@@ -6,6 +6,7 @@ import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.statement.*
+import io.ktor.util.collections.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.cancelChildren
@@ -59,6 +60,13 @@ class TelnetHelper(
     }
 
     private val logger = KotlinLogging.logger {}
+
+    // Last address set we successfully advertised to each peer (keyed by the probed host
+    // address). We push our address once per peer and then stay quiet until it actually
+    // changes — re-advertising on every probe would re-run the server-side addDevice (and
+    // its trackSignificantAction) far more often than mDNS does. A real IP change recomputes
+    // a different list here, so the next probe naturally re-advertises (#4518 review).
+    private val lastAdvertised: MutableMap<String, List<HostInfo>> = ConcurrentMap()
 
     suspend fun switchHost(
         hostInfoList: List<HostInfo>,
@@ -127,10 +135,17 @@ class TelnetHelper(
             val hostAndPort = HostAndPort(hostAddress, port)
             // Piggyback our current address onto the probe so the peer learns where to
             // reach us back without waiting for the next mDNS round (#4509 phase 3). We
-            // advertise only the local interface(s) on the peer's subnet — that is the
-            // address it can actually route to. Best-effort: a failure here must never
-            // turn a reachable host into an "unreachable" result.
-            val advertiseHeader = buildAdvertiseHeader(hostAddress)
+            // advertise only the local interface(s) on the peer's subnet — the address it
+            // can actually route to — and only when it differs from what we last delivered
+            // to this peer, so a steady network tells each peer exactly once. Best-effort:
+            // a failure here must never turn a reachable host into an "unreachable" result.
+            val advertiseHostInfo = currentAdvertiseHostInfo(hostAddress)
+            val advertiseHeader =
+                if (advertiseHostInfo.isNotEmpty() && lastAdvertised[hostAddress] != advertiseHostInfo) {
+                    buildAdvertiseHeader(advertiseHostInfo)
+                } else {
+                    null
+                }
             val httpResponse =
                 pasteClient.get(
                     timeout = timeout,
@@ -144,6 +159,11 @@ class TelnetHelper(
             logger.info { "httpResponse.status = ${httpResponse.status.value} $hostAddress:$port" }
 
             if (httpResponse.status.value == 200) {
+                // Mark as delivered only on a 200 we actually sent the header on, so a
+                // failed probe re-advertises next time instead of going silent.
+                if (advertiseHeader != null) {
+                    lastAdvertised[hostAddress] = advertiseHostInfo
+                }
                 val result = httpResponse.bodyAsText()
                 result.toIntOrNull()?.let { version ->
                     // Identity rides back on the same response (header), so version +
@@ -166,33 +186,34 @@ class TelnetHelper(
         }.getOrNull()
 
     /**
-     * Build the value for [SyncInfoHeaderCodec.HEADER] advertising the local address the
-     * peer at [peerAddress] should use to reach us: our interface(s) on the peer's subnet
-     * (#4509 phase 3). Reuses [HostInfo.filter] — the same subnet match the trust flow uses
-     * to pick a reachable address. Returns null when no local interface shares the peer's
-     * subnet (cross-subnet / offline), in which case we advertise nothing and leave address
-     * recovery to mDNS / discovery self-healing. Best-effort: swallows non-cancellation
-     * failures so building the hint can never fail the probe itself.
+     * The local address(es) the peer at [peerAddress] should use to reach us: our
+     * interface(s) on the peer's subnet (#4509 phase 3). Reuses [HostInfo.filter] — the same
+     * subnet match the trust flow uses to pick a reachable address. Empty when no local
+     * interface shares the peer's subnet (cross-subnet / offline). Cheap and non-blocking,
+     * so it can drive the "did our address change?" check on every probe.
      */
-    private suspend fun buildAdvertiseHeader(peerAddress: String): String? =
+    private fun currentAdvertiseHostInfo(peerAddress: String): List<HostInfo> =
+        networkInterfaceService
+            .getCurrentUseNetworkInterfaces()
+            .map { it.toHostInfo() }
+            .filter { it.filter(peerAddress) }
+
+    /**
+     * Encode [hostInfoList] into the value for [SyncInfoHeaderCodec.HEADER]. Best-effort:
+     * swallows non-cancellation failures so building the hint can never fail the probe, and
+     * is time-bounded because [SyncInfoFactory.createSyncInfo] waits on our own server port
+     * ([ADVERTISE_BUILD_TIMEOUT]) — a not-yet-ready server just means "no hint this round".
+     */
+    private suspend fun buildAdvertiseHeader(hostInfoList: List<HostInfo>): String? =
         runCatching {
-            val hostInfoList =
-                networkInterfaceService
-                    .getCurrentUseNetworkInterfaces()
-                    .map { it.toHostInfo() }
-                    .filter { it.filter(peerAddress) }
-            if (hostInfoList.isEmpty()) {
-                null
-            } else {
-                // withTimeoutOrNull returns null on its own timeout (no throw) but still
-                // propagates a real parent cancellation — exactly the best-effort semantics
-                // we want for the hint.
-                withTimeoutOrNull(ADVERTISE_BUILD_TIMEOUT) {
-                    SyncInfoHeaderCodec.encode(syncInfoFactory.createSyncInfo(hostInfoList))
-                }
+            // withTimeoutOrNull returns null on its own timeout (no throw) but still
+            // propagates a real parent cancellation — exactly the best-effort semantics
+            // we want for the hint.
+            withTimeoutOrNull(ADVERTISE_BUILD_TIMEOUT) {
+                SyncInfoHeaderCodec.encode(syncInfoFactory.createSyncInfo(hostInfoList))
             }
         }.onFailure {
             if (it is CancellationException) throw it
-            logger.debug(it) { "failed to build advertise header for $peerAddress" }
+            logger.debug(it) { "failed to build advertise header for $hostInfoList" }
         }.getOrNull()
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -15,9 +15,11 @@ import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.NetworkInterfaceService
 import com.crosspaste.net.SyncApi
 import com.crosspaste.net.SyncInfoFactory
+import com.crosspaste.net.SyncInfoHeaderCodec
 import com.crosspaste.net.exception.ExceptionHandler
 import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureStore
+import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.PendingKeyExchange
 import com.crosspaste.sync.PendingKeyExchangeStore
 import com.crosspaste.utils.CryptographyUtils
@@ -25,20 +27,18 @@ import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.HEADER_APP_INSTANCE_ID
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
-import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.successResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 
 fun Routing.syncRouting(
     appInfo: AppInfo,
     appTokenApi: AppTokenApi,
     configManager: CommonConfigManager,
     exceptionHandler: ExceptionHandler,
+    nearbyDeviceManager: NearbyDeviceManager,
     networkInterfaceService: NetworkInterfaceService,
     pendingKeyExchangeStore: PendingKeyExchangeStore,
     secureKeyPairSerializer: SecureKeyPairSerializer,
@@ -49,16 +49,14 @@ fun Routing.syncRouting(
     trustSyncInfo: (String, String?, SyncInfo?) -> Unit,
 ) {
     val logger = KotlinLogging.logger {}
-    val json = getJsonUtils().JSON
 
-    @OptIn(ExperimentalEncodingApi::class)
     fun ApplicationCall.clientSyncInfo(): SyncInfo? =
-        request.headers["crosspaste-sync-info"]?.let { encoded ->
-            runCatching {
-                val decoded = Base64.decode(encoded).decodeToString()
-                json.decodeFromString<SyncInfo>(decoded)
-            }.onFailure { e -> logger.warn(e) { "Failed to parse crosspaste-sync-info header" } }
-                .getOrNull()
+        request.headers[SyncInfoHeaderCodec.HEADER]?.let { encoded ->
+            SyncInfoHeaderCodec.decode(encoded)
+                ?: run {
+                    logger.warn { "Failed to parse ${SyncInfoHeaderCodec.HEADER} header" }
+                    null
+                }
         }
 
     suspend fun validateHeartbeat(
@@ -162,6 +160,15 @@ fun Routing.syncRouting(
     }
 
     get("/sync/telnet") {
+        // Address push (#4509 phase 3): the probe may carry the caller's subnet-matched
+        // SyncInfo so we learn its current address without waiting for the next mDNS
+        // round. This is an UNAUTHENTICATED routing hint — the same trust level as an
+        // mDNS TXT record — so it flows through the identical addDevice path: for an
+        // unknown peer it only populates the in-memory nearby list (never the DB), and
+        // for an already-known peer it merges into its hostInfoList. Trust is still
+        // granted solely by the ECDH heartbeat.
+        call.clientSyncInfo()?.let { nearbyDeviceManager.addDevice(it) }
+
         // Advertise our identity alongside the version so discovery can vet the peer
         // atomically. Unauthenticated, selection-only (trust is via ECDH); body is
         // unchanged so older clients ignore the extra header. See #4499 / #4500.

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -52,11 +52,9 @@ fun Routing.syncRouting(
 
     fun ApplicationCall.clientSyncInfo(): SyncInfo? =
         request.headers[SyncInfoHeaderCodec.HEADER]?.let { encoded ->
-            SyncInfoHeaderCodec.decode(encoded)
-                ?: run {
-                    logger.warn { "Failed to parse ${SyncInfoHeaderCodec.HEADER} header" }
-                    null
-                }
+            runCatching { SyncInfoHeaderCodec.decodeOrThrow(encoded) }
+                .onFailure { e -> logger.warn(e) { "Failed to parse ${SyncInfoHeaderCodec.HEADER} header" } }
+                .getOrNull()
         }
 
     suspend fun validateHeartbeat(

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -228,5 +228,5 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
             )
         }
         single<SyncRoutingApi> { get<SyncManager>() }
-        single<TelnetHelper> { TelnetHelper(get(), get()) }
+        single<TelnetHelper> { TelnetHelper(get(), get(), get(), get()) }
     }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncInfoHeaderCodecTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncInfoHeaderCodecTest.kt
@@ -4,6 +4,7 @@ import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.sync.SyncTestFixtures
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 class SyncInfoHeaderCodecTest {
@@ -26,5 +27,11 @@ class SyncInfoHeaderCodecTest {
     fun decode_garbage_returnsNull() {
         assertNull(SyncInfoHeaderCodec.decode("not-base64-or-json!!!"))
         assertNull(SyncInfoHeaderCodec.decode(""))
+    }
+
+    @Test
+    fun decodeOrThrow_garbage_throws() {
+        // decodeOrThrow preserves the failure so callers can log the cause.
+        assertFailsWith<Throwable> { SyncInfoHeaderCodec.decodeOrThrow("not-base64-or-json!!!") }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncInfoHeaderCodecTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncInfoHeaderCodecTest.kt
@@ -1,0 +1,30 @@
+package com.crosspaste.net
+
+import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.sync.SyncTestFixtures
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SyncInfoHeaderCodecTest {
+
+    @Test
+    fun encodeThenDecode_roundTripsSyncInfo() {
+        val syncInfo =
+            SyncTestFixtures.createSyncInfo(
+                hostInfoList =
+                    listOf(
+                        HostInfo(24, "192.168.1.11"),
+                        HostInfo(64, "fe80::1"),
+                    ),
+            )
+        val encoded = SyncInfoHeaderCodec.encode(syncInfo)
+        assertEquals(syncInfo, SyncInfoHeaderCodec.decode(encoded))
+    }
+
+    @Test
+    fun decode_garbage_returnsNull() {
+        assertNull(SyncInfoHeaderCodec.decode("not-base64-or-json!!!"))
+        assertNull(SyncInfoHeaderCodec.decode(""))
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TelnetHelperTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TelnetHelperTest.kt
@@ -411,6 +411,71 @@ class TelnetHelperTest {
             coVerify(exactly = 0) { syncInfoFactory.createSyncInfo(any()) }
         }
 
+    @Test
+    fun telnet_doesNotReAdvertiseToSamePeerWhenAddressUnchanged() =
+        runTest {
+            // Once a peer has received our address, a steady network must not keep
+            // re-advertising on every probe — that would re-run server-side addDevice each
+            // poll. The second probe to the same peer carries no header.
+            val pasteClient = createMockPasteClient()
+            val response = createMockResponse(200, SyncApi.VERSION.toString())
+            val headersList = mutableListOf<HeadersBuilder.() -> Unit>()
+            coEvery { pasteClient.get(any(), capture(headersList), any()) } returns response
+
+            val networkInterfaceService = mockk<NetworkInterfaceService>(relaxed = true)
+            every { networkInterfaceService.getCurrentUseNetworkInterfaces() } returns
+                listOf(NetworkInterfaceInfo("en0", 24, "192.168.1.11"))
+            val syncInfoFactory = mockk<SyncInfoFactory>()
+            coEvery { syncInfoFactory.createSyncInfo(any()) } returns
+                SyncTestFixtures.createSyncInfo(hostInfoList = listOf(HostInfo(24, "192.168.1.11")))
+
+            val helper =
+                createTelnetHelper(
+                    pasteClient,
+                    networkInterfaceService = networkInterfaceService,
+                    syncInfoFactory = syncInfoFactory,
+                )
+            helper.telnet("192.168.1.20", 13129)
+            helper.telnet("192.168.1.20", 13129)
+
+            assertNotNull(HeadersBuilder().apply(headersList[0]).build()[SyncInfoHeaderCodec.HEADER])
+            assertNull(HeadersBuilder().apply(headersList[1]).build()[SyncInfoHeaderCodec.HEADER])
+            coVerify(exactly = 1) { syncInfoFactory.createSyncInfo(any()) }
+        }
+
+    @Test
+    fun telnet_reAdvertisesAfterLocalAddressChanges() =
+        runTest {
+            // When our address on the peer's subnet changes (DHCP / network switch), the
+            // next probe must advertise again so the peer isn't left with a dead address.
+            val pasteClient = createMockPasteClient()
+            val response = createMockResponse(200, SyncApi.VERSION.toString())
+            val headersList = mutableListOf<HeadersBuilder.() -> Unit>()
+            coEvery { pasteClient.get(any(), capture(headersList), any()) } returns response
+
+            val networkInterfaceService = mockk<NetworkInterfaceService>(relaxed = true)
+            every { networkInterfaceService.getCurrentUseNetworkInterfaces() } returnsMany
+                listOf(
+                    listOf(NetworkInterfaceInfo("en0", 24, "192.168.1.11")),
+                    listOf(NetworkInterfaceInfo("en0", 24, "192.168.1.12")),
+                )
+            val syncInfoFactory = mockk<SyncInfoFactory>(relaxed = true)
+            coEvery { syncInfoFactory.createSyncInfo(any()) } returns SyncTestFixtures.createSyncInfo()
+
+            val helper =
+                createTelnetHelper(
+                    pasteClient,
+                    networkInterfaceService = networkInterfaceService,
+                    syncInfoFactory = syncInfoFactory,
+                )
+            helper.telnet("192.168.1.20", 13129)
+            helper.telnet("192.168.1.20", 13129)
+
+            assertNotNull(HeadersBuilder().apply(headersList[0]).build()[SyncInfoHeaderCodec.HEADER])
+            assertNotNull(HeadersBuilder().apply(headersList[1]).build()[SyncInfoHeaderCodec.HEADER])
+            coVerify(exactly = 2) { syncInfoFactory.createSyncInfo(any()) }
+        }
+
     // ========== E. identity (Phase A continued) ==========
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TelnetHelperTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TelnetHelperTest.kt
@@ -1,13 +1,16 @@
 package com.crosspaste.net
 
 import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.sync.SyncTestFixtures
 import com.crosspaste.utils.HEADER_APP_INSTANCE_ID
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -58,7 +61,9 @@ class TelnetHelperTest {
     private fun createTelnetHelper(
         pasteClient: PasteClient,
         syncApi: SyncApi = SyncApi,
-    ): TelnetHelper = TelnetHelper(pasteClient, syncApi)
+        networkInterfaceService: NetworkInterfaceService = mockk(relaxed = true),
+        syncInfoFactory: SyncInfoFactory = mockk(relaxed = true),
+    ): TelnetHelper = TelnetHelper(networkInterfaceService, pasteClient, syncApi, syncInfoFactory)
 
     // ========== A. telnet (single host) ==========
 
@@ -331,6 +336,82 @@ class TelnetHelperTest {
             assertEquals("192.168.1.100", result.first.hostAddress)
             assertEquals("real-1", result.second.peerAppInstanceId)
         }
+
+    // ========== D. address push (#4509 phase 3: subnet-matched advertise header) ==========
+
+    @Test
+    fun telnet_advertisesOnlySubnetMatchedInterfaceInHeader() =
+        runTest {
+            // We probe a peer at 192.168.1.20. Of our local interfaces, only en0
+            // (192.168.1.11/24) shares the peer's subnet; the 10.x interface must not be
+            // advertised — that address is unreachable from the peer.
+            val pasteClient = createMockPasteClient()
+            val response = createMockResponse(200, SyncApi.VERSION.toString())
+            val headersSlot = slot<HeadersBuilder.() -> Unit>()
+            coEvery { pasteClient.get(any(), capture(headersSlot), any()) } returns response
+
+            val networkInterfaceService = mockk<NetworkInterfaceService>(relaxed = true)
+            every { networkInterfaceService.getCurrentUseNetworkInterfaces() } returns
+                listOf(
+                    NetworkInterfaceInfo("en0", 24, "192.168.1.11"),
+                    NetworkInterfaceInfo("en1", 24, "10.0.0.5"),
+                )
+
+            val advertised =
+                SyncTestFixtures.createSyncInfo(
+                    hostInfoList = listOf(HostInfo(24, "192.168.1.11")),
+                )
+            val capturedList = slot<List<HostInfo>>()
+            val syncInfoFactory = mockk<SyncInfoFactory>()
+            coEvery { syncInfoFactory.createSyncInfo(capture(capturedList)) } returns advertised
+
+            val helper =
+                createTelnetHelper(
+                    pasteClient,
+                    networkInterfaceService = networkInterfaceService,
+                    syncInfoFactory = syncInfoFactory,
+                )
+            helper.telnet("192.168.1.20", 13129)
+
+            // Only the same-subnet interface fed the advertised SyncInfo.
+            assertEquals(listOf(HostInfo(24, "192.168.1.11")), capturedList.captured)
+
+            // The probe carries the advertise header, and it round-trips to the SyncInfo.
+            val builtHeaders = HeadersBuilder().apply(headersSlot.captured).build()
+            val headerValue = builtHeaders[SyncInfoHeaderCodec.HEADER]
+            assertNotNull(headerValue)
+            assertEquals(advertised, SyncInfoHeaderCodec.decode(headerValue))
+        }
+
+    @Test
+    fun telnet_noSubnetMatch_omitsAdvertiseHeader() =
+        runTest {
+            // None of our interfaces share the peer's subnet (cross-subnet / routed): we
+            // advertise nothing rather than leak an unreachable address.
+            val pasteClient = createMockPasteClient()
+            val response = createMockResponse(200, SyncApi.VERSION.toString())
+            val headersSlot = slot<HeadersBuilder.() -> Unit>()
+            coEvery { pasteClient.get(any(), capture(headersSlot), any()) } returns response
+
+            val networkInterfaceService = mockk<NetworkInterfaceService>(relaxed = true)
+            every { networkInterfaceService.getCurrentUseNetworkInterfaces() } returns
+                listOf(NetworkInterfaceInfo("en0", 24, "10.0.0.5"))
+            val syncInfoFactory = mockk<SyncInfoFactory>(relaxed = true)
+
+            val helper =
+                createTelnetHelper(
+                    pasteClient,
+                    networkInterfaceService = networkInterfaceService,
+                    syncInfoFactory = syncInfoFactory,
+                )
+            helper.telnet("192.168.1.20", 13129)
+
+            val builtHeaders = HeadersBuilder().apply(headersSlot.captured).build()
+            assertNull(builtHeaders[SyncInfoHeaderCodec.HEADER])
+            coVerify(exactly = 0) { syncInfoFactory.createSyncInfo(any()) }
+        }
+
+    // ========== E. identity (Phase A continued) ==========
 
     @Test
     fun switchHost_oldPeerUnknownIdentity_admittedAsFallback() =

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
@@ -111,7 +111,7 @@ class TestInstance(
     val syncClientApi =
         SyncClientApi(pasteClient, exceptionHandler, secureKeyPairSerializer, secureStore, syncApi)
 
-    val telnetHelper = TelnetHelper(pasteClient, syncApi)
+    val telnetHelper = TelnetHelper(networkInterfaceService, pasteClient, syncApi, syncInfoFactory)
 
     suspend fun start() {
         pasteServer.start()

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
@@ -10,6 +10,8 @@ import com.crosspaste.net.routing.SyncRoutingApi
 import com.crosspaste.net.routing.syncRouting
 import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureStore
+import com.crosspaste.sync.MarketingNearbyDeviceManager
+import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.PendingKeyExchangeStore
 import com.crosspaste.utils.getJsonUtils
 import io.ktor.serialization.kotlinx.json.*
@@ -22,6 +24,7 @@ class TestServerModule(
     private val appTokenApi: AppTokenApi,
     private val configManager: CommonConfigManager,
     private val exceptionHandler: ExceptionHandler,
+    private val nearbyDeviceManager: NearbyDeviceManager = MarketingNearbyDeviceManager(),
     private val networkInterfaceService: NetworkInterfaceService,
     private val pendingKeyExchangeStore: PendingKeyExchangeStore,
     private val secureKeyPairSerializer: SecureKeyPairSerializer,
@@ -45,6 +48,7 @@ class TestServerModule(
                     appTokenApi,
                     configManager,
                     exceptionHandler,
+                    nearbyDeviceManager,
                     networkInterfaceService,
                     pendingKeyExchangeStore,
                     secureKeyPairSerializer,


### PR DESCRIPTION
Closes #4518

Phase 3 of the network discovery work (relates to #4509). mDNS multicast has latency and loss, so after a device changes IP a peer can wait up to the next mDNS round before learning the new address. Most IP changes are **single-sided**: the device that moved still knows where its peer is and telnets it to reconnect — so it piggybacks its current address on that probe and the peer updates immediately.

A latency optimization on top of discovery self-healing — **no protocol version change**, fully backward compatible (older peers ignore the extra header).

## Changes

1. **Client** (`TelnetHelper`): every `/sync/telnet` probe carries a `crosspaste-sync-info` header advertising our **subnet-matched** address — the local interface(s) on the peer's subnet, selected via the existing `HostInfo.filter(peerAddress)` (the same subnet match the trust flow already uses). The port rides along from our `SyncInfo`, so the peer learns IP **and** port. Nothing is advertised when no interface shares the peer's subnet (cross-subnet / routed). Building the hint is best-effort and bounded by `ADVERTISE_BUILD_TIMEOUT`, so it can never delay or fail the probe — notably during the cold-start window where `createEndpointInfo` would otherwise block on `portFlow` until our own server is up.
2. **Server** (`SyncRouting` `/sync/telnet`): decodes the header and merges through the **same `NearbyDeviceManager.addDevice` path mDNS uses**. Trust model unchanged — an unauthenticated routing hint (same level as an mDNS TXT record): unknown peers only populate the in-memory nearby list (never the DB); already-known peers get their `hostInfoList` merged. Trust is still granted solely by the ECDH heartbeat.
3. **`SyncInfoHeaderCodec`**: shared `Base64(JSON)` wire codec used by both sides; `clientSyncInfo()` now decodes through it.

Source-IP harvesting (originally sketched as a separate step) is intentionally dropped — this subnet-matched push supersedes it (IP **and** port, authoritatively).

## Tests

- `TelnetHelperTest`: advertises only the subnet-matched interface; omits the header when no interface shares the peer's subnet.
- `SyncInfoHeaderCodecTest`: encode/decode round-trip + garbage tolerance.
- Server-merge behavior covered by existing `GeneralNearbyDeviceManager` `addDevice` tests; `SyncIntegrationTest` exercises the real telnet route.
- Full `app:desktopTest` green; ktlint clean.

> Independent of the still-open #4510 (phase 1/5) and #4515 (phase 2) — touched files are disjoint, so this can be reviewed/merged on its own.