### PR TITLE
:construction_worker: add npm ecosystem to Dependabot for web/ dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm" # Web browser extension dependencies
+    directory: "/web"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What

Add the `npm` package ecosystem (`/web`) to `.github/dependabot.yml` so Dependabot manages the web browser extension's JavaScript dependencies.

## Why

Dependabot was only configured for the `gradle` ecosystem, so the `web/` npm dependencies were never covered by version or security updates. As a result, three open Dependabot security alerts on `web/package-lock.json` had no automated fix PRs:

- **GHSA-fx2h-pf6j-xcff** (high) — vite `server.fs.deny` bypass on Windows alternate paths (vite ≤ 6.4.2)
- **GHSA-v6wh-96g9-6wx3** (medium) — launch-editor NTLMv2 hash disclosure via UNC path on Windows (vite ≤ 6.4.2)
- **GHSA-4x5r-pxfx-6jf8** (low) — @babel/core arbitrary file read via sourceMappingURL comment (≤ 7.29.0)

All three affect dev/build-time tooling only and are not part of the shipped extension, so real-world risk is minimal. This change lets Dependabot open the patch-bump PRs (vite → 6.4.3, @babel/core → 7.29.6) with correctly generated cross-platform lockfiles, and keeps web dependencies maintained going forward.

Regenerating the lockfile locally is intentionally avoided here because doing so on a single platform prunes the other platforms' optional `@rollup/rollup-*` binaries and would break CI on Linux/Windows.