### PR TITLE
:memo: fix checkered flag emoji code in commit guide

### DIFF
--- a/doc/en/CommitMessage.md
+++ b/doc/en/CommitMessage.md
@@ -18,7 +18,7 @@ Using emoji prefixes to mark commit messages is a popular practice that makes co
 | :lock:                                   | `:lock:`                      | Fix security issues                                   |
 | :apple:                                  | `:apple:`                     | Fix macOS-specific content                            |
 | :penguin:                                | `:penguin:`                   | Fix Linux-specific content                            |
-| :checkered_flag:                         | `:checked_flag:`              | Fix Windows-specific content                          |
+| :checkered_flag:                         | `:checkered_flag:`            | Fix Windows-specific content                          |
 | :robot:                                  | `:robot:`                     | Fix Android-specific content                          |
 | :green_apple:                            | `:green_apple:`               | Fix iOS-specific issues                               |
 | :bookmark:                               | `:bookmark:`                  | Release/Version tags                                  |

--- a/doc/zh/CommitMessage.md
+++ b/doc/zh/CommitMessage.md
@@ -18,7 +18,7 @@
 | :lock: (锁)                          | `:lock:`                      | 修复安全问题                 |
 | :apple: (苹果)                        | `:apple:`                     | 修复 macOS 下的内容          |
 | :penguin: (企鹅)                      | `:penguin:`                   | 修复 Linux 下的内容          |
-| :checkered_flag: (旗帜)               | `:checked_flag:`              | 修复 Windows 下的内容        |
+| :checkered_flag: (旗帜)               | `:checkered_flag:`            | 修复 Windows 下的内容        |
 | :robot: (Android机器人)                | `:robot:`                     | 修复Android上的某些内容。    |
 | :green_apple: (绿苹果)                 | `:green_apple:`               | 解决iOS上的某些问题。        |
 | :bookmark: (书签)                     | `:bookmark:`                  | 发行/版本标签                |


### PR DESCRIPTION
## Summary
- Fix the documented emoji code for `:checkered_flag:` in the English commit message guide
- Apply the same correction in the Chinese commit message guide

## Why
The table displayed the Windows-specific emoji as `:checkered_flag:`, but the code column listed `:checked_flag:`. This makes the visible emoji and the documented commit prefix inconsistent.

## Validation
- Ran `git show --check --pretty=format: HEAD`
