### PR TITLE
:construction_worker: serve updates from the OSS-backed CDN site

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUrls.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUrls.kt
@@ -12,8 +12,8 @@ object DesktopAppUrls : AppUrls {
 
     override val checkMetadataUrl: String = appUrlsProperties.getProperty("check-metadata-url")
 
-    // Desktop-only: fallback version endpoint when GitHub ([checkMetadataUrl] host)
-    // is unreachable, e.g. for users in mainland China. Intentionally NOT on the
+    // Desktop-only: fallback version endpoint when the update site
+    // ([checkMetadataUrl] host) is unreachable. Intentionally NOT on the
     // shared [AppUrls] interface — mobile (which copies commonMain) does not use it.
     val versionApiUrl: String = appUrlsProperties.getProperty("version-api-url")
 

--- a/app/src/desktopMain/resources/app-urls.properties
+++ b/app/src/desktopMain/resources/app-urls.properties
@@ -1,5 +1,5 @@
 home-url=https://crosspaste.com
 change-log-url=https://github.com/crosspaste/crosspaste-desktop/blob/main/CHANGELOG.md
-check-metadata-url=https://github.com/CrossPaste/crosspaste-desktop/releases/latest/download/metadata.properties
+check-metadata-url=https://oss.crosspaste.com/site/metadata.properties
 version-api-url=https://crosspaste.com/api/desktop.json
 issue-tracker-url=https://github.com/CrossPaste/crosspaste-desktop/issues

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -13,6 +13,12 @@ app {
 
   site {
     consistency-checks = warn
+
+    # Serve updates from the OSS-backed DCDN domain (global acceleration) so
+    # update checks and downloads work from mainland China, where GitHub is
+    # often unreachable (#4558). Release CI mirrors the full site to this
+    # prefix; GitHub Releases stays as archive and website download source.
+    base-url = "https://oss.crosspaste.com/site"
   }
 
   jvm {


### PR DESCRIPTION
Part of #4558 (Phase 2 — switch the update site to the CDN domain).

⚠️ **Merge order**: merge #4559 (Phase 1, OSS mirror in release CI) first. Both changes only take effect at the next tag build; within that build the mirror populates `site/` before the release is published, so shipping both in the same release is safe.

### Summary

- **`conveyor.conf`**: set `app.site.base-url = "https://oss.crosspaste.com/site"` (previously auto-derived from `vcs-url` as GitHub Releases). From the next release on, Sparkle appcasts, the Windows updater metadata, the apt repo, and all enclosure URLs point at the OSS-backed DCDN domain (global acceleration), reachable from mainland China.
- **`app-urls.properties`**: `check-metadata-url` now points at `https://oss.crosspaste.com/site/metadata.properties`. Mainland users no longer wait for a GitHub timeout before the `crosspaste.com/api/desktop.json` fallback kicks in; the fallback itself is unchanged.
- Comment touch-up in `DesktopAppUrls.kt` (the fallback is no longer specifically about GitHub).

### Migration behavior

- **New installs** (from the release built with this change): all update traffic goes through the CDN.
- **Existing installs overseas**: their updater still reads the old GitHub feed; keep publishing the full asset set to GitHub Releases as today and they update once normally — the updated app then carries the new baked-in feed URL. GitHub stays as archive + website download source indefinitely.
- **Existing mainland macOS installs**: cannot fetch the GitHub feed today and that does not change; they need one manual download from the website (Phase 4 will add guidance).

### Notes

- First release after this change may skip Sparkle delta generation (`consistency-checks = warn` while the new site URL has no prior versions); users get a full-size update once, deltas resume next release.
- The Windows portable-zip updater also reads `check-metadata-url` for version metadata, so its checks get faster in mainland China too; its package downloads were already dual-source (GitHub + `oss.crosspaste.com`).

### Verification

- `ktlintFormat`, `app:compileKotlinDesktop` pass; `UpdateMetadataFetcherTest` and `WindowsZipUpdater*` tests pass.
- End-to-end verification happens on the next tag build: `https://oss.crosspaste.com/site/metadata.properties` must serve the new version, and a fresh install must update via the CDN.
