### PR TITLE
:bug: migrate Windows clipboard monitoring to AddClipboardFormatListener

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
@@ -14,7 +14,6 @@ import com.crosspaste.utils.DesktopControlUtils
 import com.crosspaste.utils.cpuDispatcher
 import com.crosspaste.utils.getControlUtils
 import com.crosspaste.utils.namedScope
-import com.sun.jna.Pointer
 import com.sun.jna.platform.win32.Kernel32
 import com.sun.jna.platform.win32.WinDef.HWND
 import com.sun.jna.platform.win32.WinDef.LPARAM
@@ -65,7 +64,6 @@ class WindowsPasteboardService(
 
     private var job: Job? = null
     private var viewer: HWND? = null
-    private var nextViewer: HWND? = null
     private val event =
         Kernel32.INSTANCE.CreateEvent(
             null,
@@ -94,7 +92,6 @@ class WindowsPasteboardService(
                 0,
                 null,
             )
-        nextViewer = User32.INSTANCE.SetClipboardViewer(viewer)
         if (platform.is64bit()) {
             User32.INSTANCE.SetWindowLongPtr(
                 viewer,
@@ -107,6 +104,13 @@ class WindowsPasteboardService(
                 User32.GWL_WNDPROC,
                 this,
             )
+        }
+        if (User32.INSTANCE.AddClipboardFormatListener(viewer)) {
+            logger.info { "Clipboard format listener registered" }
+        } else {
+            logger.error {
+                "AddClipboardFormatListener failed, err=${Kernel32.INSTANCE.GetLastError()}"
+            }
         }
         val msg = MSG()
         val handles = arrayOf(event)
@@ -123,6 +127,7 @@ class WindowsPasteboardService(
             existNew = true
 
             if (result == Kernel32.WAIT_OBJECT_0) {
+                User32.INSTANCE.RemoveClipboardFormatListener(viewer)
                 User32.INSTANCE.DestroyWindow(viewer)
                 return
             }
@@ -227,41 +232,18 @@ class WindowsPasteboardService(
         uParam: WPARAM?,
         lParam: LPARAM?,
     ): Int {
-        when (uMsg) {
-            User32.WM_CHANGECBCHAIN -> {
-                // If the next window is closing, repair the chain.
-                val nv = nextViewer
-                if (nv != null && uParam != null && nv.toNative() == uParam.toNative()) {
-                    nextViewer =
-                        lParam?.let { HWND(Pointer.createConstant(it.toLong())) }
-                } else if (nv != null) {
-                    // Otherwise, pass the message to the next link
-                    User32.INSTANCE.SendMessage(nv, uMsg, uParam, lParam)
-                }
-                return 0
-            }
-
-            User32.WM_DRAWCLIPBOARD -> {
-                if (existNew) {
-                    existNew = false
-                    runCatching {
-                        val clipboardSequenceNumber = User32.INSTANCE.GetClipboardSequenceNumber()
-                        if (changeCount != clipboardSequenceNumber) {
-                            changeCount = clipboardSequenceNumber
-                            onChange()
-                        }
-                    }.apply {
-                        User32.INSTANCE.SendMessage(nextViewer, uMsg, uParam, lParam)
+        if (uMsg == User32.WM_CLIPBOARDUPDATE) {
+            if (existNew) {
+                existNew = false
+                runCatching {
+                    val clipboardSequenceNumber = User32.INSTANCE.GetClipboardSequenceNumber()
+                    if (changeCount != clipboardSequenceNumber) {
+                        changeCount = clipboardSequenceNumber
+                        onChange()
                     }
                 }
-                return 0
             }
-
-            User32.WM_DESTROY ->
-                User32.INSTANCE.ChangeClipboardChain(
-                    viewer,
-                    nextViewer,
-                )
+            return 0
         }
         return User32.INSTANCE.DefWindowProc(hWnd, uMsg, uParam, lParam).toInt()
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/api/User32.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/platform/windows/api/User32.kt
@@ -46,12 +46,9 @@ interface User32 : com.sun.jna.platform.win32.User32 {
         param: Any?,
     ): HWND?
 
-    fun SetClipboardViewer(hWndNewViewer: HWND?): HWND?
+    fun AddClipboardFormatListener(hWnd: HWND?): Boolean
 
-    fun ChangeClipboardChain(
-        hWndRemove: HWND?,
-        hWndNewNext: HWND?,
-    ): Boolean
+    fun RemoveClipboardFormatListener(hWnd: HWND?): Boolean
 
     fun MsgWaitForMultipleObjects(
         nCount: Int,
@@ -122,8 +119,7 @@ interface User32 : com.sun.jna.platform.win32.User32 {
         const val WM_DESTROY = 0x0002
         const val WM_RENDERFORMAT = 0x0305
         const val WM_RENDERALLFORMATS = 0x0306
-        const val WM_CHANGECBCHAIN = 0x030D
-        const val WM_DRAWCLIPBOARD = 0x0308
+        const val WM_CLIPBOARDUPDATE = 0x031D
 
         /**
          * PeekMessage() Options


### PR DESCRIPTION
Closes #4605

### Why

On Windows, `WindowsPasteboardService` registered for clipboard changes via `SetClipboardViewer`, inserting the window into the legacy, application-maintained **clipboard viewer chain**. Every viewer in the chain must forward `WM_DRAWCLIPBOARD`/`WM_CHANGECBCHAIN` to the next link, so a single misbehaving or crashed clipboard app breaks the chain and CrossPaste **silently stops receiving clipboard notifications until restarted**. Microsoft documents this flaw and recommends the newer API for Vista+.

This is the leading hypothesis for recent "clipboard not captured" reports on Windows (e.g. #4604), where the monitoring code itself has barely changed — pointing to an environmental interaction (other clipboard software in the chain) rather than a code regression.

### What

Migrate to `AddClipboardFormatListener` (Vista+), where Windows maintains the listener list and each subscriber is independent, removing the entire chain-breakage failure class:

- Register with `AddClipboardFormatListener` instead of `SetClipboardViewer`.
- Handle `WM_CLIPBOARDUPDATE` instead of `WM_DRAWCLIPBOARD`.
- Drop all chain-maintenance code (`WM_CHANGECBCHAIN`, `SendMessage(nextViewer, …)`, `ChangeClipboardChain`, `nextViewer` field) and the now-unused `User32` bindings/constants.
- Call `RemoveClipboardFormatListener` on teardown.
- Log listener registration (`Clipboard format listener registered`) so a debug log can confirm the monitor is alive.

The window creation, WndProc subclassing, message loop, and `existNew` + `GetClipboardSequenceNumber` de-duplication are unchanged — only the registration mechanism and notification message change. Desktop-only; no `commonMain` impact. CrossPaste no longer targets pre-Vista Windows, so no legacy fallback is kept.

### Testing

- `./gradlew ktlintFormat` clean; `:app:compileKotlinDesktop` passes.
- Windows-only runtime path — needs real-device sanity checks:
  - Copy text / image / files land in history.
  - Run another clipboard manager alongside CrossPaste, then copy (the scenario most likely to break the old chain).
  - Toggle clipboard listening off/on in settings.
  - Lock screen / switch user, then confirm capture still works.