### PR TITLE
:bug: lower WindowsProcessUtils version-resource log from error to debug

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowsProcessUtils.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/WindowsProcessUtils.kt
@@ -99,10 +99,10 @@ object WindowsProcessUtils {
                             return lplpBuffer.value.getWideString(0)
                         }
                     } else {
-                        logger.error { "FileDescription GetLastError ${Kernel32.INSTANCE.GetLastError()}" }
+                        logger.debug { "FileDescription GetLastError ${Kernel32.INSTANCE.GetLastError()}" }
                     }
                 } else {
-                    logger.error { "Translation GetLastError ${Kernel32.INSTANCE.GetLastError()}" }
+                    logger.debug { "Translation GetLastError ${Kernel32.INSTANCE.GetLastError()}" }
                 }
             }
         }


### PR DESCRIPTION
## Summary

`WindowsProcessUtils` logs `FileDescription GetLastError 1813` at **error** level when reading a process's version resource fails. Error 1813 is `ERROR_RESOURCE_TYPE_NOT_FOUND`, which simply means the target process exe has no version resource block — a normal, expected case (common for system or third-party processes). Logging it at error level pollutes the logs.

This lowers both the `FileDescription` and the adjacent `Translation` `GetLastError` messages from `error` to `debug`.

## Changes
- `WindowsProcessUtils.kt`: `logger.error` → `logger.debug` for the two version-resource lookup failure messages.

No behavior change beyond log level.