### PR TITLE
:construction_worker: drop the nested apt repo from versioned release assets

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -257,12 +257,15 @@ jobs:
 
       # Multi-arch Linux builds emit the apt repository as an output/debian/
       # directory tree instead of flat files at the site root. Surface the
-      # .debs at the top level so the versioned OSS dir and the GitHub Release
-      # keep the same flat inventory as before.
+      # .debs at the top level for the versioned OSS dir and the GitHub
+      # Release, then drop the rest of the apt repo from output/: it lives on
+      # the update site (already snapshotted above), and its index metadata
+      # references debian/-relative paths, so flat copies of it are unusable.
       - name: Flatten Linux debs
         run: |
           if [ -d output/debian ]; then
-            find output/debian -type f -name '*.deb' -exec cp -n {} output/ \;
+            find output/debian -type f -name '*.deb' -exec mv -n {} output/ \;
+            rm -rf output/debian
           fi
 
       - name: CheckSum


### PR DESCRIPTION
Follow-up to #4625/#4626, prompted by inspecting the 2.1.6.2381 upload.

## Summary

The "Flatten Linux debs" step now **moves** the `.deb`s out of `output/debian/` and deletes the rest of the directory before checksum/upload, so the versioned OSS dir (`oss://crosspaste-desktop/<version>/`) and the manually published GitHub Release keep a purely flat inventory.

Why the apt index metadata (`InRelease`, `Release`, `Packages`, `Packages.xz`) is dropped rather than flattened:

- The apt repository consumed by clients lives on the update site. The 2.1.6 deb installs `/etc/apt/sources.list.d/crosspaste.sources` with `URIs: https://oss.crosspaste.com/site/` and `Suites: debian/` (verified by extracting the shipped deb), and `Packages` records `Filename: debian/crosspaste_*.deb`. The `site/debian/` tree (already snapshotted before output/ is mutated) must therefore stay exactly as Conveyor generated it.
- Flat copies of that metadata are unusable anywhere else: the `debian/`-relative `Filename` entries cannot resolve against a flat GitHub Release or the versioned OSS dir, so shipping them would only mislead apt into 404s.
- Dropping the directory also saves ~280 MB per version in the versioned OSS dir.

## Note on existing apt users

Users who installed a deb ≤ 2.1.5 have sources pointing at the flat GitHub `releases/latest/download/` repository. That chain cannot carry them to 2.1.6 regardless of asset layout (the new metadata is `debian/`-relative, and GitHub assets cannot contain path separators). They need a one-time manual install of the 2.1.6 deb, which replaces the sources file and restores automatic updates via the CDN site. Worth a line in the GitHub Release notes.

https://claude.ai/code/session_015p2gJ7fUmzJ4Dcja9ro7vM