### PR TITLE
:hammer: remove runBlocking from DesktopAppLaunchState DI assembly

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
@@ -77,7 +77,6 @@ import com.crosspaste.utils.DesktopLocaleUtils
 import com.crosspaste.utils.DeviceUtils
 import com.crosspaste.utils.LocaleUtils
 import io.github.oshai.kotlinlogging.KLogger
-import kotlinx.coroutines.runBlocking
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -110,7 +109,7 @@ fun desktopAppModule(
         single<ChangelogService> { ChangelogService(get()) }
         single<CrossPasteWebService> { CrossPasteWebService(get(), get()) }
         single<DesktopAppLaunch> { DesktopAppLaunch(get(), get()) }
-        single<DesktopAppLaunchState> { runBlocking { get<DesktopAppLaunch>().launch() } }
+        single<DesktopAppLaunchState> { get<DesktopAppLaunch>().launchSync() }
         single<DesktopPidFileService> { DesktopPidFileService(get(), get()) }
         single<EndpointInfoFactory> { EndpointInfoFactory(get(), lazy { get<Server>() }, get()) }
         single<NativeMessagingHostService> { NativeMessagingHostService(get(), get(), get()) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppLaunch.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppLaunch.kt
@@ -94,7 +94,9 @@ class DesktopAppLaunch(
         resetLock = true
     }
 
-    override suspend fun launch(): DesktopAppLaunchState {
+    override suspend fun launch(): DesktopAppLaunchState = launchSync()
+
+    fun launchSync(): DesktopAppLaunchState {
         val appLockState = acquireLock()
         val pid = ProcessHandle.current().pid()
         val acquiredLock = appLockState.acquiredLock

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppLaunch.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppLaunch.kt
@@ -94,6 +94,10 @@ class DesktopAppLaunch(
         resetLock = true
     }
 
+    // Kept only to satisfy the shared commonMain AppLaunch interface, whose launch() is
+    // suspend so mobile platforms can perform suspending work during launch. The desktop
+    // launch path is fully synchronous and does not use this method: DI and callers invoke
+    // launchSync() directly, avoiding the runBlocking that would otherwise be needed here.
     override suspend fun launch(): DesktopAppLaunchState = launchSync()
 
     fun launchSync(): DesktopAppLaunchState {


### PR DESCRIPTION
Closes #4574

## What

Remove the `runBlocking` from the Koin desktop module that assembled `DesktopAppLaunchState` during DI resolution.

- `DesktopAppModule.kt`: `single<DesktopAppLaunchState> { runBlocking { get<DesktopAppLaunch>().launch() } }` → `single<DesktopAppLaunchState> { get<DesktopAppLaunch>().launchSync() }`
- `DesktopAppLaunch.kt`: extract the body into a non-suspend `launchSync()`; the `suspend fun launch()` override now delegates to it.

Net diff: 2 files, +4 / -3.

## Why it's behavior-preserving

`launchSync()` is byte-for-byte the old `launch()` body. Every call inside it is synchronous (`acquireLock()` / `FileChannel`, `MacAppUtils.checkAccessibilityPermissions()` / JNI, `isInstalledFromMicrosoftStore()` / path comparison, `StateFlow.value =`). The original `runBlocking` only bridged a `suspend` signature that never suspends, so removing it changes nothing semantically while eliminating the blocking call at DI assembly time.

The shared `commonMain` `AppLaunch.launch()` interface stays `suspend` (kept for the mobile projects); the desktop override remains and just delegates to `launchSync()`.

## Review summary

Independent strict review found **no P0/P1** issues. Behavior equivalence, the unbroken `commonMain`/mobile interface contract, the absence of any other caller depending on the old `suspend` semantics, and the lack of concurrency/init-order regressions were all confirmed. Two P3 notes were raised and accepted as-is:

- `suspend fun launch()` is now a dead method on desktop, kept solely to satisfy the shared interface — intentional, do not remove.
- `launchSync()` is `public` because the Koin factory lambda needs access — acceptable.

## Testing

`./gradlew app:desktopTest` → BUILD SUCCESSFUL (full desktop suite green).