### PR TITLE
:construction_worker: decouple update-site publishing from release builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -313,8 +313,16 @@ jobs:
               mv "update-site/$f" "update-site-meta/$f"
             done
           fi
+          # Drop any marker left by a previous run of this version first, so a
+          # re-run never exposes a "complete" flag over a half-re-uploaded
+          # staging prefix (|| true: the marker usually doesn't exist yet).
+          ossutil rm -f oss://crosspaste-desktop/site-staging/${{ env.VERSION }}.${{ env.REVISION }}/staging-complete || true
           ossutil cp -r -f --meta "Cache-Control:public, max-age=2592000" update-site/ oss://crosspaste-desktop/site-staging/${{ env.VERSION }}.${{ env.REVISION }}/packages/
           ossutil cp -r -f --meta "Cache-Control:public, max-age=300" update-site-meta/ oss://crosspaste-desktop/site-staging/${{ env.VERSION }}.${{ env.REVISION }}/meta/
+          # Written last: publish-release.yml refuses to publish a staging
+          # prefix that lacks this marker (i.e. an unfinished upload).
+          echo "${{ env.VERSION }}.${{ env.REVISION }}" > staging-complete
+          ossutil cp -f staging-complete oss://crosspaste-desktop/site-staging/${{ env.VERSION }}.${{ env.REVISION }}/staging-complete
 
       # conveyor default cache directory is .conveyor/cache
       # Avoid caching it, causing Github space payment

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -237,8 +237,8 @@ jobs:
 
       # Snapshot the pure Conveyor site before later steps mutate output/
       # (AppImage/extension get added, CheckSum deletes icon.svg/download.html).
-      # This copy is mirrored to a stable OSS prefix that will become the
-      # CDN-served update site (#4558).
+      # This copy is staged to a version-named OSS prefix; publishing it to the
+      # live CDN-served site/ prefix is a separate human-gated workflow (#4629).
       - name: Stage update site for OSS mirror
         run: cp -r output update-site
 
@@ -287,13 +287,15 @@ jobs:
           echo "Uploading release app to OSS..."
           ossutil cp -r output/ oss://crosspaste-desktop/${{ env.VERSION }}.${{ env.REVISION }}/
 
-      # Mirror the Conveyor site to the stable site/ prefix (#4558). Clients do
-      # not use this path yet (base-url still points at GitHub); it goes live in
-      # a later release. Two-pass upload: packages first, update metadata last,
-      # so a half-finished upload never leaves metadata pointing at missing files.
-      # Cache-Control set per group: packages are version-named and immutable,
-      # metadata must revalidate quickly through the CDN.
-      - name: Mirror update site to OSS
+      # Stage the Conveyor site to a version-named staging prefix (#4629). The
+      # build never touches the live site/ prefix that clients poll for
+      # updates: publish-release.yml copies staging to site/ when the GitHub
+      # Release is published (build is build, publish is publish). The
+      # packages/meta split is preserved so the publish step can copy packages
+      # first and flip metadata last, and Cache-Control is stamped per group
+      # here: packages are version-named and immutable, metadata must
+      # revalidate quickly through the CDN.
+      - name: Stage update site to OSS staging
         run: |
           mkdir update-site-meta
           for f in metadata.properties appcast-*.rss crosspaste.appinstaller \
@@ -311,8 +313,8 @@ jobs:
               mv "update-site/$f" "update-site-meta/$f"
             done
           fi
-          ossutil cp -r -f --meta "Cache-Control:public, max-age=2592000" update-site/ oss://crosspaste-desktop/site/
-          ossutil cp -r -f --meta "Cache-Control:public, max-age=300" update-site-meta/ oss://crosspaste-desktop/site/
+          ossutil cp -r -f --meta "Cache-Control:public, max-age=2592000" update-site/ oss://crosspaste-desktop/site-staging/${{ env.VERSION }}.${{ env.REVISION }}/packages/
+          ossutil cp -r -f --meta "Cache-Control:public, max-age=300" update-site-meta/ oss://crosspaste-desktop/site-staging/${{ env.VERSION }}.${{ env.REVISION }}/meta/
 
       # conveyor default cache directory is .conveyor/cache
       # Avoid caching it, causing Github space payment

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,9 +20,14 @@ on:
         description: "Full version whose staged site to publish (e.g. 2.1.6.2400)"
         required: true
 
+# This workflow only talks to OSS via ossutil; it never uses GITHUB_TOKEN.
+permissions: {}
+
 # Never let two publishes interleave (e.g. a release-triggered run racing a
-# manual rollback). Later runs queue instead of cancelling: a rollback must
-# not be silently dropped.
+# manual rollback): an in-progress run always finishes. Caveat: GitHub keeps
+# only ONE pending run per group — a newly queued run replaces (cancels) a
+# previously pending one, so if a rollback dispatch was queued and another
+# run superseded it, re-dispatch the rollback.
 concurrency:
   group: publish-update-site
   cancel-in-progress: false
@@ -59,11 +64,13 @@ jobs:
           access-key-id: ${{ secrets.ALIYUN_ACCESSKEY_ID }}
           access-key-secret: ${{ secrets.ALIYUN_ACCESSKEY_SECRET }}
 
-      # Guard against publishing the wrong tag or a tag whose build never
-      # staged: the staged metadata must exist and identify exactly the
-      # requested version.
+      # Guard against publishing the wrong tag, a tag whose build never
+      # staged, or a build still mid-upload: the staging-complete marker is
+      # written by build-release.yml only after both staging passes finish,
+      # and the staged metadata must identify exactly the requested version.
       - name: Verify staged site matches version
         run: |
+          ossutil stat oss://crosspaste-desktop/site-staging/${{ env.VERSION_FULL }}/staging-complete
           ossutil cp -f oss://crosspaste-desktop/site-staging/${{ env.VERSION_FULL }}/meta/metadata.properties staged-metadata.properties
           grep -q "^app.version=${{ env.VERSION }}$" staged-metadata.properties
           grep -q "^app.revision=${{ env.REVISION }}$" staged-metadata.properties

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,87 @@
+name: "Publish Update Site"
+
+# Publishes a staged update site to the live site/ prefix that clients poll
+# for updates (#4629). Building and publishing are deliberately separate
+# stages: build-release.yml only stages the Conveyor site to
+# site-staging/<version>/, and this workflow flips site/ when the maintainer
+# publishes the GitHub Release — the same manual act that already gates the
+# GitHub distribution channel.
+#
+# workflow_dispatch is the manual fallback: re-run a publish after a partial
+# failure, or roll BACK by publishing a previous version's staged site again
+# (staging prefixes are version-named and kept around).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Full version whose staged site to publish (e.g. 2.1.6.2400)"
+        required: true
+
+# Never let two publishes interleave (e.g. a release-triggered run racing a
+# manual rollback). Later runs queue instead of cancelling: a rollback must
+# not be silently dropped.
+concurrency:
+  group: publish-update-site
+  cancel-in-progress: false
+
+jobs:
+  publish-site:
+    runs-on: ubuntu-latest
+    # The rolling `beta` pre-release (build-beta-linux.yml) and any other
+    # pre-release must never flip the production update site.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    steps:
+      - name: Resolve version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION_FULL="$INPUT_VERSION"
+          else
+            VERSION_FULL="$RELEASE_TAG"
+          fi
+          if ! echo "$VERSION_FULL" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "'$VERSION_FULL' is not a release version (expected N.N.N.N), refusing to publish."
+            exit 1
+          fi
+          echo "VERSION_FULL=$VERSION_FULL" >> "$GITHUB_ENV"
+          echo "VERSION=${VERSION_FULL%.*}" >> "$GITHUB_ENV"
+          echo "REVISION=${VERSION_FULL##*.}" >> "$GITHUB_ENV"
+
+      - name: Setup ossutil
+        uses: manyuanrong/setup-ossutil@v3.0
+        with:
+          endpoint: "oss-cn-shenzhen.aliyuncs.com"
+          access-key-id: ${{ secrets.ALIYUN_ACCESSKEY_ID }}
+          access-key-secret: ${{ secrets.ALIYUN_ACCESSKEY_SECRET }}
+
+      # Guard against publishing the wrong tag or a tag whose build never
+      # staged: the staged metadata must exist and identify exactly the
+      # requested version.
+      - name: Verify staged site matches version
+        run: |
+          ossutil cp -f oss://crosspaste-desktop/site-staging/${{ env.VERSION_FULL }}/meta/metadata.properties staged-metadata.properties
+          grep -q "^app.version=${{ env.VERSION }}$" staged-metadata.properties
+          grep -q "^app.revision=${{ env.REVISION }}$" staged-metadata.properties
+          echo "Staged site identifies as ${{ env.VERSION }}.${{ env.REVISION }}."
+
+      # Two-pass server-side copy: packages first, metadata last, so clients
+      # never read metadata that points at missing files. Cache-Control is
+      # re-stamped per group (packages are version-named and immutable,
+      # metadata must revalidate quickly through the CDN).
+      - name: Publish packages
+        run: ossutil cp -r -f --meta "Cache-Control:public, max-age=2592000" oss://crosspaste-desktop/site-staging/${{ env.VERSION_FULL }}/packages/ oss://crosspaste-desktop/site/
+
+      - name: Publish update metadata
+        run: ossutil cp -r -f --meta "Cache-Control:public, max-age=300" oss://crosspaste-desktop/site-staging/${{ env.VERSION_FULL }}/meta/ oss://crosspaste-desktop/site/
+
+      - name: Verify published site
+        run: |
+          ossutil cp -f oss://crosspaste-desktop/site/metadata.properties published-metadata.properties
+          grep -q "^app.version=${{ env.VERSION }}$" published-metadata.properties
+          grep -q "^app.revision=${{ env.REVISION }}$" published-metadata.properties
+          echo "site/ now serves ${{ env.VERSION }}.${{ env.REVISION }} (CDN edge caches converge within max-age=300)."


### PR DESCRIPTION
Closes #4629

## Problem

Since #4559/#4560, the tag-triggered release build mirrors the Conveyor update site straight to the live `oss://crosspaste-desktop/site/` prefix. Once 2.1.6+ clients poll `https://oss.crosspaste.com/site/metadata.properties`, a successful build would instantly push the update to every user — before any human verification. The GitHub Release channel is manually gated; the CDN channel was not. Build and publish must be separate stages.

## Changes

**`build-release.yml` — build only stages, never touches `site/`:**
- The former "Mirror update site to OSS" step now uploads to a version-named staging prefix: `site-staging/<version>/packages/` (immutable packages, `Cache-Control: max-age=2592000`) and `site-staging/<version>/meta/` (update metadata, `max-age=300`). The packages/metadata split logic is unchanged.

**`publish-release.yml` (new) — human-gated publish:**
- Triggers on `release: published` (excluding pre-releases, so the rolling `beta` release can never flip the production site) — publishing the GitHub Release, already the manual release act, becomes the single gate for both channels. `workflow_dispatch(version)` is the fallback for re-publishing after a partial failure, and doubles as a **rollback**: dispatching a previous version points `site/` metadata back at that release (staging prefixes are version-named and kept).
- Safety: version format validation (env-indirected inputs, no shell interpolation of tag names), a `staging-complete` marker that the build writes only after both staging passes finish (and removes before re-staging, so a re-run never exposes a half-uploaded prefix as complete), staged `metadata.properties` whose `app.version`/`app.revision` must match the requested version, two-pass server-side copy (packages first, metadata last, Cache-Control re-stamped per group), post-publish read-back verification of `site/metadata.properties`, `permissions: {}` (the job never uses `GITHUB_TOKEN`), and a `publish-update-site` concurrency group so an in-progress publish always finishes before the next starts.

## Merge ordering vs. the pending 2.1.6 release

The 2.1.6 build (`2.1.6.2381`) already ran under the old workflow: `site/` is already populated (harmless — no shipped client reads it yet) and **no `site-staging/2.1.6.2381/` exists**. Therefore:

- **Recommended: publish the 2.1.6 GitHub Release first, then merge this PR.** The release event only triggers workflows present on the default branch at event time, so nothing fires for 2.1.6, and the staged flow is first exercised end-to-end by the next tag.
- If this PR merges first, publishing the 2.1.6 release will trigger `publish-release.yml`, which fails its staged-site check (staging was never uploaded for 2.1.6). That failure is loud but harmless — `site/` already serves 2.1.6 from the old build-time mirror.

## Verification

- Both workflows parse as valid YAML.
- Version parsing (`N.N.N` / revision split), the format-rejection regex, and the `app.version`/`app.revision` grep checks were exercised locally against the real published 2.1.5 `metadata.properties` (LF line endings, exact `key=value` format) — all pass.
- Not yet exercised end-to-end: the oss→oss server-side `ossutil cp -r --meta` direction is new (the same flags are already used for local→oss uploads). The first tag after this merges is the full rehearsal, before any clients depend on a `site/` flip.

## Notes

- The versioned archive upload to `oss://crosspaste-desktop/<version>/` is unchanged (nothing points at it; it serves as archive/website download source).
- The release-day checklist in the design doc has been updated to verify staging before publishing the GitHub Release, and `site/` after.
