### PR TITLE
:bug: capture network errors in ResourcesClient.request() instead of throwing

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/AbstractResourcesClient.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/AbstractResourcesClient.kt
@@ -11,6 +11,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.isSuccess
 import okio.Path
+import kotlin.coroutines.cancellation.CancellationException
 
 abstract class AbstractResourcesClient(
     val userDataPathProvider: UserDataPathProvider,
@@ -76,15 +77,23 @@ abstract class AbstractResourcesClient(
             }
     }
 
-    override suspend fun request(url: String): Result<ClientResponse> {
-        val response = clientRequest(url, getHttpClient())
-        return if (response.status.isSuccess()) {
-            Result.success(ClientResponse(response))
-        } else {
-            logger.warn { "Failed to fetch data from $url, status code: ${response.status.value}" }
-            Result.failure(kotlin.Exception("HTTP error: ${response.status.value}"))
+    override suspend fun request(url: String): Result<ClientResponse> =
+        runCatching {
+            val response = clientRequest(url, getHttpClient())
+            if (response.status.isSuccess()) {
+                ClientResponse(response)
+            } else {
+                logger.warn { "Failed to fetch data from $url, status code: ${response.status.value}" }
+                throw kotlin.Exception("HTTP error: ${response.status.value}")
+            }
+        }.onFailure { e ->
+            // Network/TLS failures (e.g. SunCertPathBuilderException behind a
+            // TLS-intercepting proxy) must surface as Result.failure, not propagate:
+            // callers rely on getOrNull()/onSuccess, and an escaping throw here would
+            // crash the periodic update-check coroutine for the whole session.
+            if (e is CancellationException) throw e
+            logger.warn(e) { "Failed to request $url" }
         }
-    }
 
     abstract suspend fun clientRequest(
         url: String,

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/AbstractResourcesClientTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/AbstractResourcesClientTest.kt
@@ -1,0 +1,91 @@
+package com.crosspaste.net
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Guards [AbstractResourcesClient.request]'s failure contract: it returns
+ * Result<ClientResponse> and must never let a network/TLS exception escape, or it
+ * would crash the caller's coroutine (e.g. the periodic update-check loop). The
+ * one exception is [CancellationException], which must propagate so structured
+ * concurrency cancellation keeps working — critical for the shared Android/iOS code.
+ */
+class AbstractResourcesClientTest {
+
+    /** Drives [clientRequest] from a lambda so each test can throw or respond at will. */
+    private class FakeResourcesClient(
+        private val httpClient: HttpClient,
+        private val onRequest: suspend (String, HttpClient) -> HttpResponse,
+    ) : AbstractResourcesClient(mockk(relaxed = true)) {
+
+        override val logger = KotlinLogging.logger {}
+
+        override fun getHttpClient(): HttpClient = httpClient
+
+        override suspend fun clientRequest(
+            url: String,
+            client: HttpClient,
+        ): HttpResponse = onRequest(url, client)
+    }
+
+    private fun mockClient(status: HttpStatusCode = HttpStatusCode.OK): HttpClient =
+        HttpClient(MockEngine { respond("body", status) })
+
+    @Test
+    fun `network exception surfaces as failure instead of throwing`() =
+        runBlocking {
+            val boom = IllegalStateException("unable to find valid certification path to requested target")
+            val client = FakeResourcesClient(mockClient()) { _, _ -> throw boom }
+
+            val result = client.request("https://example.test/meta.json")
+
+            assertTrue(result.isFailure)
+            assertSame(boom, result.exceptionOrNull())
+        }
+
+    @Test
+    fun `cancellation is re-thrown, not captured into the result`() =
+        runBlocking {
+            val client =
+                FakeResourcesClient(mockClient()) { _, _ -> throw CancellationException("scope cancelled") }
+
+            assertFailsWith<CancellationException> {
+                client.request("https://example.test/meta.json")
+            }
+            Unit
+        }
+
+    @Test
+    fun `non-success status returns failure`() =
+        runBlocking {
+            val client =
+                FakeResourcesClient(mockClient(HttpStatusCode.InternalServerError)) { url, http -> http.get(url) }
+
+            val result = client.request("https://example.test/meta.json")
+
+            assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun `success status returns success`() =
+        runBlocking {
+            val client =
+                FakeResourcesClient(mockClient(HttpStatusCode.OK)) { url, http -> http.get(url) }
+
+            val result = client.request("https://example.test/meta.json")
+
+            assertTrue(result.isSuccess)
+        }
+}


### PR DESCRIPTION
Closes #4576

## Problem

`AbstractResourcesClient.request()` returns `Result<ClientResponse>` but only handled HTTP status codes — exceptions thrown during the request itself (TLS handshake, DNS, connect) propagated out instead of becoming `Result.failure`.

This silently disabled the periodic update check for the whole session: `DesktopAppUpdateService.startPeriodicUpdateCheck()` runs `launch { while (true) { checkForUpdate(); delay(2h) } }`, so a `SunCertPathBuilderException` (e.g. behind a TLS-intercepting proxy) escaping `checkForUpdate()` killed the `while (true)` coroutine permanently and logged "Unhandled exception in DesktopAppUpdateService". The same latent crash path existed for `OpenGraphService`, `DesktopFaviconLoader`, and `WindowsZipUpdater`.

## Fix

- Wrap `clientRequest()` in `runCatching` so connection/TLS exceptions surface as `Result.failure`, matching the contract all callers already rely on (`getOrNull()` / `onSuccess`).
- Re-throw `CancellationException` so structured-concurrency cancellation keeps working — important for the shared Android/iOS code that reuses this `commonMain` class.

## Tests

New `AbstractResourcesClientTest` (4 cases, all passing):
- network exception surfaces as `failure` instead of throwing
- `CancellationException` is re-thrown, not captured into the result
- non-success HTTP status returns `failure` (unchanged behavior)
- success HTTP status returns `success` (unchanged behavior)

`ktlintFormat`, `:app:compileKotlinDesktop`, and `:app:desktopTest` all pass.