### PR TITLE
Add a Video link to the README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
       <a href="https://deepwiki.com/CrossPaste/crosspaste-desktop" target="_blank">Wiki</a>
        ·
       <a href="https://crosspaste.com/en/download" target="_blank">Download</a>
+       ·
+      <a href="https://crosspaste.com/en/video?from=github" target="_blank">Video</a>
       <br />
    </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,8 @@
       <a href="https://deepwiki.com/CrossPaste/crosspaste-desktop" target="_blank">Wiki</a>
        ·
       <a href="https://crosspaste.com/download" target="_blank">Download</a>
+       ·
+      <a href="https://crosspaste.com/video?from=github" target="_blank">Video</a>
       <br />
    </p>
 


### PR DESCRIPTION
Closes #4635

Adds a "Video" entry to the top navigation of both READMEs, after Download:

- `README.md` → https://crosspaste.com/en/video?from=github
- `README.zh-CN.md` → https://crosspaste.com/video?from=github

Matches the existing link style (`·` separator, `target="_blank"`). The `from=github` parameter attributes traffic from the repository. The video page is live on the official site.