### PR TITLE
:sparkles: add Linux aarch64 (ARM64) build target

### DIFF
--- a/.github/scripts/package_appimage.sh
+++ b/.github/scripts/package_appimage.sh
@@ -1,70 +1,101 @@
 #!/bin/bash
 set -e
 
-# 1. Define variables
+# Build an AppImage for every Linux tarball Conveyor produced under output/.
+# Conveyor emits one tarball per Linux machine, named
+#   crosspaste-<version>-linux-<arch>.tar.gz   (arch = amd64 | aarch64)
+# so we iterate the known arches instead of assuming a single amd64 archive.
+#
+# The build runs on an x86_64 runner: the x86_64 appimagetool can package a
+# foreign-arch AppDir as long as ARCH is set to the target — it fetches the
+# matching runtime (runtime-<arch>) the same way it does for amd64. No qemu or
+# arch-specific appimagetool binary is needed.
+
 OUTPUT_DIR="output"
-BUILD_DIR="build/AppDir_tmp"
+# appimagetool was downloaded into the workspace root by the CI step.
+APPIMAGETOOL="$(pwd)/appimagetool.AppImage"
 
-# 2. Find the latest tar.gz package (handle dynamic version names)
-# Assume there is only one archive under output, or we just take the newest one
-TAR_FILE=$(ls ${OUTPUT_DIR}/crosspaste-*.tar.gz | head -n 1)
+# build_appimage <tar_file> <arch_token> <appimage_arch>
+#   arch_token    matches the Conveyor tarball suffix and the output suffix (amd64 | aarch64)
+#   appimage_arch the ARCH value appimagetool expects (x86_64 | aarch64)
+build_appimage() {
+    local TAR_FILE="$1"
+    local ARCH_TOKEN="$2"
+    local APPIMAGE_ARCH="$3"
 
-if [ -z "$TAR_FILE" ]; then
-    echo "Error: No tar.gz file found in ${OUTPUT_DIR}"
-    exit 1
-fi
+    local BUILD_DIR="build/AppDir_${ARCH_TOKEN}"
 
-echo "Found archive: $TAR_FILE"
+    # Extract version from filename
+    # Example: crosspaste-1.2.4-1730-linux-amd64.tar.gz -> 1.2.4-1730
+    local APP_VERSION
+    APP_VERSION=$(basename "$TAR_FILE" | sed -E "s/crosspaste-(.*)-linux-${ARCH_TOKEN}.tar.gz/\1/")
+    echo "Packaging AppImage: arch=${ARCH_TOKEN} version=${APP_VERSION} (${TAR_FILE})"
 
-# Extract version from filename
-# Example: crosspaste-1.2.4-1730-linux-amd64.tar.gz -> 1.2.4-1730
-# Assumes the filename format is fixed, using sed to extract
-APP_VERSION=$(basename "$TAR_FILE" | sed -E 's/crosspaste-(.*)-linux-amd64.tar.gz/\1/')
-echo "Detected Version: $APP_VERSION"
+    # Prepare the AppDir directory
+    rm -rf "$BUILD_DIR"
+    mkdir -p "$BUILD_DIR"
 
-# 3. Prepare the AppDir directory
-rm -rf "$BUILD_DIR"
-mkdir -p "$BUILD_DIR"
+    echo "Extracting archive..."
+    # Use --strip-components=1 to remove the top-level directory
+    # (e.g. crosspaste-1.2.4/) and extract contents directly into BUILD_DIR
+    tar -xzf "$TAR_FILE" -C "$BUILD_DIR" --strip-components=1
 
-echo "Extracting archive..."
-# Use --strip-components=1 to remove the top-level directory
-# (e.g. crosspaste-1.2.4/) and extract contents directly into BUILD_DIR
-tar -xzf "$TAR_FILE" -C "$BUILD_DIR" --strip-components=1
+    # Configure AppImage metadata (AppRun, Desktop file, Icon) inside a subshell
+    # so the working directory stays at the workspace root for appimagetool.
+    (
+        cd "$BUILD_DIR"
 
-# 4. Configure AppImage metadata (AppRun, Desktop file, Icon)
-cd "$BUILD_DIR"
-
-# Create AppRun
-echo '#!/bin/sh
+        # Create AppRun
+        echo '#!/bin/sh
 HERE="$(dirname "$(readlink -f "${0}")")"
 exec "${HERE}/bin/crosspaste" "$@"' > AppRun
-chmod +x AppRun
+        chmod +x AppRun
 
-# Move and fix the .desktop file
-# Find the .desktop file (assumed to be under share/applications)
-DESKTOP_FILE=$(find share/applications -name "*.desktop" | head -n 1)
-cp "$DESKTOP_FILE" .
+        # Move and fix the .desktop file
+        # Find the .desktop file (assumed to be under share/applications)
+        DESKTOP_FILE=$(find share/applications -name "*.desktop" | head -n 1)
+        cp "$DESKTOP_FILE" .
 
-# Get the desktop filename
-DESKTOP_FILENAME=$(basename "$DESKTOP_FILE")
+        # Get the desktop filename
+        DESKTOP_FILENAME=$(basename "$DESKTOP_FILE")
 
-# Key points: adjust Exec and Icon
-# Ensure Exec=crosspaste (no path)
-# Ensure Icon=crosspaste (no file extension)
-sed -i 's|^Exec=.*|Exec=crosspaste|g' "$DESKTOP_FILENAME"
-sed -i 's|^Icon=.*|Icon=crosspaste|g' "$DESKTOP_FILENAME"
+        # Key points: adjust Exec and Icon
+        # Ensure Exec=crosspaste (no path)
+        # Ensure Icon=crosspaste (no file extension)
+        sed -i 's|^Exec=.*|Exec=crosspaste|g' "$DESKTOP_FILENAME"
+        sed -i 's|^Icon=.*|Icon=crosspaste|g' "$DESKTOP_FILENAME"
 
-cp share/icons/hicolor/1024x1024/apps/crosspaste.png .
+        cp share/icons/hicolor/1024x1024/apps/crosspaste.png .
 
-ln -s crosspaste.png .DirIcon
+        ln -s crosspaste.png .DirIcon
+    )
 
-cd - > /dev/null
+    echo "Building AppImage..."
+    # ARCH tells appimagetool the target architecture (and which runtime to use).
+    # --appimage-extract-and-run avoids FUSE issues in CI environments.
+    ARCH="$APPIMAGE_ARCH" "$APPIMAGETOOL" --appimage-extract-and-run \
+        "$BUILD_DIR" \
+        "${OUTPUT_DIR}/crosspaste-${APP_VERSION}-${ARCH_TOKEN}.AppImage"
 
-echo "Building AppImage..."
-# ARCH=x86_64 helps the tool detect the target architecture
-# --appimage-extract-and-run avoids FUSE issues in CI environments
-ARCH=x86_64 ./appimagetool.AppImage --appimage-extract-and-run \
-    "$BUILD_DIR" \
-    "${OUTPUT_DIR}/crosspaste-${APP_VERSION}-amd64.AppImage"
+    echo "Success! AppImage generated at: ${OUTPUT_DIR}/crosspaste-${APP_VERSION}-${ARCH_TOKEN}.AppImage"
+}
 
-echo "Success! AppImage generated at: ${OUTPUT_DIR}/crosspaste-${APP_VERSION}-amd64.AppImage"
+# Map Conveyor's Linux tarball suffix -> appimagetool ARCH value, as
+# "<tarball-suffix>:<appimagetool-arch>" pairs (avoids bash 4 associative arrays).
+ARCH_PAIRS="amd64:x86_64 aarch64:aarch64"
+
+shopt -s nullglob
+built=0
+for PAIR in $ARCH_PAIRS; do
+    ARCH_TOKEN="${PAIR%%:*}"
+    APPIMAGE_ARCH="${PAIR##*:}"
+    for TAR_FILE in ${OUTPUT_DIR}/crosspaste-*-linux-${ARCH_TOKEN}.tar.gz; do
+        build_appimage "$TAR_FILE" "$ARCH_TOKEN" "$APPIMAGE_ARCH"
+        built=1
+    done
+done
+
+if [ "$built" -eq 0 ]; then
+    echo "Error: No crosspaste-*-linux-*.tar.gz archive found in ${OUTPUT_DIR}"
+    exit 1
+fi

--- a/.github/scripts/rewriteConveyorConf.js
+++ b/.github/scripts/rewriteConveyorConf.js
@@ -208,10 +208,6 @@ const config = {
             section: 'app.inputs'
         },
         {
-            pattern: 'javacpp-.*-linux-arm64.jar',
-            section: 'app.inputs'
-        },
-        {
             pattern: 'javacpp-.*-linux-riscv64.jar',
             section: 'app.inputs'
         },
@@ -224,15 +220,7 @@ const config = {
             section: 'app.inputs'
         },
         {
-            pattern: 'leptonica-.*-linux-arm64.jar',
-            section: 'app.inputs'
-        },
-        {
             pattern: 'tesseract-.*-android-.*.jar',
-            section: 'app.inputs'
-        },
-        {
-            pattern: 'tesseract-.*-linux-arm64.jar',
             section: 'app.inputs'
         },
     ],
@@ -253,6 +241,11 @@ const config = {
             pattern: 'linux-x86_64',
             from: 'app.inputs',
             to: 'app.linux.amd64.glibc.inputs'
+        },
+        {
+            pattern: 'linux-arm64',
+            from: 'app.inputs',
+            to: 'app.linux.aarch64.glibc.inputs'
         },
         {
             pattern: 'windows-x86_64',

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -176,6 +176,7 @@ dependencies {
     macAarch64(libs.compose.desktop.macos.arm64)
     windowsAmd64(libs.compose.desktop.windows.x64)
     linuxAmd64(libs.compose.desktop.linux.x64)
+    linuxAarch64(libs.compose.desktop.linux.arm64)
 }
 
 // Force Conveyor platform configurations to align transitive dependency versions with the main build.
@@ -566,11 +567,23 @@ compose.desktop {
 
                     modules("jdk.security.auth")
 
-                    getJbrReleases(
-                        "linux-x64",
-                        jbrReleases,
-                        jbrDir,
-                    )
+                    val architecture = System.getProperty("os.arch")
+
+                    if (architecture == "amd64" || architecture == "x86_64" || buildFullPlatform) {
+                        getJbrReleases(
+                            "linux-x64",
+                            jbrReleases,
+                            jbrDir,
+                        )
+                    }
+
+                    if (architecture.contains("aarch64") || architecture.contains("arm") || buildFullPlatform) {
+                        getJbrReleases(
+                            "linux-aarch64",
+                            jbrReleases,
+                            jbrDir,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/path/DesktopAppPathProvider.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/path/DesktopAppPathProvider.kt
@@ -147,7 +147,11 @@ class DevelopmentAppPathProvider(
                     "macos-arm64"
                 }
             } else if (platform.isLinux() && platform.is64bit()) {
-                "linux-x64"
+                if (platform.arch.contains("aarch64") || platform.arch.contains("arm")) {
+                    "linux-arm64"
+                } else {
+                    "linux-x64"
+                }
             } else {
                 throw IllegalStateException("Unknown platform: ${platform.name}")
             }

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -26,6 +26,7 @@ app {
     mac.aarch64.inputs += "app/jbr/jbrsdk-21.0.9-osx-aarch64-b1163.94.tar.gz"
     windows.amd64.inputs += "app/jbr/jbrsdk-21.0.9-windows-x64-b1163.94.tar.gz"
     linux.amd64.inputs += "app/jbr/jbrsdk-21.0.9-linux-x64-b1163.94.tar.gz"
+    linux.aarch64.inputs += "app/jbr/jbrsdk-21.0.9-linux-aarch64-b1163.94.tar.gz"
   }
 
   mac {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ compose-desktop-macos-x64 = { module = "org.jetbrains.compose.desktop:desktop-jv
 compose-desktop-macos-arm64 = { module = "org.jetbrains.compose.desktop:desktop-jvm-macos-arm64", version.ref = "compose-plugin" }
 compose-desktop-windows-x64 = { module = "org.jetbrains.compose.desktop:desktop-jvm-windows-x64", version.ref = "compose-plugin" }
 compose-desktop-linux-x64 = { module = "org.jetbrains.compose.desktop:desktop-jvm-linux-x64", version.ref = "compose-plugin" }
+compose-desktop-linux-arm64 = { module = "org.jetbrains.compose.desktop:desktop-jvm-linux-arm64", version.ref = "compose-plugin" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-plugin" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-plugin" }


### PR DESCRIPTION
Closes #4581

## What

Adds a Linux **aarch64 (ARM64)** build target. All native dependencies already ship `linux-arm64` binaries (JBR, Skiko, JNA, jnativehook, tesseract/leptonica/javacpp), so this is **config-only** and needs **no arm64 CI runner** — Conveyor cross-builds the ARM64 package from the existing x64 release runner.

## Changes

- **`gradle/libs.versions.toml`** — add the `compose-desktop-linux-arm64` coordinate.
- **`app/build.gradle.kts`** — declare the `linuxAarch64(...)` Conveyor configuration (this makes the Compose Conveyor plugin emit the `linux.aarch64.glibc` machine) and download the `linux-aarch64` JBR. The Linux JBR download is now host-arch aware, and pulls both arches under `BUILD_FULL_PLATFORM`.
- **`conveyor.conf`** — feed the `linux-aarch64` JBR tarball as input for the aarch64 machine.
- **`.github/scripts/rewriteConveyorConf.js`** — route the `*-linux-arm64` OCR native jars (javacpp/leptonica/tesseract) to `app.linux.aarch64.glibc.inputs` instead of deleting them.
- **`.github/scripts/package_appimage.sh`** — package one AppImage per Linux arch (amd64 + aarch64) instead of assuming a single amd64 archive. The amd64 output name and build invocation are unchanged; when only the amd64 tarball is present the aarch64 glob matches nothing, so it is a safe no-op until the aarch64 tarball exists.
- **`DesktopAppPathProvider`** — add an aarch64 branch for dev-from-source runs (the production `LinuxAppPathProvider` is already arch-neutral).

## Verification

Validated end-to-end with a local Conveyor build (Linux machines only, no signing):

- **Packages**: produced `crosspaste_2.1.5_arm64.deb` and `crosspaste-2.1.5-linux-aarch64.tar.gz` alongside amd64.
- **Real ARM64 binaries**: the launcher, `libskiko-linux-arm64.so`, `libtesseract.so.5.5`, and the bundled JBR `libjvm.so` are all `ELF ... ARM aarch64` — no x86-64 leaked into the arm64 package.
- **Update metadata**: the generated apt repo `Packages` index contains a separate `Architecture: arm64` entry pointing at the arm64 deb, with per-arch dependencies (arm64 adds `libegl1 | libegl-mali-xlnx`). Linux updates flow through the apt repo, so no manual appcast/metadata work is needed.
- **AppImage script**: the real Conveyor aarch64 tarball name and directory layout match the script's expectations (verified in a sandbox run).
- Dependency resolution (`linuxAarch64` config) is clean and the `linux-arm64` Skiko runtime resolves; `ktlintCheck` and the AppImage script's `bash -n` pass.

## Not covered here (follow-up)

- **Real-device smoke test** on actual ARM Linux hardware: X11 clipboard monitoring, global shortcuts (jnativehook), active-window detection (JNA → libX11/libXfixes), and OCR. These cannot be validated offline and should be confirmed before/at release, ideally with community help.