### PR TITLE
Reset side search selection and scroll to the newest item on reopen and query/filter changes

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
@@ -99,6 +99,10 @@ fun SearchWindow(windowIcon: Painter?) {
     LaunchedEffect(searchWindowInfo.show) {
         if (searchWindowInfo.show) {
             ignoreFocusLoss.set(true)
+            // Reset selection and scroll to the newest item before the window paints. This runs
+            // here (not in the window content) because the content's composition is paused while
+            // the window is hidden and would not observe the reopen.
+            pasteSelectionViewModel.resetToTop()
             appWindowManager.focusSearchWindow(searchWindowInfo.trigger)
             delay(1000.milliseconds)
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/model/PasteSelectionViewModel.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/model/PasteSelectionViewModel.kt
@@ -95,6 +95,19 @@ class PasteSelectionViewModel(
         _selectedIndexes.value = listOf(0)
     }
 
+    /**
+     * Reset the search list back to the newest item: select index 0 and scroll to the top.
+     *
+     * Must be driven from a composable that stays in the composition while the search window is
+     * hidden (e.g. SearchWindow). The window content's own composition is paused while the window
+     * is invisible, so effects inside it never observe the hide/show transition and cannot reliably
+     * reset on reopen.
+     */
+    suspend fun resetToTop() {
+        _selectedIndexes.value = listOf(0)
+        searchListState?.scrollToItem(0)
+    }
+
     fun clickSelectedIndex(
         selectedIndex: Int,
         isShiftPressed: Boolean = false,

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteItemView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteItemView.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -33,8 +32,6 @@ import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.TransferableProducer
 import com.crosspaste.ui.LocalDesktopAppSizeValueState
 import com.crosspaste.ui.base.PasteContextMenuView
-import com.crosspaste.ui.model.FocusedElement
-import com.crosspaste.ui.model.PasteSelectionViewModel
 import com.crosspaste.ui.paste.PasteDataScope
 import com.crosspaste.ui.theme.AppUIColors
 import com.crosspaste.ui.theme.AppUISize.highlightedCardElevation
@@ -55,8 +52,6 @@ fun PasteDataScope.SidePasteItemView(
     val configManager = koinInject<CommonConfigManager>()
     val pasteMenuService = koinInject<DesktopPasteMenuService>()
     val pasteProducer = koinInject<TransferableProducer>()
-    val pasteSelectionViewModel = koinInject<PasteSelectionViewModel>()
-    val focusedElement by pasteSelectionViewModel.focusedElement.collectAsState()
 
     val appSizeValue = LocalDesktopAppSizeValueState.current
 
@@ -115,12 +110,12 @@ fun PasteDataScope.SidePasteItemView(
                     )
                 }.border(
                     3.dp,
+                    // Highlight the selected item the same way whether the search input or the
+                    // paste list holds focus: while typing, the first match is the candidate that
+                    // Enter will paste, so it must read as clearly selected rather than a faint
+                    // preview.
                     if (selected) {
-                        if (focusedElement == FocusedElement.PASTE_LIST) {
-                            AppUIColors.importantColor
-                        } else {
-                            AppUIColors.lightBorderColor
-                        }
+                        AppUIColors.importantColor
                     } else {
                         Color.Transparent
                     },

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/SidePasteboardContentView.kt
@@ -74,6 +74,8 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -96,10 +98,11 @@ fun SidePasteboardContentView() {
     val selectedIndexes by pasteSelectionViewModel.selectedIndexes.collectAsState()
     val loadAll by pasteSearchViewModel.loadAll.collectAsState()
 
-    // Recreate scroll state on each show/hide transition so every window open starts at position 0.
-    // scrollToItem(0) is unreliable when the window is hidden because the layout engine skips
-    // hidden windows, so we create a fresh LazyListState instead.
-    val searchListState = remember(searchWindowInfo.show) { LazyListState() }
+    // Stable scroll state shared with the ViewModel. The list is reset to the top on window open
+    // from SearchWindow.resetToTop(), not here: the window content's composition is paused while
+    // the window is hidden, so a show-keyed effect/remember inside this composable never observes
+    // the hide/show transition and cannot reliably reset scroll on reopen.
+    val searchListState = remember { LazyListState() }
     pasteSelectionViewModel.searchListState = searchListState
     val adapter = rememberScrollbarAdapter(scrollState = searchListState)
     var showScrollbar by remember { mutableStateOf(false) }
@@ -129,13 +132,21 @@ fun SidePasteboardContentView() {
         }
     }
 
-    // Reset selection and scroll position when search parameters change while window is visible.
+    // Reset selection to the first match and scroll to the top whenever the search query or any
+    // filter changes (term, sort, type, or tag). Input is debounced, so the matching results
+    // arrive a moment after the params change: re-assert once they land so the first item is
+    // selected and scrolled into view. This also covers the case where nothing matches.
     LaunchedEffect(
         inputSearch,
         searchBaseParams.sort,
         searchBaseParams.pasteTypeList,
+        searchBaseParams.tag,
     ) {
         if (searchWindowInfo.show) {
+            pasteSelectionViewModel.initSelectIndex()
+            searchListState.scrollToItem(0)
+            // Wait for the debounced query to produce its new result set, then pin to the top.
+            snapshotFlow { searchResult }.drop(1).first()
             pasteSelectionViewModel.initSelectIndex()
             searchListState.scrollToItem(0)
         }
@@ -226,6 +237,22 @@ fun SidePasteboardContentView() {
             val currentFirstItemId = searchResult.first().id
 
             if (currentFirstItemId != previousFirstItemId) {
+                // Auto-scroll to the newest item only when the user is already viewing the top
+                // of the list. Detect that via the previously-newest item's key rather than
+                // firstVisibleItemIndex: the list is keyed by item.id, so when several items are
+                // prepended at once (e.g. clipboard changes while the search window was closed),
+                // the LazyList anchors to the old top item and its index jumps past 1. The old
+                // `firstVisibleItemIndex <= 1` guard misread that as "scrolled away" and skipped
+                // the scroll, leaving the newest items off-screen above the viewport.
+                val firstVisibleKey =
+                    searchListState.layoutInfo.visibleItemsInfo
+                        .firstOrNull()
+                        ?.key
+                val wasAtTop =
+                    firstVisibleKey == null ||
+                        previousFirstItemId == null ||
+                        firstVisibleKey == previousFirstItemId
+
                 snapshotFlow { searchListState.layoutInfo }
                     .take(2)
                     .collect { layoutInfo ->
@@ -234,7 +261,7 @@ fun SidePasteboardContentView() {
                             showScrollbar = true
                         }
 
-                        if (searchListState.firstVisibleItemIndex <= 1) {
+                        if (wasAtTop) {
                             searchListState.animateScrollToItem(0)
                         }
                     }


### PR DESCRIPTION
Closes #4599
Related to #4595

## Summary
Fixes several cases where the desktop side search window did not reset its selection and scroll position to the newest (top) item, making recorded clipboard items look missing.

## Changes
- **Reopen reset moved to `SearchWindow`**: the window content's composition is paused while hidden, so show-keyed effects/`remember(show)` inside the content never observed the reopen. Reset now runs from the always-composed `SearchWindow` via a new `PasteSelectionViewModel.resetToTop()`; the list state is a stable `remember` instead of being recreated on show.
- **Auto-scroll on new items uses a key check**: replaced the `firstVisibleItemIndex <= 1` guard with a previously-top-item key comparison, so prepending several items at once (e.g. while the window was hidden) still scrolls to the newest.
- **Query/filter reset now covers `tag` and async results**: added the missing `tag` key (lost in the favorite→tag migration) and re-assert selection + scroll once the debounced results arrive; also handles the no-match case.
- **Selected item is always clearly highlighted**: the highlight no longer dims based on which pane holds focus, so the first match reads as selected while typing.

## Testing
- ktlintFormat + `:app:compileKotlinDesktop` pass.
- Manually verified: reopen returns to newest + selects first; copying several items while hidden returns to newest on reopen; search term / type / tag / sort reset selection and scroll; no-match then match selects first; arrow-key navigation highlight intact.