### PR TITLE
:hammer: split stored paste JSON codec from sync format and fix hashing and size accounting

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteExportService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteExportService.kt
@@ -158,7 +158,7 @@ class PasteExportService(
                 copyResource(basePath, index, pasteData, pasteFiles)
             }
 
-            val json = pasteData.toJson()
+            val json = pasteData.toStoredJson()
             val base64 = codecsUtils.base64Encode(json.encodeToByteArray())
             sink.write(base64.encodeToByteArray())
             sink.writeUtf8("\n")

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteImportService.kt
@@ -195,7 +195,7 @@ class PasteImportService(
 
     private fun readPasteData(line: String): PasteData? {
         val json = codecsUtils.base64Decode(line).decodeToString()
-        return PasteData.fromJson(json)
+        return PasteData.fromStoredJson(json)
     }
 
     private fun decompress(

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -111,8 +111,8 @@ class PasteReleaseService(
             val change =
                 database.transactionWithResult {
                     database.pasteDatabaseQueries.updatePasteDataToLoaded(
-                        pasteAppearItem = firstItem.toJson(),
-                        pasteCollection = PasteCollection(remainingItems).toJson(),
+                        pasteAppearItem = firstItem.toStoredJson(),
+                        pasteCollection = PasteCollection(remainingItems).toStoredJson(),
                         pasteType = pasteType.type.toLong(),
                         pasteSearchContent =
                             searchContentService.createSearchContent(

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/item/UpdatePasteItemHelper.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/item/UpdatePasteItemHelper.kt
@@ -110,7 +110,7 @@ class UpdatePasteItemHelper(
                             pasteItemReader.getSearchContent(newUrlPasteItem),
                         ),
                     ),
-                addedSize = title.length.toLong(),
+                addedSize = newUrlPasteItem.size - urlPasteItem.size,
             ).map {
                 newUrlPasteItem
             }
@@ -122,6 +122,12 @@ class UpdatePasteItemHelper(
         name: String,
         pasteItem: T,
     ): Result<T> {
+        val oldNameSize =
+            pasteItem
+                .getUserEditName()
+                ?.encodeToByteArray()
+                ?.size
+                ?.toLong() ?: 0L
         val newPasteItem: T =
             pasteItem.copy {
                 put(PasteItemProperties.NAME, name)
@@ -139,7 +145,7 @@ class UpdatePasteItemHelper(
                             pasteItemReader.getSearchContent(newPasteItem),
                         ),
                     ),
-                addedSize = name.length.toLong(),
+                addedSize = name.encodeToByteArray().size.toLong() - oldNameSize,
             ).map {
                 newPasteItem
             }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteCollectionTest.kt
@@ -44,8 +44,8 @@ class PasteCollectionTest {
     @Test
     fun `empty collection roundtrip`() {
         val original = PasteCollection(listOf())
-        val json = original.toJson()
-        val restored = PasteCollection.fromJson(json)
+        val json = original.toStoredJson()
+        val restored = PasteCollection.fromStoredJson(json)
         assertTrue(restored.pasteItems.isEmpty())
     }
 
@@ -54,8 +54,8 @@ class PasteCollectionTest {
         val textItem = createTextPasteItem(text = "hello")
         val original = PasteCollection(listOf(textItem))
 
-        val json = original.toJson()
-        val restored = PasteCollection.fromJson(json)
+        val json = original.toStoredJson()
+        val restored = PasteCollection.fromStoredJson(json)
 
         assertEquals(1, restored.pasteItems.size)
         val restoredItem = restored.pasteItems[0] as TextPasteItem
@@ -73,8 +73,8 @@ class PasteCollectionTest {
             )
         val original = PasteCollection(items)
 
-        val json = original.toJson()
-        val restored = PasteCollection.fromJson(json)
+        val json = original.toStoredJson()
+        val restored = PasteCollection.fromStoredJson(json)
 
         assertEquals(3, restored.pasteItems.size)
     }
@@ -84,8 +84,8 @@ class PasteCollectionTest {
         val htmlItem = createHtmlPasteItem(html = "<div>Hello <b>World</b></div>")
         val original = PasteCollection(listOf(htmlItem))
 
-        val json = original.toJson()
-        val restored = PasteCollection.fromJson(json)
+        val json = original.toStoredJson()
+        val restored = PasteCollection.fromStoredJson(json)
 
         assertEquals(1, restored.pasteItems.size)
     }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteDataTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteDataTest.kt
@@ -226,8 +226,8 @@ class PasteDataTest {
     @Test
     fun `toJson and fromJson roundtrip preserves key fields`() {
         val pd = createTestPasteData(text = "roundtrip test")
-        val json = pd.toJson()
-        val restored = PasteData.fromJson(json)
+        val json = pd.toStoredJson()
+        val restored = PasteData.fromStoredJson(json)
 
         assertNotNull(restored)
         assertEquals(pd.appInstanceId, restored.appInstanceId)
@@ -238,11 +238,11 @@ class PasteDataTest {
 
     @Test
     fun `fromJson returns null for invalid json`() {
-        assertNull(PasteData.fromJson("not valid json"))
+        assertNull(PasteData.fromStoredJson("not valid json"))
     }
 
     @Test
     fun `fromJson returns null for empty json`() {
-        assertNull(PasteData.fromJson("{}"))
+        assertNull(PasteData.fromStoredJson("{}"))
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteExportImportServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteExportImportServiceTest.kt
@@ -131,10 +131,10 @@ class PasteExportImportServiceTest {
     }
 
     private fun assertExportImportRoundTrip(pasteData: PasteData) {
-        val json = pasteData.toJson()
+        val json = pasteData.toStoredJson()
         val base64 = codecsUtils.base64Encode(json.encodeToByteArray())
         val decodedJson = codecsUtils.base64Decode(base64).decodeToString()
-        val restored = PasteData.fromJson(decodedJson)
+        val restored = PasteData.fromStoredJson(decodedJson)
 
         assertNotNull(restored, "Failed to deserialize PasteData from JSON")
         assertEquals(pasteData.appInstanceId, restored.appInstanceId)
@@ -230,7 +230,7 @@ class PasteExportImportServiceTest {
             val pasteDataFile = File(exportDir, "paste.data")
             pasteDataFile.bufferedWriter().use { writer ->
                 for (pd in pasteDataList) {
-                    val json = pd.toJson()
+                    val json = pd.toStoredJson()
                     val base64 = codecsUtils.base64Encode(json.encodeToByteArray())
                     writer.write(base64)
                     writer.newLine()
@@ -265,7 +265,7 @@ class PasteExportImportServiceTest {
             restoredPasteDataFile.readLines().forEach { line ->
                 if (line.isNotBlank()) {
                     val json = codecsUtils.base64Decode(line).decodeToString()
-                    PasteData.fromJson(json)?.let { restoredList.add(it) }
+                    PasteData.fromStoredJson(json)?.let { restoredList.add(it) }
                 }
             }
 
@@ -362,7 +362,7 @@ class PasteExportImportServiceTest {
             assertEquals(1, lines.size, "Should have exactly one paste data line")
 
             val json = codecsUtils.base64Decode(lines[0]).decodeToString()
-            val restored = PasteData.fromJson(json)
+            val restored = PasteData.fromStoredJson(json)
             assertNotNull(restored)
             assertEquals(PasteType.TEXT_TYPE.type, restored.pasteType)
             assertEquals("service export test", (restored.pasteAppearItem as? PasteText)?.text)

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/item/UpdatePasteItemHelperTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/item/UpdatePasteItemHelperTest.kt
@@ -1,0 +1,98 @@
+package com.crosspaste.paste.item
+
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.PasteCollection
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.SearchContentService
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
+import com.crosspaste.utils.getJsonUtils
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UpdatePasteItemHelperTest {
+
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    private val pasteDao = mockk<PasteDao>()
+    private val pasteItemReader = mockk<PasteItemReader>()
+    private val searchContentService = mockk<SearchContentService>()
+    private val helper = UpdatePasteItemHelper(pasteDao, pasteItemReader, searchContentService)
+
+    @Test
+    fun `updateTitle uses UTF-8 byte delta when replacing a title`() =
+        runTest {
+            val oldTitle = "旧标题"
+            val newTitle = "新标题🙂"
+            val original =
+                createUrlPasteItem(
+                    url = "https://example.com",
+                    extraInfo = JsonObject(mapOf(PasteItemProperties.TITLE to JsonPrimitive(oldTitle))),
+                )
+            val addedSize = slot<Long>()
+            stubUpdate(addedSize)
+
+            val result = helper.updateTitle(createPasteData(original), newTitle, original)
+
+            assertTrue(result.isSuccess)
+            assertEquals(
+                newTitle.encodeToByteArray().size.toLong() - oldTitle.encodeToByteArray().size.toLong(),
+                addedSize.captured,
+            )
+        }
+
+    @Test
+    fun `updateName uses UTF-8 byte delta when replacing a name`() =
+        runTest {
+            val oldName = "旧名称"
+            val newName = "新名称🙂"
+            val original =
+                createTextPasteItem(
+                    text = "content",
+                    extraInfo = JsonObject(mapOf(PasteItemProperties.NAME to JsonPrimitive(oldName))),
+                )
+            val addedSize = slot<Long>()
+            stubUpdate(addedSize)
+
+            val result = helper.updateName(createPasteData(original), newName, original)
+
+            assertTrue(result.isSuccess)
+            assertEquals(
+                newName.encodeToByteArray().size.toLong() - oldName.encodeToByteArray().size.toLong(),
+                addedSize.captured,
+            )
+        }
+
+    private fun stubUpdate(addedSize: io.mockk.CapturingSlot<Long>) {
+        every { pasteItemReader.getSearchContent(any()) } returns "content"
+        every { searchContentService.createSearchContent(any(), any<List<String>>()) } returns "content"
+        coEvery {
+            pasteDao.updatePasteAppearItem(
+                id = any(),
+                pasteItem = any(),
+                pasteSearchContent = any(),
+                addedSize = capture(addedSize),
+            )
+        } returns Result.success(Unit)
+    }
+
+    private fun createPasteData(item: PasteItem): PasteData =
+        PasteData(
+            id = 1L,
+            appInstanceId = "test",
+            pasteAppearItem = item,
+            pasteCollection = PasteCollection(emptyList()),
+            pasteType = item.getPasteType().type,
+            size = item.size,
+            hash = item.hash,
+        )
+}

--- a/core/src/commonMain/kotlin/com/crosspaste/db/sync/HostInfo.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/db/sync/HostInfo.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class HostInfo(
     val networkPrefixLength: Short,
-    var hostAddress: String,
+    val hostAddress: String,
     val lastSeen: Long = 0L,
 ) {
     companion object {

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/PasteCollection.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/PasteCollection.kt
@@ -3,6 +3,7 @@ package com.crosspaste.paste
 import com.crosspaste.paste.item.PasteCoordinate
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.utils.getJsonUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
@@ -16,16 +17,50 @@ data class PasteCollection(
 
     companion object {
 
+        private val logger = KotlinLogging.logger { }
+
         private val jsonUtils = getJsonUtils()
 
-        fun fromJson(json: String): PasteCollection {
+        fun fromStoredJson(json: String): PasteCollection {
             val jsonArray = jsonUtils.JSON.parseToJsonElement(json).jsonArray
             return PasteCollection(
-                jsonArray.mapNotNull {
-                    PasteItem.fromJson(it.jsonPrimitive.content)
+                jsonArray.mapIndexed { index, element ->
+                    requireNotNull(PasteItem.fromStoredJson(element.jsonPrimitive.content)) {
+                        "Unsupported or invalid stored PasteItem at index $index"
+                    }
                 },
             )
         }
+
+        internal fun fromStoredJsonTolerant(json: String): PasteCollection {
+            val jsonArray =
+                runCatching {
+                    jsonUtils.JSON.parseToJsonElement(json).jsonArray
+                }.onFailure { error ->
+                    logger.error(error) { "Failed to parse stored PasteCollection; using an empty collection" }
+                }.getOrElse {
+                    return PasteCollection(emptyList())
+                }
+
+            return PasteCollection(
+                jsonArray.mapIndexedNotNull { index, element ->
+                    val item =
+                        runCatching {
+                            PasteItem.fromStoredJson(element.jsonPrimitive.content)
+                        }.onFailure { error ->
+                            logger.error(error) { "Failed to decode stored PasteItem at index $index; skipping it" }
+                        }.getOrNull()
+
+                    if (item == null) {
+                        logger.error { "Unsupported or invalid stored PasteItem at index $index; skipping it" }
+                    }
+                    item
+                },
+            )
+        }
+
+        @Deprecated("Use fromStoredJson for the legacy database/import format")
+        fun fromJson(json: String): PasteCollection = fromStoredJson(json)
     }
 
     fun bind(
@@ -38,13 +73,16 @@ data class PasteCollection(
             },
         )
 
-    fun toJson(): String {
+    fun toStoredJson(): String {
         val jsonArray =
             buildJsonArray {
                 for (item in pasteItems) {
-                    add(item.toJson())
+                    add(item.toStoredJson())
                 }
             }
         return jsonArray.toString()
     }
+
+    @Deprecated("Use toStoredJson for the legacy database/import format")
+    fun toJson(): String = toStoredJson()
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/PasteData.kt
@@ -51,7 +51,7 @@ data class PasteData(
 
         private val jsonUtils = getJsonUtils()
 
-        fun fromJson(json: String): PasteData? =
+        fun fromStoredJson(json: String): PasteData? =
             runCatching {
                 val jsonObject = jsonUtils.JSON.parseToJsonElement(json).jsonObject
                 PasteData(
@@ -59,10 +59,12 @@ data class PasteData(
                     favorite = jsonObject["favorite"]!!.jsonPrimitive.boolean,
                     pasteAppearItem =
                         jsonObject["pasteAppearItem"]?.let {
-                            PasteItem.fromJson(it.jsonPrimitive.content)
+                            requireNotNull(PasteItem.fromStoredJson(it.jsonPrimitive.content)) {
+                                "Unsupported or invalid stored pasteAppearItem"
+                            }
                         },
                     pasteCollection =
-                        PasteCollection.fromJson(
+                        PasteCollection.fromStoredJson(
                             jsonObject["pasteCollection"]!!.jsonPrimitive.content,
                         ),
                     pasteType = jsonObject["pasteType"]!!.jsonPrimitive.long.toInt(),
@@ -73,6 +75,9 @@ data class PasteData(
             }.onFailure { e ->
                 logger.error(e) { "Error while parsing PasteData" }
             }.getOrNull()
+
+        @Deprecated("Use fromStoredJson for the legacy database/import format")
+        fun fromJson(json: String): PasteData? = fromStoredJson(json)
 
         fun mapper(
             id: Long,
@@ -93,8 +98,14 @@ data class PasteData(
                 id,
                 appInstanceId,
                 favorite,
-                pasteAppearItem?.let { PasteItem.fromJson(it) },
-                PasteCollection.fromJson(pasteCollection),
+                pasteAppearItem?.let { storedItem ->
+                    PasteItem.fromStoredJson(storedItem).also { item ->
+                        if (item == null) {
+                            logger.error { "Unsupported or invalid stored pasteAppearItem; using null" }
+                        }
+                    }
+                },
+                PasteCollection.fromStoredJsonTolerant(pasteCollection),
                 pasteType.toInt(),
                 source,
                 size,
@@ -164,15 +175,18 @@ data class PasteData(
     fun getPasteCoordinate(id: Long? = null): PasteCoordinate =
         PasteCoordinate(id ?: this.id, appInstanceId, createTime)
 
-    fun toJson(): String =
+    fun toStoredJson(): String =
         buildJsonObject {
             put("appInstanceId", appInstanceId)
             put("favorite", favorite)
-            pasteAppearItem?.toJson()?.let { put("pasteAppearItem", it) }
-            put("pasteCollection", pasteCollection.toJson())
+            pasteAppearItem?.toStoredJson()?.let { put("pasteAppearItem", it) }
+            put("pasteCollection", pasteCollection.toStoredJson())
             put("pasteType", pasteType)
             source?.let { put("source", it) }
             put("size", size)
             put("hash", hash)
         }.toString()
+
+    @Deprecated("Use toStoredJson for the legacy database/import format")
+    fun toJson(): String = toStoredJson()
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/ColorPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/ColorPasteItem.kt
@@ -3,6 +3,7 @@ package com.crosspaste.paste.item
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.CreatePasteItemHelper.createColorPasteItem
 import com.crosspaste.paste.item.PasteItem.Companion.getExtraInfoFromJson
+import com.crosspaste.paste.item.PasteItem.Companion.parseStoredIdentifiers
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
@@ -23,7 +24,7 @@ class ColorPasteItem(
     PasteColor {
 
     constructor(jsonObject: JsonObject) : this(
-        identifiers = jsonObject["identifiers"]!!.jsonPrimitive.content.split(","),
+        identifiers = parseStoredIdentifiers(jsonObject["identifiers"]!!.jsonPrimitive.content),
         hash = jsonObject["hash"]!!.jsonPrimitive.content,
         size = jsonObject["size"]!!.jsonPrimitive.long,
         color = jsonObject["color"]!!.jsonPrimitive.content.toInt(),
@@ -41,7 +42,7 @@ class ColorPasteItem(
 
     override fun isValid(): Boolean = size == 8L && hash.isNotEmpty() && hash == color.toString()
 
-    override fun toJson(): String =
+    override fun toStoredJson(): String =
         buildJsonObject {
             put("type", getPasteType().type)
             put("identifiers", identifiers.joinToString(","))

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/CreatePasteItemHelper.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/CreatePasteItemHelper.kt
@@ -174,7 +174,7 @@ object CreatePasteItemHelper {
         var size = urlBytes.size.toLong()
         extraInfo?.let {
             it[PasteItemProperties.TITLE]?.jsonPrimitive?.contentOrNull?.let { title ->
-                size += title.length.toLong()
+                size += title.encodeToByteArray().size.toLong()
             }
         }
         return UrlPasteItem(

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/FilesPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/FilesPasteItem.kt
@@ -3,6 +3,7 @@ package com.crosspaste.paste.item
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.CreatePasteItemHelper.createFilesPasteItem
 import com.crosspaste.paste.item.PasteItem.Companion.getExtraInfoFromJson
+import com.crosspaste.paste.item.PasteItem.Companion.parseStoredIdentifiers
 import com.crosspaste.presist.FileInfoTree
 import com.crosspaste.utils.getJsonUtils
 import kotlinx.serialization.SerialName
@@ -22,7 +23,7 @@ import kotlinx.serialization.json.put
 @SerialName("files")
 data class FilesPasteItem(
     override val identifiers: List<String>,
-    override var count: Long,
+    override val count: Long,
     override val hash: String,
     override val size: Long,
     @Transient
@@ -49,7 +50,7 @@ data class FilesPasteItem(
         jsonObject: JsonObject,
         fileInfoTreeMap: Map<String, FileInfoTree>,
     ) : this(
-        identifiers = jsonObject["identifiers"]!!.jsonPrimitive.content.split(","),
+        identifiers = parseStoredIdentifiers(jsonObject["identifiers"]!!.jsonPrimitive.content),
         count = fileInfoTreeMap.values.sumOf { it.getCount() },
         hash = jsonObject["hash"]!!.jsonPrimitive.content,
         size = jsonObject["size"]!!.jsonPrimitive.long,
@@ -86,7 +87,7 @@ data class FilesPasteItem(
             relativePathList.isNotEmpty() &&
             relativePathList.size == fileInfoTreeMap.size
 
-    override fun toJson(): String =
+    override fun toStoredJson(): String =
         buildJsonObject {
             put("type", getPasteType().type)
             put("identifiers", identifiers.joinToString(","))

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/HtmlPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/HtmlPasteItem.kt
@@ -3,6 +3,7 @@ package com.crosspaste.paste.item
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.CreatePasteItemHelper.createHtmlPasteItem
 import com.crosspaste.paste.item.PasteItem.Companion.getExtraInfoFromJson
+import com.crosspaste.paste.item.PasteItem.Companion.parseStoredIdentifiers
 import com.crosspaste.paste.item.PasteItemProperties.BACKGROUND
 import com.crosspaste.serializer.HtmlPasteItemSerializer
 import kotlinx.serialization.Serializable
@@ -24,7 +25,7 @@ class HtmlPasteItem(
     PasteHtml {
 
     constructor(jsonObject: JsonObject) : this(
-        identifiers = jsonObject["identifiers"]!!.jsonPrimitive.content.split(","),
+        identifiers = parseStoredIdentifiers(jsonObject["identifiers"]!!.jsonPrimitive.content),
         hash = jsonObject["hash"]!!.jsonPrimitive.content,
         size = jsonObject["size"]!!.jsonPrimitive.long,
         html = jsonObject["html"]!!.jsonPrimitive.content,
@@ -52,7 +53,7 @@ class HtmlPasteItem(
             size > 0 &&
             html.isNotEmpty()
 
-    override fun toJson(): String =
+    override fun toStoredJson(): String =
         buildJsonObject {
             put("type", getPasteType().type)
             put("identifiers", identifiers.joinToString(","))

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/ImagesPasteItem.kt
@@ -3,6 +3,7 @@ package com.crosspaste.paste.item
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.CreatePasteItemHelper.createImagesPasteItem
 import com.crosspaste.paste.item.PasteItem.Companion.getExtraInfoFromJson
+import com.crosspaste.paste.item.PasteItem.Companion.parseStoredIdentifiers
 import com.crosspaste.presist.FileInfoTree
 import com.crosspaste.utils.getJsonUtils
 import kotlinx.serialization.SerialName
@@ -22,7 +23,7 @@ import kotlinx.serialization.json.put
 @SerialName("images")
 data class ImagesPasteItem(
     override val identifiers: List<String>,
-    override var count: Long,
+    override val count: Long,
     override val hash: String,
     override val size: Long,
     @Transient
@@ -49,7 +50,7 @@ data class ImagesPasteItem(
         jsonObject: JsonObject,
         fileInfoTreeMap: Map<String, FileInfoTree>,
     ) : this(
-        identifiers = jsonObject["identifiers"]!!.jsonPrimitive.content.split(","),
+        identifiers = parseStoredIdentifiers(jsonObject["identifiers"]!!.jsonPrimitive.content),
         count = fileInfoTreeMap.values.sumOf { it.getCount() },
         hash = jsonObject["hash"]!!.jsonPrimitive.content,
         size = jsonObject["size"]!!.jsonPrimitive.long,
@@ -86,7 +87,7 @@ data class ImagesPasteItem(
             relativePathList.isNotEmpty() &&
             relativePathList.size == fileInfoTreeMap.size
 
-    override fun toJson(): String =
+    override fun toStoredJson(): String =
         buildJsonObject {
             put("type", getPasteType().type)
             put("identifiers", identifiers.joinToString(","))

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteItem.kt
@@ -21,7 +21,7 @@ sealed interface PasteItem {
 
         private val jsonUtils = getJsonUtils()
 
-        fun fromJson(json: String): PasteItem? =
+        fun fromStoredJson(json: String): PasteItem? =
             runCatching {
                 val jsonObject = jsonUtils.JSON.parseToJsonElement(json).jsonObject
                 jsonObject["type"]!!.jsonPrimitive.content.toInt().let {
@@ -43,6 +43,9 @@ sealed interface PasteItem {
                 logger.error(e) { "Failed to parse PasteItem from json" }
             }.getOrNull()
 
+        @Deprecated("Use fromStoredJson for the legacy database/import format")
+        fun fromJson(json: String): PasteItem? = fromStoredJson(json)
+
         fun getExtraInfoFromJson(jsonObject: JsonObject): JsonObject? {
             val extraInfo = jsonObject["extraInfo"] ?: return null
 
@@ -61,6 +64,13 @@ sealed interface PasteItem {
                 else -> null
             }
         }
+
+        internal fun parseStoredIdentifiers(value: String): List<String> =
+            if (value.isEmpty()) {
+                emptyList()
+            } else {
+                value.split(",")
+            }
 
         fun updateExtraInfo(
             extraInfo: JsonObject?,
@@ -116,5 +126,8 @@ sealed interface PasteItem {
 
     fun isValid(): Boolean
 
-    fun toJson(): String
+    fun toStoredJson(): String
+
+    @Deprecated("Use toStoredJson for the legacy database/import format")
+    fun toJson(): String = toStoredJson()
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/RtfPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/RtfPasteItem.kt
@@ -3,6 +3,7 @@ package com.crosspaste.paste.item
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.CreatePasteItemHelper.createRtfPasteItem
 import com.crosspaste.paste.item.PasteItem.Companion.getExtraInfoFromJson
+import com.crosspaste.paste.item.PasteItem.Companion.parseStoredIdentifiers
 import com.crosspaste.paste.item.PasteItemProperties.BACKGROUND
 import com.crosspaste.serializer.RtfPasteItemSerializer
 import kotlinx.serialization.Serializable
@@ -24,7 +25,7 @@ class RtfPasteItem(
     PasteRtf {
 
     constructor(jsonObject: JsonObject) : this(
-        identifiers = jsonObject["identifiers"]!!.jsonPrimitive.content.split(","),
+        identifiers = parseStoredIdentifiers(jsonObject["identifiers"]!!.jsonPrimitive.content),
         hash = jsonObject["hash"]!!.jsonPrimitive.content,
         size = jsonObject["size"]!!.jsonPrimitive.long,
         rtf = jsonObject["rtf"]!!.jsonPrimitive.content,
@@ -54,7 +55,7 @@ class RtfPasteItem(
             size > 0 &&
             rtf.isNotEmpty()
 
-    override fun toJson(): String =
+    override fun toStoredJson(): String =
         buildJsonObject {
             put("type", getPasteType().type)
             put("identifiers", identifiers.joinToString(","))

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/TextPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/TextPasteItem.kt
@@ -3,6 +3,7 @@ package com.crosspaste.paste.item
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.paste.item.PasteItem.Companion.getExtraInfoFromJson
+import com.crosspaste.paste.item.PasteItem.Companion.parseStoredIdentifiers
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
@@ -23,7 +24,7 @@ class TextPasteItem(
     PasteText {
 
     constructor(jsonObject: JsonObject) : this(
-        identifiers = jsonObject["identifiers"]!!.jsonPrimitive.content.split(","),
+        identifiers = parseStoredIdentifiers(jsonObject["identifiers"]!!.jsonPrimitive.content),
         hash = jsonObject["hash"]!!.jsonPrimitive.content,
         size = jsonObject["size"]!!.jsonPrimitive.long,
         text = jsonObject["text"]!!.jsonPrimitive.content,
@@ -44,7 +45,7 @@ class TextPasteItem(
             size > 0 &&
             text.isNotEmpty()
 
-    override fun toJson(): String =
+    override fun toStoredJson(): String =
         buildJsonObject {
             put("type", getPasteType().type)
             put("identifiers", identifiers.joinToString(","))

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/UrlPasteItem.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/UrlPasteItem.kt
@@ -3,6 +3,7 @@ package com.crosspaste.paste.item
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.CreatePasteItemHelper.createUrlPasteItem
 import com.crosspaste.paste.item.PasteItem.Companion.getExtraInfoFromJson
+import com.crosspaste.paste.item.PasteItem.Companion.parseStoredIdentifiers
 import com.crosspaste.paste.item.PasteItemProperties.TITLE
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -28,7 +29,7 @@ class UrlPasteItem(
     }
 
     constructor(jsonObject: JsonObject) : this(
-        identifiers = jsonObject["identifiers"]!!.jsonPrimitive.content.split(","),
+        identifiers = parseStoredIdentifiers(jsonObject["identifiers"]!!.jsonPrimitive.content),
         hash = jsonObject["hash"]!!.jsonPrimitive.content,
         size = jsonObject["size"]!!.jsonPrimitive.long,
         url = jsonObject["url"]!!.jsonPrimitive.content,
@@ -54,7 +55,7 @@ class UrlPasteItem(
             size > 0 &&
             url.isNotEmpty()
 
-    override fun toJson(): String =
+    override fun toStoredJson(): String =
         buildJsonObject {
             put("type", getPasteType().type)
             put("identifiers", identifiers.joinToString(","))

--- a/core/src/commonMain/kotlin/com/crosspaste/serializer/HtmlPasteItemSerializer.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/serializer/HtmlPasteItemSerializer.kt
@@ -25,7 +25,7 @@ class HtmlPasteItemSerializer : KSerializer<HtmlPasteItem> {
             element<String>("hash")
             element<String>("html")
             element<Long>("size")
-            element<JsonElement?>("extraInfo")
+            element<String?>("extraInfo")
         }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -98,7 +98,7 @@ class HtmlPasteItemSerializer : KSerializer<HtmlPasteItem> {
         enc.encodeStringElement(descriptor, 1, value.hash)
         enc.encodeStringElement(descriptor, 2, value.html)
         enc.encodeLongElement(descriptor, 3, value.size)
-        enc.encodeNullableSerializableElement(descriptor, 4, String.serializer(), value.extraInfo.toString())
+        enc.encodeNullableSerializableElement(descriptor, 4, String.serializer(), value.extraInfo?.toString())
         enc.endStructure(descriptor)
     }
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/serializer/RtfPasteItemSerializer.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/serializer/RtfPasteItemSerializer.kt
@@ -25,7 +25,7 @@ class RtfPasteItemSerializer : KSerializer<RtfPasteItem> {
             element<String>("hash")
             element<String>("rtf")
             element<Long>("size")
-            element<JsonElement?>("extraInfo")
+            element<String?>("extraInfo")
         }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -98,7 +98,7 @@ class RtfPasteItemSerializer : KSerializer<RtfPasteItem> {
         enc.encodeStringElement(descriptor, 1, value.hash)
         enc.encodeStringElement(descriptor, 2, value.rtf)
         enc.encodeLongElement(descriptor, 3, value.size)
-        enc.encodeNullableSerializableElement(descriptor, 4, String.serializer(), value.extraInfo.toString())
+        enc.encodeNullableSerializableElement(descriptor, 4, String.serializer(), value.extraInfo?.toString())
         enc.endStructure(descriptor)
     }
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/utils/CodecsUtils.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/utils/CodecsUtils.kt
@@ -32,5 +32,20 @@ interface CodecsUtils {
 
     fun hashByString(string: String): String = hash(string.encodeToByteArray())
 
-    fun hashByArray(array: Array<String>): String
+    fun hashByArray(array: Array<String>): String {
+        if (array.isEmpty()) return ""
+        if (array.size == 1) return hashByString(array[0])
+
+        val parts = array.map { it.encodeToByteArray() }
+        val totalSize = parts.sumOf { it.size.toLong() }
+        require(totalSize <= Int.MAX_VALUE) { "Combined input is too large: $totalSize bytes" }
+
+        val combined = ByteArray(totalSize.toInt())
+        var offset = 0
+        parts.forEach { part ->
+            part.copyInto(combined, offset)
+            offset += part.size
+        }
+        return hash(combined)
+    }
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/utils/MurmurHash3.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/utils/MurmurHash3.kt
@@ -368,8 +368,15 @@ class StreamingMurmurHash3(
     fun update(
         input: ByteArray,
         offset: Int = 0,
-        length: Int = input.size,
+        length: Int = input.size - offset,
     ) {
+        require(offset in 0..input.size) {
+            "Offset must be between 0 and ${input.size}, but was $offset"
+        }
+        require(length >= 0 && length <= input.size - offset) {
+            "Length must be between 0 and ${input.size - offset}, but was $length"
+        }
+
         var currentOffset = offset
         var remainingLength = length
 
@@ -411,26 +418,26 @@ class StreamingMurmurHash3(
             var k1 = 0uL
             var k2 = 0uL
 
-            if (bufferSize >= 15) k2 = k2 xor (buffer[14].toULong() shl 48)
-            if (bufferSize >= 14) k2 = k2 xor (buffer[13].toULong() shl 40)
-            if (bufferSize >= 13) k2 = k2 xor (buffer[12].toULong() shl 32)
-            if (bufferSize >= 12) k2 = k2 xor (buffer[11].toULong() shl 24)
-            if (bufferSize >= 11) k2 = k2 xor (buffer[10].toULong() shl 16)
-            if (bufferSize >= 10) k2 = k2 xor (buffer[9].toULong() shl 8)
+            if (bufferSize >= 15) k2 = k2 xor (buffer[14].toUByte().toULong() shl 48)
+            if (bufferSize >= 14) k2 = k2 xor (buffer[13].toUByte().toULong() shl 40)
+            if (bufferSize >= 13) k2 = k2 xor (buffer[12].toUByte().toULong() shl 32)
+            if (bufferSize >= 12) k2 = k2 xor (buffer[11].toUByte().toULong() shl 24)
+            if (bufferSize >= 11) k2 = k2 xor (buffer[10].toUByte().toULong() shl 16)
+            if (bufferSize >= 10) k2 = k2 xor (buffer[9].toUByte().toULong() shl 8)
             if (bufferSize >= 9) {
-                k2 = k2 xor buffer[8].toULong()
+                k2 = k2 xor buffer[8].toUByte().toULong()
                 h2 = h2 xor k2.mix(R3_128x64, C2_128x64, C1_128x64)
             }
 
-            if (bufferSize >= 8) k1 = k1 xor (buffer[7].toULong() shl 56)
-            if (bufferSize >= 7) k1 = k1 xor (buffer[6].toULong() shl 48)
-            if (bufferSize >= 6) k1 = k1 xor (buffer[5].toULong() shl 40)
-            if (bufferSize >= 5) k1 = k1 xor (buffer[4].toULong() shl 32)
-            if (bufferSize >= 4) k1 = k1 xor (buffer[3].toULong() shl 24)
-            if (bufferSize >= 3) k1 = k1 xor (buffer[2].toULong() shl 16)
-            if (bufferSize >= 2) k1 = k1 xor (buffer[1].toULong() shl 8)
+            if (bufferSize >= 8) k1 = k1 xor (buffer[7].toUByte().toULong() shl 56)
+            if (bufferSize >= 7) k1 = k1 xor (buffer[6].toUByte().toULong() shl 48)
+            if (bufferSize >= 6) k1 = k1 xor (buffer[5].toUByte().toULong() shl 40)
+            if (bufferSize >= 5) k1 = k1 xor (buffer[4].toUByte().toULong() shl 32)
+            if (bufferSize >= 4) k1 = k1 xor (buffer[3].toUByte().toULong() shl 24)
+            if (bufferSize >= 3) k1 = k1 xor (buffer[2].toUByte().toULong() shl 16)
+            if (bufferSize >= 2) k1 = k1 xor (buffer[1].toUByte().toULong() shl 8)
             if (bufferSize >= 1) {
-                k1 = k1 xor buffer[0].toULong()
+                k1 = k1 xor buffer[0].toUByte().toULong()
                 h1 = h1 xor k1.mix(R1_128x64, C1_128x64, C2_128x64)
             }
         }

--- a/core/src/commonTest/kotlin/com/crosspaste/paste/PasteStoredCodecTest.kt
+++ b/core/src/commonTest/kotlin/com/crosspaste/paste/PasteStoredCodecTest.kt
@@ -1,0 +1,113 @@
+package com.crosspaste.paste
+
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.utils.getJsonUtils
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class PasteStoredCodecTest {
+
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    @Test
+    fun `stored collection roundtrip keeps every item`() {
+        val original =
+            PasteCollection(
+                listOf(
+                    createTextPasteItem(text = "first"),
+                    createTextPasteItem(text = "second"),
+                ),
+            )
+
+        val restored = PasteCollection.fromStoredJson(original.toStoredJson())
+
+        assertEquals(original.pasteItems.size, restored.pasteItems.size)
+        assertEquals(original.pasteItems.map { it.toStoredJson() }, restored.pasteItems.map { it.toStoredJson() })
+        assertEquals(emptyList(), restored.pasteItems.first().identifiers)
+    }
+
+    @Test
+    fun `stored collection rejects unknown item type atomically`() {
+        val stored =
+            buildJsonArray {
+                add(createTextPasteItem(text = "known").toStoredJson())
+                add("""{"type":999,"hash":"future"}""")
+            }.toString()
+
+        assertFailsWith<IllegalArgumentException> {
+            PasteCollection.fromStoredJson(stored)
+        }
+    }
+
+    @Test
+    fun `stored PasteData rejects unknown appear item`() {
+        val stored =
+            buildJsonObject {
+                put("appInstanceId", "compatibility-test")
+                put("favorite", false)
+                put("pasteAppearItem", """{"type":999,"hash":"future"}""")
+                put("pasteCollection", "[]")
+                put("pasteType", 999)
+                put("size", 0L)
+                put("hash", "future")
+            }.toString()
+
+        assertNull(PasteData.fromStoredJson(stored))
+    }
+
+    @Test
+    fun `database mapper tolerates unknown appear item and skips bad collection items`() {
+        val knownItem = createTextPasteItem(text = "known")
+        val storedCollection =
+            buildJsonArray {
+                add(knownItem.toStoredJson())
+                add("""{"type":999,"hash":"future"}""")
+                add("not-json")
+            }.toString()
+
+        val mapped = mapDatabaseRow("""{"type":999,"hash":"future"}""", storedCollection)
+
+        assertNull(mapped.pasteAppearItem)
+        assertEquals(1, mapped.pasteCollection.pasteItems.size)
+        assertEquals(
+            knownItem.toStoredJson(),
+            mapped.pasteCollection.pasteItems
+                .single()
+                .toStoredJson(),
+        )
+    }
+
+    @Test
+    fun `database mapper uses empty collection when stored JSON is corrupt`() {
+        val mapped = mapDatabaseRow(null, "not-json")
+
+        assertEquals(emptyList(), mapped.pasteCollection.pasteItems)
+    }
+
+    private fun mapDatabaseRow(
+        pasteAppearItem: String?,
+        pasteCollection: String,
+    ): PasteData =
+        PasteData.mapper(
+            id = 1L,
+            appInstanceId = "database-test",
+            favorite = false,
+            pasteAppearItem = pasteAppearItem,
+            pasteCollection = pasteCollection,
+            pasteType = PasteType.TEXT_TYPE.type.toLong(),
+            source = null,
+            size = 0L,
+            hash = "database-test",
+            createTime = 1L,
+            pasteSearchContent = null,
+            pasteState = PasteState.LOADED.toLong(),
+            remote = false,
+        )
+}

--- a/core/src/commonTest/kotlin/com/crosspaste/paste/item/CreatePasteItemHelperTest.kt
+++ b/core/src/commonTest/kotlin/com/crosspaste/paste/item/CreatePasteItemHelperTest.kt
@@ -160,10 +160,10 @@ class CreatePasteItemHelperTest {
     @Test
     fun `createUrlPasteItem size includes title when provided`() {
         val url = "https://example.com"
-        val title = "Example"
+        val title = "示例🙂"
         val extraInfo = JsonObject(mapOf(PasteItemProperties.TITLE to JsonPrimitive(title)))
         val item = createUrlPasteItem(url = url, extraInfo = extraInfo)
-        assertEquals(url.encodeToByteArray().size.toLong() + title.length.toLong(), item.size)
+        assertEquals(url.encodeToByteArray().size.toLong() + title.encodeToByteArray().size.toLong(), item.size)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/com/crosspaste/serializer/PasteItemSerializerCompatibilityTest.kt
+++ b/core/src/commonTest/kotlin/com/crosspaste/serializer/PasteItemSerializerCompatibilityTest.kt
@@ -1,0 +1,81 @@
+package com.crosspaste.serializer
+
+import com.crosspaste.paste.item.CreatePasteItemHelper.createHtmlPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createRtfPasteItem
+import com.crosspaste.utils.getJsonUtils
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class PasteItemSerializerCompatibilityTest {
+
+    private val json = getJsonUtils().JSON
+    private val extraInfo = JsonObject(mapOf("source" to JsonPrimitive("compatibility")))
+    private val htmlSerializer = HtmlPasteItemSerializer()
+    private val rtfSerializer = RtfPasteItemSerializer()
+
+    @Test
+    fun `HTML extraInfo keeps the legacy string wire format`() {
+        val encoded =
+            json.encodeToString(
+                htmlSerializer,
+                createHtmlPasteItem(html = "<p>test</p>", extraInfo = extraInfo),
+            )
+        val encodedExtraInfo = json.parseToJsonElement(encoded).jsonObject.getValue("extraInfo")
+
+        assertIs<JsonPrimitive>(encodedExtraInfo)
+        assertEquals(extraInfo.toString(), encodedExtraInfo.content)
+        assertEquals(extraInfo, json.decodeFromString(htmlSerializer, encoded).extraInfo)
+    }
+
+    @Test
+    fun `RTF extraInfo keeps the legacy string wire format`() {
+        val encoded =
+            json.encodeToString(
+                rtfSerializer,
+                createRtfPasteItem(rtf = "{\\rtf1 test}", extraInfo = extraInfo),
+            )
+        val encodedExtraInfo = json.parseToJsonElement(encoded).jsonObject.getValue("extraInfo")
+
+        assertIs<JsonPrimitive>(encodedExtraInfo)
+        assertEquals(extraInfo.toString(), encodedExtraInfo.content)
+        assertEquals(extraInfo, json.decodeFromString(rtfSerializer, encoded).extraInfo)
+    }
+
+    @Test
+    fun `HTML and RTF encode absent extraInfo as JSON null`() {
+        val html =
+            json
+                .parseToJsonElement(
+                    json.encodeToString(htmlSerializer, createHtmlPasteItem(html = "test")),
+                ).jsonObject
+        val rtf =
+            json
+                .parseToJsonElement(
+                    json.encodeToString(rtfSerializer, createRtfPasteItem(rtf = "test")),
+                ).jsonObject
+
+        assertEquals(JsonNull, html["extraInfo"])
+        assertEquals(JsonNull, rtf["extraInfo"])
+    }
+
+    @Test
+    fun `HTML and RTF accept object extraInfo from newer peers`() {
+        val html = json.encodeToString(htmlSerializer, createHtmlPasteItem(html = "test", extraInfo = extraInfo))
+        val rtf = json.encodeToString(rtfSerializer, createRtfPasteItem(rtf = "test", extraInfo = extraInfo))
+        val htmlWithObject = replaceExtraInfoWithObject(html)
+        val rtfWithObject = replaceExtraInfoWithObject(rtf)
+
+        assertEquals(extraInfo, json.decodeFromString(htmlSerializer, htmlWithObject).extraInfo)
+        assertEquals(extraInfo, json.decodeFromString(rtfSerializer, rtfWithObject).extraInfo)
+    }
+
+    private fun replaceExtraInfoWithObject(encoded: String): String {
+        val original = json.parseToJsonElement(encoded).jsonObject
+        return JsonObject(original + ("extraInfo" to extraInfo)).toString()
+    }
+}

--- a/core/src/commonTest/kotlin/com/crosspaste/utils/MurmurHash3Test.kt
+++ b/core/src/commonTest/kotlin/com/crosspaste/utils/MurmurHash3Test.kt
@@ -4,6 +4,7 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class MurmurHash3Test {
 
@@ -119,6 +120,59 @@ class MurmurHash3Test {
         streaming17.update(input17)
         val streamingResult17 = streaming17.finish()
         assertContentEquals(regular17, streamingResult17, "17-byte input should match")
+    }
+
+    @Test
+    fun `high-bit tail bytes match regular hash for every tail length`() {
+        val seed = 42u
+
+        for (size in 1..31) {
+            val input = ByteArray(size) { index -> (0x80 + index).toByte() }
+            val regular = MurmurHash3(seed).hash128x64(input)
+            val streaming = StreamingMurmurHash3(seed)
+            streaming.update(input)
+
+            assertContentEquals(regular, streaming.finish(), "Input size $size should match")
+        }
+    }
+
+    @Test
+    fun `update offset defaults to remaining input`() {
+        val seed = 42u
+        val input = byteArrayOf(1, 2, 3, 0x80.toByte(), 0xFF.toByte())
+        val expected = MurmurHash3(seed).hash128x64(input.copyOfRange(2, input.size))
+        val streaming = StreamingMurmurHash3(seed)
+
+        streaming.update(input, offset = 2)
+
+        assertContentEquals(expected, streaming.finish())
+    }
+
+    @Test
+    fun `update rejects invalid ranges`() {
+        val input = ByteArray(8)
+
+        assertFailsWith<IllegalArgumentException> { StreamingMurmurHash3().update(input, offset = -1) }
+        assertFailsWith<IllegalArgumentException> { StreamingMurmurHash3().update(input, offset = 9) }
+        assertFailsWith<IllegalArgumentException> { StreamingMurmurHash3().update(input, offset = 4, length = 5) }
+        assertFailsWith<IllegalArgumentException> { StreamingMurmurHash3().update(input, length = -1) }
+    }
+
+    @OptIn(ExperimentalUnsignedTypes::class)
+    @Test
+    fun `asULongArray rejects partial words on every platform`() {
+        assertFailsWith<IllegalArgumentException> { ByteArray(7).asULongArray() }
+        assertFailsWith<IllegalArgumentException> { ByteArray(9).asULongArray() }
+    }
+
+    @Test
+    fun `hashByArray hashes concatenated UTF-8 bytes`() {
+        val codecsUtils = getCodecsUtils()
+        val parts = arrayOf("Cross", "粘贴", "🙂")
+        val expected = codecsUtils.hash(parts.joinToString("").encodeToByteArray())
+
+        assertEquals(expected, codecsUtils.hashByArray(parts))
+        assertEquals("", codecsUtils.hashByArray(emptyArray()))
     }
 
     @Test

--- a/core/src/desktopMain/kotlin/com/crosspaste/utils/CodecsUtils.desktop.kt
+++ b/core/src/desktopMain/kotlin/com/crosspaste/utils/CodecsUtils.desktop.kt
@@ -1,21 +1,5 @@
 package com.crosspaste.utils
 
-import java.io.ByteArrayOutputStream
-
 actual fun getCodecsUtils(): CodecsUtils = DesktopCoreCodecsUtils
 
-object DesktopCoreCodecsUtils : CodecsUtils {
-
-    override fun hashByArray(array: Array<String>): String =
-        if (array.isEmpty()) {
-            ""
-        } else if (array.size == 1) {
-            hashByString(array[0])
-        } else {
-            val outputStream = ByteArrayOutputStream()
-            array.forEach {
-                outputStream.write(it.encodeToByteArray())
-            }
-            hash(outputStream.toByteArray())
-        }
-}
+object DesktopCoreCodecsUtils : CodecsUtils

--- a/core/src/desktopMain/kotlin/com/crosspaste/utils/MurmurHash3.desktop.kt
+++ b/core/src/desktopMain/kotlin/com/crosspaste/utils/MurmurHash3.desktop.kt
@@ -5,6 +5,9 @@ import java.nio.ByteOrder
 
 @OptIn(ExperimentalUnsignedTypes::class)
 actual fun ByteArray.asULongArray(): ULongArray {
+    require(size % 8 == 0) {
+        "ByteArray size must be a multiple of 8, but was $size"
+    }
     val buffer =
         ByteBuffer
             .wrap(this)

--- a/core/src/jsMain/kotlin/com/crosspaste/utils/CodecsUtils.js.kt
+++ b/core/src/jsMain/kotlin/com/crosspaste/utils/CodecsUtils.js.kt
@@ -2,15 +2,4 @@ package com.crosspaste.utils
 
 actual fun getCodecsUtils(): CodecsUtils = JsCodecsUtils
 
-object JsCodecsUtils : CodecsUtils {
-
-    override fun hashByArray(array: Array<String>): String =
-        if (array.isEmpty()) {
-            ""
-        } else if (array.size == 1) {
-            hashByString(array[0])
-        } else {
-            val combined = array.joinToString("").encodeToByteArray()
-            hash(combined)
-        }
-}
+object JsCodecsUtils : CodecsUtils

--- a/core/src/nativeAppMain/kotlin/com/crosspaste/utils/CodecsUtils.native.kt
+++ b/core/src/nativeAppMain/kotlin/com/crosspaste/utils/CodecsUtils.native.kt
@@ -2,15 +2,4 @@ package com.crosspaste.utils
 
 actual fun getCodecsUtils(): CodecsUtils = NativeCoreCodecsUtils
 
-object NativeCoreCodecsUtils : CodecsUtils {
-
-    override fun hashByArray(array: Array<String>): String =
-        if (array.isEmpty()) {
-            ""
-        } else if (array.size == 1) {
-            hashByString(array[0])
-        } else {
-            val bytes = array.fold(ByteArray(0)) { acc, s -> acc + s.encodeToByteArray() }
-            hash(bytes)
-        }
-}
+object NativeCoreCodecsUtils : CodecsUtils

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
@@ -117,8 +117,8 @@ class SqlPasteDao(
                 pasteDatabaseQueries.createPasteDataEntity(
                     pasteData.appInstanceId,
                     pasteData.favorite,
-                    pasteData.pasteAppearItem?.toJson(),
-                    pasteData.pasteCollection.toJson(),
+                    pasteData.pasteAppearItem?.toStoredJson(),
+                    pasteData.pasteCollection.toStoredJson(),
                     pasteData.pasteType.toLong(),
                     pasteData.source,
                     pasteData.size,
@@ -138,8 +138,8 @@ class SqlPasteDao(
     override suspend fun updateFilePath(pasteData: PasteData) {
         withContext(ioDispatcher) {
             pasteDatabaseQueries.updateRemotePasteDataWithFile(
-                pasteData.pasteAppearItem?.toJson(),
-                pasteData.pasteCollection.toJson(),
+                pasteData.pasteAppearItem?.toStoredJson(),
+                pasteData.pasteCollection.toStoredJson(),
                 searchContentService.createSearchContent(
                     pasteData.source,
                     pasteData.pasteAppearItem?.let { pasteItemReader.getSearchContent(it) },
@@ -285,7 +285,7 @@ class SqlPasteDao(
                 .transactionWithResult {
                     pasteDatabaseQueries.updatePasteAppearItem(
                         id = id,
-                        pasteAppearItem = pasteItem.toJson(),
+                        pasteAppearItem = pasteItem.toStoredJson(),
                         pasteSearchContent = pasteSearchContent,
                         addedSize = addedSize,
                         hash = pasteItem.hash,


### PR DESCRIPTION
Closes #4647

## Summary

Clarifies the boundary between the stored paste format (SQLite columns, export/import files) and the kotlinx sync wire format, and fixes several latent bugs found while auditing that boundary.

- **Codec naming**: `toJson`/`fromJson` on `PasteData` / `PasteCollection` / `PasteItem` are renamed to `toStoredJson`/`fromStoredJson`; deprecated aliases remain as a migration bridge for mobile consumers of `commonMain`.
- **Strict import, tolerant database reads**: import/export parsing now rejects a record atomically when a stored item is invalid (no more silent partial imports). The database row mapper (`PasteData.mapper`) stays tolerant: an unknown or corrupt stored item degrades to `null` / is skipped with error logs, so a single bad row (e.g. after a version downgrade) cannot break every history query.
- **`StreamingMurmurHash3` fixes**: tail bytes no longer sign-extend (`toUByte().toULong()`), so streaming hashes match `hash128x64` for inputs with high-bit tail bytes; `update(input, offset)` defaults `length` to `input.size - offset`; range validation added; desktop `asULongArray` now rejects partial words like the JS/native implementations.
- **`hashByArray`**: consolidated three divergent platform implementations into one common default with a single exact-size allocation (replaces the O(n^2) native fold and the double-copy desktop stream).
- **Serializers**: absent `extraInfo` encodes as JSON null instead of the literal string `"null"`; decoders already shipped tolerate null, legacy `"null"` strings, and object forms, so both directions stay wire-compatible.
- **Size accounting**: title/name sizes use UTF-8 bytes consistently and `updateTitle`/`updateName` apply deltas instead of cumulatively inflating `PasteData.size` on every edit.
- **Misc**: stored empty identifiers parse as an empty list (was `[""]`); `HostInfo.hostAddress` and `FilesPasteItem`/`ImagesPasteItem.count` become `val`.

## Compatibility

- The streaming hash fix changes file hashes for files with `size % 16 != 0` and high-bit tail bytes. The hash is only a lookup key carried with paste metadata (receivers never recompute and compare), so cross-version file transfer is unaffected; pre-upgrade file entries just will not deduplicate against re-copies. The mobile repositories must adopt the same `commonMain` fix to avoid hash divergence.
- No performance regressions: the consolidated `hashByArray` allocates less than the previous desktop/native implementations, and the new validation checks are per-call constants outside hot loops.

## Testing

- New tests: `PasteStoredCodecTest` (strict import vs tolerant mapper paths), `PasteItemSerializerCompatibilityTest` (legacy string / JSON null / object `extraInfo` forms), `UpdatePasteItemHelperTest` (UTF-8 byte deltas), plus `MurmurHash3Test` cases for high-bit tails, offset defaults, range validation, and `hashByArray`.
- `./gradlew ktlintFormat` clean; `core:desktopTest`, `shared:desktopTest`, `app:desktopTest` all pass locally; JS/native targets are covered by CI.