### PR TITLE
:bug: build Linux ARM64 in releases and survive the apt-repo site layout

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -255,10 +255,22 @@ jobs:
           cd web/dist
           zip -r "${{ github.workspace }}/output/crosspaste-chrome-extension-${{ env.VERSION }}.${{ env.REVISION }}.zip" .
 
+      # Multi-arch Linux builds emit the apt repository as an output/debian/
+      # directory tree instead of flat files at the site root. Surface the
+      # .debs at the top level so the versioned OSS dir and the GitHub Release
+      # keep the same flat inventory as before.
+      - name: Flatten Linux debs
+        run: |
+          if [ -d output/debian ]; then
+            find output/debian -type f -name '*.deb' -exec cp -n {} output/ \;
+          fi
+
       - name: CheckSum
         run: |
           rm -f icon.svg download.html
-          shasum -a 256 * > checksum.txt
+          for f in *; do
+            if [ -f "$f" ]; then shasum -a 256 "$f"; fi
+          done > checksum.txt
         working-directory: ./output
 
       - name: Setup ossutil
@@ -290,6 +302,15 @@ jobs:
               mv update-site/$f update-site-meta/
             fi
           done
+          # Multi-arch builds nest the apt repository under debian/. Its index
+          # metadata must also revalidate quickly, while the version-named
+          # .debs inside stay immutable, so split it the same way.
+          if [ -d update-site/debian ]; then
+            (cd update-site && find debian -type f ! -name '*.deb') | while read -r f; do
+              mkdir -p "update-site-meta/$(dirname "$f")"
+              mv "update-site/$f" "update-site-meta/$f"
+            done
+          fi
           ossutil cp -r -f --meta "Cache-Control:public, max-age=2592000" update-site/ oss://crosspaste-desktop/site/
           ossutil cp -r -f --meta "Cache-Control:public, max-age=300" update-site-meta/ oss://crosspaste-desktop/site/
 

--- a/build.conveyor.conf
+++ b/build.conveyor.conf
@@ -1,6 +1,11 @@
 include required("conveyor.conf")
 
 app {
+  // Conveyor's default machine set excludes linux.aarch64.glibc, so list all
+  // release targets explicitly — otherwise the Linux ARM64 packages promised
+  // by #4581/#4582 are silently never built (the beta workflow already sets
+  // its own machines override).
+  machines = [ "windows.amd64", "mac.amd64", "mac.aarch64", "linux.amd64.glibc", "linux.aarch64.glibc" ]
   mac {
     notarization {
       issuer-id = ${env.ISSUER_ID}


### PR DESCRIPTION
Closes #4625

## Summary

The 2.1.6 release build (tag `2.1.6.2380`) failed at the `CheckSum` step and, more importantly, was not going to ship the Linux ARM64 packages promised by the release notes. Three fixes:

- **`build.conveyor.conf`**: set `app.machines` explicitly with all five release targets. Conveyor's default machine set excludes `linux.aarch64.glibc`, so the release build only produced Intel Linux artifacts ("Debian Package for Intel" only in the failed run) even though #4582 wired up all the aarch64 inputs. The beta workflow already proves this machines list builds both Linux arches correctly (both debs, tarballs, and AppImages).
- **`build-release.yml` CheckSum**: hash only regular files. Declaring the second Linux arch makes Conveyor emit the apt repository as an `output/debian/` directory tree (2.1.5 had flat `InRelease`/`Packages`/`.deb` at the site root), and `shasum -a 256 *` aborts on the directory.
- **`build-release.yml` new "Flatten Linux debs" step**: copy `.deb`s from `output/debian/` up to the top level so the versioned OSS dir and the manually published GitHub Release keep the same flat inventory as previous releases.
- **`build-release.yml` mirror step**: move non-`.deb` files under `update-site/debian/` (apt index metadata) into the short-cache (300s) upload pass, path-preserving; the version-named `.deb`s inside stay in the 30-day-cache pass. Otherwise the nested apt metadata would be cached for 30 days.

The flatten/mirror handling is layout-agnostic: if a future Conveyor version keeps flat files at the root, both new blocks are no-ops.

## Verification

- Workflow YAML parses cleanly.
- Machines list matches the beta workflow's proven override (`build-beta-linux.yml`), extended with the mac/windows defaults.
- Failed run evidence: run 28852419451 (`shasum: debian: Is a directory`; no `Debian Package for ARM` / `linux-aarch64` artifacts in the log) vs. beta run 27861473559 (both arches built).

## Release procedure after merge

The failed tag `2.1.6.2380` will be deleted; a new tag `2.1.6.<new rev-list count>` will be pushed to rerun the release build.

https://claude.ai/code/session_015p2gJ7fUmzJ4Dcja9ro7vM