### PR TITLE
:hammer: measure backoff budget with a monotonic clock

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/utils/ControlUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/ControlUtils.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
 
 expect fun getControlUtils(): ControlUtils
 
@@ -97,15 +99,16 @@ private suspend fun <T> backoffUntilValid(
     isValidResult: (T) -> Boolean,
     action: suspend () -> T,
 ): T {
-    val start = nowEpochMilliseconds()
+    // Monotonic clock: a wall-clock (NTP) jump must not stretch or cut the budget.
+    val start = TimeSource.Monotonic.markNow()
     var result = action()
     var waiting = initTime
     while (!isValidResult(result)) {
-        val remaining = maxTime - (nowEpochMilliseconds() - start)
-        if (remaining <= 0) {
+        val remaining = maxTime.milliseconds - start.elapsedNow()
+        if (remaining <= Duration.ZERO) {
             break
         }
-        delay(minOf(waiting, remaining).milliseconds)
+        delay(minOf(waiting.milliseconds, remaining))
         waiting = nextWaiting(waiting)
         result = action()
     }


### PR DESCRIPTION
Closes #4547

## Summary

`backoffUntilValid` (the shared retry loop behind `exponentialBackoffUntilValid` / `linearBackoffUntilValid`) measured its real-elapsed-time budget with the wall clock `DateUtils.nowEpochMilliseconds()`. A wall-clock jump landing inside the retry window either cuts the budget short (forward jump) or — worse — makes `remaining` huge (backward jump), so the loop keeps retrying with exponentially growing delays far beyond `maxTime`: a 1 s budget can turn into minutes of hang.

This switches the budget measurement to `kotlin.time.TimeSource.Monotonic` (`markNow()` / `elapsedNow()`), with the comparison and `delay` clamp done in `Duration`. The comment mirrors the convention already established in `X11ClipboardReader`, which deliberately uses a monotonic clock for its SelectionNotify waits.

`TimeSource.Monotonic` is common Kotlin stdlib (stable on JVM/Android/iOS), so the change is commonMain-safe for the mobile consumers of this code.

**Deliberately untouched:** `ensureMinExecutionTime`, `ensureMinExecutionTimeForCallback`, and `equalDebounce` stay on the wall clock — their failure modes under clock jumps are cosmetic and not worth widening the diff.

## Test plan

- `./gradlew ktlintFormat` — clean
- `./gradlew app:desktopTest --tests "com.crosspaste.utils.ControlUtilsTest"` — 6/6 passed, including `backoff counts action time against the budget` and both `stops within real elapsed budget` cases, which pin the budget semantics this change must preserve.