### PR TITLE
:hammer: separate QR bearer token from SAS code at the type level

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManager.kt
@@ -100,6 +100,7 @@ class GeneralNearbyDeviceManager(
                 syncManager.realTimeSyncRuntimeInfos.value
                     .find { it.appInstanceId == appInstanceId }
                     ?.let { existing ->
+                        syncManager.rememberPairingCredentialType(mergedInfo)
                         if (existing.diffSyncInfo(mergedInfo)) {
                             syncManager.updateSyncInfo(mergedInfo)
                         }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -203,11 +203,18 @@ class GeneralSyncHandler(
         emitEvent(SyncEvent.UpdateNoteName(currentSyncRuntimeInfo, noteName))
     }
 
-    override suspend fun trustByToken(
-        token: Int,
+    override suspend fun trustByBearerToken(
+        token: QrBearerToken,
         callback: (Boolean) -> Unit,
     ) {
-        emitEvent(SyncEvent.TrustByToken(currentSyncRuntimeInfo, token, callback))
+        emitEvent(SyncEvent.TrustByBearerToken(currentSyncRuntimeInfo, token, callback))
+    }
+
+    override suspend fun trustBySasCode(
+        code: SasCode,
+        callback: (Boolean) -> Unit,
+    ) {
+        emitEvent(SyncEvent.TrustBySasCode(currentSyncRuntimeInfo, code, callback))
     }
 
     override suspend fun exchangeKeysForPairing() {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -203,18 +203,24 @@ class GeneralSyncManager(
             try {
                 val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
                 val result = syncClientApi.syncInfo { buildUrl(hostAndPort) }
-                if (result is SuccessResult) {
-                    val syncInfo = result.getResult<SyncInfo>()
-                    if (syncInfo.appInfo.appInstanceId == appInstanceId &&
-                        realTimeSyncRuntimeInfos.value.any { it.appInstanceId == appInstanceId }
-                    ) {
-                        rememberPairingCredentialType(syncInfo)
-                    } else {
+                if (result !is SuccessResult) {
+                    logger.warn {
+                        "Failed to fetch pairing metadata for $appInstanceId: ${result::class.simpleName}"
+                    }
+                    return@launch
+                }
+                val syncInfo = result.getResult<SyncInfo>()
+                when {
+                    syncInfo.appInfo.appInstanceId != appInstanceId -> {
                         logger.warn {
                             "Pairing metadata identity mismatch: expected $appInstanceId, " +
                                 "received ${syncInfo.appInfo.appInstanceId}"
                         }
                     }
+                    realTimeSyncRuntimeInfos.value.none { it.appInstanceId == appInstanceId } -> {
+                        // device removed while the request was in flight; drop the result
+                    }
+                    else -> rememberPairingCredentialType(syncInfo)
                 }
             } catch (e: CancellationException) {
                 throw e

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -77,8 +77,6 @@ class GeneralSyncManager(
     override val pairingCredentialTypes: StateFlow<Map<String, PairingCredentialType>> =
         _pairingCredentialTypes.asStateFlow()
 
-    private val pairingCredentialTypeRequests: MutableSet<String> = ConcurrentSet()
-
     private val internalSyncHandlers: MutableMap<String, SyncHandler> = ConcurrentMap()
 
     private val eventChannel = Channel<SyncEvent>(Channel.UNLIMITED)
@@ -177,38 +175,33 @@ class GeneralSyncManager(
     }
 
     override fun rememberPairingCredentialType(syncInfo: SyncInfo) {
-        val credentialType =
-            if (SyncApi.supportsSASPairing(syncInfo.appInfo.pairingVersion)) {
-                PairingCredentialType.SAS_CODE
-            } else {
-                PairingCredentialType.QR_BEARER_TOKEN
-            }
+        val credentialType = pairingCredentialType(syncInfo)
         _pairingCredentialTypes.update {
             it + (syncInfo.appInfo.appInstanceId to credentialType)
         }
     }
 
-    override fun refreshPairingCredentialType(appInstanceId: String) {
-        if (_pairingCredentialTypes.value.containsKey(appInstanceId)) return
+    override suspend fun refreshPairingCredentialType(appInstanceId: String): PairingCredentialRefreshResult {
+        _pairingCredentialTypes.value[appInstanceId]?.let {
+            return PairingCredentialRefreshResult.Resolved(it)
+        }
 
         val syncRuntimeInfo =
             realTimeSyncRuntimeInfos.value.firstOrNull {
                 it.appInstanceId == appInstanceId && it.connectState == SyncState.UNVERIFIED
             }
-                ?: return
-        val host = syncRuntimeInfo.connectHostAddress ?: return
-        if (!pairingCredentialTypeRequests.add(appInstanceId)) return
+                ?: return PairingCredentialRefreshResult.DeviceUnavailable
+        val host = syncRuntimeInfo.connectHostAddress ?: return PairingCredentialRefreshResult.RetryableFailure
 
-        realTimeSyncScope.launch {
-            try {
-                val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
-                val result = syncClientApi.syncInfo { buildUrl(hostAndPort) }
-                if (result !is SuccessResult) {
-                    logger.warn {
-                        "Failed to fetch pairing metadata for $appInstanceId: ${result::class.simpleName}"
-                    }
-                    return@launch
+        return try {
+            val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
+            val result = syncClientApi.syncInfo { buildUrl(hostAndPort) }
+            if (result !is SuccessResult) {
+                logger.warn {
+                    "Failed to fetch pairing metadata for $appInstanceId: ${result::class.simpleName}"
                 }
+                PairingCredentialRefreshResult.RetryableFailure
+            } else {
                 val syncInfo = result.getResult<SyncInfo>()
                 when {
                     syncInfo.appInfo.appInstanceId != appInstanceId -> {
@@ -216,21 +209,37 @@ class GeneralSyncManager(
                             "Pairing metadata identity mismatch: expected $appInstanceId, " +
                                 "received ${syncInfo.appInfo.appInstanceId}"
                         }
+                        PairingCredentialRefreshResult.IdentityMismatch
                     }
                     realTimeSyncRuntimeInfos.value.none { it.appInstanceId == appInstanceId } -> {
-                        // device removed while the request was in flight; drop the result
+                        PairingCredentialRefreshResult.DeviceUnavailable
                     }
-                    else -> rememberPairingCredentialType(syncInfo)
+                    else -> {
+                        val credentialType = pairingCredentialType(syncInfo)
+                        rememberPairingCredentialType(syncInfo)
+                        if (realTimeSyncRuntimeInfos.value.none { it.appInstanceId == appInstanceId }) {
+                            _pairingCredentialTypes.update { it - appInstanceId }
+                            PairingCredentialRefreshResult.DeviceUnavailable
+                        } else {
+                            PairingCredentialRefreshResult.Resolved(credentialType)
+                        }
+                    }
                 }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                logger.warn(e) { "Failed to refresh pairing metadata for $appInstanceId" }
-            } finally {
-                pairingCredentialTypeRequests.remove(appInstanceId)
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to refresh pairing metadata for $appInstanceId" }
+            PairingCredentialRefreshResult.RetryableFailure
         }
     }
+
+    private fun pairingCredentialType(syncInfo: SyncInfo): PairingCredentialType =
+        if (SyncApi.supportsSASPairing(syncInfo.appInfo.pairingVersion)) {
+            PairingCredentialType.SAS_CODE
+        } else {
+            PairingCredentialType.QR_BEARER_TOKEN
+        }
 
     private fun resolveSyncs(callback: () -> Unit) {
         realTimeSyncScope.launch {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -215,14 +215,26 @@ class GeneralSyncManager(
         }
     }
 
-    override fun trustByToken(
+    override fun trustByBearerToken(
         appInstanceId: String,
-        token: Int,
+        token: QrBearerToken,
         callback: (Boolean) -> Unit,
     ) {
         internalSyncHandlers[appInstanceId]?.let { syncHandler ->
             realTimeSyncScope.launch {
-                syncHandler.trustByToken(token, callback)
+                syncHandler.trustByBearerToken(token, callback)
+            }
+        } ?: callback(false)
+    }
+
+    override fun trustBySasCode(
+        appInstanceId: String,
+        code: SasCode,
+        callback: (Boolean) -> Unit,
+    ) {
+        internalSyncHandlers[appInstanceId]?.let { syncHandler ->
+            realTimeSyncScope.launch {
+                syncHandler.trustBySasCode(code, callback)
             }
         } ?: callback(false)
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -5,8 +5,13 @@ import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
 import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.net.SyncApi
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.filter
 import com.crosspaste.net.ws.WsSessionManager
+import com.crosspaste.utils.HostAndPort
+import com.crosspaste.utils.buildUrl
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.mainDispatcher
 import com.crosspaste.utils.namedScope
@@ -30,11 +35,13 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 class GeneralSyncManager(
     override val realTimeSyncScope: CoroutineScope = namedScope(ioDispatcher, "GeneralSyncManager"),
     private val syncResolver: SyncResolverApi,
     private val syncRuntimeInfoDao: SyncRuntimeInfoDao,
+    private val syncClientApi: SyncClientApi,
     private val wsSessionManager: WsSessionManager,
 ) : SyncManager {
 
@@ -63,6 +70,14 @@ class GeneralSyncManager(
             started = WhileSubscribed(5000),
             initialValue = null,
         )
+
+    // Keep protocol capability out of SyncRuntimeInfo so its persisted and serialized schema stays stable.
+    private val _pairingCredentialTypes = MutableStateFlow<Map<String, PairingCredentialType>>(emptyMap())
+
+    override val pairingCredentialTypes: StateFlow<Map<String, PairingCredentialType>> =
+        _pairingCredentialTypes.asStateFlow()
+
+    private val pairingCredentialTypeRequests: MutableSet<String> = ConcurrentSet()
 
     private val internalSyncHandlers: MutableMap<String, SyncHandler> = ConcurrentMap()
 
@@ -120,6 +135,9 @@ class GeneralSyncManager(
                         internalSyncHandlers.remove(appInstanceId)?.cancelScope()
                         wsSessionManager.unregisterSession(appInstanceId)
                     }
+                    if (deleteSet.isNotEmpty()) {
+                        _pairingCredentialTypes.update { it - deleteSet }
+                    }
 
                     newSet.forEach { appInstanceId ->
                         internalSyncHandlers[appInstanceId] =
@@ -156,6 +174,56 @@ class GeneralSyncManager(
 
     override fun toVerify(appInstanceId: String) {
         _ignoreVerifySet.update { it - appInstanceId }
+    }
+
+    override fun rememberPairingCredentialType(syncInfo: SyncInfo) {
+        val credentialType =
+            if (SyncApi.supportsSASPairing(syncInfo.appInfo.pairingVersion)) {
+                PairingCredentialType.SAS_CODE
+            } else {
+                PairingCredentialType.QR_BEARER_TOKEN
+            }
+        _pairingCredentialTypes.update {
+            it + (syncInfo.appInfo.appInstanceId to credentialType)
+        }
+    }
+
+    override fun refreshPairingCredentialType(appInstanceId: String) {
+        if (_pairingCredentialTypes.value.containsKey(appInstanceId)) return
+
+        val syncRuntimeInfo =
+            realTimeSyncRuntimeInfos.value.firstOrNull {
+                it.appInstanceId == appInstanceId && it.connectState == SyncState.UNVERIFIED
+            }
+                ?: return
+        val host = syncRuntimeInfo.connectHostAddress ?: return
+        if (!pairingCredentialTypeRequests.add(appInstanceId)) return
+
+        realTimeSyncScope.launch {
+            try {
+                val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
+                val result = syncClientApi.syncInfo { buildUrl(hostAndPort) }
+                if (result is SuccessResult) {
+                    val syncInfo = result.getResult<SyncInfo>()
+                    if (syncInfo.appInfo.appInstanceId == appInstanceId &&
+                        realTimeSyncRuntimeInfos.value.any { it.appInstanceId == appInstanceId }
+                    ) {
+                        rememberPairingCredentialType(syncInfo)
+                    } else {
+                        logger.warn {
+                            "Pairing metadata identity mismatch: expected $appInstanceId, " +
+                                "received ${syncInfo.appInfo.appInstanceId}"
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.warn(e) { "Failed to refresh pairing metadata for $appInstanceId" }
+            } finally {
+                pairingCredentialTypeRequests.remove(appInstanceId)
+            }
+        }
     }
 
     private fun resolveSyncs(callback: () -> Unit) {
@@ -273,6 +341,7 @@ class GeneralSyncManager(
     }
 
     override fun updateSyncInfo(syncInfo: SyncInfo) {
+        rememberPairingCredentialType(syncInfo)
         realTimeSyncScope.launch {
             syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo)
         }
@@ -282,6 +351,7 @@ class GeneralSyncManager(
         syncInfo: SyncInfo,
         host: String?,
     ) {
+        rememberPairingCredentialType(syncInfo)
         realTimeSyncScope.launch {
             val connectInfo =
                 host?.let { h ->

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
@@ -35,8 +35,14 @@ class MarketingSyncHandler(
     override suspend fun updateNoteName(noteName: String) {
     }
 
-    override suspend fun trustByToken(
-        token: Int,
+    override suspend fun trustByBearerToken(
+        token: QrBearerToken,
+        callback: (Boolean) -> Unit,
+    ) {
+    }
+
+    override suspend fun trustBySasCode(
+        code: SasCode,
         callback: (Boolean) -> Unit,
     ) {
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
@@ -98,9 +98,16 @@ class MarketingSyncManager : SyncManager {
     ) {
     }
 
-    override fun trustByToken(
+    override fun trustByBearerToken(
         appInstanceId: String,
-        token: Int,
+        token: QrBearerToken,
+        callback: (Boolean) -> Unit,
+    ) {
+    }
+
+    override fun trustBySasCode(
+        appInstanceId: String,
+        code: SasCode,
         callback: (Boolean) -> Unit,
     ) {
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
@@ -86,8 +86,8 @@ class MarketingSyncManager : SyncManager {
     override fun rememberPairingCredentialType(syncInfo: SyncInfo) {
     }
 
-    override fun refreshPairingCredentialType(appInstanceId: String) {
-    }
+    override suspend fun refreshPairingCredentialType(appInstanceId: String): PairingCredentialRefreshResult =
+        PairingCredentialRefreshResult.DeviceUnavailable
 
     override fun updateAllowSend(
         appInstanceId: String,

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
@@ -56,6 +56,9 @@ class MarketingSyncManager : SyncManager {
     override val unverifiedSyncRuntimeInfo: StateFlow<SyncRuntimeInfo?> =
         MutableStateFlow(null)
 
+    override val pairingCredentialTypes: StateFlow<Map<String, PairingCredentialType>> =
+        MutableStateFlow(emptyMap())
+
     override suspend fun start() {
         internalSyncHandlers.putAll(
             syncRuntimeInfos.map { syncRuntimeInfo ->
@@ -78,6 +81,12 @@ class MarketingSyncManager : SyncManager {
     }
 
     override fun toVerify(appInstanceId: String) {
+    }
+
+    override fun rememberPairingCredentialType(syncInfo: SyncInfo) {
+    }
+
+    override fun refreshPairingCredentialType(appInstanceId: String) {
     }
 
     override fun updateAllowSend(

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PairingCredential.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PairingCredential.kt
@@ -1,0 +1,30 @@
+package com.crosspaste.sync
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Two distinct 6-digit pairing credentials that must never be interchanged.
+ *
+ * [QrBearerToken] is a short-lived *random* value the display side generates and shows
+ * (embedded in its QR / on-screen pairing code); the receiver proves possession by sending
+ * it back to `POST /sync/trust`, where `sameToken` compares it against the displayed value.
+ * It is device-independent and known before any key exchange.
+ *
+ * [SasCode] is *derived from both peers' public keys* (CryptographyUtils.computeSAS) and only
+ * exists after the ECDH key exchange; the user compares it across both screens, and it is
+ * confirmed via the `POST /sync/trust/v2/exchange` + `/confirm` endpoints. Because it depends
+ * on the scanning device's key, a QR — built before the scan — can never carry it.
+ *
+ * Keeping them as separate types makes "feed a scanned QR bearer token into the SAS
+ * comparison" — a deterministic failure for pairingVersion>=2 peers — unrepresentable at the
+ * call site, instead of relying on an internal pairingVersion `when`.
+ */
+@JvmInline
+value class QrBearerToken(
+    val value: Int,
+)
+
+@JvmInline
+value class SasCode(
+    val value: Int,
+)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PairingCredential.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PairingCredential.kt
@@ -2,6 +2,11 @@ package com.crosspaste.sync
 
 import kotlin.jvm.JvmInline
 
+enum class PairingCredentialType {
+    QR_BEARER_TOKEN,
+    SAS_CODE,
+}
+
 /**
  * Two distinct 6-digit pairing credentials that must never be interchanged.
  *

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PairingCredential.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PairingCredential.kt
@@ -7,6 +7,18 @@ enum class PairingCredentialType {
     SAS_CODE,
 }
 
+sealed interface PairingCredentialRefreshResult {
+    data class Resolved(
+        val credentialType: PairingCredentialType,
+    ) : PairingCredentialRefreshResult
+
+    data object RetryableFailure : PairingCredentialRefreshResult
+
+    data object IdentityMismatch : PairingCredentialRefreshResult
+
+    data object DeviceUnavailable : PairingCredentialRefreshResult
+}
+
 /**
  * Two distinct 6-digit pairing credentials that must never be interchanged.
  *

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -30,12 +30,20 @@ sealed interface SyncEvent {
         override fun toString(): String = "ForceResolve ${syncRuntimeInfo.appInstanceId}"
     }
 
-    data class TrustByToken(
+    data class TrustByBearerToken(
         override val syncRuntimeInfo: SyncRuntimeInfo,
-        val token: Int,
+        val token: QrBearerToken,
         val callback: (Boolean) -> Unit,
     ) : SyncRunTimeInfoEvent {
-        override fun toString(): String = "TrustByToken ${syncRuntimeInfo.appInstanceId} $token"
+        override fun toString(): String = "TrustByBearerToken ${syncRuntimeInfo.appInstanceId}"
+    }
+
+    data class TrustBySasCode(
+        override val syncRuntimeInfo: SyncRuntimeInfo,
+        val code: SasCode,
+        val callback: (Boolean) -> Unit,
+    ) : SyncRunTimeInfoEvent {
+        override fun toString(): String = "TrustBySasCode ${syncRuntimeInfo.appInstanceId}"
     }
 
     data class UpdateAllowSend(

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
@@ -48,9 +48,15 @@ interface SyncHandler {
 
     suspend fun updateNoteName(noteName: String)
 
-    // use user input token to trust
-    suspend fun trustByToken(
-        token: Int,
+    // Trust using the random QR/screen bearer token (POST /sync/trust).
+    suspend fun trustByBearerToken(
+        token: QrBearerToken,
+        callback: (Boolean) -> Unit,
+    )
+
+    // Trust using the key-derived SAS the user enters (POST /sync/trust/v2/*).
+    suspend fun trustBySasCode(
+        code: SasCode,
         callback: (Boolean) -> Unit,
     )
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
@@ -25,7 +25,7 @@ interface SyncManager : SyncRoutingApi {
 
     fun rememberPairingCredentialType(syncInfo: SyncInfo)
 
-    fun refreshPairingCredentialType(appInstanceId: String)
+    suspend fun refreshPairingCredentialType(appInstanceId: String): PairingCredentialRefreshResult
 
     fun updateAllowSend(
         appInstanceId: String,

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.sync
 
 import com.crosspaste.db.sync.SyncRuntimeInfo
+import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.net.routing.SyncRoutingApi
 import kotlinx.coroutines.flow.StateFlow
 
@@ -9,6 +10,8 @@ interface SyncManager : SyncRoutingApi {
     val realTimeSyncRuntimeInfos: StateFlow<List<SyncRuntimeInfo>>
 
     val unverifiedSyncRuntimeInfo: StateFlow<SyncRuntimeInfo?>
+
+    val pairingCredentialTypes: StateFlow<Map<String, PairingCredentialType>>
 
     suspend fun start()
 
@@ -19,6 +22,10 @@ interface SyncManager : SyncRoutingApi {
     fun ignoreVerify(appInstanceId: String)
 
     fun toVerify(appInstanceId: String)
+
+    fun rememberPairingCredentialType(syncInfo: SyncInfo)
+
+    fun refreshPairingCredentialType(appInstanceId: String)
 
     fun updateAllowSend(
         appInstanceId: String,

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
@@ -35,9 +35,19 @@ interface SyncManager : SyncRoutingApi {
         noteName: String,
     )
 
-    fun trustByToken(
+    // Trust a device using the random bearer token carried by a scanned QR / typed on a
+    // pairingVersion<2 peer's screen. Routes to POST /sync/trust.
+    fun trustByBearerToken(
         appInstanceId: String,
-        token: Int,
+        token: QrBearerToken,
+        callback: (Boolean) -> Unit,
+    )
+
+    // Trust a device using the key-derived SAS the user compares/enters on a
+    // pairingVersion>=2 peer. Routes to POST /sync/trust/v2/*.
+    fun trustBySasCode(
+        appInstanceId: String,
+        code: SasCode,
         callback: (Boolean) -> Unit,
     )
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -10,7 +10,6 @@ import com.crosspaste.dto.secure.KeyExchangeResponse
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.NetworkInterfaceService
 import com.crosspaste.net.PasteBonjourService
-import com.crosspaste.net.SyncApi
 import com.crosspaste.net.SyncInfoFactory
 import com.crosspaste.net.TelnetHelper
 import com.crosspaste.net.VersionRelation
@@ -38,7 +37,6 @@ import kotlin.coroutines.cancellation.CancellationException
 class SyncResolver(
     private val appInfo: AppInfo,
     private val localPlatform: Platform,
-    private val lazyNearbyDeviceManager: Lazy<NearbyDeviceManager>,
     private val lazyPasteBonjourService: Lazy<PasteBonjourService>,
     private val networkInterfaceService: NetworkInterfaceService,
     private val ratingPromptManager: RatingPromptManager,
@@ -67,12 +65,6 @@ class SyncResolver(
     // reconnect re-advertises too. Cleared on MarkExit/RemoveDevice so a gracefully-departed
     // device leaves nothing behind (no heartbeat would ever come to evict it otherwise).
     private val lastHeartbeatAdvertised: MutableMap<String, List<HostInfo>> = ConcurrentMap()
-
-    private fun getRemotePairingVersion(appInstanceId: String): Int? =
-        lazyNearbyDeviceManager.value.nearbySyncInfos.value
-            .firstOrNull { it.appInfo.appInstanceId == appInstanceId }
-            ?.appInfo
-            ?.pairingVersion
 
     private fun SyncEvent.appInstanceId(): String =
         when (this) {
@@ -106,8 +98,12 @@ class SyncResolver(
                         syncRuntimeInfo.forceResolve(event.callback)
                     }
 
-                    is SyncEvent.TrustByToken -> {
-                        syncRuntimeInfo.trustByToken(event.token, event.callback)
+                    is SyncEvent.TrustByBearerToken -> {
+                        syncRuntimeInfo.trustByBearerToken(event.token, event.callback)
+                    }
+
+                    is SyncEvent.TrustBySasCode -> {
+                        syncRuntimeInfo.trustBySasCode(event.code, event.callback)
                     }
 
                     is SyncEvent.UpdateAllowSend -> {
@@ -631,7 +627,7 @@ class SyncResolver(
             connectHostAddress?.let { host ->
                 val hostAndPort = HostAndPort(host, port)
                 val result =
-                    syncClientApi.trust(appInstanceId, host, token) {
+                    syncClientApi.trust(appInstanceId, host, token.value) {
                         buildUrl(hostAndPort)
                     }
 
@@ -644,30 +640,22 @@ class SyncResolver(
         return false
     }
 
-    private suspend fun SyncRuntimeInfo.trustByToken(
-        token: Int,
+    // Bearer path (POST /sync/trust): the token is the random value the remote also holds
+    // while its QR / pairing code is on screen. Works for any pairingVersion — a v2 remote
+    // still serves /sync/trust and verifies via `sameToken`. This is the QR path; it must
+    // never be diverted into the SAS comparison.
+    private suspend fun SyncRuntimeInfo.trustByBearerToken(
+        token: QrBearerToken,
         callback: (Boolean) -> Unit,
     ) {
-        if (connectState == SyncState.UNVERIFIED) {
-            val remotePairingVersion = getRemotePairingVersion(appInstanceId)
-            if (SyncApi.supportsSASPairing(remotePairingVersion)) {
-                trustByTokenV2(token, callback)
-            } else {
-                trustByTokenV1(token, callback)
-            }
-        } else {
+        if (connectState != SyncState.UNVERIFIED) {
             callback(false)
+            return
         }
-    }
-
-    private suspend fun SyncRuntimeInfo.trustByTokenV1(
-        token: Int,
-        callback: (Boolean) -> Unit,
-    ) {
         connectHostAddress?.let { host ->
             val hostAndPort = HostAndPort(host, port)
             val result =
-                syncClientApi.trust(appInstanceId, host, token) {
+                syncClientApi.trust(appInstanceId, host, token.value) {
                     buildUrl(hostAndPort)
                 }
 
@@ -687,10 +675,17 @@ class SyncResolver(
         } ?: callback(false)
     }
 
-    private suspend fun SyncRuntimeInfo.trustByTokenV2(
-        token: Int,
+    // SAS path (POST /sync/trust/v2/*): the code is the key-derived value the user compares
+    // across both screens. Only reachable for pairingVersion>=2 peers, and only via a
+    // user-entered SasCode — never a machine-read QR bearer token.
+    private suspend fun SyncRuntimeInfo.trustBySasCode(
+        code: SasCode,
         callback: (Boolean) -> Unit,
     ) {
+        if (connectState != SyncState.UNVERIFIED) {
+            callback(false)
+            return
+        }
         connectHostAddress?.let { host ->
             val hostAndPort = HostAndPort(host, port)
 
@@ -719,8 +714,10 @@ class SyncResolver(
             val localSAS =
                 CryptographyUtils.computeSAS(localCryptPublicKey, response.cryptPublicKey)
 
-            if (token != localSAS) {
-                logger.warn { "v2 SAS mismatch for $appInstanceId: expected $localSAS, got $token (possible MITM)" }
+            if (code.value != localSAS) {
+                logger.warn {
+                    "v2 SAS mismatch for $appInstanceId: expected $localSAS, got ${code.value} (possible MITM)"
+                }
                 callback(false)
                 return
             }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/TokenCache.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/TokenCache.kt
@@ -6,21 +6,21 @@ interface TokenCacheApi {
 
     fun setToken(
         appInstanceId: String,
-        token: Int,
+        token: QrBearerToken,
     )
 
-    fun getToken(appInstanceId: String): Int?
+    fun getToken(appInstanceId: String): QrBearerToken?
 }
 
 object TokenCache : TokenCacheApi {
-    private val tokenCache: MutableMap<String, Int> = ConcurrentMap()
+    private val tokenCache: MutableMap<String, QrBearerToken> = ConcurrentMap()
 
     override fun setToken(
         appInstanceId: String,
-        token: Int,
+        token: QrBearerToken,
     ) {
         tokenCache[appInstanceId] = token
     }
 
-    override fun getToken(appInstanceId: String): Int? = tokenCache.remove(appInstanceId)
+    override fun getToken(appInstanceId: String): QrBearerToken? = tokenCache.remove(appInstanceId)
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -65,7 +65,9 @@ import com.crosspaste.ui.theme.AppUISize.xLarge
 import com.crosspaste.ui.theme.AppUISize.xxxLarge
 import com.crosspaste.ui.theme.AppUISize.xxxxLarge
 import com.crosspaste.ui.theme.AppUISize.zero
+import kotlinx.coroutines.delay
 import org.koin.compose.koinInject
+import kotlin.time.Duration.Companion.seconds
 
 @Composable
 fun DeviceScope.TrustDeviceDialog() {
@@ -75,7 +77,13 @@ fun DeviceScope.TrustDeviceDialog() {
     val appSizeValue = LocalAppSizeValueState.current
     val appInstanceId = syncRuntimeInfo.appInstanceId
     val pairingCredentialTypes by syncManager.pairingCredentialTypes.collectAsState()
-    val pairingCredentialType = pairingCredentialTypes[appInstanceId]
+
+    // The manager may never learn the type (peer predates GET /sync/syncInfo, or stays
+    // unreachable while the dialog is open). After the retry ladder below gives up we fall
+    // back to the bearer-token path, which every version serves via POST /sync/trust; a
+    // real sighting later still overrides the fallback because the map entry wins.
+    var fallbackCredentialType by remember(appInstanceId) { mutableStateOf<PairingCredentialType?>(null) }
+    val pairingCredentialType = pairingCredentialTypes[appInstanceId] ?: fallbackCredentialType
     val isPairingTypeKnown = pairingCredentialType != null
 
     val tokenCount = 6
@@ -114,7 +122,14 @@ fun DeviceScope.TrustDeviceDialog() {
     }
 
     LaunchedEffect(appInstanceId) {
-        syncManager.refreshPairingCredentialType(appInstanceId)
+        var backoff = 1.seconds
+        repeat(4) {
+            if (syncManager.pairingCredentialTypes.value.containsKey(appInstanceId)) return@LaunchedEffect
+            syncManager.refreshPairingCredentialType(appInstanceId)
+            delay(backoff)
+            backoff *= 2
+        }
+        fallbackCredentialType = PairingCredentialType.QR_BEARER_TOKEN
     }
 
     LaunchedEffect(appInstanceId, pairingCredentialType) {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -50,6 +50,8 @@ import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.net.SyncApi
 import com.crosspaste.sync.NearbyDeviceManager
+import com.crosspaste.sync.QrBearerToken
+import com.crosspaste.sync.SasCode
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.ui.LocalAppSizeValueState
 import com.crosspaste.ui.base.DialogActionButton
@@ -78,6 +80,11 @@ fun DeviceScope.TrustDeviceDialog() {
 
     var isLoading by remember { mutableStateOf(false) }
 
+    // Decided once the remote's pairingVersion is known (see LaunchedEffect below): a
+    // pairingVersion>=2 peer displays a key-derived SAS the user types, everything else
+    // displays a random bearer token. This picks which typed trust entry confirmToken calls.
+    var useSasPairing by remember { mutableStateOf(false) }
+
     val focusRequesters = remember { List(tokenCount) { FocusRequester() } }
 
     val setError = { value: Boolean ->
@@ -95,6 +102,7 @@ fun DeviceScope.TrustDeviceDialog() {
                 setError = setError,
                 syncManager = syncManager,
                 syncRuntimeInfo = syncRuntimeInfo,
+                useSasPairing = useSasPairing,
             )
         }
     }
@@ -114,7 +122,8 @@ fun DeviceScope.TrustDeviceDialog() {
                 .firstOrNull { it.appInfo.appInstanceId == syncRuntimeInfo.appInstanceId }
                 ?.appInfo
                 ?.pairingVersion
-        if (SyncApi.supportsSASPairing(remotePairingVersion)) {
+        useSasPairing = SyncApi.supportsSASPairing(remotePairingVersion)
+        if (useSasPairing) {
             handler?.exchangeKeysForPairing()
         } else {
             handler?.showToken()
@@ -363,11 +372,18 @@ fun confirmToken(
     setError: (Boolean) -> Unit,
     syncManager: SyncManager,
     syncRuntimeInfo: SyncRuntimeInfo,
+    useSasPairing: Boolean,
 ) {
     tokens.joinToString("").let { token ->
         if (token.length == tokenCount) {
-            syncManager.trustByToken(syncRuntimeInfo.appInstanceId, token.toInt()) {
-                setError(!it)
+            val appInstanceId = syncRuntimeInfo.appInstanceId
+            val callback = { success: Boolean -> setError(!success) }
+            // The user typed the code the remote showed: a SAS on a pairingVersion>=2 peer,
+            // otherwise a bearer token. Pick the matching typed entry — never cross them.
+            if (useSasPairing) {
+                syncManager.trustBySasCode(appInstanceId, SasCode(token.toInt()), callback)
+            } else {
+                syncManager.trustByBearerToken(appInstanceId, QrBearerToken(token.toInt()), callback)
             }
         } else {
             setError(true)

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -49,6 +49,7 @@ import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Key
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.i18n.GlobalCopywriter
+import com.crosspaste.sync.PairingCredentialRefreshResult
 import com.crosspaste.sync.PairingCredentialType
 import com.crosspaste.sync.QrBearerToken
 import com.crosspaste.sync.SasCode
@@ -67,6 +68,7 @@ import com.crosspaste.ui.theme.AppUISize.xxxxLarge
 import com.crosspaste.ui.theme.AppUISize.zero
 import kotlinx.coroutines.delay
 import org.koin.compose.koinInject
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
@@ -77,13 +79,7 @@ fun DeviceScope.TrustDeviceDialog() {
     val appSizeValue = LocalAppSizeValueState.current
     val appInstanceId = syncRuntimeInfo.appInstanceId
     val pairingCredentialTypes by syncManager.pairingCredentialTypes.collectAsState()
-
-    // The manager may never learn the type (peer predates GET /sync/syncInfo, or stays
-    // unreachable while the dialog is open). After the retry ladder below gives up we fall
-    // back to the bearer-token path, which every version serves via POST /sync/trust; a
-    // real sighting later still overrides the fallback because the map entry wins.
-    var fallbackCredentialType by remember(appInstanceId) { mutableStateOf<PairingCredentialType?>(null) }
-    val pairingCredentialType = pairingCredentialTypes[appInstanceId] ?: fallbackCredentialType
+    val pairingCredentialType = pairingCredentialTypes[appInstanceId]
     val isPairingTypeKnown = pairingCredentialType != null
 
     val tokenCount = 6
@@ -122,14 +118,7 @@ fun DeviceScope.TrustDeviceDialog() {
     }
 
     LaunchedEffect(appInstanceId) {
-        var backoff = 1.seconds
-        repeat(4) {
-            if (syncManager.pairingCredentialTypes.value.containsKey(appInstanceId)) return@LaunchedEffect
-            syncManager.refreshPairingCredentialType(appInstanceId)
-            delay(backoff)
-            backoff *= 2
-        }
-        fallbackCredentialType = PairingCredentialType.QR_BEARER_TOKEN
+        refreshPairingCredentialTypeUntilKnown(syncManager, appInstanceId)
     }
 
     LaunchedEffect(appInstanceId, pairingCredentialType) {
@@ -228,6 +217,30 @@ fun DeviceScope.TrustDeviceDialog() {
             }
         },
     )
+}
+
+internal suspend fun refreshPairingCredentialTypeUntilKnown(
+    syncManager: SyncManager,
+    appInstanceId: String,
+    initialBackoff: Duration = 1.seconds,
+    maxBackoff: Duration = 30.seconds,
+    delayAction: suspend (Duration) -> Unit = { delay(it) },
+): PairingCredentialRefreshResult {
+    var backoff = initialBackoff
+    while (true) {
+        val result = syncManager.refreshPairingCredentialType(appInstanceId)
+        when (result) {
+            is PairingCredentialRefreshResult.Resolved,
+            PairingCredentialRefreshResult.IdentityMismatch,
+            PairingCredentialRefreshResult.DeviceUnavailable,
+            -> return result
+
+            PairingCredentialRefreshResult.RetryableFailure -> {
+                delayAction(backoff)
+                backoff = (backoff * 2).coerceAtMost(maxBackoff)
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -48,8 +49,7 @@ import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Key
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.i18n.GlobalCopywriter
-import com.crosspaste.net.SyncApi
-import com.crosspaste.sync.NearbyDeviceManager
+import com.crosspaste.sync.PairingCredentialType
 import com.crosspaste.sync.QrBearerToken
 import com.crosspaste.sync.SasCode
 import com.crosspaste.sync.SyncManager
@@ -73,26 +73,26 @@ fun DeviceScope.TrustDeviceDialog() {
     val syncManager = koinInject<SyncManager>()
 
     val appSizeValue = LocalAppSizeValueState.current
+    val appInstanceId = syncRuntimeInfo.appInstanceId
+    val pairingCredentialTypes by syncManager.pairingCredentialTypes.collectAsState()
+    val pairingCredentialType = pairingCredentialTypes[appInstanceId]
+    val isPairingTypeKnown = pairingCredentialType != null
 
     val tokenCount = 6
-    val tokens = remember { mutableStateListOf(*Array(tokenCount) { "" }) }
-    var isError by remember { mutableStateOf(false) }
+    val tokens = remember(appInstanceId, pairingCredentialType) { mutableStateListOf(*Array(tokenCount) { "" }) }
+    var isError by remember(appInstanceId, pairingCredentialType) { mutableStateOf(false) }
 
-    var isLoading by remember { mutableStateOf(false) }
+    var isLoading by remember(appInstanceId, pairingCredentialType) { mutableStateOf(false) }
 
-    // Decided once the remote's pairingVersion is known (see LaunchedEffect below): a
-    // pairingVersion>=2 peer displays a key-derived SAS the user types, everything else
-    // displays a random bearer token. This picks which typed trust entry confirmToken calls.
-    var useSasPairing by remember { mutableStateOf(false) }
-
-    val focusRequesters = remember { List(tokenCount) { FocusRequester() } }
+    val focusRequesters = remember(appInstanceId, pairingCredentialType) { List(tokenCount) { FocusRequester() } }
 
     val setError = { value: Boolean ->
         isError = value
         if (value) isLoading = false
     }
 
-    val confirmAction = {
+    val confirmAction = confirm@{
+        val credentialType = pairingCredentialType ?: return@confirm
         if (!isLoading) {
             isLoading = true
             isError = false
@@ -102,7 +102,7 @@ fun DeviceScope.TrustDeviceDialog() {
                 setError = setError,
                 syncManager = syncManager,
                 syncRuntimeInfo = syncRuntimeInfo,
-                useSasPairing = useSasPairing,
+                pairingCredentialType = credentialType,
             )
         }
     }
@@ -113,20 +113,16 @@ fun DeviceScope.TrustDeviceDialog() {
         }
     }
 
-    val nearbyDeviceManager = koinInject<NearbyDeviceManager>()
+    LaunchedEffect(appInstanceId) {
+        syncManager.refreshPairingCredentialType(appInstanceId)
+    }
 
-    LaunchedEffect(Unit) {
-        val handler = syncManager.getSyncHandlers()[syncRuntimeInfo.appInstanceId]
-        val remotePairingVersion =
-            nearbyDeviceManager.nearbySyncInfos.value
-                .firstOrNull { it.appInfo.appInstanceId == syncRuntimeInfo.appInstanceId }
-                ?.appInfo
-                ?.pairingVersion
-        useSasPairing = SyncApi.supportsSASPairing(remotePairingVersion)
-        if (useSasPairing) {
-            handler?.exchangeKeysForPairing()
-        } else {
-            handler?.showToken()
+    LaunchedEffect(appInstanceId, pairingCredentialType) {
+        val handler = syncManager.getSyncHandlers()[appInstanceId]
+        when (pairingCredentialType) {
+            PairingCredentialType.SAS_CODE -> handler?.exchangeKeysForPairing()
+            PairingCredentialType.QR_BEARER_TOKEN -> handler?.showToken()
+            null -> Unit
         }
     }
 
@@ -188,13 +184,21 @@ fun DeviceScope.TrustDeviceDialog() {
                         }
                     },
                 )
-                TokenInputRow(tokens, isError, isLoading, focusRequesters, confirmAction, cancelAction)
+                TokenInputRow(
+                    tokens,
+                    isError,
+                    isLoading || !isPairingTypeKnown,
+                    focusRequesters,
+                    confirmAction,
+                    cancelAction,
+                )
             }
         },
         confirmButton = {
             DialogActionButton(
                 text = copywriter.getText("confirm"),
                 type = DialogButtonType.FILLED,
+                enabled = isPairingTypeKnown,
                 isLoading = isLoading,
             ) {
                 confirmAction()
@@ -372,18 +376,17 @@ fun confirmToken(
     setError: (Boolean) -> Unit,
     syncManager: SyncManager,
     syncRuntimeInfo: SyncRuntimeInfo,
-    useSasPairing: Boolean,
+    pairingCredentialType: PairingCredentialType,
 ) {
     tokens.joinToString("").let { token ->
         if (token.length == tokenCount) {
             val appInstanceId = syncRuntimeInfo.appInstanceId
             val callback = { success: Boolean -> setError(!success) }
-            // The user typed the code the remote showed: a SAS on a pairingVersion>=2 peer,
-            // otherwise a bearer token. Pick the matching typed entry — never cross them.
-            if (useSasPairing) {
-                syncManager.trustBySasCode(appInstanceId, SasCode(token.toInt()), callback)
-            } else {
-                syncManager.trustByBearerToken(appInstanceId, QrBearerToken(token.toInt()), callback)
+            when (pairingCredentialType) {
+                PairingCredentialType.SAS_CODE ->
+                    syncManager.trustBySasCode(appInstanceId, SasCode(token.toInt()), callback)
+                PairingCredentialType.QR_BEARER_TOKEN ->
+                    syncManager.trustByBearerToken(appInstanceId, QrBearerToken(token.toInt()), callback)
             }
         } else {
             setError(true)

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -221,6 +221,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 GeneralSyncManager(
                     syncResolver = get(),
                     syncRuntimeInfoDao = get(),
+                    syncClientApi = get(),
                     wsSessionManager = get(),
                 )
             }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -229,7 +229,6 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
             SyncResolver(
                 appInfo = get(),
                 localPlatform = get(),
-                lazyNearbyDeviceManager = lazy { get() },
                 lazyPasteBonjourService = lazy { get() },
                 networkInterfaceService = get(),
                 ratingPromptManager = get(),

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoSerializationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoSerializationTest.kt
@@ -1,0 +1,39 @@
+package com.crosspaste.db.sync
+
+import com.crosspaste.sync.SyncTestFixtures.createSyncRuntimeInfo
+import com.crosspaste.utils.getJsonUtils
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SyncRuntimeInfoSerializationTest {
+
+    @Test
+    fun `serialized field set remains compatible with the legacy runtime schema`() {
+        val json = getJsonUtils().JSON
+        val encoded = json.parseToJsonElement(json.encodeToString(createSyncRuntimeInfo())).jsonObject
+
+        assertEquals(
+            setOf(
+                "appInstanceId",
+                "appVersion",
+                "userName",
+                "deviceId",
+                "deviceName",
+                "platform",
+                "hostInfoList",
+                "port",
+                "noteName",
+                "connectNetworkPrefixLength",
+                "connectHostAddress",
+                "connectState",
+                "allowSend",
+                "allowReceive",
+                "createTime",
+                "modifyTime",
+            ),
+            encoded.keys,
+        )
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
@@ -16,6 +16,7 @@ import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.platform.Platform
 import com.crosspaste.utils.getJsonUtils
+import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -23,6 +24,20 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class DtoSerializationTest {
+
+    @Serializable
+    private data class LegacyAppInfo(
+        val appInstanceId: String,
+        val appVersion: String,
+        val appRevision: String,
+        val userName: String,
+    )
+
+    @Serializable
+    private data class LegacySyncInfo(
+        val appInfo: LegacyAppInfo,
+        val endpointInfo: EndpointInfo,
+    )
 
     private val json = getJsonUtils().JSON
 
@@ -147,6 +162,42 @@ class DtoSerializationTest {
             )
         val encoded = json.encodeToString(original)
         val decoded = json.decodeFromString<SyncInfo>(encoded)
+
+        assertEquals("app-1", decoded.appInfo.appInstanceId)
+        assertEquals("dev-1", decoded.endpointInfo.deviceId)
+    }
+
+    @Test
+    fun `new SyncInfo decoder accepts legacy AppInfo without pairingVersion`() {
+        val legacyWire =
+            """
+            {"appInfo":{"appInstanceId":"app-1","appVersion":"1.0.0","appRevision":"rev","userName":"user"},
+             "endpointInfo":{"deviceId":"dev-1","deviceName":"Test",
+              "platform":{"name":"TestOS","arch":"x86_64","bitMode":64,"version":"1.0.0"},
+              "hostInfoList":[],"port":8080}}
+            """.trimIndent()
+
+        val decoded = json.decodeFromString<SyncInfo>(legacyWire)
+
+        assertEquals(null, decoded.appInfo.pairingVersion)
+    }
+
+    @Test
+    fun `legacy SyncInfo decoder ignores pairingVersion from new AppInfo`() {
+        val current =
+            SyncInfo(
+                appInfo = AppInfo("app-1", "1.0.0", "rev", "user", pairingVersion = 2),
+                endpointInfo =
+                    EndpointInfo(
+                        deviceId = "dev-1",
+                        deviceName = "Test",
+                        platform = testPlatform,
+                        hostInfoList = emptyList(),
+                        port = 8080,
+                    ),
+            )
+
+        val decoded = json.decodeFromString<LegacySyncInfo>(json.encodeToString(current))
 
         assertEquals("app-1", decoded.appInfo.appInstanceId)
         assertEquals("dev-1", decoded.endpointInfo.deviceId)

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsModuleDependencyTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsModuleDependencyTest.kt
@@ -123,7 +123,6 @@ class WsModuleDependencyTest : KoinTest {
                     SyncResolver(
                         appInfo = get(),
                         localPlatform = get(),
-                        lazyNearbyDeviceManager = lazy { get() },
                         lazyPasteBonjourService = lazy { get() },
                         networkInterfaceService = get(),
                         ratingPromptManager = get(),

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralNearbyDeviceManagerTest.kt
@@ -99,6 +99,14 @@ class GeneralNearbyDeviceManagerTest {
             // Already synced devices should not appear in nearby list
             val nearbyIds = manager.nearbySyncInfos.value.map { it.appInfo.appInstanceId }
             assertFalse(nearbyIds.contains("other-app-1"))
+            verify(exactly = 1) {
+                deps.syncManager.rememberPairingCredentialType(
+                    match {
+                        it.appInfo.appInstanceId == syncInfo.appInfo.appInstanceId &&
+                            it.appInfo.pairingVersion == syncInfo.appInfo.pairingVersion
+                    },
+                )
+            }
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
@@ -507,7 +507,7 @@ class GeneralSyncHandlerTest {
         }
 
     @Test
-    fun trustByToken_emitsTrustByToken() =
+    fun trustByBearerToken_emitsTrustByBearerToken() =
         runTest {
             val emitter = TestEmitter()
             val childScope = CoroutineScope(coroutineContext + Job())
@@ -517,12 +517,12 @@ class GeneralSyncHandlerTest {
             advanceTimeBy(SMALL_ADVANCE_MS)
             emitter.events.clear()
 
-            handler.trustByToken(123456) { }
+            handler.trustByBearerToken(QrBearerToken(123456)) { }
             advanceTimeBy(SMALL_ADVANCE_MS)
 
-            val event = emitter.findEvent { it is SyncEvent.TrustByToken }
+            val event = emitter.findEvent { it is SyncEvent.TrustByBearerToken }
             assertNotNull(event)
-            assertEquals(123456, (event as SyncEvent.TrustByToken).token)
+            assertEquals(QrBearerToken(123456), (event as SyncEvent.TrustByBearerToken).token)
             childScope.cancel()
         }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
@@ -154,7 +154,7 @@ class GeneralSyncManagerTest {
             val syncManager = createSyncManager(mocks, childScope)
 
             // Should not throw exception when handler doesn't exist
-            syncManager.trustByToken("non-existent", 123456) {
+            syncManager.trustByBearerToken("non-existent", QrBearerToken(123456)) {
                 // Callback should be called with false
                 assertEquals(false, it)
             }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
@@ -4,6 +4,8 @@ import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
 import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.platform.Platform
 import com.crosspaste.ui.devices.DeviceScopeFactory
@@ -23,6 +25,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -33,6 +36,7 @@ class GeneralSyncManagerTest {
             deviceScopeFactory = mockk(relaxed = true),
             syncResolver = mockk(relaxed = true),
             syncRuntimeInfoDao = mockk(relaxed = true),
+            syncClientApi = mockk(relaxed = true),
         )
 
     private fun createSyncManager(
@@ -43,6 +47,7 @@ class GeneralSyncManagerTest {
             realTimeSyncScope = scope,
             syncResolver = mocks.syncResolver,
             syncRuntimeInfoDao = mocks.syncRuntimeInfoDao,
+            syncClientApi = mocks.syncClientApi,
             wsSessionManager = WsSessionManager(),
         )
 
@@ -73,6 +78,7 @@ class GeneralSyncManagerTest {
         val deviceScopeFactory: DeviceScopeFactory,
         val syncResolver: SyncResolverApi,
         val syncRuntimeInfoDao: SyncRuntimeInfoDao,
+        val syncClientApi: SyncClientApi,
     )
 
     @Test
@@ -164,10 +170,7 @@ class GeneralSyncManagerTest {
     fun testUpdateSyncInfoNewInstance() =
         runTest {
             val mocks = createMocks()
-            val syncInfo =
-                mockk<SyncInfo> {
-                    every { appInfo.appInstanceId } returns "test-app-1"
-                }
+            val syncInfo = SyncTestFixtures.createSyncInfo(pairingVersion = 2)
 
             coEvery { mocks.syncRuntimeInfoDao.insertOrUpdateSyncInfo(any<SyncInfo>()) } just runs
 
@@ -176,9 +179,96 @@ class GeneralSyncManagerTest {
             syncManager.start()
 
             syncManager.updateSyncInfo(syncInfo)
+
+            assertEquals(
+                PairingCredentialType.SAS_CODE,
+                syncManager.pairingCredentialTypes.value[syncInfo.appInfo.appInstanceId],
+            )
             advanceUntilIdle()
 
             coVerify { mocks.syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo) }
+        }
+
+    @Test
+    fun updateSyncInfo_legacyPeerWithoutPairingVersionUsesBearerToken() =
+        runTest {
+            val mocks = createMocks()
+            val syncInfo = SyncTestFixtures.createSyncInfo(pairingVersion = null)
+
+            coEvery { mocks.syncRuntimeInfoDao.insertOrUpdateSyncInfo(any<SyncInfo>()) } just runs
+
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager = createSyncManager(mocks, childScope)
+
+            syncManager.updateSyncInfo(syncInfo)
+
+            assertEquals(
+                PairingCredentialType.QR_BEARER_TOKEN,
+                syncManager.pairingCredentialTypes.value[syncInfo.appInfo.appInstanceId],
+            )
+        }
+
+    @Test
+    fun refreshPairingCredentialType_fetchesPersistedUnverifiedDeviceMetadata() =
+        runTest {
+            val mocks = createMocks()
+            val appInstanceId = "test-app-1"
+            val syncInfosFlow =
+                MutableStateFlow(
+                    listOf(
+                        createTestSyncRuntimeInfo(
+                            appInstanceId = appInstanceId,
+                            connectState = SyncState.UNVERIFIED,
+                        ).copy(connectHostAddress = "192.168.1.100"),
+                    ),
+                )
+            val syncInfo = SyncTestFixtures.createSyncInfo(appInstanceId = appInstanceId, pairingVersion = 2)
+
+            every { mocks.syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow() } returns syncInfosFlow
+            coEvery { mocks.syncClientApi.syncInfo(any()) } returns SuccessResult(syncInfo)
+
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager = createSyncManager(mocks, childScope)
+            syncManager.start()
+            advanceUntilIdle()
+
+            syncManager.refreshPairingCredentialType(appInstanceId)
+            advanceUntilIdle()
+
+            assertEquals(
+                PairingCredentialType.SAS_CODE,
+                syncManager.pairingCredentialTypes.value[appInstanceId],
+            )
+        }
+
+    @Test
+    fun refreshPairingCredentialType_rejectsMismatchedDeviceIdentity() =
+        runTest {
+            val mocks = createMocks()
+            val appInstanceId = "test-app-1"
+            val syncInfosFlow =
+                MutableStateFlow(
+                    listOf(
+                        createTestSyncRuntimeInfo(
+                            appInstanceId = appInstanceId,
+                            connectState = SyncState.UNVERIFIED,
+                        ).copy(connectHostAddress = "192.168.1.100"),
+                    ),
+                )
+            val wrongDevice = SyncTestFixtures.createSyncInfo(appInstanceId = "different-app", pairingVersion = 2)
+
+            every { mocks.syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow() } returns syncInfosFlow
+            coEvery { mocks.syncClientApi.syncInfo(any()) } returns SuccessResult(wrongDevice)
+
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager = createSyncManager(mocks, childScope)
+            syncManager.start()
+            advanceUntilIdle()
+
+            syncManager.refreshPairingCredentialType(appInstanceId)
+            advanceUntilIdle()
+
+            assertNull(syncManager.pairingCredentialTypes.value[appInstanceId])
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
@@ -4,6 +4,7 @@ import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
 import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.net.clientapi.RequestTimeout
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.ws.WsSessionManager
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -232,9 +234,9 @@ class GeneralSyncManagerTest {
             syncManager.start()
             advanceUntilIdle()
 
-            syncManager.refreshPairingCredentialType(appInstanceId)
-            advanceUntilIdle()
+            val result = syncManager.refreshPairingCredentialType(appInstanceId)
 
+            assertEquals(PairingCredentialRefreshResult.Resolved(PairingCredentialType.SAS_CODE), result)
             assertEquals(
                 PairingCredentialType.SAS_CODE,
                 syncManager.pairingCredentialTypes.value[appInstanceId],
@@ -265,9 +267,70 @@ class GeneralSyncManagerTest {
             syncManager.start()
             advanceUntilIdle()
 
-            syncManager.refreshPairingCredentialType(appInstanceId)
+            val result = syncManager.refreshPairingCredentialType(appInstanceId)
+
+            assertEquals(PairingCredentialRefreshResult.IdentityMismatch, result)
+            assertNull(syncManager.pairingCredentialTypes.value[appInstanceId])
+        }
+
+    @Test
+    fun refreshPairingCredentialType_networkFailureIsRetryable() =
+        runTest {
+            val mocks = createMocks()
+            val appInstanceId = "test-app-1"
+            every { mocks.syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow() } returns
+                MutableStateFlow(
+                    listOf(
+                        createTestSyncRuntimeInfo(
+                            appInstanceId = appInstanceId,
+                            connectState = SyncState.UNVERIFIED,
+                        ).copy(connectHostAddress = "192.168.1.100"),
+                    ),
+                )
+            coEvery { mocks.syncClientApi.syncInfo(any()) } returns RequestTimeout
+
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager = createSyncManager(mocks, childScope)
+            syncManager.start()
             advanceUntilIdle()
 
+            val result = syncManager.refreshPairingCredentialType(appInstanceId)
+
+            assertEquals(PairingCredentialRefreshResult.RetryableFailure, result)
+            assertNull(syncManager.pairingCredentialTypes.value[appInstanceId])
+        }
+
+    @Test
+    fun refreshPairingCredentialType_deviceRemovedDuringRequestDropsMetadata() =
+        runTest {
+            val mocks = createMocks()
+            val appInstanceId = "test-app-1"
+            val syncInfosFlow =
+                MutableStateFlow(
+                    listOf(
+                        createTestSyncRuntimeInfo(
+                            appInstanceId = appInstanceId,
+                            connectState = SyncState.UNVERIFIED,
+                        ).copy(connectHostAddress = "192.168.1.100"),
+                    ),
+                )
+            val syncInfo = SyncTestFixtures.createSyncInfo(appInstanceId = appInstanceId, pairingVersion = 2)
+
+            every { mocks.syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow() } returns syncInfosFlow
+            coEvery { mocks.syncClientApi.syncInfo(any()) } coAnswers {
+                syncInfosFlow.value = emptyList()
+                yield()
+                SuccessResult(syncInfo)
+            }
+
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager = createSyncManager(mocks, childScope)
+            syncManager.start()
+            advanceUntilIdle()
+
+            val result = syncManager.refreshPairingCredentialType(appInstanceId)
+
+            assertEquals(PairingCredentialRefreshResult.DeviceUnavailable, result)
             assertNull(syncManager.pairingCredentialTypes.value[appInstanceId])
         }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -6,6 +6,7 @@ import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
+import com.crosspaste.dto.secure.KeyExchangeResponse
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.exception.PasteException
 import com.crosspaste.exception.StandardErrorCode
@@ -26,11 +27,13 @@ import com.crosspaste.net.clientapi.UnknownError
 import com.crosspaste.net.ws.WsClientConnector
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.platform.Platform
+import com.crosspaste.secure.SecureKeyPair
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.SyncTestFixtures.createConnectedSyncRuntimeInfo
 import com.crosspaste.sync.SyncTestFixtures.createConnectingSyncRuntimeInfo
 import com.crosspaste.sync.SyncTestFixtures.createSyncRuntimeInfo
 import com.crosspaste.sync.SyncTestFixtures.createUnverifiedSyncRuntimeInfo
+import com.crosspaste.utils.CryptographyUtils
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -1213,7 +1216,122 @@ class SyncResolverTest {
             assertEquals(false, callbackResult)
         }
 
-    // ========== F. Event dispatch and callback ==========
+    // ========== F. trustBySasCode ==========
+
+    @Test
+    fun trustBySasCode_matchingCode_confirmsAndConnects() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val localKey = byteArrayOf(1, 2, 3)
+            val remoteKey = byteArrayOf(4, 5, 6)
+            val sasCode = CryptographyUtils.computeSAS(localKey, remoteKey)
+            val response = createKeyExchangeResponse(remoteKey)
+            val secureKeyPair = mockk<SecureKeyPair>()
+
+            deps.stubDbRead(syncRuntimeInfo)
+            every { deps.secureStore.secureKeyPair } returns secureKeyPair
+            coEvery { secureKeyPair.getCryptPublicKeyBytes(any()) } returns localKey
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns SuccessResult(response)
+            coEvery { deps.syncClientApi.trustV2Confirm(any(), any(), any()) } returns SuccessResult(true)
+            coEvery { deps.syncInfoFactory.createSyncInfo(any()) } returns SyncTestFixtures.createSyncInfo()
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
+                SuccessResult(VersionRelation.EQUAL_TO)
+
+            val capturedInfo = slot<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
+
+            var callbackResult: Boolean? = null
+            resolver.emitEvent(
+                SyncEvent.TrustBySasCode(syncRuntimeInfo, SasCode(sasCode)) { callbackResult = it },
+            )
+
+            assertEquals(true, callbackResult)
+            assertEquals(SyncState.CONNECTED, capturedInfo.captured.connectState)
+            coVerify { deps.syncClientApi.trustV2Confirm(syncRuntimeInfo.appInstanceId, any(), any()) }
+            coVerify { deps.secureStore.saveCryptPublicKey(syncRuntimeInfo.appInstanceId, remoteKey) }
+            verify { deps.ratingPromptManager.trackSignificantAction() }
+        }
+
+    @Test
+    fun trustBySasCode_mismatch_doesNotConfirmOrSaveKey() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val localKey = byteArrayOf(1, 2, 3)
+            val remoteKey = byteArrayOf(4, 5, 6)
+            val matchingCode = CryptographyUtils.computeSAS(localKey, remoteKey)
+            val secureKeyPair = mockk<SecureKeyPair>()
+
+            deps.stubDbRead(syncRuntimeInfo)
+            every { deps.secureStore.secureKeyPair } returns secureKeyPair
+            coEvery { secureKeyPair.getCryptPublicKeyBytes(any()) } returns localKey
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns
+                SuccessResult(createKeyExchangeResponse(remoteKey))
+
+            var callbackResult: Boolean? = null
+            resolver.emitEvent(
+                SyncEvent.TrustBySasCode(syncRuntimeInfo, SasCode((matchingCode + 1) % 1_000_000)) {
+                    callbackResult = it
+                },
+            )
+
+            assertEquals(false, callbackResult)
+            coVerify(exactly = 0) { deps.syncClientApi.trustV2Confirm(any(), any(), any()) }
+            coVerify(exactly = 0) { deps.secureStore.saveCryptPublicKey(any(), any()) }
+        }
+
+    @Test
+    fun trustBySasCode_exchangeFailure_returnsFalseWithoutConfirming() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns
+                FailureResult(PasteException(StandardErrorCode.EXCHANGE_FAIL.toErrorCode(), "exchange failed"))
+
+            var callbackResult: Boolean? = null
+            resolver.emitEvent(
+                SyncEvent.TrustBySasCode(syncRuntimeInfo, SasCode(123456)) { callbackResult = it },
+            )
+
+            assertEquals(false, callbackResult)
+            coVerify(exactly = 0) { deps.syncClientApi.trustV2Confirm(any(), any(), any()) }
+        }
+
+    @Test
+    fun trustBySasCode_confirmFailure_returnsFalseWithoutSavingKey() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val localKey = byteArrayOf(1, 2, 3)
+            val remoteKey = byteArrayOf(4, 5, 6)
+            val sasCode = CryptographyUtils.computeSAS(localKey, remoteKey)
+            val secureKeyPair = mockk<SecureKeyPair>()
+
+            deps.stubDbRead(syncRuntimeInfo)
+            every { deps.secureStore.secureKeyPair } returns secureKeyPair
+            coEvery { secureKeyPair.getCryptPublicKeyBytes(any()) } returns localKey
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns
+                SuccessResult(createKeyExchangeResponse(remoteKey))
+            coEvery { deps.syncClientApi.trustV2Confirm(any(), any(), any()) } returns
+                FailureResult(PasteException(StandardErrorCode.TRUST_FAIL.toErrorCode(), "confirm failed"))
+
+            var callbackResult: Boolean? = null
+            resolver.emitEvent(
+                SyncEvent.TrustBySasCode(syncRuntimeInfo, SasCode(sasCode)) { callbackResult = it },
+            )
+
+            assertEquals(false, callbackResult)
+            coVerify(exactly = 0) { deps.secureStore.saveCryptPublicKey(any(), any()) }
+        }
+
+    // ========== G. Event dispatch and callback ==========
 
     @Test
     fun resolve_disconnected_callsSwitchHost() =
@@ -1523,5 +1641,13 @@ class SyncResolverTest {
         ResolveCallback(
             updateVersionRelation = {},
             onComplete = {},
+        )
+
+    private fun createKeyExchangeResponse(remoteKey: ByteArray): KeyExchangeResponse =
+        KeyExchangeResponse(
+            signPublicKey = byteArrayOf(7, 8, 9),
+            cryptPublicKey = remoteKey,
+            timestamp = 1L,
+            signature = byteArrayOf(10, 11, 12),
         )
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -37,7 +37,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
@@ -51,10 +50,6 @@ class SyncResolverTest {
 
     private class TestDeps {
         val pasteBonjourService: PasteBonjourService = mockk(relaxed = true)
-        val nearbyDeviceManager: NearbyDeviceManager =
-            mockk(relaxed = true) {
-                every { nearbySyncInfos } returns MutableStateFlow(emptyList())
-            }
         val networkInterfaceService: NetworkInterfaceService =
             mockk(relaxed = true) {
                 // Default to "online": discoverAndConnect now gates on having a usable
@@ -91,7 +86,6 @@ class SyncResolverTest {
             SyncResolver(
                 appInfo = appInfo,
                 localPlatform = localPlatform,
-                lazyNearbyDeviceManager = lazy { nearbyDeviceManager },
                 lazyPasteBonjourService = lazy { pasteBonjourService },
                 networkInterfaceService = networkInterfaceService,
                 ratingPromptManager = ratingPromptManager,
@@ -109,16 +103,16 @@ class SyncResolverTest {
     }
 
     private class FakeTokenCache : TokenCacheApi {
-        private val tokens = mutableMapOf<String, Int>()
+        private val tokens = mutableMapOf<String, QrBearerToken>()
 
         override fun setToken(
             appInstanceId: String,
-            token: Int,
+            token: QrBearerToken,
         ) {
             tokens[appInstanceId] = token
         }
 
-        override fun getToken(appInstanceId: String): Int? = tokens.remove(appInstanceId)
+        override fun getToken(appInstanceId: String): QrBearerToken? = tokens.remove(appInstanceId)
     }
 
     // ========== A. resolveDisconnected ==========
@@ -646,7 +640,7 @@ class SyncResolverTest {
             val connecting = createConnectingSyncRuntimeInfo(hostAddress = "192.168.1.108")
 
             deps.stubDbRead(connecting)
-            deps.tokenCache.setToken(connecting.appInstanceId, 123456)
+            deps.tokenCache.setToken(connecting.appInstanceId, QrBearerToken(123456))
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
             coEvery { deps.syncClientApi.trust(any(), any(), any(), any()) } returns SuccessResult(true)
             coEvery { deps.wsSessionManager.isConnected(any()) } returns false
@@ -1008,7 +1002,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createConnectingSyncRuntimeInfo()
 
             deps.stubDbRead(syncRuntimeInfo)
-            deps.tokenCache.setToken(syncRuntimeInfo.appInstanceId, 123456)
+            deps.tokenCache.setToken(syncRuntimeInfo.appInstanceId, QrBearerToken(123456))
 
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
             coEvery { deps.syncClientApi.trust(any(), any(), any(), any()) } returns SuccessResult(true)
@@ -1035,7 +1029,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createConnectingSyncRuntimeInfo()
 
             deps.stubDbRead(syncRuntimeInfo)
-            deps.tokenCache.setToken(syncRuntimeInfo.appInstanceId, 123456)
+            deps.tokenCache.setToken(syncRuntimeInfo.appInstanceId, QrBearerToken(123456))
 
             coEvery { deps.secureStore.existCryptPublicKey(any()) } returns false
             coEvery { deps.syncClientApi.trust(any(), any(), any(), any()) } returns
@@ -1133,10 +1127,10 @@ class SyncResolverTest {
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
 
-    // ========== E. trustByToken ==========
+    // ========== E. trustByBearerToken ==========
 
     @Test
-    fun trustByToken_unverifiedAndTrustSucceeds_callbackTrueAndConnected() =
+    fun trustByBearerToken_unverifiedAndTrustSucceeds_callbackTrueAndConnected() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -1154,7 +1148,7 @@ class SyncResolverTest {
 
             var callbackResult: Boolean? = null
             resolver.emitEvent(
-                SyncEvent.TrustByToken(syncRuntimeInfo, 123456) { callbackResult = it },
+                SyncEvent.TrustByBearerToken(syncRuntimeInfo, QrBearerToken(123456)) { callbackResult = it },
             )
 
             assertEquals(true, callbackResult)
@@ -1163,7 +1157,7 @@ class SyncResolverTest {
         }
 
     @Test
-    fun trustByToken_unverifiedAndTrustFails_callbackFalse() =
+    fun trustByBearerToken_unverifiedAndTrustFails_callbackFalse() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -1175,14 +1169,14 @@ class SyncResolverTest {
 
             var callbackResult: Boolean? = null
             resolver.emitEvent(
-                SyncEvent.TrustByToken(syncRuntimeInfo, 123456) { callbackResult = it },
+                SyncEvent.TrustByBearerToken(syncRuntimeInfo, QrBearerToken(123456)) { callbackResult = it },
             )
 
             assertEquals(false, callbackResult)
         }
 
     @Test
-    fun trustByToken_notUnverified_callbackFalse() =
+    fun trustByBearerToken_notUnverified_callbackFalse() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -1192,14 +1186,14 @@ class SyncResolverTest {
 
             var callbackResult: Boolean? = null
             resolver.emitEvent(
-                SyncEvent.TrustByToken(syncRuntimeInfo, 123456) { callbackResult = it },
+                SyncEvent.TrustByBearerToken(syncRuntimeInfo, QrBearerToken(123456)) { callbackResult = it },
             )
 
             assertEquals(false, callbackResult)
         }
 
     @Test
-    fun trustByToken_unverifiedNoConnectHostAddress_callbackFalse() =
+    fun trustByBearerToken_unverifiedNoConnectHostAddress_callbackFalse() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -1213,7 +1207,7 @@ class SyncResolverTest {
 
             var callbackResult: Boolean? = null
             resolver.emitEvent(
-                SyncEvent.TrustByToken(syncRuntimeInfo, 123456) { callbackResult = it },
+                SyncEvent.TrustByBearerToken(syncRuntimeInfo, QrBearerToken(123456)) { callbackResult = it },
             )
 
             assertEquals(false, callbackResult)

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncTestFixtures.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncTestFixtures.kt
@@ -23,12 +23,14 @@ object SyncTestFixtures {
         appVersion: String = "1.0.0",
         appRevision: String = "abc123",
         userName: String = "testUser",
+        pairingVersion: Int? = null,
     ): AppInfo =
         AppInfo(
             appInstanceId = appInstanceId,
             appVersion = appVersion,
             appRevision = appRevision,
             userName = userName,
+            pairingVersion = pairingVersion,
         )
 
     fun createEndpointInfo(
@@ -53,9 +55,15 @@ object SyncTestFixtures {
         deviceName: String = "Test Device",
         hostInfoList: List<HostInfo> = listOf(HostInfo(networkPrefixLength = 24, hostAddress = "192.168.1.100")),
         port: Int = 13129,
+        pairingVersion: Int? = null,
     ): SyncInfo =
         SyncInfo(
-            appInfo = createAppInfo(appInstanceId = appInstanceId, appVersion = appVersion),
+            appInfo =
+                createAppInfo(
+                    appInstanceId = appInstanceId,
+                    appVersion = appVersion,
+                    pairingVersion = pairingVersion,
+                ),
             endpointInfo =
                 createEndpointInfo(
                     deviceId = deviceId,

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/TrustDeviceDialogTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/TrustDeviceDialogTest.kt
@@ -1,0 +1,53 @@
+package com.crosspaste.ui.devices
+
+import com.crosspaste.sync.PairingCredentialType
+import com.crosspaste.sync.QrBearerToken
+import com.crosspaste.sync.SasCode
+import com.crosspaste.sync.SyncManager
+import com.crosspaste.sync.SyncTestFixtures.createUnverifiedSyncRuntimeInfo
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+class TrustDeviceDialogTest {
+
+    private val tokens = mutableListOf("1", "2", "3", "4", "5", "6")
+
+    @Test
+    fun confirmToken_sasPeer_routesBySessionCredentialType() {
+        val syncManager = mockk<SyncManager>(relaxed = true)
+        val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+        confirmToken(tokens, 6, {}, syncManager, syncRuntimeInfo, PairingCredentialType.SAS_CODE)
+
+        verify {
+            syncManager.trustBySasCode(
+                syncRuntimeInfo.appInstanceId,
+                SasCode(123456),
+                any(),
+            )
+        }
+        verify(exactly = 0) {
+            syncManager.trustByBearerToken(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun confirmToken_legacyPeer_routesBySessionCredentialType() {
+        val syncManager = mockk<SyncManager>(relaxed = true)
+        val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+        confirmToken(tokens, 6, {}, syncManager, syncRuntimeInfo, PairingCredentialType.QR_BEARER_TOKEN)
+
+        verify {
+            syncManager.trustByBearerToken(
+                syncRuntimeInfo.appInstanceId,
+                QrBearerToken(123456),
+                any(),
+            )
+        }
+        verify(exactly = 0) {
+            syncManager.trustBySasCode(any(), any(), any())
+        }
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/TrustDeviceDialogTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/TrustDeviceDialogTest.kt
@@ -1,13 +1,19 @@
 package com.crosspaste.ui.devices
 
+import com.crosspaste.sync.PairingCredentialRefreshResult
 import com.crosspaste.sync.PairingCredentialType
 import com.crosspaste.sync.QrBearerToken
 import com.crosspaste.sync.SasCode
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.sync.SyncTestFixtures.createUnverifiedSyncRuntimeInfo
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
 
 class TrustDeviceDialogTest {
 
@@ -50,4 +56,52 @@ class TrustDeviceDialogTest {
             syncManager.trustBySasCode(any(), any(), any())
         }
     }
+
+    @Test
+    fun refreshPairingCredentialTypeUntilKnown_retriesAfterEachCompletedFailure() =
+        runTest {
+            val syncManager = mockk<SyncManager>(relaxed = true)
+            val appInstanceId = "test-app"
+            val delays = mutableListOf<kotlin.time.Duration>()
+            coEvery { syncManager.refreshPairingCredentialType(appInstanceId) } returnsMany
+                listOf(
+                    PairingCredentialRefreshResult.RetryableFailure,
+                    PairingCredentialRefreshResult.RetryableFailure,
+                    PairingCredentialRefreshResult.Resolved(PairingCredentialType.SAS_CODE),
+                )
+
+            val result =
+                refreshPairingCredentialTypeUntilKnown(
+                    syncManager = syncManager,
+                    appInstanceId = appInstanceId,
+                    initialBackoff = 1.seconds,
+                    maxBackoff = 2.seconds,
+                    delayAction = { delays += it },
+                )
+
+            coVerify(exactly = 3) { syncManager.refreshPairingCredentialType(appInstanceId) }
+            assertEquals(PairingCredentialRefreshResult.Resolved(PairingCredentialType.SAS_CODE), result)
+            assertEquals(listOf(1.seconds, 2.seconds), delays)
+        }
+
+    @Test
+    fun refreshPairingCredentialTypeUntilKnown_identityMismatchStopsWithoutFallback() =
+        runTest {
+            val syncManager = mockk<SyncManager>(relaxed = true)
+            val appInstanceId = "test-app"
+            val delays = mutableListOf<kotlin.time.Duration>()
+            coEvery { syncManager.refreshPairingCredentialType(appInstanceId) } returns
+                PairingCredentialRefreshResult.IdentityMismatch
+
+            val result =
+                refreshPairingCredentialTypeUntilKnown(
+                    syncManager = syncManager,
+                    appInstanceId = appInstanceId,
+                    delayAction = { delays += it },
+                )
+
+            coVerify(exactly = 1) { syncManager.refreshPairingCredentialType(appInstanceId) }
+            assertEquals(PairingCredentialRefreshResult.IdentityMismatch, result)
+            assertEquals(emptyList(), delays)
+        }
 }


### PR DESCRIPTION
Closes #4643

## Summary

Device pairing uses two distinct 6-digit credentials — the random **QR bearer token** (verified by `POST /sync/trust` via `sameToken`) and the key-derived **SAS code** (verified by `POST /sync/trust/v2/exchange` + `/confirm` after ECDH). Both were typed as a plain `Int` and funneled through one `trustByToken` entry point, with an internal `pairingVersion` `when` in `SyncResolver` picking the path. That left "feed a scanned QR bearer token into the SAS comparison" representable — a deterministic failure for `pairingVersion >= 2` peers, since a QR built before the scan can never carry a SAS that depends on the scanning device's key.

This PR separates the two credentials at the type level so crossing them is impossible at the call site.

## Changes

- New `PairingCredential.kt` with `@JvmInline value class QrBearerToken` and `@JvmInline value class SasCode`, documenting why the two must never be interchanged.
- `SyncManager` / `SyncHandler` / `SyncEvent` / `SyncResolver`: split `trustByToken` into `trustByBearerToken(QrBearerToken)` → `POST /sync/trust` and `trustBySasCode(SasCode)` → `POST /sync/trust/v2/*`. The internal `pairingVersion` dispatch (`getRemotePairingVersion` + `supportsSASPairing` branch) is removed from `SyncResolver`, which also drops its `NearbyDeviceManager` dependency.
- `TrustDeviceDialog`: decides once (when the remote's `pairingVersion` is known) whether the typed code is a SAS or a bearer token, and calls the matching entry point. The same `LaunchedEffect` already chose between `exchangeKeysForPairing()` and `showToken()`, so the decision now lives in one place.
- `TokenCache` is typed as `QrBearerToken` since it only ever holds bearer tokens.
- Event `toString()` no longer includes the credential value.
- Tests updated (`SyncResolverTest`, `GeneralSyncHandlerTest`, `GeneralSyncManagerTest`, `WsModuleDependencyTest`).

## Behavior

No protocol or wire-format changes. The QR scan path and the typed-code path hit the same endpoints as before for each `pairingVersion`; only the compile-time typing and the location of the version decision changed.