### PR TITLE
:bug: probe X11 clipboard readiness before reading to cut XWayland latency

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/utils/ControlUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/ControlUtils.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.milliseconds
 
 expect fun getControlUtils(): ControlUtils
 
@@ -58,23 +59,57 @@ interface ControlUtils {
         return result
     }
 
+    /**
+     * Retries [action] with exponentially growing waits (initTime, 2x, 4x, ...)
+     * until [isValidResult] passes or [maxTime] ms of real elapsed time is spent.
+     * Suits cases where readiness is usually immediate and rarely late.
+     */
     suspend fun <T> exponentialBackoffUntilValid(
         initTime: Long,
         maxTime: Long,
         isValidResult: (T) -> Boolean,
         action: suspend () -> T,
-    ): T {
-        var result = action()
-        var sum = 0L
-        var waiting = initTime
-        while (!isValidResult(result) && sum < maxTime) {
-            delay(waiting)
-            sum += waiting
-            waiting *= 2
-            result = action()
+    ): T = backoffUntilValid(initTime, maxTime, { it * 2 }, isValidResult, action)
+
+    /**
+     * Retries [action] with linearly growing waits (initTime, 2x, 3x, ...)
+     * until [isValidResult] passes or [maxTime] ms of real elapsed time is spent.
+     * Keeps late-readiness detection latency low where exponential gaps would
+     * overshoot (e.g. a clipboard owner that becomes readable after a few
+     * hundred ms).
+     */
+    suspend fun <T> linearBackoffUntilValid(
+        initTime: Long,
+        maxTime: Long,
+        isValidResult: (T) -> Boolean,
+        action: suspend () -> T,
+    ): T = backoffUntilValid(initTime, maxTime, { it + initTime }, isValidResult, action)
+}
+
+/**
+ * Shared retry loop: the budget is real elapsed time (action time included),
+ * and the final wait is clamped so the total never overshoots [maxTime].
+ */
+private suspend fun <T> backoffUntilValid(
+    initTime: Long,
+    maxTime: Long,
+    nextWaiting: (Long) -> Long,
+    isValidResult: (T) -> Boolean,
+    action: suspend () -> T,
+): T {
+    val start = nowEpochMilliseconds()
+    var result = action()
+    var waiting = initTime
+    while (!isValidResult(result)) {
+        val remaining = maxTime - (nowEpochMilliseconds() - start)
+        if (remaining <= 0) {
+            break
         }
-        return result
+        delay(minOf(waiting, remaining).milliseconds)
+        waiting = nextWaiting(waiting)
+        result = action()
     }
+    return result
 }
 
 fun <T> Flow<T>.equalDebounce(

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/LinuxPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/LinuxPasteboardService.kt
@@ -39,6 +39,10 @@ class LinuxPasteboardService(
 
     companion object {
         const val XFIXES_SET_SELECTION_OWNER_NOTIFY_MASK = (1 shl 0).toLong()
+
+        // Generous headroom for XWayland's bridge to start serving the new
+        // selection; native X11 owners typically answer the first probe.
+        private const val CLIPBOARD_READY_TIMEOUT_MS = 2000L
     }
 
     override val logger: KLogger = KotlinLogging.logger {}
@@ -142,14 +146,28 @@ class LinuxPasteboardService(
             return
         }
 
+        // XFixes only says the selection owner changed, not that the owner can
+        // already serve data. Under XWayland the bridge keeps failing conversions
+        // ("Owner failed to convert data") for hundreds of ms after the notify,
+        // so probe TARGETS directly and start the AWT read only once the owner
+        // actually answers — the read below then almost always succeeds first try.
+        if (!X11ClipboardReader.awaitClipboardReadable(CLIPBOARD_READY_TIMEOUT_MS)) {
+            logger.warn {
+                "Clipboard owner not ready within ${CLIPBOARD_READY_TIMEOUT_MS}ms, reading anyway"
+            }
+        }
+
         val contents =
-            controlUtils.exponentialBackoffUntilValid(
+            controlUtils.linearBackoffUntilValid(
                 initTime = 20L,
                 maxTime = 1000L,
                 isValidResult = ::isValidContents,
             ) {
                 getPasteboardContentsBySafe()
             }
+        if (!isValidContents(contents)) {
+            logger.warn { "Clipboard contents still invalid after backoff; this change may be lost" }
+        }
         if (contents != ownerTransferable) {
             contents?.let {
                 ownerTransferable = it
@@ -172,8 +190,9 @@ class LinuxPasteboardService(
      * just that flavor. Falls back to the original transferable on any failure.
      *
      * Known tradeoff: this raw read happens after AWT captured [transferable]
-     * (the backoff in [onChange] can add up to ~1s, plus the dispatch of the
-     * consumer coroutine this runs in), so a copy performed inside
+     * (the readiness probe plus backoff in [onChange] can add up to a few
+     * seconds, plus the dispatch of the consumer coroutine this runs in), so a
+     * copy performed inside
      * that window would pair the newer clipboard's html with the older entry's
      * other flavors. The window is narrow and the result is still well-formed
      * html, so we accept it — there is no reliable cheap equivalence check

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/X11ClipboardReader.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/X11ClipboardReader.kt
@@ -14,7 +14,9 @@ import java.io.ByteArrayOutputStream
 
 /**
  * Reads the `text/html` payload of the X11 `CLIPBOARD` selection as **raw
- * bytes**, bypassing AWT's charset handling.
+ * bytes**, bypassing AWT's charset handling. Also hosts
+ * [awaitClipboardReadable], a selection-readiness probe built on the same
+ * ICCCM machinery.
  *
  * AWT exposes `text/html` to consumers only through `charset=Unicode` (UTF-16)
  * String/Reader flavors and, on Linux, picks the source target with logic that
@@ -39,6 +41,11 @@ object X11ClipboardReader {
     private val logger = KotlinLogging.logger {}
 
     private const val SELECTION_TIMEOUT_MS = 1000L
+
+    // Readiness probe cadence: how long to wait for each TARGETS answer and
+    // how long to pause before re-asking an owner that said "not yet".
+    private const val PROBE_NOTIFY_TIMEOUT_MS = 200L
+    private const val PROBE_INTERVAL_MS = 20L
 
     // long_length for XGetWindowProperty is in 32-bit units; cap a single read
     // at 16 MiB of payload, looping on bytesAfter for anything larger.
@@ -82,6 +89,90 @@ object X11ClipboardReader {
         val bytes: ByteArray,
         val charsetName: String?,
     )
+
+    /**
+     * Blocks until the `CLIPBOARD` selection owner can actually convert data,
+     * or [timeoutMs] elapses.
+     *
+     * X11 has no "owner is ready" event — XFixes only reports that ownership
+     * changed, and the only readiness signal ICCCM offers is a successful
+     * conversion. Under XWayland the bridge often answers conversions with
+     * `property=None` ("Owner failed to convert data" in AWT) for hundreds of
+     * ms after the ownership change, so reading via AWT right after the notify
+     * fails repeatedly. This probe issues cheap `TARGETS` conversions every
+     * [PROBE_INTERVAL_MS] until one succeeds, letting the caller's real read
+     * start as soon as the owner is actually serving data.
+     *
+     * Returns true once the owner answers a `TARGETS` request. Returns false
+     * fast when the selection has no owner (a cleared clipboard; the next copy
+     * fires its own XFixes notify) and false on timeout or any X error.
+     * Callers should still read defensively: `TARGETS` success does not
+     * guarantee that every concrete data target converts.
+     */
+    fun awaitClipboardReadable(timeoutMs: Long): Boolean {
+        val x11 = X11Api.INSTANCE
+        val display = x11.XOpenDisplay(null)
+        if (display == null) {
+            logger.warn { "awaitClipboardReadable: XOpenDisplay returned null" }
+            return false
+        }
+        return try {
+            awaitClipboardReadable(x11, display, timeoutMs)
+        } catch (e: Throwable) {
+            logger.warn(e) { "Failed to probe X11 clipboard readiness" }
+            false
+        } finally {
+            x11.XCloseDisplay(display)
+        }
+    }
+
+    private fun awaitClipboardReadable(
+        x11: X11Api,
+        display: X11.Display,
+        timeoutMs: Long,
+    ): Boolean {
+        val clipboard = x11.XInternAtom(display, "CLIPBOARD", false)
+        val targets = x11.XInternAtom(display, "TARGETS", false)
+        val property = x11.XInternAtom(display, "CROSSPASTE_READY_PROBE", false)
+        val root = x11.XDefaultRootWindow(display)
+        val window = x11.XCreateSimpleWindow(display, root, 0, 0, 1, 1, 0, 0, 0)
+        try {
+            x11.XSelectInput(display, window, NativeLong(X11.PropertyChangeMask.toLong()))
+            // Monotonic clock: a wall-clock (NTP) jump must not stretch or cut the wait.
+            val deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000
+            while (true) {
+                if (x11.XGetSelectionOwner(display, clipboard) == null) {
+                    logger.debug { "awaitClipboardReadable: CLIPBOARD has no owner" }
+                    return false
+                }
+                x11.XConvertSelection(display, clipboard, targets, property, window, NO_EVENT_TIMESTAMP)
+                x11.XFlush(display)
+
+                val remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000
+                if (remainingMs <= 0) {
+                    return false
+                }
+                val notify =
+                    waitForSelectionNotify(
+                        x11,
+                        display,
+                        window,
+                        timeoutMs = minOf(PROBE_NOTIFY_TIMEOUT_MS, remainingMs),
+                    )
+                if (notify?.property != null && notify.property.toLong() != 0L) {
+                    x11.XDeleteProperty(display, window, notify.property)
+                    return true
+                }
+
+                if (System.nanoTime() + PROBE_INTERVAL_MS * 1_000_000 >= deadlineNanos) {
+                    return false
+                }
+                Thread.sleep(PROBE_INTERVAL_MS)
+            }
+        } finally {
+            x11.XDestroyWindow(display, window)
+        }
+    }
 
     /**
      * Reads the best available `text/html` target of the `CLIPBOARD` selection.
@@ -293,10 +384,11 @@ object X11ClipboardReader {
         x11: X11Api,
         display: X11.Display,
         window: X11.Window,
+        timeoutMs: Long = SELECTION_TIMEOUT_MS,
     ): X11.XSelectionEvent? {
         val event = X11.XEvent()
         // Monotonic clock: a wall-clock (NTP) jump must not stretch or cut the wait.
-        val deadlineNanos = System.nanoTime() + SELECTION_TIMEOUT_MS * 1_000_000
+        val deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000
         while (System.nanoTime() < deadlineNanos) {
             if (x11.XCheckTypedWindowEvent(display, window, X11.SelectionNotify, event)) {
                 event.setType(X11.XSelectionEvent::class.java)
@@ -305,7 +397,12 @@ object X11ClipboardReader {
             }
             Thread.sleep(5L)
         }
-        logger.warn { "Timed out waiting for SelectionNotify" }
+        if (timeoutMs >= SELECTION_TIMEOUT_MS) {
+            logger.warn { "Timed out waiting for SelectionNotify" }
+        } else {
+            // Short-timeout waits are probe attempts that retry anyway.
+            logger.debug { "Timed out waiting for SelectionNotify (${timeoutMs}ms probe)" }
+        }
         return null
     }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/ControlUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/ControlUtilsTest.kt
@@ -1,0 +1,126 @@
+package com.crosspaste.utils
+
+import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ControlUtilsTest {
+
+    private val controlUtils = getControlUtils()
+
+    @Test
+    fun `exponential backoff returns immediately on valid first result`() =
+        runBlocking {
+            var calls = 0
+            val start = nowEpochMilliseconds()
+            val result =
+                controlUtils.exponentialBackoffUntilValid(
+                    initTime = 100L,
+                    maxTime = 1000L,
+                    isValidResult = { it: Int -> it > 0 },
+                ) {
+                    calls++
+                    42
+                }
+            assertEquals(42, result)
+            assertEquals(1, calls)
+            assertTrue(nowEpochMilliseconds() - start < 100L, "valid first result must not wait")
+        }
+
+    @Test
+    fun `exponential backoff retries until result becomes valid`() =
+        runBlocking {
+            var calls = 0
+            val result =
+                controlUtils.exponentialBackoffUntilValid(
+                    initTime = 5L,
+                    maxTime = 1000L,
+                    isValidResult = { it: Int -> it >= 3 },
+                ) {
+                    ++calls
+                }
+            assertEquals(3, result)
+            assertEquals(3, calls)
+        }
+
+    @Test
+    fun `linear backoff retries until result becomes valid`() =
+        runBlocking {
+            var calls = 0
+            val result =
+                controlUtils.linearBackoffUntilValid(
+                    initTime = 5L,
+                    maxTime = 1000L,
+                    isValidResult = { it: Int -> it >= 4 },
+                ) {
+                    ++calls
+                }
+            assertEquals(4, result)
+            assertEquals(4, calls)
+        }
+
+    @Test
+    fun `exponential backoff stops within real elapsed budget`() =
+        runBlocking {
+            val maxTime = 150L
+            val start = nowEpochMilliseconds()
+            val result =
+                controlUtils.exponentialBackoffUntilValid(
+                    initTime = 10L,
+                    maxTime = maxTime,
+                    isValidResult = { it: Int -> false },
+                ) {
+                    -1
+                }
+            val elapsed = nowEpochMilliseconds() - start
+            assertEquals(-1, result)
+            assertTrue(elapsed >= maxTime, "budget should be exhausted before giving up, elapsed=$elapsed")
+            // The final wait is clamped to the remaining budget, so the loop must
+            // not overshoot by a whole exponential step (a generous CI slack only).
+            assertTrue(elapsed < maxTime + 500L, "budget overshot, elapsed=$elapsed")
+        }
+
+    @Test
+    fun `linear backoff stops within real elapsed budget`() =
+        runBlocking {
+            val maxTime = 150L
+            val start = nowEpochMilliseconds()
+            val result =
+                controlUtils.linearBackoffUntilValid(
+                    initTime = 10L,
+                    maxTime = maxTime,
+                    isValidResult = { it: Int -> false },
+                ) {
+                    -1
+                }
+            val elapsed = nowEpochMilliseconds() - start
+            assertEquals(-1, result)
+            assertTrue(elapsed >= maxTime, "budget should be exhausted before giving up, elapsed=$elapsed")
+            assertTrue(elapsed < maxTime + 500L, "budget overshot, elapsed=$elapsed")
+        }
+
+    @Test
+    fun `backoff counts action time against the budget`() =
+        runBlocking {
+            val maxTime = 100L
+            var calls = 0
+            val start = nowEpochMilliseconds()
+            val result =
+                controlUtils.linearBackoffUntilValid(
+                    initTime = 10L,
+                    maxTime = maxTime,
+                    isValidResult = { it: Int -> false },
+                ) {
+                    calls++
+                    // A slow action must consume the budget instead of stretching it.
+                    Thread.sleep(60L)
+                    -1
+                }
+            val elapsed = nowEpochMilliseconds() - start
+            assertEquals(-1, result)
+            assertTrue(calls <= 3, "slow actions must shrink the retry count, calls=$calls")
+            assertTrue(elapsed < maxTime + 60L + 500L, "budget overshot, elapsed=$elapsed")
+        }
+}


### PR DESCRIPTION
Closes #4543
Relates to #4490 (kept open for the native Wayland clipboard implementation)

### Problem

On Arch/Wayland, the gap between the XFixes ownership notify and finished ingestion repeatedly hits 1.5–2.7 s: the XWayland bridge keeps failing selection conversions (`Owner failed to convert data`) for hundreds of ms, and the exponential backoff around the AWT read both overshoots its budget and detects late readiness with up-to-640 ms gaps. When the budget runs out, the copy is silently dropped.

### Changes

- **`ControlUtils` (commonMain, mobile-safe)**: keep `exponentialBackoffUntilValid` and add `linearBackoffUntilValid`; both delegate to a shared loop whose budget is real elapsed time (action time included) and whose final wait is clamped to the remaining budget — a 1000 ms budget no longer sleeps up to ~1260 ms. The Windows-only blocking variant is untouched.
- **`X11ClipboardReader.awaitClipboardReadable`**: X11 has no "owner is ready" event, so probe with cheap `TARGETS` conversions (20 ms cadence, 200 ms per-answer wait, caller-supplied cap) on a single display connection until the owner actually answers. Returns fast when the selection has no owner; short-timeout probe waits log at debug to avoid warn spam.
- **`LinuxPasteboardService`**: run the readiness probe (2 s cap) before the AWT read, switch the read to linear backoff (20 ms init / 1 s budget) as a defensive fallback (`TARGETS` success does not guarantee every data target converts), and warn when the probe times out or contents remain invalid so lost copies are visible in logs.

### Impact

- XWayland: local ingestion drops from 1.5–2.7 s to the bridge's actual readiness time + ~30 ms.
- Native X11: unaffected on the happy path — one extra `TARGETS` round trip (a few ms); owners that never answer `TARGETS` were already a failure path under AWT.
- macOS: `exponentialBackoffUntilValid` now strictly honors its budget (no behavioral change on successful reads).

### Testing

- New `ControlUtilsTest` (6 tests): immediate return on valid first result, retry-until-valid for both strategies, real-elapsed budget enforcement, and action time counting against the budget. All pass via `./gradlew app:desktopTest`.
- `ktlintFormat` clean.
- Not yet verified on a real Wayland machine (developed on macOS) — verification on Arch + Wayland (e.g. by the #4490 reporter) is welcome before release.