### PR TITLE
:bug: rank LAN interfaces above cellular for device discovery

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/net/AbstractNetworkInterfaceService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/AbstractNetworkInterfaceService.kt
@@ -14,6 +14,11 @@ abstract class AbstractNetworkInterfaceService : NetworkInterfaceService {
         private const val INVALID_END_OCTET_1 = ".1"
         private const val INVALID_END_OCTET_255 = ".255"
 
+        // Legacy interface names: letters followed by a trailing numeric index (eth0, wlan0,
+        // en1). The captured digits are the interface index. systemd predictable names
+        // (enp0s3) have digits embedded mid-name and intentionally do NOT match.
+        private val LEGACY_INDEXED_NAME_REGEX = Regex("^[a-zA-Z]+([0-9]+)$")
+
         // Known virtual network interface name prefixes (case-insensitive matching)
         internal val VIRTUAL_NIC_NAME_PREFIXES =
             listOf(
@@ -50,6 +55,46 @@ abstract class AbstractNetworkInterfaceService : NetworkInterfaceService {
                 "52:54:00", // QEMU/KVM
                 "00:16:3e", // Xen
             )
+
+        // Known LAN-capable physical interface name prefixes (Wi-Fi + Ethernet),
+        // covering both legacy names (eth0, wlan0) and systemd predictable names
+        // (enp0s3, eno1, ens33, wlp2s0, wlx...). macOS uses en* for both Wi-Fi and Ethernet.
+        internal val KNOWN_LAN_NIC_NAME_PREFIXES =
+            listOf(
+                "eth", // Linux legacy Ethernet
+                // Short prefixes "en"/"em" can collide with unrelated names (e.g. some
+                // tunnels). This is safe because interfaceTypeRank checks isLikelyVirtual
+                // BEFORE isKnownLanByName, so virtual interfaces are still ranked down even
+                // if their name starts with one of these. Keep that ordering if refactoring.
+                "en", // macOS en* + systemd eno/enp/ens/enx
+                "em", // some server Ethernet (em0)
+                "wlan", // Linux legacy Wi-Fi
+                "wlp",
+                "wlx", // systemd predictable Wi-Fi
+            )
+
+        // Cellular / mobile-broadband interface name prefixes. These can never reach
+        // LAN peers, so they must rank last for local-network device sync.
+        internal val CELLULAR_NIC_NAME_PREFIXES =
+            listOf(
+                "rmnet", // Qualcomm (Android), covers rmnet_data4
+                "rev_rmnet",
+                "ccmni", // MediaTek (Android)
+                "pdp_ip", // legacy Android cellular
+                "clat", // 464XLAT clat daemon (cellular NAT64)
+                "wwan", // WWAN modems (desktop/laptop)
+                "wwp", // systemd predictable WWAN
+            )
+
+        fun isKnownLanByName(name: String): Boolean {
+            val lowerName = name.lowercase()
+            return KNOWN_LAN_NIC_NAME_PREFIXES.any { lowerName.startsWith(it) }
+        }
+
+        fun isLikelyCellularByName(name: String): Boolean {
+            val lowerName = name.lowercase()
+            return CELLULAR_NIC_NAME_PREFIXES.any { lowerName.startsWith(it) }
+        }
 
         fun isLikelyVirtualByName(name: String): Boolean {
             val lowerName = name.lowercase()
@@ -145,28 +190,62 @@ abstract class AbstractNetworkInterfaceService : NetworkInterfaceService {
         )
     }
 
+    // Interface type ranking for a LAN sync app: known Wi-Fi/Ethernet first, then
+    // unknown physical, then virtual, and cellular last (cellular can never reach
+    // LAN peers, so selecting it makes the device undiscoverable).
+    private fun interfaceTypeRank(info: NetworkInterfaceInfo): Int =
+        when {
+            isLikelyCellularByName(info.name) -> 3
+            info.isLikelyVirtual -> 2
+            isKnownLanByName(info.name) -> 0
+            else -> 1
+        }
+
+    // Trailing numeric index of a legacy-style interface name (eth0 -> 0, eth1 -> 1,
+    // wlan0 -> 0). Lower index is preferred so eth0/wlan0 win over eth1. Only legacy
+    // "<letters><digits>" names carry a meaningful index; systemd predictable names
+    // (enp0s3, ens33, wlp2s0) embed bus/slot numbers that are NOT interface indices, so
+    // they default to 0 and let the later address-based keys decide.
+    private fun interfaceIndex(name: String): Int =
+        LEGACY_INDEXED_NAME_REGEX
+            .matchEntire(name)
+            ?.groupValues
+            ?.get(1)
+            ?.toIntOrNull() ?: 0
+
+    // Preference among RFC1918 private ranges for a home/SOHO LAN sync app:
+    // 192.168.x (home/SOHO) < 172.16-31.x < 10.x (corporate/VPN/carrier NAT) < other.
+    private fun subnetPreferenceRank(hostAddress: String): Int {
+        val octets = hostAddress.split(".")
+        val first = octets.getOrNull(0)?.toIntOrNull()
+        val second = octets.getOrNull(1)?.toIntOrNull()
+        return when {
+            first == 192 && second == 168 -> 0
+            first == 172 && second != null && second in 16..31 -> 1
+            first == 10 -> 2
+            else -> 3
+        }
+    }
+
+    private fun lastOctet(hostAddress: String): Int =
+        hostAddress
+            .split(".")
+            .lastOrNull()
+            ?.toIntOrNull() ?: Int.MIN_VALUE
+
     protected fun sortAddresses(addresses: List<NetworkInterfaceInfo>): List<NetworkInterfaceInfo> =
         addresses.sortedWith(
-            compareBy<NetworkInterfaceInfo> { networkInterfaceInfo ->
-                // Physical interfaces first, virtual interfaces last
-                if (networkInterfaceInfo.isLikelyVirtual) 1 else 0
-            }.thenByDescending { networkInterfaceInfo ->
-                // Prefer smaller networks (larger networkPrefixLength)
-                networkInterfaceInfo.networkPrefixLength
-            }.thenByDescending { networkInterfaceInfo ->
-                // Then sort by the last octet of the IP address
-                networkInterfaceInfo.hostAddress
-                    .split(".")
-                    .lastOrNull()
-                    ?.toIntOrNull() ?: Int.MIN_VALUE
-            }.thenBy { networkInterfaceInfo ->
-                // Prefer network interfaces named eth* or en*
-                when {
-                    networkInterfaceInfo.name.startsWith("eth") -> 0
-                    networkInterfaceInfo.name.startsWith("en") -> 1
-                    else -> 2
-                }
-            },
+            // 1. Interface type: known Wi-Fi/Ethernet first, unknown next, virtual after,
+            //    cellular last. This keeps wlan0/eth0 above rmnet_data4 etc.
+            compareBy<NetworkInterfaceInfo> { interfaceTypeRank(it) }
+                // 2. Lower interface index first (eth0 before eth1); eth0 and wlan0 tie here.
+                .thenBy { interfaceIndex(it.name) }
+                // 3. Prefer home/LAN private ranges: 192.168.x < 172.16-31.x < 10.x < other.
+                .thenBy { subnetPreferenceRank(it.hostAddress) }
+                // 4. Prefer smaller networks (larger networkPrefixLength).
+                .thenByDescending { it.networkPrefixLength }
+                // 5. Finally sort by the last octet of the IP address.
+                .thenByDescending { lastOctet(it.hostAddress) },
         )
 
     override fun getSortedNetworkInterfaceInfo(): List<NetworkInterfaceInfo> =

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/VirtualNetworkInterfaceDetectionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/VirtualNetworkInterfaceDetectionTest.kt
@@ -191,29 +191,31 @@ class NetworkInterfaceSortingTest {
     }
 
     @Test
-    fun `among physical interfaces sorting by prefix length then octet then name`() {
+    fun `among known LAN interfaces subnet preference then octet decides`() {
         val eth0 = NetworkInterfaceInfo("eth0", 24, "192.168.1.50", isLikelyVirtual = false)
         val en0 = NetworkInterfaceInfo("en0", 24, "192.168.1.100", isLikelyVirtual = false)
         val wlan0 = NetworkInterfaceInfo("wlan0", 16, "10.0.0.200", isLikelyVirtual = false)
 
         val sorted = sort(listOf(wlan0, en0, eth0))
 
-        // eth0 and en0 both /24, en0 has higher last octet -> en0 first among /24
-        // then eth0, then wlan0 (/16)
+        // All three are known-LAN (tier 0), index 0. eth0/en0 are on 192.168.x (subnet
+        // rank 0), wlan0 on 10.x (subnet rank 2) -> wlan0 last. eth0 vs en0: same subnet
+        // and prefix, en0 has higher last octet -> en0 first.
         assertEquals("en0", sorted[0].name)
         assertEquals("eth0", sorted[1].name)
         assertEquals("wlan0", sorted[2].name)
     }
 
     @Test
-    fun `among virtual interfaces same sorting rules apply`() {
+    fun `among virtual interfaces lower index wins`() {
         val vmnet1 = NetworkInterfaceInfo("vmnet1", 24, "192.168.100.1", isLikelyVirtual = true)
         val docker0 = NetworkInterfaceInfo("docker0", 16, "172.17.0.1", isLikelyVirtual = true)
 
-        val sorted = sort(listOf(docker0, vmnet1))
+        val sorted = sort(listOf(vmnet1, docker0))
 
-        assertEquals("vmnet1", sorted[0].name)
-        assertEquals("docker0", sorted[1].name)
+        // Both virtual (tier 2); index decides first: docker0 (0) before vmnet1 (1).
+        assertEquals("docker0", sorted[0].name)
+        assertEquals("vmnet1", sorted[1].name)
     }
 
     @Test
@@ -252,7 +254,8 @@ class NetworkInterfaceSortingTest {
         val sorted = sort(interfaces)
 
         assertEquals(2, sorted.size)
-        assertEquals("vmnet8", sorted[0].name)
+        // Both virtual; index decides: docker0 (0) before vmnet8 (8).
+        assertEquals("docker0", sorted[0].name)
     }
 
     @Test
@@ -272,14 +275,119 @@ class NetworkInterfaceSortingTest {
     }
 
     @Test
-    fun `eth preferred over en with same prefix and octet`() {
-        val eth = NetworkInterfaceInfo("eth0", 24, "192.168.1.100", isLikelyVirtual = false)
-        val en = NetworkInterfaceInfo("en0", 24, "192.168.1.100", isLikelyVirtual = false)
+    fun `wifi preferred over cellular - issue 4567`() {
+        // Real-world report: rmnet_data4 (cellular, /30) was selected over wlan0 (/24),
+        // making the device undiscoverable on the LAN.
+        val rmnet = NetworkInterfaceInfo("rmnet_data4", 30, "10.123.45.6", isLikelyVirtual = false)
+        val wlan0 = NetworkInterfaceInfo("wlan0", 24, "192.168.1.50", isLikelyVirtual = false)
 
-        val sorted = sort(listOf(en, eth))
+        val sorted = sort(listOf(rmnet, wlan0))
+
+        assertEquals("wlan0", sorted[0].name)
+        assertEquals("rmnet_data4", sorted[1].name)
+    }
+
+    @Test
+    fun `ethernet preferred over cellular even with longer prefix`() {
+        val eth0 = NetworkInterfaceInfo("eth0", 24, "192.168.1.50", isLikelyVirtual = false)
+        val rmnet = NetworkInterfaceInfo("rmnet0", 32, "10.8.0.2", isLikelyVirtual = false)
+
+        val sorted = sort(listOf(rmnet, eth0))
 
         assertEquals("eth0", sorted[0].name)
-        assertEquals("en0", sorted[1].name)
+    }
+
+    @Test
+    fun `cellular ranked last behind unknown and virtual interfaces`() {
+        val rmnet = NetworkInterfaceInfo("rmnet_data4", 30, "10.123.45.6", isLikelyVirtual = false)
+        val unknown = NetworkInterfaceInfo("ppp0", 24, "192.168.5.2", isLikelyVirtual = false)
+        val virtual = NetworkInterfaceInfo("vmnet8", 24, "192.168.200.1", isLikelyVirtual = true)
+
+        val sorted = sort(listOf(rmnet, virtual, unknown))
+
+        // unknown physical (tier 1) < virtual (tier 2) < cellular (tier 3)
+        assertEquals("ppp0", sorted[0].name)
+        assertEquals("vmnet8", sorted[1].name)
+        assertEquals("rmnet_data4", sorted[2].name)
+    }
+
+    @Test
+    fun `lower interface index preferred - eth0 before eth1`() {
+        val eth1 = NetworkInterfaceInfo("eth1", 24, "192.168.1.100", isLikelyVirtual = false)
+        val eth0 = NetworkInterfaceInfo("eth0", 24, "192.168.1.50", isLikelyVirtual = false)
+
+        val sorted = sort(listOf(eth1, eth0))
+
+        // Index decides before subnet/octet: eth0 wins despite lower last octet.
+        assertEquals("eth0", sorted[0].name)
+        assertEquals("eth1", sorted[1].name)
+    }
+
+    @Test
+    fun `eth0 and wlan0 share type and index priority - address decides`() {
+        // eth0 and wlan0 are both known-LAN (tier 0) with index 0, so neither name wins;
+        // the same subnet/prefix here means the higher last octet decides deterministically.
+        val eth0 = NetworkInterfaceInfo("eth0", 24, "192.168.1.10", isLikelyVirtual = false)
+        val wlan0 = NetworkInterfaceInfo("wlan0", 24, "192.168.1.20", isLikelyVirtual = false)
+
+        val sortedA = sort(listOf(eth0, wlan0))
+        val sortedB = sort(listOf(wlan0, eth0))
+
+        // Order is independent of input order and driven by the address tiebreaker.
+        assertEquals("wlan0", sortedA[0].name)
+        assertEquals("wlan0", sortedB[0].name)
+    }
+
+    @Test
+    fun `192_168 subnet preferred over 10 subnet for same interface type`() {
+        val wlanHome = NetworkInterfaceInfo("wlan0", 24, "192.168.1.50", isLikelyVirtual = false)
+        val ethCorp = NetworkInterfaceInfo("eth1", 24, "10.20.30.40", isLikelyVirtual = false)
+
+        // Different index (0 vs 1) would normally favor index 0 anyway; use same index to
+        // isolate the subnet rule.
+        val wlanTen = NetworkInterfaceInfo("wlan0", 24, "10.0.0.50", isLikelyVirtual = false)
+        val ethHome = NetworkInterfaceInfo("eth0", 24, "192.168.1.60", isLikelyVirtual = false)
+
+        assertEquals("wlan0", sort(listOf(ethCorp, wlanHome)).first().name)
+        // Same type and index: 192.168 (eth0) beats 10.x (wlan0).
+        assertEquals("eth0", sort(listOf(wlanTen, ethHome)).first().name)
+    }
+
+    @Test
+    fun `systemd predictable wifi name treated as known LAN`() {
+        val wlp = NetworkInterfaceInfo("wlp2s0", 24, "192.168.1.50", isLikelyVirtual = false)
+        val rmnet = NetworkInterfaceInfo("rmnet_data4", 30, "10.123.45.6", isLikelyVirtual = false)
+
+        val sorted = sort(listOf(rmnet, wlp))
+
+        assertEquals("wlp2s0", sorted[0].name)
+    }
+
+    @Test
+    fun `systemd predictable name index is not parsed from bus numbers`() {
+        // enp0s3's trailing "3" is a PCI slot number, NOT an interface index. It must
+        // default to index 0 so it is not pushed behind eth0; the address decides instead.
+        val enp = NetworkInterfaceInfo("enp0s3", 24, "192.168.1.90", isLikelyVirtual = false)
+        val eth0 = NetworkInterfaceInfo("eth0", 24, "192.168.1.10", isLikelyVirtual = false)
+
+        val sorted = sort(listOf(eth0, enp))
+
+        // Both index 0 -> same subnet/prefix -> higher last octet wins (enp0s3 = 90).
+        assertEquals("enp0s3", sorted[0].name)
+        assertEquals("eth0", sorted[1].name)
+    }
+
+    @Test
+    fun `systemd names with embedded digits ordered by address not bus numbers`() {
+        // enp3s0 and wlp2s0 have digits embedded mid-name (bus/slot), so both default to
+        // index 0 instead of 3/2; the address tiebreaker decides, not the bus numbers.
+        val enp3s0 = NetworkInterfaceInfo("enp3s0", 24, "192.168.1.80", isLikelyVirtual = false)
+        val wlp2s0 = NetworkInterfaceInfo("wlp2s0", 24, "192.168.1.40", isLikelyVirtual = false)
+
+        val sorted = sort(listOf(wlp2s0, enp3s0))
+
+        // Both index 0 -> enp3s0 has higher last octet -> enp3s0 first.
+        assertEquals("enp3s0", sorted[0].name)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Closes #4567.

On Android (and any device with a cellular/WWAN interface), the mobile-data
interface `rmnet_data4` was selected as the default outbound interface over
Wi-Fi `wlan0`. Because device sync only works over the LAN, the device became
undiscoverable until the user manually switched to `wlan0`.

### Root cause

`AbstractNetworkInterfaceService.sortAddresses()` ranked interfaces primarily
by **descending `networkPrefixLength`** ("prefer the smaller subnet"). Cellular
links are point-to-point and get the longest prefix (e.g. `/30` or `/32`), so
they always outranked Wi-Fi `/24`. There was no notion of interface *type*, so
`rmnet_data4` was treated as an ordinary physical interface and won.

## Fix

Rework the ranking around **interface type** instead of subnet size. New sort
keys, in order:

1. **Type rank** — known Wi-Fi/Ethernet (`0`) < unknown (`1`) < virtual (`2`) < **cellular (`3`, last)**
2. **Interface index** ascending — `eth0` before `eth1`; `eth0` and `wlan0` tie here
3. **Private-range preference** — `192.168.x` < `172.16-31.x` < `10.x` < other
4. **`networkPrefixLength`** descending
5. **Last octet** descending

Details:
- Added name-prefix classification for known-LAN interfaces (`eth/en/em/wlan/wlp/wlx`,
  covering both legacy and systemd predictable names) and cellular interfaces
  (`rmnet/rev_rmnet/ccmni/pdp_ip/clat/wwan/wwp`).
- Type rank checks cellular → virtual → known-LAN → unknown, so virtual interfaces
  still rank down even if their name starts with a short LAN prefix like `en`/`em`.
- The interface index is parsed only from legacy `<letters><digits>` names, so
  systemd bus/slot numbers (`enp0s3`, `wlp2s0`) are not mistaken for indices and
  default to `0`, letting the address-based keys decide.

## Tests

`VirtualNetworkInterfaceDetectionTest` updated and extended (16 sorting cases):
Wi-Fi > cellular (the #4567 repro), Ethernet > cellular, cellular ranked last,
`eth0 < eth1`, `eth0 == wlan0`, private-range preference, and systemd
predictable-name handling. Full `net.*`, `sync.*`, and `NetworkUtilsTest`
suites pass with no regressions.

## Review notes

Independent strict review found no blocking (P0) issues.
- **Conceded / fixed**: `interfaceIndex` originally mis-parsed systemd predictable
  names (`enp0s3` → 3) from bus numbers; now restricted to legacy names.
- **Held / recorded (no change)**: `en`/`em` short-prefix collisions (mitigated by
  the cellular→virtual→LAN check order, now documented); `eth` vs `en` now share a
  tier by design (`eth0 == wlan0`); defensive `lastOctet` fallback; `clat` NAT64
  edge case.

## ⚠️ Follow-up required

This is the **shared/mirrored** networking logic; the file lives under
`desktopMain`. To actually fix the Android user in #4567, the **mobile
repository must apply the same change** to its `AbstractNetworkInterfaceService`.