### PR TITLE
:bug: resolve clipboard source app on Wayland via compositor IPC

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/LinuxAppWindowManager.kt
@@ -6,6 +6,8 @@ import com.crosspaste.listener.ShortcutKeys
 import com.crosspaste.listener.ShortcutKeysAction
 import com.crosspaste.listener.ShortcutKeysListener
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.platform.linux.LinuxActiveAppResolver
+import com.crosspaste.platform.linux.LinuxDesktopAppIcon
 import com.crosspaste.platform.linux.api.X11Api
 import com.crosspaste.platform.linux.api.X11Api.Companion.bringToBack
 import com.sun.jna.NativeLong
@@ -28,6 +30,11 @@ class LinuxAppWindowManager(
 ) : DesktopAppWindowManager(appSize) {
 
     private val prevLinuxAppInfo: MutableStateFlow<LinuxAppInfo?> = MutableStateFlow(null)
+
+    // Wayland sessions resolve the focused app through compositor IPC where
+    // available; X11 sessions (and the paste-back focus logic below, which is
+    // X11-only either way) keep the _NET_ACTIVE_WINDOW path.
+    private val activeAppResolver = LinuxActiveAppResolver.detect()
 
     private val classNameSet: MutableSet<String> = ConcurrentSet()
 
@@ -60,8 +67,8 @@ class LinuxAppWindowManager(
         }
 
     override fun getCurrentActiveAppName(): String? =
-        X11Api.getActiveWindow()?.let { linuxAppInfo ->
-            getAppName(linuxAppInfo)
+        activeAppResolver.getActiveApp()?.let { activeApp ->
+            registerApp(activeApp.appName, activeApp.x11Window)
         }
 
     override fun getRunningAppNames(): List<String> =
@@ -84,29 +91,39 @@ class LinuxAppWindowManager(
             }
         }
 
-    private fun getAppName(linuxAppInfo: LinuxAppInfo): String {
-        val className = linuxAppInfo.className
-        if (!classNameSet.contains(className)) {
+    private fun getAppName(linuxAppInfo: LinuxAppInfo): String =
+        registerApp(linuxAppInfo.className, linuxAppInfo.window)
+
+    private fun registerApp(
+        appName: String,
+        window: Window?,
+    ): String {
+        if (!classNameSet.contains(appName)) {
             ioScope.launch {
-                saveAppImage(linuxAppInfo.window, className)
+                saveAppImage(appName, window)
             }
-            classNameSet.add(className)
+            classNameSet.add(appName)
         }
-        return className
+        return appName
     }
 
     @Synchronized
     private fun saveAppImage(
-        window: Window,
-        className: String,
+        appName: String,
+        window: Window?,
     ) {
         runCatching {
-            val iconPath = userDataPathProvider.resolveIconPath(appInfo.appInstanceId, className)
-            if (!iconPath.toFile().exists()) {
+            val iconPath = userDataPathProvider.resolveIconPath(appInfo.appInstanceId, appName)
+            if (iconPath.toFile().exists()) {
+                return
+            }
+            if (window != null) {
                 X11Api.saveAppIcon(window, iconPath.toNioPath())
+            } else if (!LinuxDesktopAppIcon.saveAppIcon(appName, iconPath.toNioPath())) {
+                logger.debug { "No desktop-entry icon found for $appName" }
             }
         }.onFailure { e ->
-            logger.warn(e) { "Failed to save app icon for $className" }
+            logger.warn(e) { "Failed to save app icon for $appName" }
         }
     }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/HyprlandActiveAppResolver.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/HyprlandActiveAppResolver.kt
@@ -1,0 +1,81 @@
+package com.crosspaste.platform.linux
+
+import com.crosspaste.utils.getJsonUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import java.io.ByteArrayOutputStream
+import java.net.UnixDomainSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Resolves the focused app over Hyprland's IPC socket: one short-lived
+ * connection per query, sending `j/activewindow` and parsing the `class` field
+ * of the JSON reply (Hyprland reports `class` for both native Wayland and
+ * XWayland windows). Hyprland answers and closes the socket immediately, the
+ * same blocking round trip `hyprctl` performs.
+ */
+class HyprlandActiveAppResolver(
+    private val socketPath: Path,
+) : LinuxActiveAppResolver {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun getActiveApp(): LinuxActiveApp? =
+        runCatching {
+            parseActiveWindowClass(request("j/activewindow"))?.let { appName ->
+                LinuxActiveApp(appName, x11Window = null)
+            }
+        }.getOrElse { e ->
+            logger.warn(e) { "Failed to resolve active app via Hyprland IPC" }
+            null
+        }
+
+    private fun request(command: String): String =
+        SocketChannel.open(UnixDomainSocketAddress.of(socketPath)).use { channel ->
+            val out = ByteBuffer.wrap(command.toByteArray(Charsets.UTF_8))
+            while (out.hasRemaining()) {
+                channel.write(out)
+            }
+            val result = ByteArrayOutputStream()
+            val buffer = ByteBuffer.allocate(8192)
+            while (channel.read(buffer) >= 0 && result.size() <= MAX_REPLY_BYTES) {
+                buffer.flip()
+                result.write(buffer.array(), 0, buffer.limit())
+                buffer.clear()
+            }
+            result.toString(Charsets.UTF_8.name())
+        }
+
+    companion object {
+
+        private const val MAX_REPLY_BYTES = 1024 * 1024
+
+        private val jsonUtils = getJsonUtils()
+
+        fun detect(env: (String) -> String?): HyprlandActiveAppResolver? {
+            val signature = env("HYPRLAND_INSTANCE_SIGNATURE") ?: return null
+            return listOfNotNull(
+                env("XDG_RUNTIME_DIR")?.let { "$it/hypr/$signature/.socket.sock" },
+                "/tmp/hypr/$signature/.socket.sock",
+            ).map(Path::of)
+                .firstOrNull(Files::exists)
+                ?.let { HyprlandActiveAppResolver(it) }
+        }
+
+        /**
+         * Extracts the window class from a `j/activewindow` reply. Hyprland
+         * answers `{}` (or non-JSON like `Invalid`) when no window is focused —
+         * both map to null.
+         */
+        fun parseActiveWindowClass(reply: String): String? =
+            runCatching {
+                val window = jsonUtils.JSON.parseToJsonElement(reply) as? JsonObject ?: return null
+                (window["class"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
+            }.getOrNull()
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/LinuxActiveAppResolver.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/LinuxActiveAppResolver.kt
@@ -1,0 +1,120 @@
+package com.crosspaste.platform.linux
+
+import com.crosspaste.platform.linux.api.WMCtrl
+import com.crosspaste.platform.linux.api.X11Api
+import com.sun.jna.platform.unix.X11
+import com.sun.jna.platform.unix.X11.Window
+import com.sun.jna.ptr.IntByReference
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+/**
+ * The active application resolved for a clipboard change.
+ *
+ * [x11Window] is non-null only when the app was resolved through X11, where the
+ * window carries the `_NET_WM_ICON` used for icon capture; Wayland-resolved
+ * apps fall back to desktop-entry icon lookup instead.
+ */
+data class LinuxActiveApp(
+    val appName: String,
+    val x11Window: Window?,
+)
+
+/**
+ * Resolves which application currently has focus.
+ *
+ * Wayland deliberately offers no universal "who is focused" API, so the answer
+ * is compositor-specific: Hyprland and Sway expose it over their IPC sockets,
+ * while everything else falls back to X11's `_NET_ACTIVE_WINDOW` — correct for
+ * native X11 sessions and for XWayland apps, but blind to native Wayland
+ * windows (see [X11ActiveAppResolver] for how stale answers are suppressed).
+ */
+interface LinuxActiveAppResolver {
+
+    fun getActiveApp(): LinuxActiveApp?
+
+    companion object {
+
+        private val logger = KotlinLogging.logger {}
+
+        /**
+         * Picks the best resolver for the current session. The [env] parameter
+         * exists for tests; production callers use the real environment.
+         */
+        fun detect(env: (String) -> String? = System::getenv): LinuxActiveAppResolver {
+            val isWayland =
+                env("XDG_SESSION_TYPE")?.equals("wayland", ignoreCase = true) == true ||
+                    env("WAYLAND_DISPLAY") != null
+            if (!isWayland) {
+                logger.info { "Active app resolver: X11 (X11 session)" }
+                return X11ActiveAppResolver(guardAgainstStaleFocus = false)
+            }
+            HyprlandActiveAppResolver.detect(env)?.let {
+                logger.info { "Active app resolver: Hyprland IPC" }
+                return it
+            }
+            SwayActiveAppResolver.detect(env)?.let {
+                logger.info { "Active app resolver: Sway IPC" }
+                return it
+            }
+            logger.info {
+                "Active app resolver: X11 via XWayland (focus-guarded); " +
+                    "native Wayland windows cannot be identified on this compositor"
+            }
+            return X11ActiveAppResolver(guardAgainstStaleFocus = true)
+        }
+    }
+}
+
+/**
+ * Resolves the active app from X11's `_NET_ACTIVE_WINDOW`.
+ *
+ * In a Wayland session this property only tracks XWayland windows: when focus
+ * moves to a native Wayland window it goes stale, pointing at whichever X app
+ * was focused last. A stale source is worse than none (it mislabels history
+ * and can wrongly trigger source exclusion), so with [guardAgainstStaleFocus]
+ * the resolver first checks `XGetInputFocus` — compositors withdraw the
+ * XWayland input focus (None/PointerRoot) while a Wayland surface is focused,
+ * and in that state we report no source instead of a stale one. Best-effort:
+ * compositors that park focus on a dummy X window defeat the guard, which then
+ * behaves like today's unguarded read.
+ */
+class X11ActiveAppResolver(
+    private val guardAgainstStaleFocus: Boolean,
+) : LinuxActiveAppResolver {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun getActiveApp(): LinuxActiveApp? =
+        runCatching {
+            val x11 = X11Api.INSTANCE
+            val display = x11.XOpenDisplay(null) ?: return null
+            try {
+                if (guardAgainstStaleFocus && !hasXInputFocus(x11, display)) {
+                    logger.debug { "X input focus withdrawn (Wayland window focused), no source" }
+                    null
+                } else {
+                    WMCtrl.getActiveWindow(display)?.let { window ->
+                        WMCtrl.getWindowClass(display, window)?.let { windowClass ->
+                            LinuxActiveApp(windowClass.second, window)
+                        }
+                    }
+                }
+            } finally {
+                x11.XCloseDisplay(display)
+            }
+        }.getOrElse { e ->
+            logger.warn(e) { "Failed to resolve active app via X11" }
+            null
+        }
+
+    private fun hasXInputFocus(
+        x11: X11Api,
+        display: X11.Display,
+    ): Boolean {
+        val focusReturn = X11.WindowByReference()
+        val revertToReturn = IntByReference()
+        x11.XGetInputFocus(display, focusReturn, revertToReturn)
+        // None (0) and PointerRoot (1) mean no real X window holds the focus.
+        return (focusReturn.value?.toLong() ?: 0L) > 1L
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/LinuxDesktopAppIcon.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/LinuxDesktopAppIcon.kt
@@ -1,0 +1,112 @@
+package com.crosspaste.platform.linux
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Resolves an application icon from freedesktop desktop entries, for apps that
+ * have no X11 window to capture `_NET_WM_ICON` from (i.e. native Wayland
+ * windows reported by a compositor IPC as an `app_id`/class).
+ *
+ * Lookup: find `applications/<appId>.desktop` across the XDG data dirs, read
+ * its `Icon=` key (falling back to the app id itself, which usually doubles as
+ * the icon name), then search `icons/hicolor/<size>x<size>/apps/` (largest
+ * first) and `pixmaps/` for a PNG. SVG-only themes are not rendered — the app
+ * then simply has no icon, matching how an unresolvable X11 icon behaves.
+ */
+object LinuxDesktopAppIcon {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val ICON_SIZES = listOf(512, 256, 192, 128, 96, 64, 48)
+
+    /**
+     * Copies the best icon PNG found for [appId] to [iconPath]. Returns false
+     * when no PNG icon could be resolved.
+     */
+    fun saveAppIcon(
+        appId: String,
+        iconPath: Path,
+        env: (String) -> String? = System::getenv,
+    ): Boolean {
+        val source = findIconPng(appId, dataDirs(env)) ?: return false
+        return runCatching {
+            Files.copy(source, iconPath, StandardCopyOption.REPLACE_EXISTING)
+            true
+        }.getOrElse { e ->
+            logger.warn(e) { "Failed to copy icon $source for $appId" }
+            false
+        }
+    }
+
+    fun dataDirs(env: (String) -> String?): List<Path> {
+        val dataHome =
+            env("XDG_DATA_HOME")
+                ?: env("HOME")?.let { "$it/.local/share" }
+        val dataDirs = (env("XDG_DATA_DIRS") ?: "/usr/local/share:/usr/share").split(':')
+        return (listOfNotNull(dataHome) + dataDirs)
+            .filter { it.isNotBlank() }
+            .map(Path::of)
+    }
+
+    fun findIconPng(
+        appId: String,
+        dataDirs: List<Path>,
+    ): Path? {
+        val iconName = desktopEntryIconName(appId, dataDirs) ?: appId
+        if (iconName.startsWith('/')) {
+            return Path.of(iconName).takeIf { it.toString().endsWith(".png") && Files.isRegularFile(it) }
+        }
+        for (size in ICON_SIZES) {
+            for (dir in dataDirs) {
+                val candidate = dir.resolve("icons/hicolor/${size}x$size/apps/$iconName.png")
+                if (Files.isRegularFile(candidate)) {
+                    return candidate
+                }
+            }
+        }
+        for (dir in dataDirs) {
+            val candidate = dir.resolve("pixmaps/$iconName.png")
+            if (Files.isRegularFile(candidate)) {
+                return candidate
+            }
+        }
+        return null
+    }
+
+    private fun desktopEntryIconName(
+        appId: String,
+        dataDirs: List<Path>,
+    ): String? {
+        for (dir in dataDirs) {
+            for (fileName in linkedSetOf("$appId.desktop", "${appId.lowercase()}.desktop")) {
+                val desktopFile = dir.resolve("applications").resolve(fileName)
+                if (Files.isRegularFile(desktopFile)) {
+                    runCatching { Files.readString(desktopFile) }
+                        .getOrNull()
+                        ?.let { parseDesktopIconName(it) }
+                        ?.let { return it }
+                }
+            }
+        }
+        return null
+    }
+
+    /** Reads the `Icon=` key of the `[Desktop Entry]` section. */
+    fun parseDesktopIconName(content: String): String? {
+        var inDesktopEntry = false
+        for (rawLine in content.lineSequence()) {
+            val line = rawLine.trim()
+            if (line.startsWith("[")) {
+                inDesktopEntry = line == "[Desktop Entry]"
+                continue
+            }
+            if (inDesktopEntry && line.startsWith("Icon=")) {
+                return line.removePrefix("Icon=").trim().takeIf { it.isNotEmpty() }
+            }
+        }
+        return null
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/SwayActiveAppResolver.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/SwayActiveAppResolver.kt
@@ -1,0 +1,138 @@
+package com.crosspaste.platform.linux
+
+import com.crosspaste.utils.getJsonUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import java.net.UnixDomainSocketAddress
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Resolves the focused app over Sway's i3-compatible IPC socket (`$SWAYSOCK`):
+ * one `GET_TREE` request per query, then a walk of the layout tree for the
+ * single `focused: true` node. Native Wayland windows carry `app_id`; XWayland
+ * windows carry `window_properties.class` instead. The framing is the i3 IPC
+ * format: `"i3-ipc"` magic + u32 LE payload length + u32 LE message type.
+ */
+class SwayActiveAppResolver(
+    private val socketPath: Path,
+) : LinuxActiveAppResolver {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun getActiveApp(): LinuxActiveApp? =
+        runCatching {
+            requestTree()?.let { tree ->
+                parseFocusedAppName(tree)?.let { appName ->
+                    LinuxActiveApp(appName, x11Window = null)
+                }
+            }
+        }.getOrElse { e ->
+            logger.warn(e) { "Failed to resolve active app via Sway IPC" }
+            null
+        }
+
+    private fun requestTree(): String? =
+        SocketChannel.open(UnixDomainSocketAddress.of(socketPath)).use { channel ->
+            val request = ByteBuffer.allocate(MAGIC.size + 8).order(ByteOrder.LITTLE_ENDIAN)
+            request.put(MAGIC)
+            request.putInt(0)
+            request.putInt(GET_TREE)
+            request.flip()
+            while (request.hasRemaining()) {
+                channel.write(request)
+            }
+
+            val header = ByteBuffer.allocate(MAGIC.size + 8).order(ByteOrder.LITTLE_ENDIAN)
+            if (!readFully(channel, header)) {
+                return null
+            }
+            header.flip()
+            val magic = ByteArray(MAGIC.size)
+            header.get(magic)
+            if (!magic.contentEquals(MAGIC)) {
+                logger.warn { "Sway IPC reply has invalid magic" }
+                return null
+            }
+            val length = header.int
+            header.int // message type, unused
+            if (length <= 0 || length > MAX_REPLY_BYTES) {
+                logger.warn { "Sway IPC reply has implausible length $length" }
+                return null
+            }
+            val payload = ByteBuffer.allocate(length)
+            if (!readFully(channel, payload)) {
+                return null
+            }
+            payload.flip()
+            Charsets.UTF_8.decode(payload).toString()
+        }
+
+    private fun readFully(
+        channel: SocketChannel,
+        buffer: ByteBuffer,
+    ): Boolean {
+        while (buffer.hasRemaining()) {
+            if (channel.read(buffer) < 0) {
+                return false
+            }
+        }
+        return true
+    }
+
+    companion object {
+
+        private val MAGIC = "i3-ipc".toByteArray(Charsets.US_ASCII)
+
+        private const val GET_TREE = 4
+
+        private const val MAX_REPLY_BYTES = 16 * 1024 * 1024
+
+        private val jsonUtils = getJsonUtils()
+
+        fun detect(env: (String) -> String?): SwayActiveAppResolver? =
+            env("SWAYSOCK")
+                ?.let(Path::of)
+                ?.takeIf(Files::exists)
+                ?.let { SwayActiveAppResolver(it) }
+
+        /**
+         * Finds the `focused: true` node in a `GET_TREE` reply and returns its
+         * app name, or null when nothing (or only a container/workspace) has
+         * focus.
+         */
+        fun parseFocusedAppName(treeJson: String): String? =
+            runCatching {
+                (jsonUtils.JSON.parseToJsonElement(treeJson) as? JsonObject)?.let { root ->
+                    findFocusedNode(root)?.let { appNameOf(it) }
+                }
+            }.getOrNull()
+
+        private fun findFocusedNode(node: JsonObject): JsonObject? {
+            if ((node["focused"] as? JsonPrimitive)?.booleanOrNull == true) {
+                return node
+            }
+            for (key in listOf("nodes", "floating_nodes")) {
+                (node[key] as? JsonArray)?.forEach { child ->
+                    (child as? JsonObject)?.let { childNode ->
+                        findFocusedNode(childNode)?.let { return it }
+                    }
+                }
+            }
+            return null
+        }
+
+        private fun appNameOf(node: JsonObject): String? =
+            (node["app_id"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
+                ?: ((node["window_properties"] as? JsonObject)?.get("class") as? JsonPrimitive)
+                    ?.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/X11Api.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/linux/api/X11Api.kt
@@ -7,6 +7,7 @@ import com.sun.jna.NativeLong
 import com.sun.jna.platform.unix.X11
 import com.sun.jna.platform.unix.X11.Display
 import com.sun.jna.platform.unix.X11.Window
+import com.sun.jna.ptr.IntByReference
 import com.sun.jna.ptr.NativeLongByReference
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
@@ -31,6 +32,12 @@ interface X11Api : X11 {
         display: Display,
         selection: X11.Atom,
     ): Window?
+
+    fun XGetInputFocus(
+        display: Display,
+        focusReturn: X11.WindowByReference,
+        revertToReturn: IntByReference,
+    ): Int
 
     companion object {
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/platform/linux/LinuxActiveAppResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/platform/linux/LinuxActiveAppResolverTest.kt
@@ -1,0 +1,243 @@
+package com.crosspaste.platform.linux
+
+import java.nio.file.Files
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class LinuxActiveAppResolverTest {
+
+    private val tempDirs = mutableListOf<java.nio.file.Path>()
+
+    private fun tempDir(): java.nio.file.Path = Files.createTempDirectory("crosspaste-test").also { tempDirs.add(it) }
+
+    @AfterTest
+    fun cleanup() {
+        tempDirs.forEach { it.toFile().deleteRecursively() }
+    }
+
+    // ---- Hyprland ----
+
+    @Test
+    fun `hyprland reply parses class field`() {
+        val reply =
+            """{"address":"0x1","class":"firefox","title":"Mozilla Firefox","pid":42,"xwayland":false}"""
+        assertEquals("firefox", HyprlandActiveAppResolver.parseActiveWindowClass(reply))
+    }
+
+    @Test
+    fun `hyprland empty object means no focused window`() {
+        assertNull(HyprlandActiveAppResolver.parseActiveWindowClass("{}"))
+    }
+
+    @Test
+    fun `hyprland non json reply maps to null`() {
+        assertNull(HyprlandActiveAppResolver.parseActiveWindowClass("Invalid"))
+        assertNull(HyprlandActiveAppResolver.parseActiveWindowClass(""))
+    }
+
+    @Test
+    fun `hyprland blank class maps to null`() {
+        assertNull(HyprlandActiveAppResolver.parseActiveWindowClass("""{"class":""}"""))
+    }
+
+    // ---- Sway ----
+
+    @Test
+    fun `sway tree resolves focused wayland app_id`() {
+        val tree =
+            """
+            {
+              "type": "root", "focused": false,
+              "nodes": [
+                {
+                  "type": "output", "focused": false,
+                  "nodes": [
+                    {
+                      "type": "workspace", "focused": false,
+                      "nodes": [
+                        {"type": "con", "focused": false, "app_id": "org.kde.dolphin"},
+                        {"type": "con", "focused": true, "app_id": "foot"}
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+        assertEquals("foot", SwayActiveAppResolver.parseFocusedAppName(tree))
+    }
+
+    @Test
+    fun `sway tree resolves focused xwayland window class`() {
+        val tree =
+            """
+            {
+              "focused": false,
+              "nodes": [
+                {
+                  "focused": true,
+                  "app_id": null,
+                  "window_properties": {"class": "jetbrains-idea", "instance": "jetbrains-idea"}
+                }
+              ]
+            }
+            """.trimIndent()
+        assertEquals("jetbrains-idea", SwayActiveAppResolver.parseFocusedAppName(tree))
+    }
+
+    @Test
+    fun `sway tree searches floating nodes`() {
+        val tree =
+            """
+            {
+              "focused": false,
+              "nodes": [{"focused": false, "app_id": "background"}],
+              "floating_nodes": [{"focused": true, "app_id": "pavucontrol"}]
+            }
+            """.trimIndent()
+        assertEquals("pavucontrol", SwayActiveAppResolver.parseFocusedAppName(tree))
+    }
+
+    @Test
+    fun `sway focused workspace without app maps to null`() {
+        val tree =
+            """
+            {
+              "focused": false,
+              "nodes": [{"type": "workspace", "focused": true, "nodes": []}]
+            }
+            """.trimIndent()
+        assertNull(SwayActiveAppResolver.parseFocusedAppName(tree))
+    }
+
+    @Test
+    fun `sway garbage maps to null`() {
+        assertNull(SwayActiveAppResolver.parseFocusedAppName("not json"))
+        assertNull(SwayActiveAppResolver.parseFocusedAppName("[]"))
+    }
+
+    // ---- backend detection ----
+
+    @Test
+    fun `x11 session picks unguarded x11 resolver`() {
+        val resolver = LinuxActiveAppResolver.detect { name -> if (name == "XDG_SESSION_TYPE") "x11" else null }
+        assertIs<X11ActiveAppResolver>(resolver)
+    }
+
+    @Test
+    fun `wayland session without compositor ipc falls back to guarded x11`() {
+        val resolver = LinuxActiveAppResolver.detect { name -> if (name == "XDG_SESSION_TYPE") "wayland" else null }
+        assertIs<X11ActiveAppResolver>(resolver)
+    }
+
+    @Test
+    fun `hyprland socket is detected`() {
+        val runtimeDir = tempDir()
+        val socket = runtimeDir.resolve("hypr/sig123/.socket.sock")
+        socket.parent.createDirectories()
+        Files.createFile(socket)
+        val env =
+            mapOf(
+                "XDG_SESSION_TYPE" to "wayland",
+                "HYPRLAND_INSTANCE_SIGNATURE" to "sig123",
+                "XDG_RUNTIME_DIR" to runtimeDir.toString(),
+            )
+        val resolver = LinuxActiveAppResolver.detect { env[it] }
+        assertIs<HyprlandActiveAppResolver>(resolver)
+    }
+
+    @Test
+    fun `sway socket is detected`() {
+        val socket = tempDir().resolve("sway-ipc.sock")
+        Files.createFile(socket)
+        val env =
+            mapOf(
+                "XDG_SESSION_TYPE" to "wayland",
+                "SWAYSOCK" to socket.toString(),
+            )
+        val resolver = LinuxActiveAppResolver.detect { env[it] }
+        assertIs<SwayActiveAppResolver>(resolver)
+    }
+
+    // ---- desktop entry icon ----
+
+    @Test
+    fun `desktop entry icon name is parsed from desktop entry section only`() {
+        val content =
+            """
+            [Desktop Entry]
+            Name=Firefox
+            Icon=firefox-logo
+            Exec=firefox %u
+
+            [Desktop Action new-window]
+            Icon=other-icon
+            """.trimIndent()
+        assertEquals("firefox-logo", LinuxDesktopAppIcon.parseDesktopIconName(content))
+    }
+
+    @Test
+    fun `desktop entry without icon maps to null`() {
+        assertNull(LinuxDesktopAppIcon.parseDesktopIconName("[Desktop Entry]\nName=Foo"))
+    }
+
+    @Test
+    fun `icon png is found via desktop entry and hicolor theme`() {
+        val dataDir = tempDir()
+        dataDir
+            .resolve("applications")
+            .createDirectories()
+            .resolve("org.mozilla.firefox.desktop")
+            .writeText("[Desktop Entry]\nIcon=firefox-logo\n")
+        val iconFile =
+            dataDir
+                .resolve("icons/hicolor/128x128/apps")
+                .createDirectories()
+                .resolve("firefox-logo.png")
+        Files.write(iconFile, byteArrayOf(1, 2, 3))
+
+        assertEquals(iconFile, LinuxDesktopAppIcon.findIconPng("org.mozilla.firefox", listOf(dataDir)))
+    }
+
+    @Test
+    fun `app id doubles as icon name when no desktop file exists`() {
+        val dataDir = tempDir()
+        val iconFile =
+            dataDir
+                .resolve("pixmaps")
+                .createDirectories()
+                .resolve("foot.png")
+        Files.write(iconFile, byteArrayOf(1))
+
+        assertEquals(iconFile, LinuxDesktopAppIcon.findIconPng("foot", listOf(dataDir)))
+    }
+
+    @Test
+    fun `larger icon sizes win over pixmaps`() {
+        val dataDir = tempDir()
+        val big =
+            dataDir
+                .resolve("icons/hicolor/256x256/apps")
+                .createDirectories()
+                .resolve("foot.png")
+        Files.write(big, byteArrayOf(1))
+        val pixmap =
+            dataDir
+                .resolve("pixmaps")
+                .createDirectories()
+                .resolve("foot.png")
+        Files.write(pixmap, byteArrayOf(2))
+
+        assertEquals(big, LinuxDesktopAppIcon.findIconPng("foot", listOf(dataDir)))
+    }
+
+    @Test
+    fun `missing icon maps to null`() {
+        assertNull(LinuxDesktopAppIcon.findIconPng("ghost-app", listOf(tempDir())))
+    }
+}


### PR DESCRIPTION
Closes #4545

### Problem

In Wayland sessions the pasteboard listener resolves the copy source via X11's `_NET_ACTIVE_WINDOW`, which only tracks XWayland windows. With a native Wayland app focused, the property goes stale and CrossPaste records whichever X app was focused last — mislabeling history and potentially mis-triggering source exclusion. Native Wayland apps also get no icon (no X window to read `_NET_WM_ICON` from).

### Changes

- **`LinuxActiveAppResolver`** — new abstraction, backend picked once at startup:
  - **Hyprland**: IPC socket (`$HYPRLAND_INSTANCE_SIGNATURE`), `j/activewindow` → `class`; covers native Wayland and XWayland windows.
  - **Sway**: i3-compatible IPC (`$SWAYSOCK`), `GET_TREE` → focused node's `app_id` (Wayland) or `window_properties.class` (XWayland); floating windows included.
  - **X11 fallback**: pure X11 sessions keep the existing `_NET_ACTIVE_WINDOW` path, byte-for-byte unchanged behavior.
- **Focus guard for the X11 fallback in Wayland sessions**: compositors withdraw the XWayland input focus (None/PointerRoot) while a native Wayland surface is focused, so `XGetInputFocus` (new JNA binding in `X11Api`) is checked first and a **null source is reported instead of a stale one**. XWayland apps still resolve correctly. Best-effort: a compositor parking focus on a dummy X window degrades to today's behavior.
- **`LinuxDesktopAppIcon`** — icons for Wayland-resolved apps via freedesktop desktop entries: `applications/<appId>.desktop` across XDG data dirs → `Icon=` key (app id doubles as icon name when no desktop file exists) → `icons/hicolor/<size>x<size>/apps/*.png` (largest first), then `pixmaps/`. SVG-only themes yield no icon, matching the unresolvable-X11-icon behavior.
- **`LinuxAppWindowManager`** — `getCurrentActiveAppName()` goes through the resolver; icon capture branches on X11-window-present vs desktop-entry lookup. `getRunningAppNames` and paste-back focus stay on X11 (same root cause, different fix — tracked separately per #4545).

### Known limitations (by design, documented in #4545)

- GNOME: no compositor interface without a user-installed extension — XWayland apps resolve, native Wayland apps get a null source (better than a wrong one).
- KDE Plasma (DBus / KWin scripting) is a planned follow-up.

### Testing

- New `LinuxActiveAppResolverTest` (19 tests): Hyprland reply parsing (normal/empty/garbage/blank), Sway tree walking (app_id, XWayland class, floating nodes, focused workspace, garbage), backend detection with fake env/sockets, desktop-entry icon parsing and lookup priorities. All pass.
- Full `./gradlew app:desktopTest` suite green; `ktlintFormat` clean.
- Developed on macOS — the IPC paths compile and parse-level logic is unit-tested, but live verification on real Hyprland/Sway sessions is welcome before release.