### PR TITLE
✨ Discovery-driven fast reconnect for paired peers

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRoutingApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRoutingApi.kt
@@ -25,6 +25,14 @@ interface SyncRoutingApi {
         }
     }
 
+    fun fastReconnect(appInstanceId: String) {
+        getSyncHandler(appInstanceId)?.let { syncHandler ->
+            realTimeSyncScope.launch(CoroutineName("FastReconnect")) {
+                syncHandler.fastReconnect()
+            }
+        }
+    }
+
     fun notifyExit() {
         val logger = KotlinLogging.logger {}
         // Ensure that all notifications are completed before exiting, with a timeout

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
@@ -3,8 +3,10 @@ package com.crosspaste.sync
 import com.crosspaste.app.AppInfo
 import com.crosspaste.app.RatingPromptManager
 import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.db.sync.SyncState
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.utils.DateUtils
+import com.crosspaste.utils.KeyedThrottler
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
@@ -35,6 +37,10 @@ class GeneralNearbyDeviceManager(
     override val searching: StateFlow<Boolean> = _searching
 
     private val syncInfos = MutableStateFlow<Map<String, SyncInfo>>(mapOf())
+
+    // Collapse the burst of serviceResolved callbacks (mDNS cache replay across interfaces)
+    // into a single discovery-driven reconnect per device per cooldown window.
+    private val reconnectThrottle = KeyedThrottler<String>(FAST_RECONNECT_COOLDOWN_MS)
 
     private val isSelf: (String) -> Boolean = { appInstanceId ->
         appInstanceId == appInfo.appInstanceId
@@ -97,6 +103,19 @@ class GeneralNearbyDeviceManager(
                         if (existing.diffSyncInfo(mergedInfo)) {
                             syncManager.updateSyncInfo(mergedInfo)
                         }
+
+                        // Discovery-driven fast reconnect: a paired DISCONNECTED peer
+                        // just proved reachable (serviceResolved). For a same-IP
+                        // reappearance diffSyncInfo is false, so nothing is written to the
+                        // DB and the sync state machine never sees it — drive the reconnect
+                        // from here. Excludes UNMATCHED / INCOMPATIBLE / UNVERIFIED
+                        // ("reachable but rejected"): those are not address-reachability
+                        // problems and are left to polling backoff.
+                        if (existing.connectState == SyncState.DISCONNECTED &&
+                            reconnectThrottle.tryAcquire(appInstanceId, now)
+                        ) {
+                            syncManager.fastReconnect(appInstanceId)
+                        }
                     }
             }
 
@@ -126,5 +145,11 @@ class GeneralNearbyDeviceManager(
 
     override fun stopSearching() {
         _searching.value = false
+    }
+
+    companion object {
+        // serviceResolved is an edge signal that arrives in short bursts; one reconnect
+        // per device per this window is enough (discovery-driven-fast-reconnect §4.2).
+        private const val FAST_RECONNECT_COOLDOWN_MS = 5000L
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -100,10 +100,12 @@ class GeneralSyncHandler(
         // A changed connect address only warrants an immediate re-resolve when the
         // device is currently CONNECTED (e.g. mDNS advertised a new address for a
         // live peer). For CONNECTING / DISCONNECTED / etc. we must NOT short-circuit
-        // here — let the connectState handling below run so SyncPollingManager applies
-        // exponential backoff. Otherwise a discover -> authenticate -> fail pass that
-        // thrashes the address (CONNECTING@new <-> DISCONNECTED@stale) re-emits Resolve
-        // on every DB write and bypasses backoff (#4499 / #4500 tight loop).
+        // here — that would re-emit Resolve on every DB write and reproduce the #4499 /
+        // #4500 tight loop (a discover -> authenticate -> fail pass thrashes the address
+        // CONNECTING@new <-> DISCONNECTED@stale). Backoff is no longer applied in
+        // handleValueChange at all: it is driven solely by the polling loop's
+        // markPollFailure (see createPollingCallback), so external/discovery DB writes
+        // can never starve polling (discovery-driven-fast-reconnect, fix one).
         if (current.connectState == SyncState.CONNECTED &&
             previous.connectHostAddress != null &&
             current.connectHostAddress != null &&
@@ -116,12 +118,12 @@ class GeneralSyncHandler(
         if (current.connectState != previous.connectState) {
             when (current.connectState) {
                 SyncState.DISCONNECTED -> {
-                    syncPollingManager.fail()
                     emitEvent(SyncEvent.RefreshSyncInfo(current.appInstanceId, current.hostInfoList))
                     // Only attempt immediate reconnection when transitioning from CONNECTED.
                     // For CONNECTING -> DISCONNECTED (a failed connection attempt),
                     // let polling handle retry with backoff to avoid tight retry loops
-                    // (e.g. NOT_MATCH_APP_INSTANCE_ID on dual-boot machines).
+                    // (e.g. NOT_MATCH_APP_INSTANCE_ID on dual-boot machines). Backoff is
+                    // applied by the failed poll's markPollFailure, not by this DB write.
                     if (previous.connectState == SyncState.CONNECTED) {
                         emitEvent(SyncEvent.Resolve(current, createCallback()))
                     }
@@ -130,7 +132,6 @@ class GeneralSyncHandler(
                 SyncState.UNMATCHED,
                 SyncState.UNVERIFIED,
                 -> {
-                    syncPollingManager.fail()
                     emitEvent(SyncEvent.RefreshSyncInfo(current.appInstanceId, current.hostInfoList))
                 }
                 SyncState.CONNECTING -> {
@@ -153,16 +154,6 @@ class GeneralSyncHandler(
         if (!hostInfoListEqual(previous.hostInfoList, current.hostInfoList)) {
             if (current.connectState == SyncState.CONNECTED) {
                 emitEvent(SyncEvent.Resolve(current, createCallback()))
-            }
-        }
-
-        when (current.connectState) {
-            SyncState.DISCONNECTED,
-            SyncState.INCOMPATIBLE,
-            SyncState.UNMATCHED,
-            SyncState.UNVERIFIED,
-            -> {
-                syncPollingManager.fail()
             }
         }
     }
@@ -189,6 +180,15 @@ class GeneralSyncHandler(
 
     override suspend fun forceResolve() {
         emitEvent(SyncEvent.ForceResolve(currentSyncRuntimeInfo, createCallback()))
+    }
+
+    override suspend fun fastReconnect() {
+        // A paired-but-DISCONNECTED peer just proved reachable via mDNS serviceResolved.
+        // Treat that reachability edge as a fresh start: clear the connection-failure
+        // backoff so the polling fallback retries promptly if this immediate attempt
+        // races the peer's server coming up, then drive an immediate reconnect.
+        syncPollingManager.reset()
+        forceResolve()
     }
 
     override suspend fun updateAllowSend(allowSend: Boolean) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
@@ -31,6 +31,17 @@ interface SyncHandler {
 
     suspend fun forceResolve()
 
+    /**
+     * Discovery-driven fast reconnect: invoked when mDNS re-discovers a paired but
+     * DISCONNECTED peer. The same-IP reappearance never writes the DB, so the normal
+     * state-machine path can't observe it — discovery drives the reconnect directly.
+     * Default behaviour is a plain [forceResolve]; [GeneralSyncHandler] additionally
+     * resets the connection-failure backoff first.
+     */
+    suspend fun fastReconnect() {
+        forceResolve()
+    }
+
     suspend fun updateAllowSend(allowSend: Boolean)
 
     suspend fun updateAllowReceive(allowReceive: Boolean)

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/KeyedThrottler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/KeyedThrottler.kt
@@ -1,0 +1,37 @@
+package com.crosspaste.utils
+
+import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
+import io.ktor.util.collections.ConcurrentMap
+
+/**
+ * Per-key leading-edge throttle (a.k.a. cooldown) for collapsing bursts of imperative
+ * callbacks — e.g. mDNS `serviceResolved`, scroll load-more — into one action per window.
+ *
+ * [tryAcquire] fires immediately on the first call for a key, then suppresses follow-ups
+ * until [intervalMillis] has elapsed. This is the opposite of a trailing [Flow.equalDebounce]:
+ * use Flow operators (`debounce` / `sample` / `conflate`) when the source is already a Flow;
+ * reach for this only when the trigger is a plain (often per-key) function call.
+ *
+ * Best-effort under concurrency: the check-then-record is not atomic, so a burst arriving on
+ * several threads within the same instant may let a few extra calls through. That is harmless
+ * for the intended use (the window still bounds steady-state firing). Use a stronger primitive
+ * if you need strict exactly-once-per-window semantics.
+ */
+class KeyedThrottler<K>(
+    private val intervalMillis: Long,
+) {
+    private val lastFired: MutableMap<K, Long> = ConcurrentMap()
+
+    /** Returns true (and arms the cooldown) at most once per [intervalMillis] for [key]. */
+    fun tryAcquire(
+        key: K,
+        now: Long = nowEpochMilliseconds(),
+    ): Boolean {
+        val last = lastFired[key]
+        if (last != null && now - last < intervalMillis) {
+            return false
+        }
+        lastFired[key] = now
+        return true
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManagerTest.kt
@@ -4,6 +4,7 @@ import com.crosspaste.app.RatingPromptManager
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.db.sync.SyncRuntimeInfo
+import com.crosspaste.db.sync.SyncState
 import com.crosspaste.sync.SyncTestFixtures.createSyncInfo
 import com.crosspaste.sync.SyncTestFixtures.createSyncRuntimeInfo
 import io.mockk.every
@@ -12,6 +13,7 @@ import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -218,6 +220,125 @@ class GeneralNearbyDeviceManagerTest {
 
             // diffSyncInfo should detect port change and trigger updateSyncInfo
             verify { deps.syncManager.updateSyncInfo(any()) }
+        }
+
+    // ========== Discovery-driven fast reconnect (§6 cases 1-4) ==========
+
+    /**
+     * Case 1 (core): a paired DISCONNECTED device is re-discovered at the SAME address.
+     * diffSyncInfo is false, so nothing is written to the DB (updateSyncInfo not called),
+     * yet the discovery edge must still drive exactly one fast reconnect.
+     */
+    @Test
+    fun addDevice_disconnectedPairedDevice_sameAddress_triggersFastReconnect() =
+        runTest {
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val deps = TestDeps(childScope)
+            val manager = deps.createManager(childScope)
+
+            deps.realTimeSyncRuntimeInfos.value =
+                listOf(
+                    createSyncRuntimeInfo(
+                        appInstanceId = "other-app-1",
+                        connectState = SyncState.DISCONNECTED,
+                    ),
+                )
+            advanceUntilIdle()
+
+            manager.addDevice(createSyncInfo(appInstanceId = "other-app-1"))
+            advanceUntilIdle()
+
+            verify(exactly = 1) { deps.syncManager.fastReconnect("other-app-1") }
+            verify(exactly = 0) { deps.syncManager.updateSyncInfo(any()) }
+            childScope.cancel()
+        }
+
+    /** Case 2: a paired DISCONNECTED device re-discovered at a NEW address also reconnects. */
+    @Test
+    fun addDevice_disconnectedPairedDevice_newAddress_triggersFastReconnect() =
+        runTest {
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val deps = TestDeps(childScope)
+            val manager = deps.createManager(childScope)
+
+            deps.realTimeSyncRuntimeInfos.value =
+                listOf(
+                    createSyncRuntimeInfo(
+                        appInstanceId = "other-app-1",
+                        connectState = SyncState.DISCONNECTED,
+                        hostInfoList = listOf(HostInfo(24, "192.168.1.100")),
+                    ),
+                )
+            advanceUntilIdle()
+
+            manager.addDevice(
+                createSyncInfo(
+                    appInstanceId = "other-app-1",
+                    hostInfoList = listOf(HostInfo(24, "10.0.0.1")),
+                ),
+            )
+            advanceUntilIdle()
+
+            verify(exactly = 1) { deps.syncManager.fastReconnect("other-app-1") }
+            childScope.cancel()
+        }
+
+    /** Case 3: a burst of serviceResolved within the cooldown window collapses to one reconnect. */
+    @Test
+    fun addDevice_burst_fastReconnectThrottledToOnce() =
+        runTest {
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val deps = TestDeps(childScope)
+            val manager = deps.createManager(childScope)
+
+            deps.realTimeSyncRuntimeInfos.value =
+                listOf(
+                    createSyncRuntimeInfo(
+                        appInstanceId = "other-app-1",
+                        connectState = SyncState.DISCONNECTED,
+                    ),
+                )
+            advanceUntilIdle()
+
+            repeat(8) { manager.addDevice(createSyncInfo(appInstanceId = "other-app-1")) }
+            advanceUntilIdle()
+
+            verify(exactly = 1) { deps.syncManager.fastReconnect("other-app-1") }
+            childScope.cancel()
+        }
+
+    /**
+     * Case 4: "reachable but rejected" states (UNMATCHED / INCOMPATIBLE / UNVERIFIED) and the
+     * already-CONNECTED state must NOT trigger fast reconnect — only DISCONNECTED does.
+     */
+    @Test
+    fun addDevice_nonDisconnectedStates_doNotFastReconnect() =
+        runTest {
+            listOf(
+                SyncState.UNMATCHED,
+                SyncState.INCOMPATIBLE,
+                SyncState.UNVERIFIED,
+                SyncState.CONNECTED,
+            ).forEach { state ->
+                val childScope = CoroutineScope(coroutineContext + Job())
+                val deps = TestDeps(childScope)
+                val manager = deps.createManager(childScope)
+
+                deps.realTimeSyncRuntimeInfos.value =
+                    listOf(
+                        createSyncRuntimeInfo(
+                            appInstanceId = "other-app-1",
+                            connectState = state,
+                        ),
+                    )
+                advanceUntilIdle()
+
+                manager.addDevice(createSyncInfo(appInstanceId = "other-app-1"))
+                advanceUntilIdle()
+
+                verify(exactly = 0) { deps.syncManager.fastReconnect(any()) }
+                childScope.cancel()
+            }
         }
 
     companion object {

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
@@ -164,7 +164,7 @@ class GeneralSyncHandlerTest {
         }
 
     @Test
-    fun handleValueChange_stateToDisconnected_emitsFailAndRefreshSyncInfo() =
+    fun handleValueChange_stateToDisconnected_emitsRefreshSyncInfo() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -251,12 +251,16 @@ class GeneralSyncHandlerTest {
      * Regression for #4499 / #4500: within a single failing resolve pass the address
      * thrashes (CONNECTING@new -> DISCONNECTED@stale). The DISCONNECTED write changes
      * BOTH state and address. The address-change branch must NOT short-circuit with an
-     * immediate Resolve here — that bypassed SyncPollingManager's backoff and produced
-     * the ~530ms tight loop. Instead the DISCONNECTED handling must run: increment the
-     * fail count (backoff) and emit RefreshSyncInfo, but no Resolve (previous != CONNECTED).
+     * immediate Resolve here — that bypassed backoff and produced the ~530ms tight loop.
+     * It still emits RefreshSyncInfo (previous != CONNECTED, so no Resolve).
+     *
+     * Backoff is NO LONGER applied from this DB write (discovery-driven-fast-reconnect,
+     * fix one): handleValueChange must not call fail(), so external/discovery DB writes
+     * can't starve polling. The real backoff for a failed attempt comes from the polling
+     * callback's markPollFailure (covered by pollingCallback_markPollFailure_incrementsFailCount).
      */
     @Test
-    fun handleValueChange_addressThrashOnFailure_appliesBackoffWithoutResolve() =
+    fun handleValueChange_addressThrashOnFailure_noResolveNoBackoffFromDbWrite() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -280,7 +284,73 @@ class GeneralSyncHandlerTest {
 
             assertTrue(emitter.events.none { it is SyncEvent.Resolve })
             assertTrue(emitter.events.any { it is SyncEvent.RefreshSyncInfo })
-            assertEquals(failBefore + 1, handler.syncPollingManager.currentFailCount)
+            assertEquals(failBefore, handler.syncPollingManager.currentFailCount)
+            childScope.cancel()
+        }
+
+    /**
+     * Case 5 (fix one regression): repeated external DB emits for a DISCONNECTED device
+     * (e.g. mDNS address jitter writing the row) must NOT touch the backoff. Before fix one
+     * the trailing `when` block called fail() on every such write, starving the polling
+     * alarm. Now fail() is never called from handleValueChange, so fail count stays put and
+     * no Resolve is emitted (the device is not CONNECTED).
+     */
+    @Test
+    fun handleValueChange_repeatedDisconnectedDbWrites_doNotStarveBackoff() =
+        runTest {
+            val emitter = TestEmitter()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val base =
+                createSyncRuntimeInfo(
+                    connectState = SyncState.DISCONNECTED,
+                    hostInfoList = listOf(HostInfo(24, "192.168.1.100")),
+                )
+
+            val handler = GeneralSyncHandler(base, emitter.emitEvent, childScope)
+            advanceTimeBy(SMALL_ADVANCE_MS)
+            emitter.events.clear()
+            val failBefore = handler.syncPollingManager.currentFailCount
+
+            // Several external DB emits (address jitter) while staying DISCONNECTED.
+            handler.updateSyncRuntimeInfo(base.copy(hostInfoList = listOf(HostInfo(24, "192.168.1.101"))))
+            advanceTimeBy(SMALL_ADVANCE_MS)
+            handler.updateSyncRuntimeInfo(base.copy(hostInfoList = listOf(HostInfo(24, "192.168.1.102"))))
+            advanceTimeBy(SMALL_ADVANCE_MS)
+            handler.updateSyncRuntimeInfo(base.copy(hostInfoList = listOf(HostInfo(24, "192.168.1.103"))))
+            advanceTimeBy(SMALL_ADVANCE_MS)
+
+            assertEquals(failBefore, handler.syncPollingManager.currentFailCount)
+            assertTrue(emitter.events.none { it is SyncEvent.Resolve })
+            childScope.cancel()
+        }
+
+    /**
+     * fastReconnect (discovery-driven, fix two): clears the connection-failure backoff and
+     * emits a ForceResolve. serviceResolved is a reachability edge, so a fresh start is
+     * warranted; a successful reconnect would also reset via the CONNECTED transition, but
+     * resetting up front lets the polling fallback retry promptly if this attempt races.
+     */
+    @Test
+    fun fastReconnect_resetsBackoffAndEmitsForceResolve() =
+        runTest {
+            val emitter = TestEmitter()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncRuntimeInfo = createSyncRuntimeInfo(connectState = SyncState.DISCONNECTED)
+
+            val handler = GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
+            advanceTimeBy(SMALL_ADVANCE_MS)
+
+            // Build up backoff via real poll failures.
+            handler.createPollingCallback().markPollFailure()
+            handler.createPollingCallback().markPollFailure()
+            assertTrue(handler.syncPollingManager.currentFailCount > 0)
+            emitter.events.clear()
+
+            handler.fastReconnect()
+            advanceTimeBy(SMALL_ADVANCE_MS)
+
+            assertEquals(0, handler.syncPollingManager.currentFailCount)
+            assertTrue(emitter.events.any { it is SyncEvent.ForceResolve })
             childScope.cancel()
         }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/KeyedThrottlerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/KeyedThrottlerTest.kt
@@ -1,0 +1,40 @@
+package com.crosspaste.utils
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KeyedThrottlerTest {
+
+    @Test
+    fun tryAcquire_firstCall_fires() {
+        val throttler = KeyedThrottler<String>(1000L)
+        assertTrue(throttler.tryAcquire("a", now = 0L))
+    }
+
+    @Test
+    fun tryAcquire_withinInterval_suppressed() {
+        val throttler = KeyedThrottler<String>(1000L)
+        assertTrue(throttler.tryAcquire("a", now = 0L))
+        assertFalse(throttler.tryAcquire("a", now = 500L))
+        assertFalse(throttler.tryAcquire("a", now = 999L))
+    }
+
+    @Test
+    fun tryAcquire_afterInterval_firesAgain() {
+        val throttler = KeyedThrottler<String>(1000L)
+        assertTrue(throttler.tryAcquire("a", now = 0L))
+        assertTrue(throttler.tryAcquire("a", now = 1000L))
+        assertFalse(throttler.tryAcquire("a", now = 1500L))
+        assertTrue(throttler.tryAcquire("a", now = 2000L))
+    }
+
+    @Test
+    fun tryAcquire_keysAreIndependent() {
+        val throttler = KeyedThrottler<String>(1000L)
+        assertTrue(throttler.tryAcquire("a", now = 0L))
+        assertTrue(throttler.tryAcquire("b", now = 0L))
+        assertFalse(throttler.tryAcquire("a", now = 100L))
+        assertFalse(throttler.tryAcquire("b", now = 100L))
+    }
+}


### PR DESCRIPTION
Closes #4526

## What

Fixes a paired peer staying "offline" long after mDNS has already re-discovered it. Two independent root causes, two fixes (see the issue for the full root-cause analysis):

- **Fix A (backoff starvation):** `GeneralSyncHandler.handleValueChange` no longer calls `SyncPollingManager.fail()`. Backoff is now driven **solely** by real connection-attempt failures via the polling callback's `markPollFailure`, so discovery / external DB writes can't starve the polling alarm.
- **Fix B (discovery-driven reconnect):** new `SyncHandler.fastReconnect()` (default = `forceResolve()`; `GeneralSyncHandler` resets backoff first), routed via a default `SyncRoutingApi.fastReconnect(appInstanceId)`. `GeneralNearbyDeviceManager.addDevice` triggers it for a paired **DISCONNECTED** peer on `serviceResolved` — gated by state (excludes `UNMATCHED` / `INCOMPATIBLE` / `UNVERIFIED`, which are "reachable but rejected") and a per-device cooldown. This is required because a same-IP reappearance never writes the DB, so the state machine can't observe it.

Also extracts the per-key leading-edge throttle (the Fix B cooldown) into a small reusable `KeyedThrottler` util, with isolated deterministic tests (time injected via a `now` parameter).

## Tests

- `KeyedThrottlerTest` (4) — leading-edge cooldown, per-key isolation, fire-again-after-window.
- `GeneralNearbyDeviceManagerTest` (+4) — same-IP / new-address reconnect, burst throttled to one, non-DISCONNECTED states do not reconnect.
- `GeneralSyncHandlerTest` (+2, 2 updated) — repeated DISCONNECTED DB writes no longer starve backoff; `fastReconnect` resets backoff + emits `ForceResolve`; the #4499 address-thrash guard updated (a DB write no longer drives backoff — the real backoff now comes only from `markPollFailure`).
- Regression: `SyncIntegrationTest`, `SyncResolverTest`, `SyncPasteTaskExecutorTest`, `SyncPollingManagerTest`, `GeneralSyncManagerTest` all green.

## Notes

- No protocol or version change.
- The atomic `compute`-based throttles in `DesktopPasteBonjourService` are **intentionally left as-is**, not migrated to `KeyedThrottler`: they guard an expensive blocking `jmdns.list` on a key (`hostAddress`) shared across devices, where concurrent `refreshTarget` calls genuinely contend the same key and need strict atomicity. `KeyedThrottler` is best-effort by design (documented), which is fine only for the cheap, self-limiting reconnect trigger.
