### PR TITLE
:zap: use plain remember for RichTextState in side preview views

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/HtmlSidePreviewView.kt
@@ -20,7 +20,7 @@ import com.crosspaste.ui.paste.PasteDataScope
 import com.crosspaste.ui.theme.AppUISize.small2X
 import com.crosspaste.utils.ColorAccessibility
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
-import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 import org.koin.compose.koinInject
 
@@ -60,7 +60,7 @@ fun PasteDataScope.HtmlSidePreviewView() {
             )
         },
     ) {
-        val state = rememberRichTextState()
+        val state = remember { RichTextState() }
 
         LaunchedEffect(htmlPasteItem.hash) {
             pasteItemReader.getPreviewHtml(htmlPasteItem)?.let { state.setHtml(it) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/RtfSidePreviewView.kt
@@ -20,7 +20,7 @@ import com.crosspaste.ui.paste.PasteDataScope
 import com.crosspaste.ui.theme.AppUISize.small2X
 import com.crosspaste.utils.ColorAccessibility
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
-import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 import org.koin.compose.koinInject
 
@@ -60,7 +60,7 @@ fun PasteDataScope.RtfSidePreviewView() {
             )
         },
     ) {
-        val state = rememberRichTextState()
+        val state = remember { RichTextState() }
 
         LaunchedEffect(rtfPasteItem.hash) {
             pasteItemReader.getPreviewHtml(rtfPasteItem)?.let { state.setHtml(it) }


### PR DESCRIPTION
Closes #4617

## Summary

Replace `rememberRichTextState()` with `remember { RichTextState() }` in `HtmlSidePreviewView` and `RtfSidePreviewView`.

`rememberRichTextState()` internally uses `rememberSaveable(saver = RichTextState.Saver)`, which is unnecessary for these read-only side-window previews and causes two problems:

1. **Memory retention**: the whole rich text document gets serialized into the `SaveableStateRegistry` when the preview leaves composition, keeping large clipboard HTML/RTF content resident in memory.
2. **Stale content flash**: on re-entering composition the saved old content is restored first, then overwritten by `LaunchedEffect(hash) { state.setHtml(...) }`, which can briefly display the previous item's content.

The preview content is read-only and driven unidirectionally from the paste item via `LaunchedEffect(hash)`, so a plain `remember` is sufficient.

## Changes

- `HtmlSidePreviewView.kt`: `rememberRichTextState()` → `remember { RichTextState() }`
- `RtfSidePreviewView.kt`: `rememberRichTextState()` → `remember { RichTextState() }`

## Testing

- `./gradlew ktlintFormat` passes; no behavioral change expected other than dropping the saveable semantics.