### PR TITLE
Fix Windows native messaging bridge launch: keep backslash path, %~dp0 pid lookup, PS5.1-safe stdin drain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,15 @@ SQLDelight manages database schema in `.sq` files:
 - **Storage**: Local-only architecture with no cloud dependencies
 - **Performance**: Coroutines for async operations, caching for clipboard history
 
+## Windows cmd.exe / PowerShell Interop Pitfalls
+
+Lessons from #4633 (native messaging bridge never launched). They apply to any generated script, manifest, or config that Windows will execute:
+
+- **Never normalize Windows paths to forward slashes when the path will be executed by cmd.exe** (`.bat`/`.cmd` hosts, `cmd /c` invocations — e.g. Chromium launches non-`.exe` native messaging hosts via `cmd /d /s /c "<path>"`). cmd.exe cannot execute a forward-slash path. In JSON, keep backslashes and escape them (`\\`) instead of converting to `/`. Forward-slash paths appearing to work in manual tests (PowerShell `Start-Process`, Win32 APIs) proves nothing about cmd.exe.
+- **Never embed literal non-ASCII paths in generated `.bat` files.** The files are written as UTF-8 but cmd.exe reads them in the OEM code page (e.g. GBK), garbling non-ASCII (e.g. Chinese user profile) paths. Derive paths at run time instead (`%~dp0` for script-relative files); cmd expands it in Unicode.
+- **Target Windows PowerShell 5.1 semantics in generated PowerShell**, not PowerShell 7. Known trap: `[System.Threading.Tasks.Task]::Run({ ScriptBlock })` fails overload resolution on 5.1 (`MethodCountCouldNotFindBest`) — and even when converted, ScriptBlocks can't run on non-runspace threads. Prefer pure .NET calls (e.g. `$stream.CopyToAsync(...)`).
+- Reference implementation for all three rules: `NativeMessagingHostService` and its test.
+
 ## Code Formatting
 
 Before attempting to compile or build the project, always run `./gradlew ktlintFormat` first. If the command fails with errors, investigate and fix the issues. If it succeeds and modifies files, understand that the changes are purely stylistic and semantically equivalent to the original code — do not treat reformatted code as something that needs review or further modification.

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopPidFileService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopPidFileService.kt
@@ -12,8 +12,14 @@ class DesktopPidFileService(
 
     private val logger = KotlinLogging.logger {}
 
+    companion object {
+        // The Windows native messaging bridge script locates this file via %~dp0,
+        // so it must stay in the same directory as the script (pasteUserPath).
+        const val PID_FILE_NAME = "crosspaste.pid"
+    }
+
     val pidFilePath: Path
-        get() = appPathProvider.pasteUserPath.resolve("crosspaste.pid")
+        get() = appPathProvider.pasteUserPath.resolve(PID_FILE_NAME)
 
     fun start() {
         val pid = ProcessHandle.current().pid().toString()

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/NativeMessagingHostService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/NativeMessagingHostService.kt
@@ -49,6 +49,10 @@ class NativeMessagingHostService(
                 .map { it.trim() }
                 .filter { it.isNotEmpty() }
 
+        // The path must keep native separators: Chromium launches non-.exe hosts
+        // via `cmd.exe /d /s /c "<path> <origin>"` (launch_context_win.cc), and
+        // cmd.exe cannot execute a forward-slash path — so on Windows the
+        // backslashes are JSON-escaped rather than normalized to "/".
         internal fun buildManifest(
             extensionIds: List<String>,
             bridgeScriptPath: String,
@@ -58,7 +62,7 @@ class NativeMessagingHostService(
                 {
                   "name": "$HOST_NAME",
                   "description": "CrossPaste Desktop Native Messaging Host",
-                  "path": "${bridgeScriptPath.replace("\\", "/")}",
+                  "path": "${bridgeScriptPath.replace("\\", "\\\\")}",
                   "type": "stdio",
                   "allowed_origins": [$origins]
                 }
@@ -93,13 +97,17 @@ class NativeMessagingHostService(
 
         // NOTE: PowerShell's $PID is a read-only automatic variable — assigning to it
         // throws, so the desktop process id must live in its own variable ($appPid).
-        internal fun buildWindowsBridgeScript(pidFilePath: String): String {
-            val normalized = pidFilePath.replace("/", "\\")
-            return """
-                @echo off
-                powershell -NoProfile -Command "${'$'}stdin=[Console]::OpenStandardInput(); ${'$'}null=[System.Threading.Tasks.Task]::Run({${'$'}buf=New-Object byte[] 4096; while(${'$'}stdin.Read(${'$'}buf,0,4096) -gt 0){}}); ${'$'}stdout=[Console]::OpenStandardOutput(); ${'$'}msg=[System.Text.Encoding]::UTF8.GetBytes('{\"status\":\"running\"}'); ${'$'}lenBytes=[System.BitConverter]::GetBytes(${'$'}msg.Length); ${'$'}pidFile='$normalized'; while(${'$'}true){ if(-not(Test-Path ${'$'}pidFile)){exit}; ${'$'}appPid=[int](Get-Content ${'$'}pidFile -ErrorAction SilentlyContinue); if(-not(Get-Process -Id ${'$'}appPid -ErrorAction SilentlyContinue)){exit}; ${'$'}stdout.Write(${'$'}lenBytes,0,4); ${'$'}stdout.Write(${'$'}msg,0,${'$'}msg.Length); ${'$'}stdout.Flush(); Start-Sleep -Seconds 5 }"
-                """.trimIndent()
-        }
+        // The pid file is located via %~dp0 (the script's own directory — both files
+        // live in pasteUserPath): the script is saved as UTF-8 but cmd.exe reads it
+        // in the OEM code page, so a literal non-ASCII path (e.g. a Chinese user
+        // profile) would be garbled, while %~dp0 expands at run time in Unicode.
+        // Stdin draining uses CopyToAsync because a ScriptBlock passed to
+        // Task::Run fails overload resolution on Windows PowerShell 5.1.
+        internal fun buildWindowsBridgeScript(pidFileName: String): String =
+            """
+            @echo off
+            powershell -NoProfile -Command "${'$'}stdin=[Console]::OpenStandardInput(); ${'$'}null=${'$'}stdin.CopyToAsync([System.IO.Stream]::Null); ${'$'}stdout=[Console]::OpenStandardOutput(); ${'$'}msg=[System.Text.Encoding]::UTF8.GetBytes('{\"status\":\"running\"}'); ${'$'}lenBytes=[System.BitConverter]::GetBytes(${'$'}msg.Length); ${'$'}pidFile='%~dp0$pidFileName'; while(${'$'}true){ if(-not(Test-Path ${'$'}pidFile)){exit}; ${'$'}appPid=[int](Get-Content ${'$'}pidFile -ErrorAction SilentlyContinue); if(-not(Get-Process -Id ${'$'}appPid -ErrorAction SilentlyContinue)){exit}; ${'$'}stdout.Write(${'$'}lenBytes,0,4); ${'$'}stdout.Write(${'$'}msg,0,${'$'}msg.Length); ${'$'}stdout.Flush(); Start-Sleep -Seconds 5 }"
+            """.trimIndent()
     }
 
     fun register() {
@@ -114,12 +122,11 @@ class NativeMessagingHostService(
 
     private fun writeBridgeScript(): Path {
         val scriptPath = getBridgeScriptPath()
-        val pidFilePath = pidFileService.pidFilePath.toString()
         val content =
             if (platform.isWindows()) {
-                buildWindowsBridgeScript(pidFilePath)
+                buildWindowsBridgeScript(DesktopPidFileService.PID_FILE_NAME)
             } else {
-                buildUnixBridgeScript(pidFilePath)
+                buildUnixBridgeScript(pidFileService.pidFilePath.toString())
             }
         FilePersist
             .createOneFilePersist(scriptPath)

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/NativeMessagingHostServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/NativeMessagingHostServiceTest.kt
@@ -74,16 +74,18 @@ class NativeMessagingHostServiceTest {
     }
 
     @Test
-    fun buildManifest_normalizesWindowsBackslashesInPath() {
+    fun buildManifest_preservesWindowsBackslashesInPath() {
         val manifest =
             NativeMessagingHostService.buildManifest(
                 extensionIds = listOf("aaa"),
                 bridgeScriptPath = "C:\\Users\\me\\data\\native-messaging-host.bat",
             )
 
+        // cmd.exe (which Chromium uses to launch .bat hosts) cannot execute
+        // forward-slash paths, so the manifest must keep native backslashes.
         val parsed = Json.parseToJsonElement(manifest).jsonObject
         assertEquals(
-            "C:/Users/me/data/native-messaging-host.bat",
+            "C:\\Users\\me\\data\\native-messaging-host.bat",
             parsed.getValue("path").jsonPrimitive.content,
         )
     }
@@ -116,21 +118,41 @@ class NativeMessagingHostServiceTest {
     }
 
     @Test
-    fun buildWindowsBridgeScript_normalizesForwardSlashesAndContainsEchoOff() {
+    fun buildWindowsBridgeScript_locatesPidFileViaScriptDirectory() {
         val script =
-            NativeMessagingHostService.buildWindowsBridgeScript("C:/Users/me/data/crosspaste.pid")
+            NativeMessagingHostService.buildWindowsBridgeScript(DesktopPidFileService.PID_FILE_NAME)
 
         assertTrue(script.startsWith("@echo off"), "missing @echo off")
+        // The pid file path must be derived from %~dp0 at run time: the script
+        // is saved as UTF-8 but cmd.exe reads it in the OEM code page, so a
+        // literal non-ASCII profile path would be garbled.
         assertTrue(
-            script.contains("\$pidFile='C:\\Users\\me\\data\\crosspaste.pid'"),
-            "pidFile path not normalized to backslashes",
+            script.contains("\$pidFile='%~dp0crosspaste.pid'"),
+            "pidFile must be resolved via %~dp0",
+        )
+    }
+
+    @Test
+    fun buildWindowsBridgeScript_drainsStdinWithoutScriptBlockTask() {
+        val script =
+            NativeMessagingHostService.buildWindowsBridgeScript(DesktopPidFileService.PID_FILE_NAME)
+
+        // A ScriptBlock passed to Task::Run fails overload resolution on
+        // Windows PowerShell 5.1 ("multiple ambiguous overloads found").
+        assertTrue(
+            !script.contains("[System.Threading.Tasks.Task]::Run"),
+            "must not drain stdin via Task::Run(ScriptBlock)",
+        )
+        assertTrue(
+            script.contains("CopyToAsync([System.IO.Stream]::Null)"),
+            "stdin must be drained via CopyToAsync",
         )
     }
 
     @Test
     fun buildWindowsBridgeScript_doesNotAssignReadOnlyPidVariable() {
         val script =
-            NativeMessagingHostService.buildWindowsBridgeScript("C:/Users/me/data/crosspaste.pid")
+            NativeMessagingHostService.buildWindowsBridgeScript(DesktopPidFileService.PID_FILE_NAME)
 
         // PowerShell's $PID is a read-only automatic variable; assigning to it throws.
         assertTrue(!script.contains("\$pid="), "script must not assign to read-only \$pid")

--- a/web/src/background/native-host.ts
+++ b/web/src/background/native-host.ts
@@ -43,6 +43,11 @@ function attemptConnect(): void {
     });
 
     port.onDisconnect.addListener(() => {
+      // Reading lastError marks it as checked, silencing Chrome's
+      // "Unchecked runtime.lastError" console noise on every reconnect.
+      const reason =
+        chrome.runtime.lastError?.message ?? "host closed the connection";
+      console.log(`[NativeMessaging] disconnected: ${reason}`);
       port = null;
       if (initialResolve) {
         initialResolve(false);
@@ -53,7 +58,8 @@ function attemptConnect(): void {
       }
       scheduleReconnect();
     });
-  } catch {
+  } catch (e) {
+    console.log("[NativeMessaging] connectNative failed:", e);
     if (initialResolve) {
       initialResolve(false);
       initialResolve = null;


### PR DESCRIPTION
Closes #4633

## Summary

Real-machine Windows verification of the #4620 registry fix revealed the next failure layer: Chrome now finds and launches the native messaging host, but the connection dies with `Error when communicating with the native messaging host` on every reconnect attempt.

**Root cause**: `buildManifest` normalized the bridge script path to forward slashes, and Chromium launches non-`.exe` hosts via `cmd.exe /d /s /c "<path> <origin>"` ([launch_context_win.cc](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/extensions/api/messaging/launch_context_win.cc)) — cmd.exe cannot execute a forward-slash path, so the bridge exited before emitting a single protocol frame.

## Changes

**Desktop** (`NativeMessagingHostService`):
- Keep native backslashes in the manifest `path` field, JSON-escaped (`\\`), instead of normalizing to `/`.
- Locate the pid file via `%~dp0` at run time instead of embedding a literal path: the script is saved as UTF-8 but cmd.exe reads `.bat` files in the OEM code page, so a non-ASCII profile path (e.g. a Chinese user name) would be garbled. Pid file name is now a shared constant on `DesktopPidFileService`.
- Drain stdin with `$stdin.CopyToAsync([System.IO.Stream]::Null)`: passing a ScriptBlock to `Task::Run` fails overload resolution on Windows PowerShell 5.1 (`MethodCountCouldNotFindBest`, captured from real-machine stderr), so the drain never actually worked.

**Extension** (`web/src/background/native-host.ts`):
- Read `chrome.runtime.lastError` in `onDisconnect` and log the disconnect reason — silences the `Unchecked runtime.lastError` console noise and surfaces the actual failure, which is what made this diagnosis possible.

## Testing

- `NativeMessagingHostServiceTest` updated: manifest now asserted to preserve backslashes; bridge script asserted to use `%~dp0` and `CopyToAsync` (new test); all tests pass.
- End-to-end verified on a real Windows machine (desktop portable build + unpacked extension): service worker logs `[NativeMessaging] Desktop app detected, pausing extension` and the reconnect error loop stops.
- macOS/Linux unaffected: their paths contain no backslashes (manifest no-op) and the Unix bridge script is unchanged.

## Release note

2.1.6.2386 is still a draft — this fix should go into a rebuilt 2.1.6 so the same-machine pause protection actually ships working on Windows, together with the #4620 loop fix it completes.