### PR TITLE
:hammer: group Koin module declarations by sub-domain with regions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ SQLDelight manages database schema in `.sq` files:
 - **UI sizing**: When adding size/dimension constants in UI code, prefer using values defined in `com.crosspaste.ui.theme.AppUISize` instead of inline literal `dp`/`sp` values.
 - **Thread-safe collections**: In `commonMain` code, prefer thread-safe Map/Set from `io.ktor.util.collections` (e.g., `ConcurrentMap`, `ConcurrentSet`) over platform-specific concurrent collections.
 - **Coroutine `delay`**: Always pass a `Duration` to `kotlinx.coroutines.delay`, never a raw number. Write `delay(280L.milliseconds)` / `delay(2.seconds)`, not `delay(280L)` or `delay(2000)`. Add `import kotlin.time.Duration.Companion.milliseconds` (or `.seconds`) as needed. This applies to both production code and tests.
+- **Koin module declaration order**: Inside a Koin `module { }`, declaration order is irrelevant at runtime (`single { }` is lazy and resolved by type — confirmed no `createdAtStart` eager singletons), so order serves readability only. Group bindings by functional sub-domain with `// region <Name>` / `// endregion` markers, and sort alphabetically by bound type within each group. Do not order the whole module strictly alphabetically (it scatters related bindings). Modules that are already cohesive single-responsibility functions need no extra regions.
 
 ## Key Technical Details
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
@@ -95,61 +95,46 @@ fun desktopAppModule(
     platform: Platform,
 ): Module =
     module {
+        // region App
         single<AppControl> { DesktopAppControl(get()) }
         single<AppEnv> { appEnv }
         single<AppExitService> { DesktopAppExitService }
         single<AppInfo> { get<AppInfoFactory>().createAppInfo() }
         single<AppInfoFactory> { DesktopAppInfoFactory(get()) }
-        single<AppMetadataRepository> { appMetadataRepository }
         single<AppLaunchState> { get<DesktopAppLaunchState>() }
         single<AppLock> { get<DesktopAppLaunch>() }
-        single<AppPathProvider> { appPathProvider }
         single<AppRestartService> { DesktopAppRestartService(get(), get()) }
         single<AppStartUpService> { DesktopAppStartUpService(get(), get(), get(), get()) }
-        single<DesktopPidFileService> { DesktopPidFileService(get(), get()) }
-        single<NativeMessagingHostService> { NativeMessagingHostService(get(), get(), get()) }
-        single<UpdateMetadataFetcher> { UpdateMetadataFetcher(get()) }
-        single<WindowsZipUpdater> { WindowsZipUpdater(get(), get(), get(), get(), get(), get()) }
         single<AppUpdateService> { DesktopAppUpdateService(get(), get(), get(), get(), get(), get(), get()) }
         single<AppUrls> { DesktopAppUrls }
         single<ChangelogService> { ChangelogService(get()) }
         single<CrossPasteWebService> { CrossPasteWebService(get(), get()) }
-        single<CacheManager> { DesktopCacheManager(get(), get()) }
-        single<CommonConfigManager> { configManager as CommonConfigManager }
-        single<CrossPasteLogger> { crossPasteLogger }
         single<DesktopAppLaunch> { DesktopAppLaunch(get(), get()) }
         single<DesktopAppLaunchState> { runBlocking { get<DesktopAppLaunch>().launch() } }
-        single<DesktopConfigManager> { configManager }
-        single<DesktopMigration> { DesktopMigration(get(), get(), get(), get()) }
-        single<ModuleDownloadManager> { ModuleDownloadManager(get(), get()) }
-        single<ModuleManager> {
-            val ocrModule = get<com.crosspaste.image.OCRModule>()
-            ModuleManager(
-                mapOf(
-                    ocrModule.moduleId to ocrModule,
-                ),
-            )
-        }
-        single<DeviceUtils> { deviceUtils }
+        single<DesktopPidFileService> { DesktopPidFileService(get(), get()) }
         single<EndpointInfoFactory> { EndpointInfoFactory(get(), lazy { get<Server>() }, get()) }
+        single<NativeMessagingHostService> { NativeMessagingHostService(get(), get(), get()) }
+        single<UpdateMetadataFetcher> { UpdateMetadataFetcher(get()) }
+        single<WindowsZipUpdater> { WindowsZipUpdater(get(), get(), get(), get(), get(), get()) }
+        // endregion
+
+        // region Config
+        single<AppMetadataRepository> { appMetadataRepository }
+        single<CommonConfigManager> { configManager as CommonConfigManager }
+        single<DesktopConfigManager> { configManager }
+        single<ReadWriteConfig<Int>>(named("readWritePort")) { ReadWritePort(get()) }
+        single<SimpleConfigFactory> { DesktopSimpleConfigFactory(get()) }
+        // endregion
+
+        // region Image & Coil
         single<FileExtImageLoader> { DesktopFileExtLoader(get(), get(), get()) }
-        single<FilePersist> { FilePersist }
         single<ImageHandler<BufferedImage>> { DesktopImageHandler }
-        single<MemoryCache> {
-            MemoryCache
-                .Builder()
-                .strongReferencesEnabled(true)
-                .weakReferencesEnabled(true)
-                .maxSizeBytes(256L * 1024L * 1024L)
-                .maxSizePercent(get<PlatformContext>(), 0.85)
-                .build()
-        }
-        single<ImageLoader>(ImageLoaderQualifiers.GENERATE_IMAGE) {
+        single<ImageLoader>(ImageLoaderQualifiers.APP_SOURCE) {
             ImageLoader
                 .Builder(get<PlatformContext>())
                 .components {
-                    add(GenerateImageFactory(get()))
-                        .add(GenerateImageKeyer())
+                    add(AppSourceFactory(get()))
+                        .add(AppSourceKeyer())
                 }.memoryCache { get<MemoryCache>() }
                 .build()
         }
@@ -162,12 +147,12 @@ fun desktopAppModule(
                 }.memoryCache { get<MemoryCache>() }
                 .build()
         }
-        single<ImageLoader>(ImageLoaderQualifiers.APP_SOURCE) {
+        single<ImageLoader>(ImageLoaderQualifiers.GENERATE_IMAGE) {
             ImageLoader
                 .Builder(get<PlatformContext>())
                 .components {
-                    add(AppSourceFactory(get()))
-                        .add(AppSourceKeyer())
+                    add(GenerateImageFactory(get()))
+                        .add(GenerateImageKeyer())
                 }.memoryCache { get<MemoryCache>() }
                 .build()
         }
@@ -180,16 +165,48 @@ fun desktopAppModule(
                 }.memoryCache { get<MemoryCache>() }
                 .build()
         }
+        single<MemoryCache> {
+            MemoryCache
+                .Builder()
+                .strongReferencesEnabled(true)
+                .weakReferencesEnabled(true)
+                .maxSizeBytes(256L * 1024L * 1024L)
+                .maxSizePercent(get<PlatformContext>(), 0.85)
+                .build()
+        }
+        single<ThumbnailLoader> { DesktopThumbnailLoader(get(), get()) }
+        single<VideoThumbnailLoader> { DesktopVideoThumbnailLoader(get(), get()) }
+        // endregion
+
+        // region Module loader
+        single<ModuleDownloadManager> { ModuleDownloadManager(get(), get()) }
+        single<ModuleManager> {
+            val ocrModule = get<com.crosspaste.image.OCRModule>()
+            ModuleManager(
+                mapOf(
+                    ocrModule.moduleId to ocrModule,
+                ),
+            )
+        }
+        // endregion
+
+        // region Path
+        single<AppPathProvider> { appPathProvider }
+        single<DesktopMigration> { DesktopMigration(get(), get(), get(), get()) }
+        single<UserDataPathProvider> { UserDataPathProvider(get(), getPlatformPathProvider(get())) }
+        // endregion
+
+        // region Infra & misc
+        single<AppShareService> { DesktopAppShareService(get(), get(), get(), get()) }
+        single<CacheManager> { DesktopCacheManager(get(), get()) }
+        single<CrossPasteLogger> { crossPasteLogger }
+        single<DeviceUtils> { deviceUtils }
+        single<FilePersist> { FilePersist }
+        single<FontManager> { DesktopFontManager(get()) }
         single<KLogger> { klogger }
         single<LocaleUtils> { DesktopLocaleUtils }
-        single<QRCodeGenerator> { DesktopQRCodeGenerator(get(), get(), get()) }
-        single<ReadWriteConfig<Int>>(named("readWritePort")) { ReadWritePort(get()) }
-        single<AppShareService> { DesktopAppShareService(get(), get(), get(), get()) }
         single<Platform> { platform }
-        single<SimpleConfigFactory> { DesktopSimpleConfigFactory(get()) }
+        single<QRCodeGenerator> { DesktopQRCodeGenerator(get(), get(), get()) }
         single<SyncInfoFactory> { SyncInfoFactory(get(), get()) }
-        single<ThumbnailLoader> { DesktopThumbnailLoader(get(), get()) }
-        single<UserDataPathProvider> { UserDataPathProvider(get(), getPlatformPathProvider(get())) }
-        single<VideoThumbnailLoader> { DesktopVideoThumbnailLoader(get(), get()) }
-        single<FontManager> { DesktopFontManager(get()) }
+        // endregion
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -95,8 +95,8 @@ class DesktopModule(
     // SqlDelight
     override fun sqlDelightModule() =
         module {
-            single<DriverFactory> { DesktopDriverFactory(get()) }
             single<Database> { createDatabase(get()) }
+            single<DriverFactory> { DesktopDriverFactory(get()) }
             single<PasteDao> {
                 SqlPasteDao(
                     appInfo = get(),

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -64,10 +64,8 @@ import org.koin.dsl.module
 
 fun desktopNetworkModule(marketingMode: Boolean): Module =
     module {
-        single<ExceptionHandler> { DesktopExceptionHandler() }
-        single<FaviconLoader> { DesktopFaviconLoader(get(), get()) }
+        // region MCP
         single<McpResourceProvider> { McpResourceProvider(get(), get()) }
-        single<McpToolProvider> { McpToolProvider(get(), get(), get(), get(), get(), get()) }
         single<McpServer> {
             DesktopMcpServer(
                 mcpPort = (get<DesktopConfigManager>().getCurrentConfig()).mcpServerPort,
@@ -75,13 +73,13 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 mcpResourceProvider = get(),
             )
         }
-        single<NearbyDeviceManager> {
-            if (marketingMode) {
-                MarketingNearbyDeviceManager()
-            } else {
-                GeneralNearbyDeviceManager(get(), get(), get(), get())
-            }
-        }
+        single<McpToolProvider> { McpToolProvider(get(), get(), get(), get(), get(), get()) }
+        // endregion
+
+        // region Network core
+        single<ExceptionHandler> { DesktopExceptionHandler() }
+        single<NetworkInterfaceService> { DesktopNetworkInterfaceService(get(), get()) }
+        single<NetworkProfileService> { DesktopNetworkProfileService(get(), get(), get(), get()) }
         single<NetworkStateMonitor> {
             val platform = get<Platform>()
             when {
@@ -91,29 +89,21 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 else -> NoopNetworkStateMonitor()
             }
         }
-        single<NetworkInterfaceService> { DesktopNetworkInterfaceService(get(), get()) }
-        single<NetworkProfileService> { DesktopNetworkProfileService(get(), get(), get(), get()) }
-        single<ResourcesClient> { DesktopResourcesClient(get(), get()) }
         single<PasteBonjourService> { DesktopPasteBonjourService(get(), get(), get(), get()) }
-        single<PendingKeyExchangeStore> { PendingKeyExchangeStore() }
-        single<PushSessionManager> {
-            PushSessionManager(
-                pasteDao = get(),
-                pasteboardService = get(),
-            )
-        }
+        single<TelnetHelper> { TelnetHelper(get(), get(), get(), get()) }
+        // endregion
+
+        // region HTTP client & API
+        single<FaviconLoader> { DesktopFaviconLoader(get(), get()) }
         single<PasteClient> { PasteClient(get(), get(), get()) }
+        single<PasteClientApi> { PasteClientApi(get(), get()) }
         single<PullClientApi> { PullClientApi(get(), get(), get()) }
         single<PushClientApi> { PushClientApi(get(), get(), get()) }
-        single<PasteClientApi> { PasteClientApi(get(), get()) }
-        single<FilePushService> {
-            FilePushService(
-                pasteSyncProcessManager = get(),
-                pushClientApi = get(),
-                userDataPathProvider = get(),
-            )
-        }
-        single<SharePushOrchestrator> { SharePushOrchestrator(get(), get(), get()) }
+        single<ResourcesClient> { DesktopResourcesClient(get(), get()) }
+        single<SyncClientApi> { SyncClientApi(get(), get(), get(), get(), get()) }
+        // endregion
+
+        // region Server
         single<Server> {
             DesktopPasteServer(
                 get(named("readWritePort")),
@@ -124,39 +114,6 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
         }
         single<ServerFactory<NettyApplicationEngine, NettyApplicationEngine.Configuration>> {
             DesktopServerFactory()
-        }
-        single<WsSessionManager> {
-            WsSessionManager()
-        }
-        single<WsPendingRequests> {
-            WsPendingRequests()
-        }
-        single<WsMessageHandler> {
-            WsMessageHandler(
-                lazyAppControl = lazy { get() },
-                lazyCacheManager = lazy { get() },
-                lazyPasteDao = lazy { get() },
-                lazyPasteboardService = lazy { get() },
-                lazySyncRoutingApi = lazy { get() },
-                secureStore = get(),
-                userDataPathProvider = get(),
-                wsPendingRequests = get(),
-                wsSessionManager = get(),
-            )
-        }
-        single<WsClientConnector> {
-            val wsHttpClient =
-                HttpClient(CIO) {
-                    install(WebSockets) {
-                        pingIntervalMillis = 30_000
-                    }
-                }
-            WsClientConnector(
-                appInfo = get(),
-                client = wsHttpClient,
-                wsSessionManager = get(),
-                wsMessageHandler = get(),
-            )
         }
         single<ServerModule> {
             DesktopServerModule(
@@ -187,7 +144,76 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
             )
         }
         single<SyncApi> { SyncApi }
-        single<SyncClientApi> { SyncClientApi(get(), get(), get(), get(), get()) }
+        single<SyncRoutingApi> { get<SyncManager>() }
+        // endregion
+
+        // region WebSocket
+        single<WsClientConnector> {
+            val wsHttpClient =
+                HttpClient(CIO) {
+                    install(WebSockets) {
+                        pingIntervalMillis = 30_000
+                    }
+                }
+            WsClientConnector(
+                appInfo = get(),
+                client = wsHttpClient,
+                wsSessionManager = get(),
+                wsMessageHandler = get(),
+            )
+        }
+        single<WsMessageHandler> {
+            WsMessageHandler(
+                lazyAppControl = lazy { get() },
+                lazyCacheManager = lazy { get() },
+                lazyPasteDao = lazy { get() },
+                lazyPasteboardService = lazy { get() },
+                lazySyncRoutingApi = lazy { get() },
+                secureStore = get(),
+                userDataPathProvider = get(),
+                wsPendingRequests = get(),
+                wsSessionManager = get(),
+            )
+        }
+        single<WsPendingRequests> {
+            WsPendingRequests()
+        }
+        single<WsSessionManager> {
+            WsSessionManager()
+        }
+        // endregion
+
+        // region Sync & devices
+        single<FilePushService> {
+            FilePushService(
+                pasteSyncProcessManager = get(),
+                pushClientApi = get(),
+                userDataPathProvider = get(),
+            )
+        }
+        single<NearbyDeviceManager> {
+            if (marketingMode) {
+                MarketingNearbyDeviceManager()
+            } else {
+                GeneralNearbyDeviceManager(get(), get(), get(), get())
+            }
+        }
+        single<PendingKeyExchangeStore> { PendingKeyExchangeStore() }
+        single<PushSessionManager> {
+            PushSessionManager(
+                pasteDao = get(),
+                pasteboardService = get(),
+            )
+        }
+        single<SharePushOrchestrator> { SharePushOrchestrator(get(), get(), get()) }
+        single<SyncDeviceManager> {
+            SyncDeviceManager(
+                secureStore = get(),
+                syncClientApi = get(),
+                syncRuntimeInfoDao = get(),
+                wsSessionManager = get(),
+            )
+        }
         single<SyncManager> {
             if (marketingMode) {
                 MarketingSyncManager()
@@ -198,14 +224,6 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                     wsSessionManager = get(),
                 )
             }
-        }
-        single<SyncDeviceManager> {
-            SyncDeviceManager(
-                secureStore = get(),
-                syncClientApi = get(),
-                syncRuntimeInfoDao = get(),
-                wsSessionManager = get(),
-            )
         }
         single<SyncResolverApi> {
             SyncResolver(
@@ -227,6 +245,5 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 wsSessionManager = get(),
             )
         }
-        single<SyncRoutingApi> { get<SyncManager>() }
-        single<TelnetHelper> { TelnetHelper(get(), get(), get(), get()) }
+        // endregion
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
@@ -73,61 +73,8 @@ import java.awt.image.BufferedImage
 
 fun desktopPasteComponentModule(headless: Boolean): Module =
     module {
-        single<CleanScheduler> { CleanScheduler(get(), get(), get()) }
+        // region Pasteboard & transfer
         single<CurrentPaste> { DesktopCurrentPaste(lazy { get() }) }
-        single<RenderingService<String>>(named("urlRendering")) {
-            OpenGraphService(get(), get<ImageHandler<BufferedImage>>(), get(), get(), get())
-        }
-        single<DesktopPasteMenuService> {
-            DesktopPasteMenuService(
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-            )
-        }
-        single<DesktopPasteTagMenuService> {
-            DesktopPasteTagMenuService(get(), get())
-        }
-        single<FilePullService> { FilePullService(get(), get(), get(), get(), get(), get()) }
-        single<PastePullService> { PastePullService(get(), get(), get(), get()) }
-        single<PasteReleaseService> {
-            PasteReleaseService(
-                commonConfigManager = get(),
-                currentPaste = get(),
-                database = get(),
-                pasteDao = get(),
-                pasteItemReader = get(),
-                pasteProcessPlugins =
-                    listOf(
-                        RemoveInvalidPlugin,
-                        DistinctPlugin(get()),
-                        GenerateTextPlugin(get()),
-                        GenerateUrlPlugin,
-                        TextToColorPlugin,
-                        FilesToImagesPlugin(get()),
-                        FileToUrlPlugin(get()),
-                        RemoveFolderImagePlugin(get()),
-                        RemoveHtmlImagePlugin(get()),
-                        SortPlugin,
-                    ),
-                searchContentService = get(),
-                taskSubmitter = get(),
-                userDataPathProvider = get(),
-            )
-        }
-        single<GenerateImageService> { GenerateImageService() }
-        single<GuidePasteDataService> { DesktopGuidePasteDataService(get(), get(), get(), get(), get(), get()) }
         single<DesktopSourceExclusionService> { DesktopSourceExclusionService(get()) }
         single<PasteboardService> {
             if (headless) {
@@ -148,34 +95,6 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
                 )
             }
         }
-        single<PasteExportParamFactory<Path>> { DesktopPasteExportParamFactory() }
-        single<PasteExportService> { PasteExportService(get(), get(), get()) }
-        single<PasteImportParamFactory<Path>> { DesktopPasteImportParamFactory() }
-        single<PasteImportService> { PasteImportService(get(), get(), get(), get(), get()) }
-        single<PasteSyncProcessManager<Long>> { DefaultPasteSyncProcessManager() }
-        single<PasteItemReader> { DefaultPasteItemReader() }
-        single<PasteDataHelper> { PasteDataHelper(get()) }
-        single<SearchContentService> { DesktopSearchContentService() }
-        single<TaskExecutor> {
-            TaskExecutor(
-                listOf(
-                    CleanPasteTaskExecutor(get(), get()),
-                    CleanTaskTaskExecutor(get()),
-                    DelayedDeletePasteTaskExecutor(get()),
-                    DeletePasteTaskExecutor(get()),
-                    OpenGraphTaskExecutor(
-                        lazy { get<RenderingService<String>>(named("urlRendering")) },
-                        get(),
-                    ),
-                    PullFileTaskExecutor(get(), get(), get(), get(), get(), get()),
-                    PullIconTaskExecutor(get(), get(), get(), get()),
-                    SwitchLanguageTaskExecutor(get(), get()),
-                    SyncPasteTaskExecutor(get(), get(), get(), get(), get(), get(), get(), get()),
-                ),
-                get(),
-            )
-        }
-        single<TaskSubmitter> { DesktopTaskSubmitter(get(), get(), get(), lazy { get() }) }
         single<TransferableConsumer> {
             DesktopTransferableConsumer(
                 get(),
@@ -204,7 +123,108 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
                 ),
             )
         }
+        // endregion
+
+        // region Paste menu
+        single<DesktopPasteMenuService> {
+            DesktopPasteMenuService(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+            )
+        }
+        single<DesktopPasteTagMenuService> {
+            DesktopPasteTagMenuService(get(), get())
+        }
+        // endregion
+
+        // region Import & Export
+        single<PasteExportParamFactory<Path>> { DesktopPasteExportParamFactory() }
+        single<PasteExportService> { PasteExportService(get(), get(), get()) }
+        single<PasteImportParamFactory<Path>> { DesktopPasteImportParamFactory() }
+        single<PasteImportService> { PasteImportService(get(), get(), get(), get(), get()) }
+        // endregion
+
+        // region Paste data & items
+        single<GuidePasteDataService> { DesktopGuidePasteDataService(get(), get(), get(), get(), get(), get()) }
+        single<PasteDataHelper> { PasteDataHelper(get()) }
+        single<PasteItemReader> { DefaultPasteItemReader() }
+        single<PasteReleaseService> {
+            PasteReleaseService(
+                commonConfigManager = get(),
+                currentPaste = get(),
+                database = get(),
+                pasteDao = get(),
+                pasteItemReader = get(),
+                pasteProcessPlugins =
+                    listOf(
+                        RemoveInvalidPlugin,
+                        DistinctPlugin(get()),
+                        GenerateTextPlugin(get()),
+                        GenerateUrlPlugin,
+                        TextToColorPlugin,
+                        FilesToImagesPlugin(get()),
+                        FileToUrlPlugin(get()),
+                        RemoveFolderImagePlugin(get()),
+                        RemoveHtmlImagePlugin(get()),
+                        SortPlugin,
+                    ),
+                searchContentService = get(),
+                taskSubmitter = get(),
+                userDataPathProvider = get(),
+            )
+        }
+        single<PasteSyncProcessManager<Long>> { DefaultPasteSyncProcessManager() }
+        single<SearchContentService> { DesktopSearchContentService() }
         single<UpdatePasteItemHelper> {
             UpdatePasteItemHelper(get(), get(), get())
         }
+        // endregion
+
+        // region Sync pull
+        single<FilePullService> { FilePullService(get(), get(), get(), get(), get(), get()) }
+        single<PastePullService> { PastePullService(get(), get(), get(), get()) }
+        // endregion
+
+        // region Tasks
+        single<TaskExecutor> {
+            TaskExecutor(
+                listOf(
+                    CleanPasteTaskExecutor(get(), get()),
+                    CleanTaskTaskExecutor(get()),
+                    DelayedDeletePasteTaskExecutor(get()),
+                    DeletePasteTaskExecutor(get()),
+                    OpenGraphTaskExecutor(
+                        lazy { get<RenderingService<String>>(named("urlRendering")) },
+                        get(),
+                    ),
+                    PullFileTaskExecutor(get(), get(), get(), get(), get(), get()),
+                    PullIconTaskExecutor(get(), get(), get(), get()),
+                    SwitchLanguageTaskExecutor(get(), get()),
+                    SyncPasteTaskExecutor(get(), get(), get(), get(), get(), get(), get(), get()),
+                ),
+                get(),
+            )
+        }
+        single<TaskSubmitter> { DesktopTaskSubmitter(get(), get(), get(), lazy { get() }) }
+        // endregion
+
+        // region Misc
+        single<CleanScheduler> { CleanScheduler(get(), get(), get()) }
+        single<GenerateImageService> { GenerateImageService() }
+        single<RenderingService<String>>(named("urlRendering")) {
+            OpenGraphService(get(), get<ImageHandler<BufferedImage>>(), get(), get(), get())
+        }
+        // endregion
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
@@ -58,43 +58,44 @@ import org.koin.dsl.module
 
 fun desktopUiModule(): Module =
     module {
-        single<ActiveGraphicsDevice> { get<DesktopAppSize>() }
+        // region App & window
         single<AppFileChooser> { DesktopAppFileChooser(get()) }
         single<AppSize> { get<DesktopAppSize>() }
-        single<AppSourceIconTransformer> { DefaultAppSourceIconTransformer }
         single<AppTokenApi> { DesktopAppTokenService(get(), get()) }
         single<AppWindowManager> { get<DesktopAppWindowManager>() }
         single<DesktopAppSize> { DesktopAppSize(get()) }
         single<DesktopAppWindowManager> {
             getDesktopAppWindowManager(get(), get(), lazy { get() }, lazy { get() }, lazy { get() }, get(), get())
         }
-        single<DesktopIconColorExtractor> { DesktopIconColorExtractor(get()) }
-        single<DesktopScreenProvider> { DesktopScreenProvider(get(), get(), get(), get(), get(), get()) }
+        single<RatingPromptManager> { DesktopRatingPromptManager() }
+        single<UserAttentionService> { DesktopUserAttentionService(get<DesktopAppWindowManager>()) }
+        // endregion
+
+        // region Input & listeners
+        single<ActiveGraphicsDevice> { get<DesktopAppSize>() }
         single<DesktopShortcutKeysListener> { DesktopShortcutKeysListener(get(), get()) }
-        single<DeviceScopeFactory> { DesktopDeviceScopeFactory() }
-        single<GlobalCopywriter> { DesktopGlobalCopywriter(get(), lazy { get() }, get()) }
         single<GlobalListener> { DesktopGlobalListener(get(), get(), get(), get()) }
-        single<MenuHelper> { MenuHelper(get(), get(), get(), get(), get(), get()) }
-        single<NavigationManager> { get<DesktopScreenProvider>() }
         single<NativeKeyListener> { get<DesktopShortcutKeysListener>() }
         single<NativeMouseListener> { get<DesktopAppSize>() }
-        single<NotificationManager> { DesktopNotificationManager(get(), get(), get(), get()) }
-        single<PlatformContext> { PlatformContext.INSTANCE }
-        single<RatingPromptManager> { DesktopRatingPromptManager() }
-        single<ScreenProvider> { get<DesktopScreenProvider>() }
         single<ShortcutKeys> { DesktopShortcutKeys(get(), get(), get()) }
         single<ShortcutKeysAction> {
             DesktopShortKeysAction(get(), get(), get(), get(), get(), get(), get())
         }
         single<ShortcutKeysListener> { get<DesktopShortcutKeysListener>() }
         single<ShortcutKeysLoader> { DesktopShortcutKeysLoader(get(), get()) }
+        // endregion
+
+        // region UI screens & navigation
+        single<DesktopScreenProvider> { DesktopScreenProvider(get(), get(), get(), get(), get(), get()) }
+        single<DeviceScopeFactory> { DesktopDeviceScopeFactory() }
+        single<GlobalCopywriter> { DesktopGlobalCopywriter(get(), lazy { get() }, get()) }
+        single<MenuHelper> { MenuHelper(get(), get(), get(), get(), get(), get()) }
+        single<NavigationManager> { get<DesktopScreenProvider>() }
+        single<ScreenProvider> { get<DesktopScreenProvider>() }
         single<SmartImageDisplayStrategy> { SmartImageDisplayStrategy() }
-        single<UserAttentionService> { DesktopUserAttentionService(get<DesktopAppWindowManager>()) }
-        single<SoundService> { DesktopSoundService(get()) }
         single<StoragePathManager> { DesktopStoragePathManager() }
         single<SyncScopeFactory> { DesktopSyncScopeFactory() }
         single<ThemeDetector> { DesktopThemeDetector(get()) }
-        single<TokenCacheApi> { TokenCache }
         single<UISupport> {
             DesktopUISupport(
                 get(),
@@ -106,4 +107,14 @@ fun desktopUiModule(): Module =
                 get<DesktopAppWindowManager>(),
             )
         }
+        // endregion
+
+        // region Misc
+        single<AppSourceIconTransformer> { DefaultAppSourceIconTransformer }
+        single<DesktopIconColorExtractor> { DesktopIconColorExtractor(get()) }
+        single<NotificationManager> { DesktopNotificationManager(get(), get(), get(), get()) }
+        single<PlatformContext> { PlatformContext.INSTANCE }
+        single<SoundService> { DesktopSoundService(get()) }
+        single<TokenCacheApi> { TokenCache }
+        // endregion
     }


### PR DESCRIPTION
Closes #4572

## What

Reorganize the desktop Koin DI module declarations for readability:

- Group `single<...>` bindings by **functional sub-domain** with `// region` / `// endregion` markers, sorted **alphabetically by bound type** within each group.
- `DesktopAppModule`: App / Config / Image & Coil / Module loader / Path / Infra & misc
- `DesktopNetworkModule`: MCP / Network core / HTTP client & API / Server / WebSocket / Sync & devices
- `DesktopUiModule`: App & window / Input & listeners / UI screens & navigation / Misc
- `DesktopPasteComponentModule`: Pasteboard & transfer / Paste menu / Import & Export / Paste data & items / Sync pull / Tasks / Misc
- `DesktopModule`: already split into cohesive per-responsibility module functions; only alphabetized `Database` / `DriverFactory` in `sqlDelightModule`
- Documented the convention in `CLAUDE.md` (Code Style).

## Why it's safe (no behavior change)

Inside a Koin `module { }`, declaration order is irrelevant at runtime: `single { }` is lazy and resolved by type, and there are no `createdAtStart` eager singletons (`grep -rn createdAtStart` -> no matches). This is a pure readability change.

Verified mechanically: for each reordered file, the set of `single<...>` bindings and the set of non-comment lines are **byte-identical** to `main` aside from ordering and added comments.

## Review summary

Independent strict review (cold-read of `git diff main..HEAD`): **no P0/P1**. Confirmed binding sets equivalent, the four `single<ImageLoader>` are distinct qualifiers (not last-wins overrides), and the `createdAtStart` claim holds.

- One **P3** (informational, not introduced by this PR): `single<DesktopAppLaunchState> { runBlocking { ... launch() } }` contains a blocking side effect in its provider lambda. Deliberately **left out of this refactor** to keep it pure; tracked separately for the startup `runBlocking` cleanup batch.

## Test

- `:app:ktlintDesktopMainSourceSetCheck` — pass
- `:app:compileKotlinDesktop` — pass
- `:app:desktopTest` — BUILD SUCCESSFUL

(Note: a pre-existing `:shared` ktlint failure lives in untracked generated SQLDelight code under `build/`, unrelated to this change.)