### PR TITLE
🐛 resolve Windows clipboard source via GetClipboardOwner instead of foreground window

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/WinAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/WinAppWindowManager.kt
@@ -64,7 +64,22 @@ class WinAppWindowManager(
             appInfo?.getAppName(winAppInfoCaches)
         }
 
+    /**
+     * Resolves the app behind the current clipboard change.
+     *
+     * Prefers User32 GetClipboardOwner — the window that actually wrote the clipboard — so
+     * that background tools writing the clipboard without taking focus (e.g. dictation tools
+     * injecting text into another app) are attributed correctly instead of being mistaken for
+     * the foreground app. Falls back to the foreground window when the clipboard owner is null
+     * (owner already exited or a delayed-rendering clipboard) or its app name cannot be
+     * resolved.
+     */
     override fun getCurrentActiveAppName(): String? =
+        INSTANCE.GetClipboardOwner()?.let { ownerHwnd ->
+            WinAppInfo(ownerHwnd).getAppName(winAppInfoCaches)
+        } ?: getForegroundAppName()
+
+    private fun getForegroundAppName(): String? =
         WinAppInfo(INSTANCE.GetForegroundWindow()).getAppName(winAppInfoCaches)
 
     override fun getRunningAppNames(): List<String> {

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/api/User32.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/api/User32.kt
@@ -91,6 +91,8 @@ interface User32 : com.sun.jna.platform.win32.User32 {
 
     fun GetClipboardData(uFormat: Int): HANDLE?
 
+    fun GetClipboardOwner(): HWND?
+
     fun IsClipboardFormatAvailable(format: Int): Boolean
 
     fun EnumClipboardFormats(format: Int): Int


### PR DESCRIPTION
Closes #4596

### Problem

On Windows, the clipboard source is resolved from the **foreground window**
(`GetForegroundWindow()`). When an app writes the clipboard **without taking focus** — e.g.
Wispr Flow (#4594), a background dictation tool that injects text into the currently focused
app — the foreground window stays on the target app (Chrome), so the change is misattributed
to Chrome instead of the real writer. This is not a timing/race issue; the foreground window
just can't answer "which process wrote the clipboard".

### Change

`WinAppWindowManager.getCurrentActiveAppName()` now resolves the source from
`GetClipboardOwner()` — the window that last called `SetClipboardData` — and falls back to
`GetForegroundWindow()` only when the clipboard owner is null (owner already exited or a
delayed-rendering clipboard) or its app name cannot be resolved. Added the `GetClipboardOwner`
declaration to the project's `User32` JNA interface.

With this, Wispr Flow is attributed correctly and the existing per-app Source Control
exclusion works as expected — no new "filter by window title/process" setting needed.

### Note

`getCurrentActiveAppName()` is also reused by the drag-source path (`DragTargetContentView`),
which now goes through the same owner-first logic. For drag-and-drop the foreground window
would be the more accurate signal; this is a minor known trade-off and can be split out later
if it proves noticeable.

### Verification

- `./gradlew ktlintFormat` + `./gradlew app:compileKotlinDesktop` pass.
- Pending real-device Windows validation (confirm `GetClipboardOwner` resolves to `wispr.exe`
  during repro, and normal Ctrl+C copies are unaffected).