### PR TITLE
:bug: distrust implausible wide-charset labels when decoding clipboard html

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/HtmlClipboardDecoder.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/HtmlClipboardDecoder.kt
@@ -45,7 +45,8 @@ object HtmlClipboardDecoder {
      *  1. A leading BOM (and it is stripped).
      *  2. An in-document `<meta>` / XML charset declaration.
      *  3. [knownCharset], when supplied — the charset named by the X11 target we
-     *     requested (e.g. `text/html;charset=UTF-16`).
+     *     requested (e.g. `text/html;charset=UTF-16`) — unless the label is
+     *     implausible for the bytes (see [isPlausibleLabel]).
      *  4. ICU4J's statistical detection.
      *  5. UTF-8 as a last resort.
      *
@@ -77,8 +78,13 @@ object HtmlClipboardDecoder {
         }
 
         if (knownCharset != null) {
-            logger.info { "Decoding clipboard html as known charset ${knownCharset.name()}" }
-            return String(bytes, knownCharset)
+            if (isPlausibleLabel(knownCharset, bytes)) {
+                logger.info { "Decoding clipboard html as known charset ${knownCharset.name()}" }
+                return String(bytes, knownCharset)
+            }
+            logger.info {
+                "Known charset ${knownCharset.name()} is implausible for these bytes; falling back to detection"
+            }
         }
 
         detectByContent(bytes)?.let { charset ->
@@ -99,6 +105,26 @@ object HtmlClipboardDecoder {
         bytes
             .take(limit)
             .joinToString(" ") { "%02x".format(it.toInt() and 0xff) }
+
+    /**
+     * Whether [charset] can plausibly describe [bytes]. A `text/html` payload
+     * starts with an ASCII character (`<` or whitespace; a BOM was handled
+     * earlier), so bytes genuinely encoded as UTF-16/32 must carry a NUL within
+     * the first two bytes. A wide-charset label on NUL-free bytes is a lying
+     * transport label — AWT / JBR advertise `text/html;charset=UTF-16` targets
+     * while serving UTF-8 bytes — and trusting it would re-mojibake the text
+     * that reading the selection bytes directly was meant to rescue.
+     */
+    private fun isPlausibleLabel(
+        charset: Charset,
+        bytes: ByteArray,
+    ): Boolean {
+        val name = charset.name().uppercase()
+        if (!name.startsWith("UTF-16") && !name.startsWith("UTF-32")) {
+            return true
+        }
+        return bytes.size < 2 || bytes[0] == 0.toByte() || bytes[1] == 0.toByte()
+    }
 
     private fun detectByBom(bytes: ByteArray): Pair<Charset, Int>? {
         fun has(vararg prefix: Int): Boolean =

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/HtmlClipboardDecoderTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/HtmlClipboardDecoderTest.kt
@@ -125,6 +125,24 @@ class HtmlClipboardDecoderTest {
     }
 
     @Test
+    fun `falls back to detection when a utf-16 label lies about bare utf-8 bytes`() {
+        // IntelliJ / JBR serves UTF-8 bytes for text/html;charset=UTF-16. With
+        // no BOM and no in-document declaration, the lying label must not be
+        // trusted: genuine UTF-16 html starts with an ASCII '<', so its first
+        // two bytes would contain a NUL. These bytes have none, so the label is
+        // implausible and content detection must win.
+        val html = "<html><body><p>你好，世界 — IntelliJ 复制的中文</p></body></html>"
+
+        val decoded =
+            HtmlClipboardDecoder.decode(
+                html.toByteArray(Charsets.UTF_8),
+                knownCharset = Charset.forName("UTF-16"),
+            )
+
+        assertEquals(html, decoded)
+    }
+
+    @Test
     fun `bom overrides a wrong known charset`() {
         // Bytes are UTF-8 with a BOM; even if a bogus known charset is supplied,
         // the BOM must win so the document is not corrupted.


### PR DESCRIPTION
Closes #4549

## Summary

Follow-up to #4542. The decode order BOM → in-document declaration → target-label charset → ICU → UTF-8 left one blind spot: JBR serves UTF-8 bytes for its `text/html;charset=UTF-16` target, and when the payload carries no BOM and no `<meta>`/XML declaration, the lying label was trusted and the UTF-8 bytes were decoded as UTF-16 — re-introducing the mojibake the fix exists to remove.

This adds a plausibility check before trusting `knownCharset`: a `text/html` payload starts with an ASCII character (`<` or whitespace; a BOM is handled earlier), so bytes genuinely encoded as UTF-16/32 must carry a NUL within the first two bytes. A wide-charset label on NUL-free bytes is implausible and falls through to ICU content detection instead (verified against the project's ICU 78.3: a bare UTF-8 CJK fragment detects as UTF-8 with confidence 100; a truthful BOM-less UTF-16LE payload detects as UTF-16LE).

Deliberately **not** a reorder of `knownCharset` after ICU: a truthful legacy label (e.g. `charset=ISO-8859-1`) stays more authoritative than statistical detection, which can misfire between single-byte encodings. Non-wide labels are unaffected, and a truthful BOM-less UTF-16LE label still passes the check (the leading `<` encodes as `3C 00`).

## Test plan

- `./gradlew ktlintFormat` — clean
- `./gradlew app:desktopTest --tests "com.crosspaste.paste.HtmlClipboardDecoderTest"` — 14/14 passed, including the new blind-spot case (bare UTF-8 fragment + lying `knownCharset=UTF-16` decodes losslessly) and the pre-existing truthful-label cases (`decodes known utf-16le charset target without bom`, BOM/meta precedence) that pin the behavior this change must not regress.