### PR TITLE
:bug: guard update-check trigger against invokeAndWait on the EDT

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUpdateService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUpdateService.kt
@@ -149,7 +149,7 @@ class DesktopAppUpdateService(
                 SwingUtilities.invokeAndWait(trigger)
             }
             result
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             logger.error(e) { "Failed to trigger update check UI" }
             false
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUpdateService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUpdateService.kt
@@ -124,18 +124,29 @@ class DesktopAppUpdateService(
     private fun SoftwareUpdateController.tryTriggerUpdateUI(): Boolean =
         try {
             var result = false
-            SwingUtilities.invokeAndWait {
-                result =
-                    when (canTriggerUpdateCheckUI()) {
-                        SoftwareUpdateController.Availability.AVAILABLE -> {
-                            triggerUpdateCheckUI()
-                            true
+            val trigger =
+                Runnable {
+                    result =
+                        when (canTriggerUpdateCheckUI()) {
+                            SoftwareUpdateController.Availability.AVAILABLE -> {
+                                triggerUpdateCheckUI()
+                                true
+                            }
+                            else -> {
+                                logger.warn {
+                                    "SoftwareUpdateController is not available, cannot trigger update check UI"
+                                }
+                                false
+                            }
                         }
-                        else -> {
-                            logger.warn { "SoftwareUpdateController is not available, cannot trigger update check UI" }
-                            false
-                        }
-                    }
+                }
+            // Conveyor requires the trigger to run on the EDT, but the menu click that
+            // gets us here already runs there — invokeAndWait from the EDT throws
+            // java.lang.Error, which the catch below would not even see.
+            if (SwingUtilities.isEventDispatchThread()) {
+                trigger.run()
+            } else {
+                SwingUtilities.invokeAndWait(trigger)
             }
             result
         } catch (e: Exception) {


### PR DESCRIPTION
Closes #4554
Closes #4551

### Summary

Clicking **Check for Updates** when a newer version is available threw an uncaught `java.lang.Error: Cannot call invokeAndWait from the event dispatcher thread` on Conveyor-packaged builds (reported on Windows 2.1.3 after 2.1.4 shipped; the Conveyor-installer and macOS paths in 2.1.4 are still affected).

The menu click handler runs on the AWT EDT (Compose Desktop dispatches input there), and `DesktopAppUpdateService.tryTriggerUpdateUI()` unconditionally called `SwingUtilities.invokeAndWait`, which throws `java.lang.Error` when already on the EDT — and the surrounding `catch (e: Exception)` cannot catch an `Error`, so it propagated to the UI.

### Fix

Mirror the guard already used by `WindowsZipUpdater.conveyorCanSelfUpdate()`: run the Conveyor trigger directly when `SwingUtilities.isEventDispatchThread()` is true, and only use `invokeAndWait` from non-EDT threads. Conveyor still gets its EDT requirement satisfied in both cases.

Also widen the surrounding handler to `catch (e: Throwable)` so any future non-`Exception` failure from the trigger falls back to opening the browser download page instead of propagating to the UI.

### Verification

- `./gradlew ktlintFormat` and `./gradlew app:compileKotlinDesktop` pass
- `WindowsZipUpdaterTest`, `WindowsZipUpdaterDownloadTest`, `UpdateMetadataFetcherTest` pass
- The error is deterministic (EDT + non-null `SoftwareUpdateController` + newer version advertised); with the guard, the trigger runs inline on the EDT instead of throwing