### PR TITLE
:construction_worker: mirror the Conveyor update site to a stable OSS prefix

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -235,6 +235,13 @@ jobs:
           signing_key: ${{ secrets.SIGNING_KEY }}
           agree_to_license: 1
 
+      # Snapshot the pure Conveyor site before later steps mutate output/
+      # (AppImage/extension get added, CheckSum deletes icon.svg/download.html).
+      # This copy is mirrored to a stable OSS prefix that will become the
+      # CDN-served update site (#4558).
+      - name: Stage update site for OSS mirror
+        run: cp -r output update-site
+
       - name: Package AppImage
         run: |
           chmod +x ./.github/scripts/package_appimage.sh
@@ -267,6 +274,24 @@ jobs:
         run: |
           echo "Uploading release app to OSS..."
           ossutil cp -r output/ oss://crosspaste-desktop/${{ env.VERSION }}.${{ env.REVISION }}/
+
+      # Mirror the Conveyor site to the stable site/ prefix (#4558). Clients do
+      # not use this path yet (base-url still points at GitHub); it goes live in
+      # a later release. Two-pass upload: packages first, update metadata last,
+      # so a half-finished upload never leaves metadata pointing at missing files.
+      # Cache-Control set per group: packages are version-named and immutable,
+      # metadata must revalidate quickly through the CDN.
+      - name: Mirror update site to OSS
+        run: |
+          mkdir update-site-meta
+          for f in metadata.properties appcast-*.rss crosspaste.appinstaller \
+                   InRelease Release Packages Packages.xz install.ps1; do
+            if compgen -G "update-site/$f" > /dev/null; then
+              mv update-site/$f update-site-meta/
+            fi
+          done
+          ossutil cp -r -f --meta "Cache-Control:public, max-age=2592000" update-site/ oss://crosspaste-desktop/site/
+          ossutil cp -r -f --meta "Cache-Control:public, max-age=300" update-site-meta/ oss://crosspaste-desktop/site/
 
       # conveyor default cache directory is .conveyor/cache
       # Avoid caching it, causing Github space payment


### PR DESCRIPTION
Part of #4558 (Phase 1 — mirror the update site to OSS).

### Summary

On every release build, mirror the complete Conveyor site to a stable OSS prefix (`oss://crosspaste-desktop/site/`) in addition to the existing versioned archive upload. **Zero client impact**: `app.site.base-url` still points at GitHub Releases; nothing reads `site/` yet. The switch happens in a later release (Phase 2).

### Design points

- **Snapshot before mutation**: the site is staged right after the Conveyor build, before the AppImage/extension are added to `output/` and before the CheckSum step deletes `icon.svg`/`download.html`, so `site/` holds the pure Conveyor site.
- **Two-pass upload, metadata last**: packages upload first; `metadata.properties`, `appcast-*.rss`, `crosspaste.appinstaller`, apt index files (`InRelease`/`Release`/`Packages*`) and `install.ps1` upload last. A half-finished upload can never leave update metadata pointing at files that are not there yet.
- **Cache-Control set at upload time**: version-named packages get `max-age=2592000` (immutable in practice), update metadata gets `max-age=300` so the CDN picks up new releases quickly without manual purges.

### Verification

- YAML validated; the new steps only use tools already present in the job (`ossutil` via the existing setup step, same credentials/endpoint).
- Real verification happens on the next tag build: check `https://oss.crosspaste.com/site/metadata.properties` afterwards.
