### PR TITLE
:sparkles: add telnet scenario to e2e harness

### DIFF
--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
@@ -13,6 +13,7 @@ import com.crosspaste.e2e.scenario.Scenario
 import com.crosspaste.e2e.scenario.ScenarioContext
 import com.crosspaste.e2e.scenario.ScenarioResult
 import com.crosspaste.e2e.scenario.TargetSpec
+import com.crosspaste.e2e.scenario.TelnetScenario
 import com.crosspaste.e2e.scenario.WrongTokenScenario
 import com.crosspaste.utils.getDateUtils
 import com.github.ajalt.clikt.core.CliktCommand
@@ -22,13 +23,14 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.long
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import kotlin.coroutines.cancellation.CancellationException
 
 class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
     private val scenario by option(
         "--scenario",
         "-s",
         help =
-            "Scenario to run: discovery, pair, wrong-token, push-text, push-url, " +
+            "Scenario to run: discovery, pair, wrong-token, telnet, push-text, push-url, " +
                 "push-html, push-rtf, push-color, pull-icon, or all.",
     ).default("discovery")
 
@@ -115,7 +117,15 @@ class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
                 runBlocking {
                     scenarios.map { s ->
                         val started = System.nanoTime()
-                        val result = s.run(ctx)
+                        // A scenario that throws (e.g. a probe hitting an unreachable port)
+                        // must not abort the whole batch — capture it as a Fail so later
+                        // scenarios still run and the summary/JUnit report are still emitted.
+                        val result =
+                            runCatching { s.run(ctx) }
+                                .getOrElse { e ->
+                                    if (e is CancellationException) throw e
+                                    ScenarioResult.Fail("Scenario '${s.name}' threw", e)
+                                }
                         val durationMs = (System.nanoTime() - started) / 1_000_000.0
                         RunResult(s.name, result, durationMs)
                     }
@@ -155,6 +165,7 @@ private fun selectScenarios(
         "discovery" -> listOf(DiscoveryScenario())
         "pair" -> listOf(PairScenario())
         "wrong-token" -> listOf(WrongTokenScenario())
+        "telnet" -> listOf(TelnetScenario())
         "push-text" -> listOf(PushTextScenario(payloads.text))
         "push-url" -> listOf(PushUrlScenario(payloads.url))
         "push-html" -> listOf(PushHtmlScenario(payloads.html))
@@ -167,6 +178,9 @@ private fun selectScenarios(
                 DiscoveryScenario(),
                 WrongTokenScenario(),
                 PairScenario(),
+                // After pair: peer is trusted, so telnet's address-push exercises the gated
+                // server merge path; its identity-header check needs no trust.
+                TelnetScenario(),
                 PushTextScenario(payloads.text),
                 PushUrlScenario(payloads.url),
                 PushHtmlScenario(payloads.html),

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/BonjourAdvertiser.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/BonjourAdvertiser.kt
@@ -2,10 +2,7 @@ package com.crosspaste.e2e.peer
 
 import com.crosspaste.app.AppInfo
 import com.crosspaste.db.sync.HostInfo
-import com.crosspaste.dto.sync.EndpointInfo
-import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.e2e.net.NetworkUtils
-import com.crosspaste.platform.Platform
 import com.crosspaste.utils.TxtRecordUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import javax.jmdns.JmDNS
@@ -51,24 +48,7 @@ class BonjourAdvertiser(
                         networkPrefixLength = prefix,
                         hostAddress = addr.hostAddress,
                     )
-                val syncInfo =
-                    SyncInfo(
-                        appInfo = appInfo,
-                        endpointInfo =
-                            EndpointInfo(
-                                deviceId = appInfo.appInstanceId,
-                                deviceName = appInfo.userName,
-                                platform =
-                                    Platform(
-                                        name = Platform.UNKNOWN_OS,
-                                        arch = "x64",
-                                        bitMode = 64,
-                                        version = appInfo.appVersion,
-                                    ),
-                                hostInfoList = listOf(hostInfo),
-                                port = advertisedPort,
-                            ),
-                    )
+                val syncInfo = buildPeerSyncInfo(appInfo, listOf(hostInfo), advertisedPort)
                 val txt = TxtRecordUtils.encodeToTxtRecordDict(syncInfo)
                 val info =
                     ServiceInfo.create(

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/PeerSyncInfo.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/PeerSyncInfo.kt
@@ -1,0 +1,39 @@
+package com.crosspaste.e2e.peer
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.dto.sync.EndpointInfo
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.platform.Platform
+
+/**
+ * Builds the [SyncInfo] that describes this headless peer — the same shape the real app
+ * advertises over mDNS and pushes on `/sync/telnet`. Shared by [BonjourAdvertiser] (one
+ * announcement per interface) and the telnet address-push scenario (one header carrying the
+ * peer's subnet addresses) so both present an identical identity to the target.
+ *
+ * No real server is bound, so [port] is the same placeholder marker the mDNS announcement
+ * uses; the target may fail to reach back but the identity it records is still correct.
+ */
+internal fun buildPeerSyncInfo(
+    appInfo: AppInfo,
+    hostInfoList: List<HostInfo>,
+    port: Int,
+): SyncInfo =
+    SyncInfo(
+        appInfo = appInfo,
+        endpointInfo =
+            EndpointInfo(
+                deviceId = appInfo.appInstanceId,
+                deviceName = appInfo.userName,
+                platform =
+                    Platform(
+                        name = Platform.UNKNOWN_OS,
+                        arch = "x64",
+                        bitMode = 64,
+                        version = appInfo.appVersion,
+                    ),
+                hostInfoList = hostInfoList,
+                port = port,
+            ),
+    )

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/TelnetScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/TelnetScenario.kt
@@ -1,0 +1,127 @@
+package com.crosspaste.e2e.scenario
+
+import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.e2e.net.NetworkUtils
+import com.crosspaste.e2e.peer.BonjourAdvertiser
+import com.crosspaste.e2e.peer.buildPeerSyncInfo
+import com.crosspaste.net.SyncInfoHeaderCodec
+import com.crosspaste.utils.HEADER_APP_INSTANCE_ID
+import com.crosspaste.utils.HostAndPort
+import com.crosspaste.utils.buildUrl
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+
+/**
+ * Validates the `/sync/telnet` identity + address-push protocol (#4499 / #4500, #4509 phase 3).
+ *
+ * Two things shipped on this endpoint that earlier phases of the harness never exercised:
+ *  1. **Identity in the response** — the probe response carries the target's appInstanceId in
+ *     the [HEADER_APP_INSTANCE_ID] header so discovery can vet a candidate atomically with the
+ *     version check. Fully observable: we assert the header is present and (when the target id
+ *     is known) matches it. A target predating #4500 omits the header, which this flags.
+ *  2. **Address push in the request** — the caller may attach its current [SyncInfo] in the
+ *     [SyncInfoHeaderCodec.HEADER] header so a known peer's new address propagates without
+ *     waiting for the next mDNS round. The server merges it into its nearby map, but only for
+ *     an already-paired peer, and returns the same 200/version regardless. That merge is not
+ *     observable from a black-box client, so we exercise the real (web-compatible) codec
+ *     against the live endpoint after pairing and assert it still answers 200 with its
+ *     identity — a regression guard against the endpoint rejecting a valid header.
+ */
+class TelnetScenario : Scenario {
+    override val name: String = "telnet"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val target = resolveOrDiscover(ctx) ?: return ScenarioResult.Fail("Could not resolve target.")
+        println("[telnet] Target: ${target.appInstanceId} at ${target.host}:${target.port}")
+
+        // Probe 1: plain telnet — verify the version body and the identity response header.
+        val plain = observe(probe(ctx, target, syncInfoHeader = null), target)
+        val firstSeen =
+            plain.observation
+                ?: return ScenarioResult.Fail(plain.failure ?: "telnet probe failed")
+
+        // Probe 2: address push. The server only merges the pushed SyncInfo for a peer it has
+        // already paired with, so pair first to drive the real (gated) code path end-to-end.
+        ensureTrust(ctx, target)?.let { return it }
+        val header =
+            peerSyncInfoHeader(ctx)
+                ?: return ScenarioResult.Fail(
+                    "No usable LAN interface to advertise; cannot build the address-push header.",
+                )
+        val pushed = observe(probe(ctx, target, syncInfoHeader = header), target)
+        if (pushed.observation == null) {
+            return ScenarioResult.Fail("Address-push probe failed: ${pushed.failure}")
+        }
+
+        return ScenarioResult.Pass(
+            "telnet identity=${firstSeen.advertisedId} version=${firstSeen.version}; " +
+                "address-push header accepted (server-side merge not observable).",
+        )
+    }
+
+    private suspend fun probe(
+        ctx: ScenarioContext,
+        target: TargetSpec,
+        syncInfoHeader: String?,
+    ): HttpResponse =
+        ctx.peer.pasteClient.get(
+            headersBuilder = {
+                syncInfoHeader?.let { append(SyncInfoHeaderCodec.HEADER, it) }
+            },
+        ) {
+            buildUrl(HostAndPort(target.host, target.port))
+            buildUrl("sync", "telnet")
+        }
+
+    private suspend fun observe(
+        response: HttpResponse,
+        target: TargetSpec,
+    ): TelnetProbe {
+        if (!response.status.isSuccess()) {
+            return TelnetProbe.fail("telnet returned HTTP ${response.status.value}")
+        }
+        val body = response.bodyAsText()
+        val version =
+            body.toIntOrNull()
+                ?: return TelnetProbe.fail("telnet body is not a version int: '$body'")
+        val advertisedId =
+            response.headers[HEADER_APP_INSTANCE_ID]
+                ?: return TelnetProbe.fail(
+                    "telnet response missing '$HEADER_APP_INSTANCE_ID' header (target predates #4500?)",
+                )
+        target.appInstanceId?.let { expected ->
+            if (advertisedId != expected) {
+                return TelnetProbe.fail("telnet identity '$advertisedId' != expected '$expected'")
+            }
+        }
+        return TelnetProbe.ok(TelnetObservation(version, advertisedId))
+    }
+
+    private fun peerSyncInfoHeader(ctx: ScenarioContext): String? {
+        val hostInfoList =
+            NetworkUtils.enumerateLanInet4().map { (addr, prefix) ->
+                HostInfo(networkPrefixLength = prefix, hostAddress = addr.hostAddress)
+            }
+        if (hostInfoList.isEmpty()) return null
+        val syncInfo =
+            buildPeerSyncInfo(ctx.peer.appInfo, hostInfoList, BonjourAdvertiser.ADVERTISED_PORT)
+        return SyncInfoHeaderCodec.encode(syncInfo)
+    }
+}
+
+private data class TelnetObservation(
+    val version: Int,
+    val advertisedId: String,
+)
+
+private class TelnetProbe private constructor(
+    val observation: TelnetObservation?,
+    val failure: String?,
+) {
+    companion object {
+        fun ok(observation: TelnetObservation): TelnetProbe = TelnetProbe(observation, null)
+
+        fun fail(reason: String): TelnetProbe = TelnetProbe(null, reason)
+    }
+}


### PR DESCRIPTION
Closes #4561

## What

Adds a `telnet` scenario to the `:e2e` harness covering the `/sync/telnet` identity + address-push protocol (#4499 / #4500, #4509 phase 3) that earlier e2e phases never exercised.

The scenario does two probes:

1. **Plain probe** — asserts the response carries the target's `appInstanceId` header (matching the known target id) and that the body is a valid version int. Validates identity-on-telnet; a target predating #4500 omits the header, which the scenario flags.
2. **Address-push probe** — after pairing, attaches the peer's `SyncInfo` via the web-compatible `SyncInfoHeaderCodec` header and asserts the endpoint still answers `200` with its identity. The server-side nearby-map merge is gated to already-paired peers and is **not observable from a black-box client**, so this is a regression guard against the endpoint rejecting a valid header (and against codec format drift vs. the web client) — not a merge assertion. This is stated explicitly in the scenario KDoc and the Pass message.

### Design notes

- The harness peer is deliberately **client-only** (no server), so reusing the production `TelnetHelper` is avoided — it pulls in `EndpointInfoFactory`/`SyncInfoFactory`, whose `createEndpointInfo` waits on a local server port that this peer never opens. The scenario probes `/sync/telnet` directly via `pasteClient.get` instead, consistent with the module's existing client-only design.
- `buildPeerSyncInfo` is extracted from `BonjourAdvertiser` into `PeerSyncInfo.kt` so the mDNS announcement and the telnet address-push header present an identical peer identity (pure refactor, semantically equivalent).
- Wired into `--scenario telnet` and into `--scenario all` after `pair`, so by the time `telnet` runs the peer is already trusted and the address-push drives the gated server merge path.
- Hardened the scenario runner so a scenario that throws (e.g. a probe to an unreachable port — `telnet` is the first scenario to issue a raw, non-`*ClientApi`-wrapped network call) is captured as a `Fail` instead of aborting the whole batch, keeping the summary and JUnit report intact. `CancellationException` is rethrown.

## Review

Independent strict review (cold read of the diff): **0 P0**, 1 P1 + 2 P2 + 1 P3.

- **P1** — a throwing scenario would crash the whole `runBlocking` batch → **fixed** (per-scenario try/catch in the runner).
- **P3** — fragile `!!` on the probe failure message → **fixed** (null-safe fallback).
- **2× P2** (standalone token-prompt UX; nearby-map "pollution") → **conceded on rebuttal**: the token prompt is already preceded by `ensureTrust`'s own log line, and `BonjourAdvertiser` already advertises the same placeholder port over mDNS, so the address-push merges an equivalent record rather than introducing new state.
- Reviewer confirmed the address-push assertion is honest (no faked merge verification), the `BonjourAdvertiser` extraction is semantically equivalent, and the identity-header assertion matches server behaviour.

## Testing

- `:e2e:ktlintFormat`, `:e2e:ktlintCheck`, `:e2e:compileKotlinDesktop` all pass.
- The `:e2e` module has no unit tests by design — it is a CLI harness that runs against a real running app. Run-level verification is `./gradlew :e2e:run --args="--scenario telnet --target-app-id <id>"` against a live peer.