### PR TITLE
:bug: gate /sync/telnet address-push to already-paired peers

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -160,12 +160,17 @@ fun Routing.syncRouting(
     get("/sync/telnet") {
         // Address push (#4509 phase 3): the probe may carry the caller's subnet-matched
         // SyncInfo so we learn its current address without waiting for the next mDNS
-        // round. This is an UNAUTHENTICATED routing hint — the same trust level as an
-        // mDNS TXT record — so it flows through the identical addDevice path: for an
-        // unknown peer it only populates the in-memory nearby list (never the DB), and
-        // for an already-known peer it merges into its hostInfoList. Trust is still
-        // granted solely by the ECDH heartbeat.
-        call.clientSyncInfo()?.let { nearbyDeviceManager.addDevice(it) }
+        // round. This is an UNAUTHENTICATED routing hint, so we only honor it for a peer
+        // we have already paired with (ECDH crypt key on file) — its purpose is to let a
+        // known peer reconnect fast after an IP change. Unknown-peer discovery stays
+        // mDNS's job; gating here keeps the in-memory nearby map bounded by the number of
+        // real paired devices instead of by attacker-controlled appInstanceId headers.
+        // Trust is still granted solely by the ECDH heartbeat.
+        call.clientSyncInfo()?.let { syncInfo ->
+            if (secureStore.existCryptPublicKey(syncInfo.appInfo.appInstanceId)) {
+                nearbyDeviceManager.addDevice(syncInfo)
+            }
+        }
 
         // Advertise our identity alongside the version so discovery can vet the peer
         // atomically. Unauthenticated, selection-only (trust is via ECDH); body is


### PR DESCRIPTION
Closes #4528

## Problem
`/sync/telnet` decoded the caller-supplied `crosspaste-sync-info` header and fed
it into `NearbyDeviceManager.addDevice()` for **any** `appInstanceId`. The
endpoint is unauthenticated and the server module installs no rate limiting, so:

- **Unbounded memory growth** — `GeneralNearbyDeviceManager.syncInfos` has no
  size cap or TTL; its only eviction path is the mDNS service-removed event,
  which never fires for telnet-injected entries. Forged `appInstanceId` headers
  grow the map without bound.
- **O(N^2) recompute** — `nearbySyncInfos` re-filters and re-sorts the full map
  on every update.
- **Rating-prompt inflation** — `addDevice` calls `trackSignificantAction()`
  unconditionally.

mDNS injection is possible too, but requires a responder and is multicast
rate-limited; the HTTP path drops the cost to one cheap GET, widening the attack
surface.

## Fix
Only honor the telnet address-push hint for peers we have already paired with
(`secureStore.existCryptPublicKey`). The header's purpose is to let a *known*
peer reconnect fast after an IP change; unknown-peer discovery stays mDNS's job.
This bounds the nearby map by the number of real paired devices and removes the
unknown-ID rating inflation, collapsing the new HTTP surface back to mDNS parity.

The ECDH-based trust model (unknown peers never persisted, trust only via the
ECDH heartbeat — #4509) is unchanged. The residual known-peer vector (an
attacker who already knows a paired `appInstanceId`) is bounded, ECDH-protected,
and identical to the pre-existing mDNS vector, so it is intentionally left out of
scope here.

## Notes
- Independent of the in-flight `feat/issue-4526-discovery-driven-fast-reconnect`
  branch; the edited telnet block already exists on `main` (from #4519).
- `:app:compileKotlinDesktop` passes; `ktlintFormat` clean.