### PR TITLE
:hammer: make ImageHandler and ImageWriter I/O methods suspend

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/image/ImageHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/image/ImageHandler.kt
@@ -7,11 +7,11 @@ import okio.Path
 
 interface ImageHandler<Image> : ImageWriter<Image> {
 
-    fun readImage(imagePath: Path): Image?
+    suspend fun readImage(imagePath: Path): Image?
 
-    fun readImage(source: Source): Image?
+    suspend fun readImage(source: Source): Image?
 
-    fun readImage(byteReadChannel: ByteReadChannel): Image?
+    suspend fun readImage(byteReadChannel: ByteReadChannel): Image?
 
-    fun readSize(imagePath: Path): IntSize?
+    suspend fun readSize(imagePath: Path): IntSize?
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/image/ImageWriter.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/image/ImageWriter.kt
@@ -4,7 +4,7 @@ import okio.Path
 
 interface ImageWriter<Image> {
 
-    fun writeImage(
+    suspend fun writeImage(
         image: Image,
         formatName: String,
         imagePath: Path,

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/TransferableConsumer.kt
@@ -2,6 +2,7 @@ package com.crosspaste.paste
 
 import com.crosspaste.paste.plugin.type.PasteTypePlugin
 import com.crosspaste.utils.LoggerExtension.logExecutionTime
+import com.crosspaste.utils.LoggerExtension.logSuspendExecutionTime
 import io.github.oshai.kotlinlogging.KLogger
 import kotlin.collections.component1
 
@@ -38,13 +39,13 @@ interface TransferableConsumer {
         }
     }
 
-    fun updatePasteData(
+    suspend fun updatePasteData(
         pasteId: Long,
         dataFlavorMap: Map<String, List<PasteDataFlavor>>,
         pasteTransferable: PasteTransferable,
         pasteCollector: PasteCollector,
     ) {
-        logExecutionTime(logger, "updatePasteData") {
+        logSuspendExecutionTime(logger, "updatePasteData") {
             for ((itemIndex, entry) in dataFlavorMap.entries.withIndex()) {
                 val (identity, flavors) = entry
                 val plugin = getPlugin(identity) ?: continue

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/type/PasteTypePlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/plugin/type/PasteTypePlugin.kt
@@ -21,7 +21,7 @@ interface PasteTypePlugin {
     )
 
     // identity: unused on Desktop, required by Android/iOS to resolve platform-specific representations
-    fun loadRepresentation(
+    suspend fun loadRepresentation(
         pasteId: Long,
         itemIndex: Int,
         identity: String,
@@ -49,7 +49,7 @@ interface PasteTypePlugin {
         }
     }
 
-    fun doLoadRepresentation(
+    suspend fun doLoadRepresentation(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
@@ -69,7 +69,7 @@ interface PasteTypePlugin {
         pasteCollector.collectError(pasteId, itemIndex, error)
     }
 
-    fun buildTransferable(
+    suspend fun buildTransferable(
         pasteItem: PasteItem,
         mixedCategory: Boolean,
         map: MutableMap<PasteDataFlavor, Any>,

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopFileExtLoader.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopFileExtLoader.kt
@@ -14,7 +14,7 @@ class DesktopFileExtLoader(
     userDataPathProvider: UserDataPathProvider,
 ) : AbstractFileExtImageLoader(userDataPathProvider) {
 
-    private val toSave: (String, Path, Path) -> Unit =
+    private val toSave: suspend (String, Path, Path) -> Unit =
         if (platform.isMacos()) {
             { key, _, result -> macSaveExtIcon(key, result) }
         } else if (platform.isWindows()) {
@@ -41,7 +41,7 @@ private fun macSaveExtIcon(
     MacAppUtils.saveIconByExt(key, savePath.toString())
 }
 
-private fun windowsSaveExtIcon(
+private suspend fun windowsSaveExtIcon(
     filePath: Path,
     savePath: Path,
     imageHandler: ImageHandler<BufferedImage>,

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopImageHandler.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopImageHandler.kt
@@ -16,6 +16,7 @@ import com.drew.metadata.webp.WebpDirectory
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import kotlinx.io.Source
+import kotlinx.io.asInputStream
 import okio.Path
 import java.awt.image.BufferedImage
 import javax.imageio.ImageIO
@@ -91,7 +92,7 @@ object DesktopImageHandler : ImageHandler<BufferedImage> {
             },
         )
 
-    override fun writeImage(
+    override suspend fun writeImage(
         image: BufferedImage,
         formatName: String,
         imagePath: Path,
@@ -112,19 +113,22 @@ object DesktopImageHandler : ImageHandler<BufferedImage> {
             }
         }
 
-    override fun readImage(imagePath: Path): BufferedImage? =
+    override suspend fun readImage(imagePath: Path): BufferedImage? =
         runCatching {
             ImageIO.read(imagePath.toFile())
         }.getOrNull()
 
-    override fun readImage(source: Source): BufferedImage? = readImage(ByteReadChannel(source))
+    override suspend fun readImage(source: Source): BufferedImage? =
+        runCatching {
+            ImageIO.read(source.asInputStream())
+        }.getOrNull()
 
-    override fun readImage(byteReadChannel: ByteReadChannel): BufferedImage? =
+    override suspend fun readImage(byteReadChannel: ByteReadChannel): BufferedImage? =
         runCatching {
             ImageIO.read(byteReadChannel.toInputStream())
         }.getOrNull()
 
-    override fun readSize(imagePath: Path): IntSize? =
+    override suspend fun readSize(imagePath: Path): IntSize? =
         runCatching {
             val metadata = ImageMetadataReader.readMetadata(imagePath.toFile())
             extractors.firstNotNullOfOrNull { extractor -> extractor(metadata) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/WebpImageWriter.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/WebpImageWriter.kt
@@ -18,7 +18,7 @@ class WebpImageWriter : ImageWriter<BufferedImage> {
 
     private val fileUtils = getFileUtils()
 
-    override fun writeImage(
+    override suspend fun writeImage(
         image: BufferedImage,
         formatName: String,
         imagePath: Path,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopWriteTransferable.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/DesktopWriteTransferable.kt
@@ -11,7 +11,7 @@ class DesktopWriteTransferableBuilder {
 
     fun isEmpty(): Boolean = map.isEmpty()
 
-    fun add(
+    suspend fun add(
         pasteTypePlugin: PasteTypePlugin,
         pasteItem: PasteItem,
         mixedCategory: Boolean,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopColorTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopColorTypePlugin.kt
@@ -20,7 +20,7 @@ class DesktopColorTypePlugin : ColorTypePlugin {
     ) {
     }
 
-    override fun doLoadRepresentation(
+    override suspend fun doLoadRepresentation(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
@@ -32,7 +32,7 @@ class DesktopColorTypePlugin : ColorTypePlugin {
     ) {
     }
 
-    override fun buildTransferable(
+    override suspend fun buildTransferable(
         pasteItem: PasteItem,
         mixedCategory: Boolean,
         map: MutableMap<PasteDataFlavor, Any>,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopFilesTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopFilesTypePlugin.kt
@@ -59,7 +59,7 @@ class DesktopFilesTypePlugin(
         }
     }
 
-    override fun doLoadRepresentation(
+    override suspend fun doLoadRepresentation(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
@@ -153,7 +153,7 @@ class DesktopFilesTypePlugin(
         }
     }
 
-    override fun buildTransferable(
+    override suspend fun buildTransferable(
         pasteItem: PasteItem,
         mixedCategory: Boolean,
         map: MutableMap<PasteDataFlavor, Any>,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopHtmlTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopHtmlTypePlugin.kt
@@ -51,7 +51,7 @@ class DesktopHtmlTypePlugin(
         }
     }
 
-    override fun doLoadRepresentation(
+    override suspend fun doLoadRepresentation(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
@@ -81,7 +81,7 @@ class DesktopHtmlTypePlugin(
         }
     }
 
-    override fun buildTransferable(
+    override suspend fun buildTransferable(
         pasteItem: PasteItem,
         mixedCategory: Boolean,
         map: MutableMap<PasteDataFlavor, Any>,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopImageTypePlugin.kt
@@ -72,7 +72,7 @@ class DesktopImageTypePlugin(
         }
     }
 
-    override fun doLoadRepresentation(
+    override suspend fun doLoadRepresentation(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
@@ -209,7 +209,7 @@ class DesktopImageTypePlugin(
         return bufferedImage
     }
 
-    override fun buildTransferable(
+    override suspend fun buildTransferable(
         pasteItem: PasteItem,
         mixedCategory: Boolean,
         map: MutableMap<PasteDataFlavor, Any>,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopRtfTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopRtfTypePlugin.kt
@@ -53,7 +53,7 @@ class DesktopRtfTypePlugin : RtfTypePlugin {
         }
     }
 
-    override fun doLoadRepresentation(
+    override suspend fun doLoadRepresentation(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
@@ -89,7 +89,7 @@ class DesktopRtfTypePlugin : RtfTypePlugin {
         }
     }
 
-    override fun buildTransferable(
+    override suspend fun buildTransferable(
         pasteItem: PasteItem,
         mixedCategory: Boolean,
         map: MutableMap<PasteDataFlavor, Any>,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopTextTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopTextTypePlugin.kt
@@ -37,7 +37,7 @@ class DesktopTextTypePlugin : TextTypePlugin {
         }
     }
 
-    override fun doLoadRepresentation(
+    override suspend fun doLoadRepresentation(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
@@ -59,7 +59,7 @@ class DesktopTextTypePlugin : TextTypePlugin {
         }
     }
 
-    override fun buildTransferable(
+    override suspend fun buildTransferable(
         pasteItem: PasteItem,
         mixedCategory: Boolean,
         map: MutableMap<PasteDataFlavor, Any>,

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopUrlTypePlugin.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/plugin/type/DesktopUrlTypePlugin.kt
@@ -39,7 +39,7 @@ class DesktopUrlTypePlugin(
         }
     }
 
-    override fun doLoadRepresentation(
+    override suspend fun doLoadRepresentation(
         transferData: Any,
         pasteId: Long,
         itemIndex: Int,
@@ -76,7 +76,7 @@ class DesktopUrlTypePlugin(
         }
     }
 
-    override fun buildTransferable(
+    override suspend fun buildTransferable(
         pasteItem: PasteItem,
         mixedCategory: Boolean,
         map: MutableMap<PasteDataFlavor, Any>,


### PR DESCRIPTION
Closes #4569

## Problem

`ImageHandler.readImage(byteReadChannel: ByteReadChannel)` is a non-suspend method, but ktor's `ByteReadChannel.toByteArray()` is `suspend`, forcing implementations into the `runBlocking { byteReadChannel.toByteArray() }` anti-pattern. The only caller (`OpenGraphService`) runs on a network/IO dispatcher, so this blocks a dispatcher thread and defeats `ByteReadChannel`'s async I/O design. More broadly, all image read/write in `ImageHandler`/`ImageWriter` is blocking I/O exposed through non-suspend signatures.

## Change

Mark all I/O methods of `ImageHandler` and `ImageWriter` `suspend`:

- `ImageWriter.writeImage`
- `ImageHandler.readImage(Path)` / `readImage(Source)` / `readImage(ByteReadChannel)` / `readSize(Path)`

Propagated through the plugin layer (desktop plugins call these):

- `PasteTypePlugin.loadRepresentation` / `doLoadRepresentation` / `buildTransferable` -> `suspend`
- `TransferableConsumer.updatePasteData` -> `suspend` (switches `logExecutionTime` -> existing `logSuspendExecutionTime`)
- All 7 desktop `*TypePlugin` implementations + `DesktopWriteTransferableBuilder` + `DesktopFileExtLoader`
- `DesktopImageHandler.readImage(Source)` decodes directly via `source.asInputStream()` instead of delegating to the now-suspend `ByteReadChannel` overload

Call sites already in suspend contexts need no changes (`OpenGraphService`, `produceState` in `ImageSidePreviewView`, `DesktopTransferableProducer.produce`, `DesktopTransferableConsumer.consume`).

## Mobile follow-up

`commonMain` interface changes sync to the mobile repo. After `syncDesktop`, the android/iOS `ImageHandler`/`ImageWriter`/`PasteTypePlugin` overrides must be marked `suspend` (and `runBlocking` removed from `readImage(ByteReadChannel)`).

## Verification

- `./gradlew ktlintFormat` clean
- `./gradlew :app:compileKotlinDesktop` BUILD SUCCESSFUL
- `./gradlew :app:compileTestKotlinDesktop` BUILD SUCCESSFUL