### PR TITLE
:art: reduce SyncResolver connection-polling log noise while keeping failures diagnosable

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/TelnetHelper.kt
@@ -6,6 +6,7 @@ import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.statement.*
+import io.ktor.http.isSuccess
 import io.ktor.util.collections.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineName
@@ -102,6 +103,9 @@ class TelnetHelper(
                                             }
                                         }
                                     } else {
+                                        // INFO: reached this address but it is the wrong peer
+                                        // (stale/reused IP, ghost). The only signal that tells a
+                                        // failed switch apart from a genuinely unreachable peer.
                                         logger.info {
                                             "switchHost skip ${hostInfo.hostAddress}:$port " +
                                                 "identity mismatch (${telnetResult.peerAppInstanceId} != $expectedAppInstanceId)"
@@ -162,7 +166,14 @@ class TelnetHelper(
                     buildUrl(hostAndPort)
                     buildUrl("sync", "telnet")
                 }
-            logger.info { "httpResponse.status = ${httpResponse.status.value} $hostAddress:$port" }
+            // A 200 is the steady-state norm and runs every poll while disconnected, so keep it at
+            // debug; surface any non-200 at info — it means we reached the host but its server
+            // answered abnormally, which "no reachable host" alone can't distinguish.
+            if (httpResponse.status.isSuccess()) {
+                logger.debug { "httpResponse.status = ${httpResponse.status.value} $hostAddress:$port" }
+            } else {
+                logger.info { "httpResponse.status = ${httpResponse.status.value} $hostAddress:$port" }
+            }
 
             if (httpResponse.status.value == 200) {
                 // Mark as delivered only on a 200 we actually sent the header on, so a

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -169,7 +169,9 @@ class SyncResolver(
     // ──────────────────────────────────────────────────────────────
 
     private suspend fun SyncRuntimeInfo.resolve(callback: ResolveCallback) {
-        logger.info { "Resolve $appInstanceId (state=$connectState)" }
+        // Per-poll entry trace: debug only. At INFO we log just the state transitions
+        // (connected / disconnected / incompatible / …), so steady-state polling stays quiet.
+        logger.debug { "Resolve $appInstanceId (state=$connectState)" }
 
         // Extensions (e.g. Chrome) are client-only: they connect TO us via WebSocket
         // and have no server to telnet/heartbeat back to. Use WebSocket liveness instead.
@@ -261,11 +263,15 @@ class SyncResolver(
 
         val result =
             discoverReachableHost() ?: run {
-                logger.info { "$appInstanceId no reachable host, hostInfoList: $hostInfoList" }
-                // Only persist when the state actually changes. Re-writing
-                // DISCONNECTED on every poll bumps modifyTime, re-emits the
-                // DB flow, and churns the handler for no reason.
+                // Log + persist only on the transition into DISCONNECTED. Re-writing
+                // DISCONNECTED every poll bumps modifyTime, re-emits the DB flow, and
+                // churns the handler; re-logging it floods the log. Kept at INFO (not
+                // debug) so a user's default-level logs still capture when and why a peer
+                // went unreachable — connection issues get reported far more often than
+                // anyone will re-run with debug enabled, and the connection layer is new
+                // enough that losing this signal would hurt triage.
                 if (connectState != SyncState.DISCONNECTED) {
+                    logger.info { "$appInstanceId no reachable host, hostInfoList: $hostInfoList" }
                     updateConnectState(SyncState.DISCONNECTED)
                 }
                 return
@@ -275,7 +281,11 @@ class SyncResolver(
         callback.updateVersionRelation(versionRelation)
 
         if (versionRelation != VersionRelation.EQUAL_TO) {
-            logger.info { "$appInstanceId version incompatible: $versionRelation" }
+            // INCOMPATIBLE re-enters discoverAndConnect on every poll; log only on the
+            // transition into it so a version mismatch doesn't repeat the same line forever.
+            if (connectState != SyncState.INCOMPATIBLE) {
+                logger.info { "$appInstanceId version incompatible: $versionRelation" }
+            }
             updateConnectState(SyncState.INCOMPATIBLE, hostInfo.hostAddress, hostInfo.networkPrefixLength)
             return
         }
@@ -453,17 +463,22 @@ class SyncResolver(
 
         // Fast path: probe the freshest address first (skipped when there are none).
         ordered.firstOrNull()?.let { freshest ->
-            logger.info { "$appInstanceId fast probe ${freshest.hostAddress}:$port (lastSeen=${freshest.lastSeen})" }
+            // Per-poll probe trace stays at debug; the conclusion (connecting / no reachable
+            // host) is logged at info by the caller, so dropping this loses nothing for triage.
+            logger.debug { "$appInstanceId fast probe ${freshest.hostAddress}:$port (lastSeen=${freshest.lastSeen})" }
             telnetHelper.telnet(freshest.hostAddress, port, TelnetHelper.FAST_TIMEOUT)?.let { telnetResult ->
                 if (telnetResult.identityAccepted(appInstanceId)) {
                     return@discoverReachableHost Pair(freshest, telnetResult.versionRelation)
                 }
+                // INFO: a reachable address answered with the wrong identity (stale/reused IP,
+                // ghost peer). This is the only signal that separates "unreachable" from
+                // "reached the wrong device", so it must survive at the user's default level.
                 logger.info {
                     "$appInstanceId fast probe identity mismatch " +
                         "(${telnetResult.peerAppInstanceId}), skipping ${freshest.hostAddress}"
                 }
             }
-            logger.info { "$appInstanceId fast probe failed, falling back to full list" }
+            logger.debug { "$appInstanceId fast probe failed, falling back to full list" }
         }
 
         // Slow path: race the recency-ordered list in parallel with a longer timeout.


### PR DESCRIPTION
Closes #4522

## Problem
After startup, INFO-level logs are dominated by SyncResolver's connection-polling output. The resolve loop runs per device on every poll (~60s steady state, faster during backoff/startup when devices are DISCONNECTED), and several routine lines were logged at INFO on every pass — `Resolve <id> (state=...)`, `no reachable host`, `fast probe ...`, and TelnetHelper's `httpResponse.status = 200 ...`. With multiple devices or an offline session this floods the log with hundreds of repeated lines.

## Approach
Classify logs by **conclusion vs. process**, not by frequency:

| Kept at INFO (de-duplicated, only on state change) | Demoted to DEBUG (pure per-poll trace) |
|---|---|
| `no reachable host` (on transition into DISCONNECTED) | `Resolve <id> (state=...)` entry trace |
| `version incompatible` (on transition into INCOMPATIBLE) | `fast probe <addr>` |
| `identity mismatch` (stale/reused IP, ghost peer) | `fast probe failed, falling back` |
| non-200 telnet status | 200 telnet status |

Heartbeat failure reasons and other state transitions were already edge-triggered INFO and are left unchanged.

## Why keep failures at INFO
The connection layer is still new and not fully stable. Asking users to enable debug mode and reproduce a connection issue is impractical, so the signals that distinguish root causes — "unreachable" vs. "reached the wrong device" vs. "server answered abnormally" vs. "version mismatch" — must survive at the default level. They are de-duplicated so they appear once per transition rather than every poll.

## Effect
- Steady-state connected / persistently-offline devices: **0 INFO lines per poll**.
- Any anomaly still leaves an INFO trace → issues remain triagable without debug mode.
- Full per-poll trace remains available via `enableDebugMode`.

## Notes
- Independent PR based on `main` (not stacked on #4520).
- `./gradlew ktlintCheck` and `:app:compileKotlinDesktop` both pass.