### PR TITLE
:bug: replace deprecated wmic with registry MachineGuid for Windows device UUID

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/utils/DeviceUtils.desktop.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/utils/DeviceUtils.desktop.kt
@@ -2,11 +2,11 @@ package com.crosspaste.utils
 
 import com.crosspaste.platform.Platform
 import com.crosspaste.platform.macos.MacDeviceUtils
+import com.sun.jna.platform.win32.Advapi32Util
 import com.sun.jna.platform.win32.Kernel32Util
+import com.sun.jna.platform.win32.WinReg
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.io.BufferedReader
 import java.io.File
-import java.io.InputStreamReader
 import java.net.InetAddress
 import java.util.UUID
 
@@ -36,26 +36,28 @@ object WindowsDeviceUtils : DeviceUtils {
 
     private val logger = KotlinLogging.logger {}
 
-    private fun getProductUUID(): String? {
+    // HKLM\SOFTWARE\Microsoft\Cryptography\MachineGuid is a stable per-OS-install
+    // identifier present on every supported Windows version. It replaces the
+    // deprecated `wmic csproduct get UUID`, which is removed on Windows 11 24H2+.
+    private const val CRYPTOGRAPHY_KEY = "SOFTWARE\\Microsoft\\Cryptography"
+    private const val MACHINE_GUID_VALUE = "MachineGuid"
+
+    private fun getMachineGuid(): String? =
         runCatching {
-            val command = listOf("wmic", "csproduct", "get", "UUID")
-            val process = ProcessBuilder(command).start()
-            val reader = BufferedReader(InputStreamReader(process.inputStream))
-            var line: String
-            while (reader.readLine().also { line = it } != null) {
-                if (line.trim { it <= ' ' }.isNotEmpty() && line.trim { it <= ' ' } != "UUID") {
-                    return line.trim { it <= ' ' }
-                }
-            }
+            Advapi32Util
+                .registryGetStringValue(
+                    WinReg.HKEY_LOCAL_MACHINE,
+                    CRYPTOGRAPHY_KEY,
+                    MACHINE_GUID_VALUE,
+                ).trim()
+                .takeIf { it.isNotEmpty() }
         }.onFailure { e ->
-            logger.error(e) { "Failed to get product UUID" }
-        }
-        return null
-    }
+            logger.warn(e) { "Failed to read MachineGuid from registry" }
+        }.getOrNull()
 
-    override fun createAppInstanceId(): String = getProductUUID() ?: UUID.randomUUID().toString()
+    override fun createAppInstanceId(): String = getMachineGuid() ?: UUID.randomUUID().toString()
 
-    override fun getDeviceId(): String = getProductUUID() ?: "Unknown"
+    override fun getDeviceId(): String = getMachineGuid() ?: "Unknown"
 
     override fun getDeviceName(): String = Kernel32Util.getComputerName()
 }


### PR DESCRIPTION
Closes #4579

## What

`WindowsDeviceUtils` read the device UUID via `wmic csproduct get UUID`. `wmic` is removed on Windows 11 24H2+, so `getDeviceId()` returned `"Unknown"` there. This reads `HKLM\SOFTWARE\Microsoft\Cryptography\MachineGuid` via JNA `Advapi32Util` instead — no subprocess, available on every supported Windows version.

Single file changed: `app/src/desktopMain/kotlin/com/crosspaste/utils/DeviceUtils.desktop.kt`.

## Review summary

Independent strict review found **no P0/P1**. Three informational findings, all accepted as-is:

- **(P2) `appInstanceId` source change** — `MachineGuid` is per-OS-install, not per-hardware; a Windows reinstall resets it (SMBIOS UUID did not). Accepted: trust is anchored on ECDH/`appInstanceId`, not `deviceId`; existing installs keep their persisted `appInstanceId`.
- **(P2) `deviceId` changes once on upgrade** for older Windows that could still run `wmic`, triggering one benign connect-modified re-sync. No data loss.
- **(P3) registry-read failure still falls back to `"Unknown"`** — pre-existing behavior; `MachineGuid` is more reliable than the old subprocess, so failures are less likely, not more.

Bonus: the old `wmic` reader never closed `process.inputStream`; the new implementation has no subprocess and removes that stream/process leak.

## Out of scope

`WinProcessUtils.kt` also uses `wmic process ...` for child-process enumeration and breaks the same way on 24H2+. Tracked separately (not in this PR).

## Testing

- `./gradlew :app:compileKotlinDesktop` — BUILD SUCCESSFUL
- `./gradlew :app:desktopTest` — BUILD SUCCESSFUL (no regressions)
- Registry path is Windows-only and not exercisable from the macOS/Linux `desktopTest` runner; verified by review of JNA `Advapi32Util` semantics (returns `""` not null on missing value, throws `Win32Exception` caught by `runCatching` when key/value absent).