### PR TITLE
:sparkles: push subnet-matched address on steady-state heartbeat to cut peer reconnection latency

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -32,6 +32,7 @@ import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.StripedMutex
 import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.util.collections.ConcurrentMap
 import kotlin.coroutines.cancellation.CancellationException
 
 class SyncResolver(
@@ -56,6 +57,16 @@ class SyncResolver(
     private val logger = KotlinLogging.logger {}
 
     private val deviceMutex = StripedMutex()
+
+    // Last subnet-matched address set we advertised to each peer over the liveness heartbeat,
+    // keyed by appInstanceId. We piggyback our address onto the heartbeat so a peer learns our
+    // (possibly changed) return address without waiting for the next mDNS round (#4509), but
+    // only when it actually changed — re-posting every cycle would re-run the peer's
+    // trustSyncInfo (a DB write) on every heartbeat. A real IP change recomputes a different
+    // list, so the next heartbeat re-advertises; any non-success drops the entry so a
+    // reconnect re-advertises too. Cleared on MarkExit/RemoveDevice so a gracefully-departed
+    // device leaves nothing behind (no heartbeat would ever come to evict it otherwise).
+    private val lastHeartbeatAdvertised: MutableMap<String, List<HostInfo>> = ConcurrentMap()
 
     private fun getRemotePairingVersion(appInstanceId: String): Int? =
         lazyNearbyDeviceManager.value.nearbySyncInfos.value
@@ -130,10 +141,15 @@ class SyncResolver(
 
                     is SyncEvent.MarkExit -> {
                         syncDeviceManager.markExit(syncRuntimeInfo)
+                        // No more heartbeats will come to clear this on failure; drop it now
+                        // so the entry can't linger after a graceful exit (a reconnect starts
+                        // with an empty marker and re-advertises, which is what we want).
+                        lastHeartbeatAdvertised.remove(syncRuntimeInfo.appInstanceId)
                     }
 
                     is SyncEvent.RemoveDevice -> {
                         syncDeviceManager.removeDevice(syncRuntimeInfo)
+                        lastHeartbeatAdvertised.remove(syncRuntimeInfo.appInstanceId)
                     }
                 }
             } else {
@@ -516,12 +532,35 @@ class SyncResolver(
         callback: ResolveCallback,
     ): Int {
         val hostAndPort = HostAndPort(host, port)
+
+        // Piggyback our current return address onto the heartbeat (#4509). Advertise only the
+        // local interface(s) on the peer's subnet — the address it can actually route to — and
+        // only when it differs from what we last delivered, so a steady connection tells each
+        // peer exactly once and then sends plain GET heartbeats.
+        val advertiseHostInfo = subnetMatchedHostInfo(host)
+        val advertiseSyncInfo =
+            if (advertiseHostInfo.isNotEmpty() && lastHeartbeatAdvertised[targetAppInstanceId] != advertiseHostInfo) {
+                syncInfoFactory.createSyncInfo(advertiseHostInfo)
+            } else {
+                null
+            }
+
         val result =
             syncClientApi.heartbeat(
+                syncInfo = advertiseSyncInfo,
                 targetAppInstanceId = targetAppInstanceId,
             ) {
                 buildUrl(hostAndPort)
             }
+
+        if (result is SuccessResult) {
+            // Mark delivered only on success, so a failed heartbeat re-advertises next time.
+            advertiseSyncInfo?.let { lastHeartbeatAdvertised[targetAppInstanceId] = advertiseHostInfo }
+        } else {
+            // Forget on any failure so the next successful heartbeat (e.g. after a reconnect)
+            // re-advertises our address to the peer.
+            lastHeartbeatAdvertised.remove(targetAppInstanceId)
+        }
 
         return when (result) {
             is SuccessResult -> {
@@ -582,18 +621,7 @@ class SyncResolver(
                     }
 
                 if (result is SuccessResult) {
-                    val hostInfoList =
-                        networkInterfaceService
-                            .getCurrentUseNetworkInterfaces()
-                            .map { it.toHostInfo() }
-                            .filter { it.filter(host) }
-                    val syncInfo = syncInfoFactory.createSyncInfo(hostInfoList)
-                    syncClientApi.heartbeat(
-                        syncInfo = syncInfo,
-                        targetAppInstanceId = appInstanceId,
-                    ) {
-                        buildUrl(HostAndPort(host, port))
-                    }
+                    advertiseAddressViaHeartbeat(host, port, appInstanceId)
                     return@trustByTokenCache true
                 }
             }
@@ -629,18 +657,7 @@ class SyncResolver(
                 }
 
             if (result is SuccessResult) {
-                val hostInfoList =
-                    networkInterfaceService
-                        .getCurrentUseNetworkInterfaces()
-                        .map { it.toHostInfo() }
-                        .filter { it.filter(host) }
-                val syncInfo = syncInfoFactory.createSyncInfo(hostInfoList)
-                syncClientApi.heartbeat(
-                    syncInfo = syncInfo,
-                    targetAppInstanceId = appInstanceId,
-                ) {
-                    buildUrl(HostAndPort(host, port))
-                }
+                advertiseAddressViaHeartbeat(host, port, appInstanceId)
                 syncRuntimeInfoDao.updateConnectInfo(
                     this.copy(
                         connectState = SyncState.CONNECTED,
@@ -708,18 +725,7 @@ class SyncResolver(
             // Step 4: Save remote key locally and send heartbeat
             secureStore.saveCryptPublicKey(appInstanceId, response.cryptPublicKey)
 
-            val hostInfoList =
-                networkInterfaceService
-                    .getCurrentUseNetworkInterfaces()
-                    .map { it.toHostInfo() }
-                    .filter { it.filter(host) }
-            val syncInfo = syncInfoFactory.createSyncInfo(hostInfoList)
-            syncClientApi.heartbeat(
-                syncInfo = syncInfo,
-                targetAppInstanceId = appInstanceId,
-            ) {
-                buildUrl(HostAndPort(host, port))
-            }
+            advertiseAddressViaHeartbeat(host, port, appInstanceId)
             syncRuntimeInfoDao.updateConnectInfo(
                 this.copy(
                     connectState = SyncState.CONNECTED,
@@ -755,5 +761,41 @@ class SyncResolver(
         hostInfoList: List<HostInfo>,
     ) {
         lazyPasteBonjourService.value.refreshTarget(appInstanceId, hostInfoList)
+    }
+
+    /**
+     * Our local interface address(es) on [host]'s subnet — the address the peer at [host] can
+     * actually route back to. Reuses [HostInfo.filter], the same subnet match the discovery and
+     * trust flows use. Empty when no local interface shares the peer's subnet (cross-subnet /
+     * offline), in which case we advertise nothing and leave reachability to the next mDNS round.
+     */
+    private fun subnetMatchedHostInfo(host: String): List<HostInfo> =
+        networkInterfaceService
+            .getCurrentUseNetworkInterfaces()
+            .map { it.toHostInfo() }
+            .filter { it.filter(host) }
+
+    /**
+     * Heartbeat that always carries our subnet-matched address — used by the trust handshakes,
+     * where the peer must receive our [SyncInfo] to finish pairing. Records what we advertised
+     * (on success) into [lastHeartbeatAdvertised] so the subsequent steady-state liveness
+     * heartbeat doesn't redundantly re-send the same address right after a fresh pairing.
+     */
+    private suspend fun advertiseAddressViaHeartbeat(
+        host: String,
+        port: Int,
+        appInstanceId: String,
+    ) {
+        val advertiseHostInfo = subnetMatchedHostInfo(host)
+        val result =
+            syncClientApi.heartbeat(
+                syncInfo = syncInfoFactory.createSyncInfo(advertiseHostInfo),
+                targetAppInstanceId = appInstanceId,
+            ) {
+                buildUrl(HostAndPort(host, port))
+            }
+        if (result is SuccessResult) {
+            lastHeartbeatAdvertised[appInstanceId] = advertiseHostInfo
+        }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -6,6 +6,7 @@ import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
+import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.exception.PasteException
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.NetworkInterfaceInfo
@@ -42,6 +43,8 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SyncResolverTest {
@@ -480,6 +483,192 @@ class SyncResolverTest {
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
 
+    // ========== A2. steady-state heartbeat address advertise (#4509) ==========
+
+    @Test
+    fun verifyConnection_advertisesSubnetMatchedAddressOncePerChange() =
+        runTest {
+            // Steady state: the liveness heartbeat piggybacks our subnet-matched return
+            // address so the peer learns it without waiting for mDNS — but only the first
+            // time. A second heartbeat with the same local address must send GET (null
+            // syncInfo) so the peer's trustSyncInfo isn't re-run every cycle.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo(hostAddress = "192.168.1.108")
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            coEvery { deps.syncInfoFactory.createSyncInfo(any()) } returns mockk<SyncInfo>(relaxed = true)
+
+            val advertised = mutableListOf<SyncInfo?>()
+            coEvery {
+                deps.syncClientApi.heartbeat(captureNullable(advertised), any(), any())
+            } returns SuccessResult(VersionRelation.EQUAL_TO)
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(2, advertised.size)
+            assertNotNull(advertised[0], "first heartbeat should advertise our address")
+            assertNull(advertised[1], "unchanged address must not re-advertise")
+        }
+
+    @Test
+    fun verifyConnection_localAddressChanges_reAdvertises() =
+        runTest {
+            // When our own interface address changes between heartbeats, the recomputed
+            // subnet-matched list differs from what we last delivered, so we advertise again.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo(hostAddress = "192.168.1.108")
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            coEvery { deps.syncInfoFactory.createSyncInfo(any()) } returns mockk<SyncInfo>(relaxed = true)
+
+            var localInterfaces = listOf(NetworkInterfaceInfo("en0", 24, "192.168.1.2"))
+            every { deps.networkInterfaceService.getCurrentUseNetworkInterfaces() } answers { localInterfaces }
+
+            val advertised = mutableListOf<SyncInfo?>()
+            coEvery {
+                deps.syncClientApi.heartbeat(captureNullable(advertised), any(), any())
+            } returns SuccessResult(VersionRelation.EQUAL_TO)
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+            // Our IP moves within the peer's subnet.
+            localInterfaces = listOf(NetworkInterfaceInfo("en0", 24, "192.168.1.3"))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(2, advertised.size)
+            assertNotNull(advertised[0], "first heartbeat advertises")
+            assertNotNull(advertised[1], "changed local address must re-advertise")
+        }
+
+    @Test
+    fun verifyConnection_crossSubnetPeer_advertisesNothing() =
+        runTest {
+            // No local interface shares the peer's subnet → nothing routable to advertise;
+            // the heartbeat falls back to a plain GET and discovery self-healing covers it.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo(hostAddress = "10.0.0.9")
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            every { deps.networkInterfaceService.getCurrentUseNetworkInterfaces() } returns
+                listOf(NetworkInterfaceInfo("en0", 24, "192.168.1.2"))
+
+            val advertised = mutableListOf<SyncInfo?>()
+            coEvery {
+                deps.syncClientApi.heartbeat(captureNullable(advertised), any(), any())
+            } returns SuccessResult(VersionRelation.EQUAL_TO)
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(1, advertised.size)
+            assertNull(advertised[0], "cross-subnet peer must not be advertised to")
+            coVerify(exactly = 0) { deps.syncInfoFactory.createSyncInfo(any()) }
+        }
+
+    @Test
+    fun verifyConnection_failedHeartbeatReAdvertisesOnReconnect() =
+        runTest {
+            // A non-success heartbeat must forget what we advertised, so the next successful
+            // heartbeat (after a reconnect) re-advertises even though the address is unchanged.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo(hostAddress = "192.168.1.108")
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            coEvery { deps.syncInfoFactory.createSyncInfo(any()) } returns mockk<SyncInfo>(relaxed = true)
+            // Reconnect probes (after the failure) find nothing, so the pass settles without
+            // changing the device we re-read from the DB on the next pass.
+            coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns null
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns null
+
+            val advertised = mutableListOf<SyncInfo?>()
+            coEvery {
+                deps.syncClientApi.heartbeat(captureNullable(advertised), any(), any())
+            } returnsMany
+                listOf(
+                    SuccessResult(VersionRelation.EQUAL_TO),
+                    ConnectionRefused,
+                    SuccessResult(VersionRelation.EQUAL_TO),
+                )
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(3, advertised.size)
+            assertNotNull(advertised[0], "first heartbeat advertises")
+            assertNull(advertised[1], "address unchanged → failing heartbeat was a plain GET")
+            assertNotNull(advertised[2], "failure cleared the marker → re-advertise on recovery")
+        }
+
+    @Test
+    fun markExit_clearsAdvertiseMarker_soReconnectReAdvertises() =
+        runTest {
+            // A graceful exit removes the dedup marker; otherwise no heartbeat would ever
+            // come to evict it. After exit, a reconnect re-advertises even though our address
+            // never changed (without the cleanup the second heartbeat would be a silent GET).
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo(hostAddress = "192.168.1.108")
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            coEvery { deps.syncInfoFactory.createSyncInfo(any()) } returns mockk<SyncInfo>(relaxed = true)
+
+            val advertised = mutableListOf<SyncInfo?>()
+            coEvery {
+                deps.syncClientApi.heartbeat(captureNullable(advertised), any(), any())
+            } returns SuccessResult(VersionRelation.EQUAL_TO)
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+            resolver.emitEvent(SyncEvent.MarkExit(syncRuntimeInfo))
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(2, advertised.size)
+            assertNotNull(advertised[0], "first heartbeat advertises")
+            assertNotNull(advertised[1], "exit cleared the marker → reconnect re-advertises")
+        }
+
+    @Test
+    fun trustHandshake_recordsAdvertiseMarker_soNextHeartbeatStaysQuiet() =
+        runTest {
+            // A fresh pairing (trustByTokenCache) sends our SyncInfo as part of the handshake.
+            // It must record what it advertised, so the very next steady-state heartbeat does
+            // NOT redundantly re-send the same address (map would otherwise still be empty).
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val connecting = createConnectingSyncRuntimeInfo(hostAddress = "192.168.1.108")
+
+            deps.stubDbRead(connecting)
+            deps.tokenCache.setToken(connecting.appInstanceId, 123456)
+            coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
+            coEvery { deps.syncClientApi.trust(any(), any(), any(), any()) } returns SuccessResult(true)
+            coEvery { deps.wsSessionManager.isConnected(any()) } returns false
+            coEvery { deps.syncInfoFactory.createSyncInfo(any()) } returns mockk<SyncInfo>(relaxed = true)
+
+            val advertised = mutableListOf<SyncInfo?>()
+            coEvery {
+                deps.syncClientApi.heartbeat(captureNullable(advertised), any(), any())
+            } returns SuccessResult(VersionRelation.EQUAL_TO)
+
+            // Pass 1: pairing via token cache → handshake heartbeat carries our address.
+            resolver.emitEvent(SyncEvent.Resolve(connecting, createTestCallback()))
+
+            // Pass 2: now CONNECTED → steady-state liveness heartbeat on the same address.
+            deps.stubDbRead(createConnectedSyncRuntimeInfo(hostAddress = "192.168.1.108"))
+            resolver.emitEvent(SyncEvent.Resolve(connecting, createTestCallback()))
+
+            assertEquals(2, advertised.size)
+            assertNotNull(advertised[0], "pairing handshake advertises our address")
+            assertNull(advertised[1], "handshake recorded the marker → steady heartbeat is a GET")
+        }
+
     // ========== B. resolveConnecting ==========
 
     @Test
@@ -513,13 +702,7 @@ class SyncResolverTest {
 
             deps.stubDbRead(syncRuntimeInfo)
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns true
-            coEvery {
-                deps.syncClientApi.heartbeat(
-                    syncInfo = isNull(),
-                    targetAppInstanceId = any(),
-                    toUrl = any(),
-                )
-            } returns DecryptFail
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns DecryptFail
 
             // No token cached, telnet returns null -> DISCONNECTED
             coEvery { deps.telnetHelper.telnet(any(), any(), any()) } returns null


### PR DESCRIPTION
Closes #4520

## Problem

Follow-up to network discovery self-healing (#4509). The `/sync/telnet` address push (#4518) only covers the "disconnect → reconnect" path. When a connection is steady and CONNECTED and one side unilaterally changes its IP, the recurring liveness heartbeat (`SyncResolver.heartbeat()`, used by `verifyConnection`) sends a plain `GET /sync/heartbeat` with no `SyncInfo`. The peer never learns our new return address until the next mDNS round.

The capability already exists (`POST /sync/heartbeat/syncInfo` → server `trustSyncInfo`); it was just only used by the trust/pairing handshakes.

## Change

Piggyback our subnet-matched return address onto the steady-state heartbeat, deduped per peer so a stable connection advertises exactly once per address change (re-posting every cycle would re-run the peer's `trustSyncInfo` DB write needlessly).

- `SyncResolver.heartbeat()`: compute `subnetMatchedHostInfo(host)` and send it as `SyncInfo` only when it differs from `lastHeartbeatAdvertised[peer]`; otherwise plain GET.
- Record the advertised set on success; drop it on any heartbeat failure (so a reconnect re-advertises) and on `MarkExit`/`RemoveDevice` (so a gracefully-departed device leaves no stale map entry).
- Route the three trust handshakes (`trustByTokenCache`/`trustByTokenV1`/`trustByTokenV2`) through a shared `advertiseAddressViaHeartbeat` that records the same bookkeeping, so a fresh pairing doesn't redundantly re-advertise on the very next heartbeat.
- Extract `subnetMatchedHostInfo`, collapsing the subnet-match previously duplicated in the three trust flows.

## Scope

Desktop `commonMain` only; no protocol change. When a WebSocket session is active, HTTP heartbeats are skipped (WS reconnection covers an IP change), so this targets the HTTP-heartbeat steady state.

## Tests

Added to `SyncResolverTest` (all green, plus full `sync.*` + `net.*` suites):
- advertises subnet-matched address once per change
- re-advertises when the local address changes
- cross-subnet peer is not advertised to
- failed heartbeat re-advertises on reconnect
- `MarkExit` clears the marker so a reconnect re-advertises
- trust handshake records the marker so the next steady heartbeat stays a GET