### PR TITLE
:bookmark: prepare 2.1.5 release notes and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+# [2.1.5] - 2026-06-11
+# Highlights 🌟
+
+- 🛠️ **Fixed "Check for Updates" throwing an error**
+  Clicking Check for Updates when a newer version was available threw
+  "Cannot call invokeAndWait from the event dispatcher thread" on
+  Conveyor-packaged builds (Windows installer and macOS). The trigger
+  now runs directly when already on the event dispatch thread, so
+  manual update checks work reliably again (#4554 #4555).
+
 # [2.1.4] - 2026-06-10
 # Highlights 🌟
 

--- a/app/src/desktopMain/resources/crosspaste-version.properties
+++ b/app/src/desktopMain/resources/crosspaste-version.properties
@@ -1,1 +1,1 @@
-version=2.1.4
+version=2.1.5

--- a/app/src/desktopMain/resources/whats-new/en.md
+++ b/app/src/desktopMain/resources/whats-new/en.md
@@ -1,3 +1,8 @@
+# [2.1.5] - 2026-06-11
+
+## 🛠️ Fixed the "Check for Updates" error
+Fixed an error (Cannot call invokeAndWait from the event dispatcher thread) that appeared when clicking Check for Updates while a new version was available. This affected the Windows installer and macOS builds; manual update checks now work reliably again.
+
 # [2.1.4] - 2026-06-10
 
 ## 🔄 Faster, more reliable reconnection

--- a/app/src/desktopMain/resources/whats-new/zh.md
+++ b/app/src/desktopMain/resources/whats-new/zh.md
@@ -1,3 +1,8 @@
+# [2.1.5] - 2026-06-11
+
+## 🛠️ 修复"检查更新"报错
+修复了在有新版本可用时,点击"检查更新"会弹出错误(Cannot call invokeAndWait from the event dispatcher thread)的问题。该问题影响 Windows 安装版与 macOS 用户,现在手动检查更新可以正常工作了。
+
 # [2.1.4] - 2026-06-10
 
 ## 🔄 设备连接更稳、重连更快


### PR DESCRIPTION
Closes #4556

### Summary

Prepare the 2.1.5 hotfix release for #4554 (fix merged in #4555).

- Bump version from 2.1.4 to 2.1.5 in `crosspaste-version.properties`
- Add bilingual What's New entries (`whats-new/zh.md`, `whats-new/en.md`)
- Add 2.1.5 release notes to `CHANGELOG.md`

### Release contents since 2.1.4

- #4555 — guard update-check trigger against `invokeAndWait` on the EDT
- #4553 — README download badge update (docs only)

### Verification

- `ChangelogServiceTest` passes (newest What's New entry matches the shipping version)
