### PR TITLE
:hammer: Extract PairingV3Transport seam for in-process pairing v3 tests

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PairingV3ClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PairingV3ClientApi.kt
@@ -25,11 +25,11 @@ import io.ktor.util.reflect.*
 class PairingV3ClientApi(
     private val pasteClient: PasteClient,
     private val exceptionHandler: ExceptionHandler,
-) {
+) : PairingV3Transport {
 
     private val logger = KotlinLogging.logger {}
 
-    suspend fun sendIntent(
+    override suspend fun sendIntent(
         intent: PairingIntentV3,
         toUrl: URLBuilder.() -> Unit,
     ): ClientApiResult =
@@ -46,7 +46,7 @@ class PairingV3ClientApi(
             response.body<PairingOfferV3>()
         }
 
-    suspend fun sendProof(
+    override suspend fun sendProof(
         proof: PairingProofV3,
         toUrl: URLBuilder.() -> Unit,
     ): ClientApiResult =
@@ -63,7 +63,7 @@ class PairingV3ClientApi(
             response.body<PairingProofResponseV3>()
         }
 
-    suspend fun sendCommit(
+    override suspend fun sendCommit(
         commit: PairingCommitV3,
         toUrl: URLBuilder.() -> Unit,
     ): ClientApiResult =
@@ -80,7 +80,7 @@ class PairingV3ClientApi(
             response.body<PairingCommitAckV3>()
         }
 
-    suspend fun sendCancel(
+    override suspend fun sendCancel(
         cancel: PairingCancelV3,
         toUrl: URLBuilder.() -> Unit,
     ): ClientApiResult =

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PairingV3Transport.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PairingV3Transport.kt
@@ -1,0 +1,36 @@
+package com.crosspaste.net.clientapi
+
+import com.crosspaste.dto.pairing.v3.PairingCancelV3
+import com.crosspaste.dto.pairing.v3.PairingCommitV3
+import com.crosspaste.dto.pairing.v3.PairingIntentV3
+import com.crosspaste.dto.pairing.v3.PairingProofV3
+import io.ktor.http.URLBuilder
+
+/**
+ * Transport seam for the pairing v3 initiator → acceptor calls. Implemented by
+ * [PairingV3ClientApi] (real HTTP) in production; a test may provide an
+ * in-process implementation that routes each call into the peer's
+ * `PairingProtocolV3Service.handle*` methods. No cryptographic logic lives here.
+ */
+interface PairingV3Transport {
+
+    suspend fun sendIntent(
+        intent: PairingIntentV3,
+        toUrl: URLBuilder.() -> Unit,
+    ): ClientApiResult
+
+    suspend fun sendProof(
+        proof: PairingProofV3,
+        toUrl: URLBuilder.() -> Unit,
+    ): ClientApiResult
+
+    suspend fun sendCommit(
+        commit: PairingCommitV3,
+        toUrl: URLBuilder.() -> Unit,
+    ): ClientApiResult
+
+    suspend fun sendCancel(
+        cancel: PairingCancelV3,
+        toUrl: URLBuilder.() -> Unit,
+    ): ClientApiResult
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
@@ -11,7 +11,7 @@ import com.crosspaste.dto.pairing.v3.PairingProofV3
 import com.crosspaste.dto.pairing.v3.PairingV3ErrorCode
 import com.crosspaste.net.clientapi.ClientApiResult
 import com.crosspaste.net.clientapi.FailureResult
-import com.crosspaste.net.clientapi.PairingV3ClientApi
+import com.crosspaste.net.clientapi.PairingV3Transport
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.UnknownError
 import com.crosspaste.secure.SecureKeyPairSerializer
@@ -54,7 +54,7 @@ import kotlin.time.Duration.Companion.seconds
  */
 class PairingProtocolV3Service(
     private val appInfo: AppInfo,
-    private val pairingV3ClientApi: PairingV3ClientApi,
+    private val pairingV3ClientApi: PairingV3Transport,
     private val pakeProvider: PakeProvider,
     private val receiptCache: PairingReceiptCache,
     private val rateLimiter: PairingRateLimiter,

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -30,6 +30,7 @@ import com.crosspaste.net.SyncApi
 import com.crosspaste.net.TelnetHelper
 import com.crosspaste.net.WindowsNetworkStateMonitor
 import com.crosspaste.net.clientapi.PairingV3ClientApi
+import com.crosspaste.net.clientapi.PairingV3Transport
 import com.crosspaste.net.clientapi.PasteClientApi
 import com.crosspaste.net.clientapi.PullClientApi
 import com.crosspaste.net.clientapi.PushClientApi
@@ -107,6 +108,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
         // region HTTP client & API
         single<FaviconLoader> { DesktopFaviconLoader(get(), get()) }
         single<PairingV3ClientApi> { PairingV3ClientApi(get(), get()) }
+        single<PairingV3Transport> { get<PairingV3ClientApi>() }
         single<PasteClient> { PasteClient(get(), get(), get()) }
         single<PasteClientApi> { PasteClientApi(get(), get()) }
         single<PullClientApi> { PullClientApi(get(), get(), get()) }


### PR DESCRIPTION
Closes #4660

## Summary

Minimal interface extraction so the pairing v3 initiator→acceptor path has a substitutable transport, enabling an in-process integration test (both roles + real SPAKE2 crypto in one process, no HTTP server). Zero behavior change; production still uses the real HTTP client.

- **New** `app/src/commonMain/.../net/clientapi/PairingV3Transport.kt` — interface with the four `send*` methods (`sendIntent`/`sendProof`/`sendCommit`/`sendCancel`). No cryptographic logic lives at this layer.
- `PairingV3ClientApi` now implements `PairingV3Transport` (four `override`s; bodies unchanged).
- `PairingProtocolV3Service` constructor param type narrows to `PairingV3Transport` (no body changes — it only calls `send*`).
- `DesktopNetworkModule` binds `single<PairingV3Transport> { get<PairingV3ClientApi>() }`.

## Motivation

Mobile Pairing v3 Phase 5 needs to drive the production `Spake2PakeProvider` (OpenSSL on iOS, BouncyCastle on the JVM) through the full handshake — including wrong/expired PIN, generation rotation, replay, cancel, and commit retry — in `commonTest` without a real server. Mobile's `commonMain` is synced from this repo, so the seam lands here first; a test-side `PairingV3Transport` then maps each `send*` call onto the peer service's public `handle*` methods.

## Testing

- `./gradlew ktlintFormat` — no changes.
- `./gradlew app:desktopTest --tests "com.crosspaste.net.PairingV3IntegrationTest"` — all passing (the existing two-instance loopback suite exercises the service through the new interface via the real `PairingV3ClientApi`).

Production DI stays fail-closed (`UnavailablePakeProvider` not touched) and `PAIRING_VERSION` remains 2.