### PR TITLE
:bug: fix endless clipboard duplication loop between Chrome extension and desktop

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/NativeMessagingHostService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/NativeMessagingHostService.kt
@@ -3,10 +3,10 @@ package com.crosspaste.app
 import com.crosspaste.path.AppPathProvider
 import com.crosspaste.platform.Platform
 import com.crosspaste.presist.FilePersist
+import com.sun.jna.platform.win32.Advapi32Util
+import com.sun.jna.platform.win32.WinReg
 import io.github.oshai.kotlinlogging.KotlinLogging
 import okio.Path
-import okio.Path.Companion.toOkioPath
-import java.io.File
 import java.util.Properties
 
 class NativeMessagingHostService(
@@ -20,6 +20,19 @@ class NativeMessagingHostService(
     companion object {
         const val HOST_NAME = "com.crosspaste.desktop"
         const val MANIFEST_FILE = "$HOST_NAME.json"
+
+        // On Windows, Chromium-family browsers discover native messaging hosts
+        // ONLY through the registry — manifest files inside the browser profile
+        // are never scanned (https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging).
+        // Edge and Brave also fall back to the Chrome key, but registering their
+        // own vendor keys keeps discovery independent of that fallback.
+        internal val WINDOWS_REGISTRY_KEYS =
+            listOf(
+                "Software\\Google\\Chrome\\NativeMessagingHosts\\$HOST_NAME",
+                "Software\\Chromium\\NativeMessagingHosts\\$HOST_NAME",
+                "Software\\Microsoft\\Edge\\NativeMessagingHosts\\$HOST_NAME",
+                "Software\\BraveSoftware\\Brave-Browser\\NativeMessagingHosts\\$HOST_NAME",
+            )
 
         val CHROME_EXTENSION_IDS: List<String> by lazy {
             val props = Properties()
@@ -78,11 +91,13 @@ class NativeMessagingHostService(
             done
             """.trimIndent()
 
+        // NOTE: PowerShell's $PID is a read-only automatic variable — assigning to it
+        // throws, so the desktop process id must live in its own variable ($appPid).
         internal fun buildWindowsBridgeScript(pidFilePath: String): String {
             val normalized = pidFilePath.replace("/", "\\")
             return """
                 @echo off
-                powershell -NoProfile -Command "${'$'}stdin=[Console]::OpenStandardInput(); ${'$'}null=[System.Threading.Tasks.Task]::Run({${'$'}buf=New-Object byte[] 4096; while(${'$'}stdin.Read(${'$'}buf,0,4096) -gt 0){}}); ${'$'}stdout=[Console]::OpenStandardOutput(); ${'$'}msg=[System.Text.Encoding]::UTF8.GetBytes('{\"status\":\"running\"}'); ${'$'}lenBytes=[System.BitConverter]::GetBytes(${'$'}msg.Length); ${'$'}pidFile='$normalized'; while(${'$'}true){ if(-not(Test-Path ${'$'}pidFile)){exit}; ${'$'}pid=[int](Get-Content ${'$'}pidFile -ErrorAction SilentlyContinue); if(-not(Get-Process -Id ${'$'}pid -ErrorAction SilentlyContinue)){exit}; ${'$'}stdout.Write(${'$'}lenBytes,0,4); ${'$'}stdout.Write(${'$'}msg,0,${'$'}msg.Length); ${'$'}stdout.Flush(); Start-Sleep -Seconds 5 }"
+                powershell -NoProfile -Command "${'$'}stdin=[Console]::OpenStandardInput(); ${'$'}null=[System.Threading.Tasks.Task]::Run({${'$'}buf=New-Object byte[] 4096; while(${'$'}stdin.Read(${'$'}buf,0,4096) -gt 0){}}); ${'$'}stdout=[Console]::OpenStandardOutput(); ${'$'}msg=[System.Text.Encoding]::UTF8.GetBytes('{\"status\":\"running\"}'); ${'$'}lenBytes=[System.BitConverter]::GetBytes(${'$'}msg.Length); ${'$'}pidFile='$normalized'; while(${'$'}true){ if(-not(Test-Path ${'$'}pidFile)){exit}; ${'$'}appPid=[int](Get-Content ${'$'}pidFile -ErrorAction SilentlyContinue); if(-not(Get-Process -Id ${'$'}appPid -ErrorAction SilentlyContinue)){exit}; ${'$'}stdout.Write(${'$'}lenBytes,0,4); ${'$'}stdout.Write(${'$'}msg,0,${'$'}msg.Length); ${'$'}stdout.Flush(); Start-Sleep -Seconds 5 }"
                 """.trimIndent()
         }
     }
@@ -118,6 +133,11 @@ class NativeMessagingHostService(
     private fun writeManifests(bridgeScriptPath: Path) {
         val manifest = buildManifest(CHROME_EXTENSION_IDS, bridgeScriptPath.toString())
 
+        if (platform.isWindows()) {
+            registerWindowsManifest(manifest)
+            return
+        }
+
         for (dir in getManifestDirs()) {
             val dirFile = dir.toFile()
             if (!dirFile.parentFile.exists()) continue
@@ -128,6 +148,31 @@ class NativeMessagingHostService(
                     .saveBytes(manifest.encodeToByteArray())
             }.onFailure { e ->
                 logger.warn(e) { "Failed to write manifest to $dir" }
+            }
+        }
+    }
+
+    // Windows browsers resolve native messaging hosts via the registry, not via
+    // manifest files in the profile directory: write one manifest under the app
+    // data dir and point each vendor's HKCU key at it.
+    private fun registerWindowsManifest(manifest: String) {
+        val manifestPath = appPathProvider.pasteUserPath.resolve(MANIFEST_FILE)
+        FilePersist
+            .createOneFilePersist(manifestPath)
+            .saveBytes(manifest.encodeToByteArray())
+        val manifestFilePath = manifestPath.toFile().absolutePath
+
+        for (keyPath in WINDOWS_REGISTRY_KEYS) {
+            runCatching {
+                Advapi32Util.registryCreateKey(WinReg.HKEY_CURRENT_USER, keyPath)
+                Advapi32Util.registrySetStringValue(
+                    WinReg.HKEY_CURRENT_USER,
+                    keyPath,
+                    "",
+                    manifestFilePath,
+                )
+            }.onFailure { e ->
+                logger.warn(e) { "Failed to register native messaging host key: $keyPath" }
             }
         }
     }
@@ -158,20 +203,8 @@ class NativeMessagingHostService(
                 ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
                 ".config/microsoft-edge/NativeMessagingHosts",
             ).map { home.resolve(it) }
-        } else if (platform.isWindows()) {
-            windowsManifestDirs()
         } else {
             emptyList()
         }
-    }
-
-    private fun windowsManifestDirs(): List<Path> {
-        val localAppData = System.getenv("LOCALAPPDATA") ?: return emptyList()
-        return listOf(
-            "Google/Chrome/User Data/NativeMessagingHosts",
-            "Chromium/User Data/NativeMessagingHosts",
-            "BraveSoftware/Brave-Browser/User Data/NativeMessagingHosts",
-            "Microsoft/Edge/User Data/NativeMessagingHosts",
-        ).map { File(localAppData).resolve(it).toOkioPath() }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/NativeMessagingHostServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/NativeMessagingHostServiceTest.kt
@@ -126,4 +126,26 @@ class NativeMessagingHostServiceTest {
             "pidFile path not normalized to backslashes",
         )
     }
+
+    @Test
+    fun buildWindowsBridgeScript_doesNotAssignReadOnlyPidVariable() {
+        val script =
+            NativeMessagingHostService.buildWindowsBridgeScript("C:/Users/me/data/crosspaste.pid")
+
+        // PowerShell's $PID is a read-only automatic variable; assigning to it throws.
+        assertTrue(!script.contains("\$pid="), "script must not assign to read-only \$pid")
+        assertTrue(script.contains("\$appPid="), "desktop pid must be read into \$appPid")
+        assertTrue(script.contains("Get-Process -Id \$appPid"), "liveness check must use \$appPid")
+    }
+
+    @Test
+    fun windowsRegistryKeys_coverChromiumFamilyAndEndWithHostName() {
+        val keys = NativeMessagingHostService.WINDOWS_REGISTRY_KEYS
+
+        assertTrue(keys.isNotEmpty())
+        assertTrue(keys.all { it.endsWith("\\${NativeMessagingHostService.HOST_NAME}") })
+        assertTrue(keys.any { it.contains("Google\\Chrome") }, "missing Chrome key")
+        assertTrue(keys.any { it.contains("Microsoft\\Edge") }, "missing Edge key")
+        assertTrue(keys.any { it.contains("BraveSoftware") }, "missing Brave key")
+    }
 }

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -107,10 +107,12 @@ let offscreenReady = false;
 
 const CLIPBOARD_POLL_INTERVAL_MS = 1000; // 1 second
 const STORAGE_KEY_LAST_HASH = "clipboard_lastHash";
-// After a LOCAL_COPY, Chrome's clipboard.write sanitizes text/html and may
-// regenerate text/plain from the HTML, so the first post-write poll reads
-// bytes that don't match the original paste's hash. Within this window we
-// absorb the re-read hash into lastHash once instead of ingesting it.
+// After any clipboard write of our own (LOCAL_COPY from the side panel, or a
+// remote paste_push written via the offscreen document), Chrome's
+// clipboard.write sanitizes text/html and may regenerate text/plain from the
+// HTML, so the first post-write poll reads bytes that don't match the original
+// paste's hash. Within this window we absorb the re-read hash into lastHash
+// once instead of ingesting it.
 const STORAGE_KEY_LOCAL_COPY_UNTIL = "clipboard_localCopyUntil";
 const LOCAL_COPY_SUPPRESS_MS = 2000;
 
@@ -377,9 +379,10 @@ async function syncAllDevices(): Promise<void> {
         targetAppInstanceId: device.targetAppInstanceId,
       });
       if (data) {
-        if ((await ingestPaste(data, broadcastToSidePanel)) !== null) {
-          await setLastHash(data.hash);
-        }
+        // Do NOT touch lastHash here: pulling stores the paste without writing
+        // the clipboard, so lastHash must keep tracking the actual clipboard
+        // content or the next poll re-ingests it as a new local copy.
+        await ingestPaste(data, broadcastToSidePanel);
       }
       await updateRuntime(device.targetAppInstanceId, (s) => {
         s.lastHttpSuccessAt = Date.now();
@@ -533,6 +536,9 @@ async function initializeWebSocket(): Promise<void> {
     },
     broadcastToSidePanel,
     setLastHash,
+    getLastHash,
+    armClipboardWriteSuppress: () => setLocalCopyUntil(Date.now() + LOCAL_COPY_SUPPRESS_MS),
+    disarmClipboardWriteSuppress: () => setLocalCopyUntil(0),
     showOversizePasteNotice,
     onRemoteRemoveDevice: async (targetId) => {
       wsManager?.disconnectDevice(targetId);

--- a/web/src/offscreen/offscreen.ts
+++ b/web/src/offscreen/offscreen.ts
@@ -123,6 +123,37 @@ function readClipboard(): Promise<ClipboardResult> {
   });
 }
 
+/**
+ * Fallback clipboard write via a synthetic copy event. Some Chromium forks
+ * (e.g. Brave) reject navigator.clipboard.write in offscreen documents with
+ * "Document is not focused" (#4619); execCommand("copy") with a copy-event
+ * listener is the documented offscreen-safe path. Text and HTML only —
+ * clipboardData.setData cannot carry images.
+ */
+function writeViaExecCommand(data: { text?: string; html?: string }): boolean {
+  const onCopy = (e: ClipboardEvent) => {
+    e.preventDefault();
+    if (data.text) e.clipboardData?.setData("text/plain", data.text);
+    if (data.html) e.clipboardData?.setData("text/html", data.html);
+  };
+  document.addEventListener("copy", onCopy);
+  try {
+    // execCommand("copy") only fires with an active selection.
+    div.textContent = "x";
+    const range = document.createRange();
+    range.selectNodeContents(div);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    const ok = document.execCommand("copy");
+    selection?.removeAllRanges();
+    return ok;
+  } finally {
+    document.removeEventListener("copy", onCopy);
+    div.textContent = "";
+  }
+}
+
 async function writeClipboard(data: {
   text?: string;
   html?: string;
@@ -150,6 +181,10 @@ async function writeClipboard(data: {
     await navigator.clipboard.write([new ClipboardItem(blobs)]);
     return true;
   } catch (e) {
+    if (data.text || data.html) {
+      const ok = writeViaExecCommand(data);
+      if (ok) return true;
+    }
     console.error("[Offscreen] writeClipboard failed:", e);
     return false;
   }

--- a/web/src/shared/storage/paste-store.ts
+++ b/web/src/shared/storage/paste-store.ts
@@ -150,6 +150,30 @@ export const PasteStore = {
     return items;
   },
 
+  /**
+   * Latest receivedAt among non-deleted entries with the given hash, or null.
+   * Used to detect clipboard echo loops: a paste_push whose hash we already
+   * ingested moments ago is a bounce of our own push, not new user content.
+   */
+  async latestReceivedAtByHash(hash: string): Promise<number | null> {
+    const db = await getDb();
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const hashIndex = tx.store.index("hash");
+    let latest: number | null = null;
+
+    let cursor = await hashIndex.openCursor(hash);
+    while (cursor) {
+      const entry = cursor.value as PasteData;
+      if (entry.pasteState !== PasteState.DELETED && entry.receivedAt !== undefined) {
+        if (latest === null || entry.receivedAt > latest) latest = entry.receivedAt;
+      }
+      cursor = await cursor.continue();
+    }
+
+    await tx.done;
+    return latest;
+  },
+
   /** Mark a paste as DELETED by auto-increment ID. Returns the hash if found. */
   async deleteById(id: number): Promise<string | null> {
     const db = await getDb();

--- a/web/src/shared/ws/__tests__/paste-push-policy.test.ts
+++ b/web/src/shared/ws/__tests__/paste-push-policy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { ECHO_SUPPRESS_MS, shouldWriteRemotePaste } from "../paste-push-policy";
+
+describe("shouldWriteRemotePaste", () => {
+  const now = 1_000_000;
+
+  it("writes a genuinely new paste", () => {
+    expect(
+      shouldWriteRemotePaste({ hash: "aaa", lastHash: "bbb", priorReceivedAt: null, now }),
+    ).toBe(true);
+  });
+
+  it("skips when clipboard already holds this hash per our own tracking", () => {
+    expect(
+      shouldWriteRemotePaste({ hash: "aaa", lastHash: "aaa", priorReceivedAt: null, now }),
+    ).toBe(false);
+  });
+
+  it("skips an echo: same hash ingested moments ago", () => {
+    expect(
+      shouldWriteRemotePaste({
+        hash: "aaa",
+        lastHash: "bbb",
+        priorReceivedAt: now - ECHO_SUPPRESS_MS + 1000,
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("writes a legitimate re-copy: same hash but ingested long ago", () => {
+    expect(
+      shouldWriteRemotePaste({
+        hash: "aaa",
+        lastHash: "bbb",
+        priorReceivedAt: now - ECHO_SUPPRESS_MS - 1000,
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats the exact window boundary as no longer an echo", () => {
+    expect(
+      shouldWriteRemotePaste({
+        hash: "aaa",
+        lastHash: "bbb",
+        priorReceivedAt: now - ECHO_SUPPRESS_MS,
+        now,
+      }),
+    ).toBe(true);
+  });
+});

--- a/web/src/shared/ws/paste-push-policy.ts
+++ b/web/src/shared/ws/paste-push-policy.ts
@@ -1,0 +1,26 @@
+/**
+ * A paste_push whose hash we already ingested within this window is treated as
+ * an echo of our own push bouncing off a peer (see #4619), not new user
+ * content: it is still stored, but never written back to the system clipboard,
+ * which is the edge that closes the feedback loop.
+ */
+export const ECHO_SUPPRESS_MS = 10_000;
+
+/**
+ * Decide whether a received paste_push should be written to the system
+ * clipboard. Pure so the loop-breaking rules are unit-testable.
+ */
+export function shouldWriteRemotePaste(params: {
+  hash: string;
+  lastHash: string;
+  priorReceivedAt: number | null;
+  now: number;
+}): boolean {
+  // Clipboard already holds this exact content per our own tracking.
+  if (params.hash === params.lastHash) return false;
+  // Recently ingested same hash: this push is an echo, not a new copy event.
+  if (params.priorReceivedAt !== null && params.now - params.priorReceivedAt < ECHO_SUPPRESS_MS) {
+    return false;
+  }
+  return true;
+}

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -3,8 +3,10 @@ import { parsePasteData, type PasteData } from "@/shared/models/paste-data";
 import { PasteType } from "@/shared/models/paste-item";
 import type { FilesPasteItem, ImagesPasteItem } from "@/shared/models/paste-item";
 import { BlobStore } from "@/shared/storage/blob-store";
+import { PasteStore } from "@/shared/storage/paste-store";
 import { ingestPaste } from "@/shared/paste/paste-ingestion";
 import { writeRemotePasteToClipboard } from "@/shared/clipboard/clipboard-sync-writer";
+import { shouldWriteRemotePaste } from "./paste-push-policy";
 
 /** Payload of a FILE_PULL_REQUEST message (matches Kotlin WsPullFileRequest sealed class). */
 interface WsChunkRequest {
@@ -41,6 +43,16 @@ export interface WsMessageHandlerDeps {
   broadcastToSidePanel: (message: unknown) => void;
   /** Set the clipboard last hash after writing to clipboard, so poll skips it. */
   setLastHash: (hash: string) => Promise<void>;
+  /** Read the clipboard last hash tracked by the poll loop. */
+  getLastHash: () => Promise<string>;
+  /**
+   * Arm the post-write suppress window BEFORE writing to the clipboard, so the
+   * next poll absorbs the browser-sanitized re-read (whose bytes never match
+   * the pushed hash) instead of ingesting it as a new local copy.
+   */
+  armClipboardWriteSuppress: () => Promise<void>;
+  /** Clear the suppress window when the clipboard write did not happen. */
+  disarmClipboardWriteSuppress: () => Promise<void>;
   /** Handle remote removal: remove device from storage and disconnect WebSocket. */
   onRemoteRemoveDevice: (targetAppInstanceId: string) => Promise<void>;
   /** Surface an oversize-paste rejection from [sourceAppInstanceId] to the user. */
@@ -102,13 +114,30 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
         return;
       }
 
+      // Query BEFORE ingest: after ingest the latest same-hash entry is the
+      // paste we just stored, which would defeat the echo check.
+      const priorReceivedAt = await PasteStore.latestReceivedAtByHash(pasteData.hash);
+
       const newId = await ingestPaste(pasteData, deps.broadcastToSidePanel);
       if (newId !== null) {
         await pullFilesIfNeeded(appInstanceId, pasteData);
 
-        const written = await writeRemotePasteToClipboard(pasteData);
-        if (written) {
-          await deps.setLastHash(pasteData.hash);
+        const writeAllowed = shouldWriteRemotePaste({
+          hash: pasteData.hash,
+          lastHash: await deps.getLastHash(),
+          priorReceivedAt,
+          now: Date.now(),
+        });
+        if (writeAllowed) {
+          await deps.armClipboardWriteSuppress();
+          const written = await writeRemotePasteToClipboard(pasteData);
+          if (written) {
+            await deps.setLastHash(pasteData.hash);
+          } else {
+            // Nothing hit the clipboard, so leaving the window armed would
+            // absorb (and silently drop) the user's next real copy.
+            await deps.disarmClipboardWriteSuppress();
+          }
         }
       }
 


### PR DESCRIPTION
Closes #4619

## Root cause

The reporter's setup runs the Chrome extension (Brave) on the same Windows machine as the desktop app. The designed protection for this topology — the extension pausing itself via native messaging while the desktop is running — **has never worked on Windows**: the desktop only wrote manifest files into browser profile directories (`%LOCALAPPDATA%\...\User Data\NativeMessagingHosts`), but on Windows Chromium-family browsers discover native messaging hosts **exclusively through `HKCU` registry keys**. The reporter's console log confirms it: `Specified native messaging host not found.`

With that protection dead, both processes watch and write the same system clipboard, and a feedback loop forms:

1. The extension's 1s clipboard poll captures content and pushes it to the desktop.
2. The desktop stores the received paste and unconditionally writes it back into the shared clipboard (its own listener ignores the write via `LocalOnlyFlavor`, but the extension's poll cannot).
3. The write/read round trip mutates bytes (EOL conversion, CF_HTML wrapping, sanitization), so the extension sees a "new" hash and pushes again → endless loop; every cycle creates a fresh row on the desktop, which the paired Android devices then sync as duplicates.

Two additional extension-side defects amplified or independently caused duplicates:

- `handlePastePush` wrote every received paste to the clipboard without arming the post-write suppress window (#4235 only fixed the `LOCAL_COPY` path), so the sanitized re-read was re-ingested and pushed back.
- The HTTP pull path set `lastHash` without writing the clipboard, poisoning the poll's dedup baseline.
- On Brave, `navigator.clipboard.write` in the offscreen document fails with `NotAllowedError: Document is not focused`.

## Changes

**Desktop (root fix)**
- `NativeMessagingHostService`: on Windows, write a single manifest under the app data dir and register `HKCU\Software\{Google\Chrome, Chromium, Microsoft\Edge, BraveSoftware\Brave-Browser}\NativeMessagingHosts\com.crosspaste.desktop` pointing at it (JNA `Advapi32Util`).
- Fix the PowerShell bridge script assigning to `$pid` — a read-only automatic variable, so the desktop-liveness check silently never worked; renamed to `$appPid`.

**Chrome extension (loop breaking, defense in depth)**
- `handlePastePush`: skip the clipboard write when the pushed hash equals `lastHash` or was already ingested within a 10s echo window (`shouldWriteRemotePaste`, pure and unit-tested); arm the suppress window before writing and disarm it if the write fails. The paste is still stored either way.
- `syncAllDevices`: stop setting `lastHash` on HTTP pull.
- Offscreen: fall back to `execCommand("copy")` with a copy-event listener when `navigator.clipboard.write` is rejected (Brave).
- `PasteStore.latestReceivedAtByHash` supports the echo check.

## Review

Independent strict review found no P0. Decisions of record:

- A desktop-side guard that skipped rewriting a remote paste when the clipboard already held equivalent text was implemented, then **dropped by owner decision**: the registry fix removes the reported scenario entirely, the extension-side echo window covers the remaining loop edge, and the guard could wrongly skip rich HTML/RTF writes when the clipboard held the same plain text (review P1).
- The 10s echo window can, in a narrow case, skip writing a legitimate re-copy of identical content pushed within 10s while the local clipboard changed in between. Kept at 10s deliberately: the miss is self-healing (content is still stored), while a shorter window risks not outpacing the loop period.

## Testing

- `./gradlew app:desktopTest` — full suite green (includes 2 new tests: bridge script must not assign `$pid`; registry key coverage).
- `web`: `npm test` 84/84 green (5 new tests for `shouldWriteRemotePaste`); `tsc --noEmit` introduces no new errors.
- ⚠️ Needs real-Windows verification before release: registry keys picked up by Chrome/Edge/Brave, bridge script heartbeat, extension pausing while desktop runs, and the Brave `execCommand` fallback.

https://claude.ai/code/session_015p2gJ7fUmzJ4Dcja9ro7vM
