### PR TITLE
:bug: Fix SPAKE2 session lifecycle races and fail closed pending constant-time EC review

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
@@ -1103,58 +1103,67 @@ class PairingProtocolV3Service(
             } finally {
                 pinSecret.fill(0)
             }
-        val pakeSession =
-            pakeProvider.createSession(
-                role = PakeRole.ACCEPTOR,
-                pin = pin,
-                context =
-                    PakeContext(
-                        sessionId = sessionIdBytes,
-                        initiatorAppInstanceId = initiatorAppInstanceId,
-                        acceptorAppInstanceId = appInfo.appInstanceId,
-                        pinContext = pinContext,
-                    ),
-            )
-        val localPakeShare =
-            try {
-                pakeSession.localShare()
-            } catch (e: Exception) {
+        var pakeSession: PakeSession? = null
+        var localPakeShare: ByteArray? = null
+        var ownershipTransferred = false
+        try {
+            val createdSession =
+                pakeProvider.createSession(
+                    role = PakeRole.ACCEPTOR,
+                    pin = pin,
+                    context =
+                        PakeContext(
+                            sessionId = sessionIdBytes,
+                            initiatorAppInstanceId = initiatorAppInstanceId,
+                            acceptorAppInstanceId = appInfo.appInstanceId,
+                            pinContext = pinContext,
+                        ),
+                )
+            pakeSession = createdSession
+            val createdShare = createdSession.localShare()
+            localPakeShare = createdShare
+            val pinExpiresAt = nowEpochMillis() + pinLifetime.inWholeMilliseconds
+            val unsignedOffer =
+                PairingOfferV3(
+                    protocolVersion = PairingV3.PROTOCOL_VERSION,
+                    selectedCiphersuite = pakeProvider.ciphersuite,
+                    sessionId = sessionIdBytes,
+                    requestHash = intentHash,
+                    tokenGeneration = tokenGeneration,
+                    pinExpiresAt = pinExpiresAt,
+                    initiatorAppInstanceId = initiatorAppInstanceId,
+                    acceptorAppInstanceId = appInfo.appInstanceId,
+                    acceptorSignPublicKey = ownSignPublicKey,
+                    acceptorCryptPublicKey = ownCryptPublicKey,
+                    acceptorNonce = acceptorNonce,
+                    acceptorPakeShare = createdShare,
+                    signature = ByteArray(0),
+                )
+            val offer =
+                unsignedOffer.copy(
+                    signature =
+                        CryptographyUtils.signData(secureStore.secureKeyPair.signKeyPair.privateKey) {
+                            PairingTranscriptCodec.encodeOfferSignaturePayload(unsignedOffer)
+                        },
+                )
+            val material =
+                GenerationMaterial(
+                    pin = pin,
+                    pakeSession = createdSession,
+                    localPakeShare = createdShare,
+                    offer = offer,
+                    offerHash = PairingTranscriptCodec.offerHash(offer),
+                    pinExpiresAt = pinExpiresAt,
+                )
+            ownershipTransferred = true
+            return material
+        } finally {
+            if (!ownershipTransferred) {
                 runCatching { pin.fill('\u0000') }
-                pakeSession.destroy()
-                throw e
+                runCatching { localPakeShare?.fill(0) }
+                runCatching { pakeSession?.destroy() }
             }
-        val pinExpiresAt = nowEpochMillis() + pinLifetime.inWholeMilliseconds
-        val unsignedOffer =
-            PairingOfferV3(
-                protocolVersion = PairingV3.PROTOCOL_VERSION,
-                selectedCiphersuite = pakeProvider.ciphersuite,
-                sessionId = sessionIdBytes,
-                requestHash = intentHash,
-                tokenGeneration = tokenGeneration,
-                pinExpiresAt = pinExpiresAt,
-                initiatorAppInstanceId = initiatorAppInstanceId,
-                acceptorAppInstanceId = appInfo.appInstanceId,
-                acceptorSignPublicKey = ownSignPublicKey,
-                acceptorCryptPublicKey = ownCryptPublicKey,
-                acceptorNonce = acceptorNonce,
-                acceptorPakeShare = localPakeShare,
-                signature = ByteArray(0),
-            )
-        val offer =
-            unsignedOffer.copy(
-                signature =
-                    CryptographyUtils.signData(secureStore.secureKeyPair.signKeyPair.privateKey) {
-                        PairingTranscriptCodec.encodeOfferSignaturePayload(unsignedOffer)
-                    },
-            )
-        return GenerationMaterial(
-            pin = pin,
-            pakeSession = pakeSession,
-            localPakeShare = localPakeShare,
-            offer = offer,
-            offerHash = PairingTranscriptCodec.offerHash(offer),
-            pinExpiresAt = pinExpiresAt,
-        )
+        }
     }
 
     private fun launchRotation(sessionId: String) {

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/UnavailablePakeProvider.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/UnavailablePakeProvider.kt
@@ -2,9 +2,9 @@ package com.crosspaste.pairing.v3
 
 /**
  * Explicit fallback for platforms that do not yet provide a reviewed [PakeEcOps]
- * backend. Desktop uses the real BouncyCastle provider; this remains available to
- * shared/mobile wiring until every Kotlin/Native target has its production EC
- * backend. Unsupported targets fail closed instead of substituting a fake PAKE.
+ * backend. Production wiring uses this until every target has passed the
+ * constant-time review. Unsupported targets fail closed instead of substituting
+ * a fake or test-only PAKE.
  */
 object UnavailablePakeProvider : PakeProvider {
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -42,7 +42,6 @@ import com.crosspaste.net.ws.WsClientConnector
 import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsPendingRequests
 import com.crosspaste.net.ws.WsSessionManager
-import com.crosspaste.pairing.v3.BouncyCastlePakeEcOps
 import com.crosspaste.pairing.v3.PairingAcceptanceWindow
 import com.crosspaste.pairing.v3.PairingProtocolV3Service
 import com.crosspaste.pairing.v3.PairingRateLimiter
@@ -51,7 +50,7 @@ import com.crosspaste.pairing.v3.PairingSessionStore
 import com.crosspaste.pairing.v3.PairingV3
 import com.crosspaste.pairing.v3.PairingVersionCoordinator
 import com.crosspaste.pairing.v3.PakeProvider
-import com.crosspaste.pairing.v3.Spake2PakeProvider
+import com.crosspaste.pairing.v3.UnavailablePakeProvider
 import com.crosspaste.platform.Platform
 import com.crosspaste.sync.FilePushService
 import com.crosspaste.sync.GeneralNearbyDeviceManager
@@ -183,10 +182,9 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
         single<PairingReceiptCache> { PairingReceiptCache() }
         single<PairingSessionStore> { PairingSessionStore() }
         single<PairingVersionCoordinator> { PairingVersionCoordinator() }
-        // Real SPAKE2/P-256 provider (ADR D7, RFC 9382) over the BouncyCastle EC
-        // backend. The service independently gates both initiating and accepting
-        // on PAIRING_VERSION, so registering the provider cannot expose v3 early.
-        single<PakeProvider> { Spake2PakeProvider(BouncyCastlePakeEcOps()) }
+        // BouncyCastle's P-256 point formulas are not guaranteed constant-time
+        // for every input. Fail closed until a reviewed production backend lands.
+        single<PakeProvider> { UnavailablePakeProvider }
         // endregion
 
         // region WebSocket

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
@@ -19,8 +19,11 @@ import com.crosspaste.pairing.v3.PairingV3
 import com.crosspaste.pairing.v3.PairingV3PinResult
 import com.crosspaste.pairing.v3.PairingV3RefreshResult
 import com.crosspaste.pairing.v3.PairingV3StartResult
+import com.crosspaste.pairing.v3.PakeContext
+import com.crosspaste.pairing.v3.PakeException
 import com.crosspaste.pairing.v3.PakeProvider
 import com.crosspaste.pairing.v3.PakeRole
+import com.crosspaste.pairing.v3.PakeSession
 import com.crosspaste.pairing.v3.Spake2PakeProvider
 import com.crosspaste.pairing.v3.TestPakeProvider
 import com.crosspaste.pairing.v3.pairingV3ErrorCodeOf
@@ -207,6 +210,43 @@ class PairingV3IntegrationTest {
                     .firstOrNull { card -> card.sessionId == started.sessionId }
                     ?.state,
             )
+        }
+
+    @Test
+    fun testGenerationFailureDuringSessionCreationClearsPin() =
+        runBlocking {
+            val failingProvider = FailingGenerationPakeProvider(failDuringCreate = true)
+            val acceptor = createInstance("generation-create-failure", pakeProvider = failingProvider)
+            val initiator = createInstance("generation-create-initiator")
+            acceptor.start()
+            initiator.start()
+            acceptor.pairingAcceptanceWindow.open()
+
+            val manual = ManualInitiator(initiator, acceptor)
+            manual.buildIntent()
+            initiator.pairingV3ClientApi.sendIntent(manual.intent, urlFor(acceptor))
+
+            val observedPin = assertNotNull(failingProvider.observedPin)
+            assertTrue(observedPin.all { character -> character == '\u0000' })
+        }
+
+    @Test
+    fun testGenerationFailureDuringLocalShareClearsPinAndDestroysSession() =
+        runBlocking {
+            val failingProvider = FailingGenerationPakeProvider(failDuringCreate = false)
+            val acceptor = createInstance("generation-share-failure", pakeProvider = failingProvider)
+            val initiator = createInstance("generation-share-initiator")
+            acceptor.start()
+            initiator.start()
+            acceptor.pairingAcceptanceWindow.open()
+
+            val manual = ManualInitiator(initiator, acceptor)
+            manual.buildIntent()
+            initiator.pairingV3ClientApi.sendIntent(manual.intent, urlFor(acceptor))
+
+            val observedPin = assertNotNull(failingProvider.observedPin)
+            assertTrue(observedPin.all { character -> character == '\u0000' })
+            assertTrue(failingProvider.session.destroyed)
         }
 
     // ---- Gate and validation refusals ----
@@ -752,6 +792,41 @@ class PairingV3IntegrationTest {
     ) {
         assertIs<FailureResult>(result)
         assertEquals(expected, pairingV3ErrorCodeOf(result.exception.getErrorCode().code))
+    }
+
+    private class FailingGenerationPakeProvider(
+        private val failDuringCreate: Boolean,
+    ) : PakeProvider {
+
+        override val ciphersuite: String = "FAKE-PAKE-FOR-TESTS"
+        var observedPin: CharArray? = null
+        val session = FailingLocalShareSession()
+
+        override suspend fun createSession(
+            role: PakeRole,
+            pin: CharArray,
+            context: PakeContext,
+        ): PakeSession {
+            observedPin = pin
+            if (failDuringCreate) {
+                throw PakeException("injected createSession failure")
+            }
+            return session
+        }
+    }
+
+    private class FailingLocalShareSession : PakeSession {
+
+        var destroyed = false
+
+        override suspend fun localShare(): ByteArray = throw PakeException("injected localShare failure")
+
+        override suspend fun deriveSharedSecret(peerShare: ByteArray): ByteArray =
+            throw PakeException("unexpected deriveSharedSecret call")
+
+        override fun destroy() {
+            destroyed = true
+        }
     }
 
     /**

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -18,9 +18,14 @@ group = "com.crosspaste"
 version = versionProperties.getProperty("version")
 
 plugins {
+    alias(libs.plugins.atomicfu)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.ktlint)
+}
+
+atomicfu {
+    transformJvm = false
 }
 
 ktlint {
@@ -67,6 +72,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
+            implementation(libs.atomicfu.lib)
             implementation(libs.cryptography.core)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)

--- a/core/src/commonMain/kotlin/com/crosspaste/pairing/v3/PakeProvider.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/pairing/v3/PakeProvider.kt
@@ -21,9 +21,10 @@ package com.crosspaste.pairing.v3
  *    PairingProofResponseV3 are the RFC-required key confirmation. Providers
  *    do NOT exchange cA/cB; this interface will not grow confirmation methods.
  * 5. **Implementation** (ADR D7): a thin, fully test-vectored protocol layer
- *    over reviewed EC primitives (BouncyCastle on JVM/Android, OpenSSL 3 on
- *    Kotlin/Native) behind a narrow point-operations abstraction. Hand-rolled
- *    field or point arithmetic in application code is forbidden.
+ *    over reviewed EC primitives behind a narrow point-operations abstraction.
+ *    Hand-rolled field or point arithmetic in application code is forbidden.
+ *    BouncyCastle is retained for vectors only after the 2026-07-24 constant-time
+ *    review; production platforms fail closed until reviewed backends land.
  */
 interface PakeProvider {
 

--- a/core/src/commonMain/kotlin/com/crosspaste/pairing/v3/Spake2P256.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/pairing/v3/Spake2P256.kt
@@ -2,6 +2,7 @@ package com.crosspaste.pairing.v3
 
 import dev.whyoleg.cryptography.CryptographyProvider
 import dev.whyoleg.cryptography.algorithms.SHA256
+import kotlinx.atomicfu.atomic
 
 /**
  * Frozen constants and the protocol composition for SPAKE2 over P-256, RFC 9382
@@ -167,18 +168,27 @@ private class Spake2Session(
     private val peerConstant: ByteArray,
 ) : PakeSession {
 
-    private var destroyed = false
+    private val lifecycle = atomic(SESSION_ACTIVE)
 
     override suspend fun localShare(): ByteArray {
-        check(!destroyed) { "session destroyed" }
+        check(lifecycle.value != SESSION_DESTROY_PENDING && lifecycle.value != SESSION_DESTROYED) {
+            "session destroyed"
+        }
         return localShare.copyOf()
     }
 
     override suspend fun deriveSharedSecret(peerShare: ByteArray): ByteArray {
-        check(!destroyed) { "session destroyed" }
+        check(lifecycle.compareAndSet(SESSION_ACTIVE, SESSION_DERIVING)) {
+            if (lifecycle.value == SESSION_DERIVING) {
+                "session already deriving"
+            } else {
+                "session destroyed"
+            }
+        }
         if (peerShare.size != PairingV3.PAKE_SHARE_SIZE ||
             peerShare[0] != PairingV3.PAKE_SHARE_UNCOMPRESSED_PREFIX
         ) {
+            finishDerivation()
             throw PakeException("SPAKE2 peer share must be a canonical uncompressed P-256 point")
         }
 
@@ -219,11 +229,55 @@ private class Spake2Session(
             k?.fill(0)
             tt?.fill(0)
             digest?.fill(0)
+            finishDerivation()
         }
     }
 
     override fun destroy() {
-        destroyed = true
+        while (true) {
+            when (lifecycle.value) {
+                SESSION_ACTIVE -> {
+                    if (lifecycle.compareAndSet(SESSION_ACTIVE, SESSION_DESTROYED)) {
+                        clearSecrets()
+                        return
+                    }
+                }
+
+                SESSION_DERIVING -> {
+                    if (lifecycle.compareAndSet(SESSION_DERIVING, SESSION_DESTROY_PENDING)) {
+                        return
+                    }
+                }
+
+                SESSION_DESTROY_PENDING,
+                SESSION_DESTROYED,
+                -> return
+            }
+        }
+    }
+
+    private fun finishDerivation() {
+        while (true) {
+            when (lifecycle.value) {
+                SESSION_DERIVING -> {
+                    if (lifecycle.compareAndSet(SESSION_DERIVING, SESSION_ACTIVE)) {
+                        return
+                    }
+                }
+
+                SESSION_DESTROY_PENDING -> {
+                    if (lifecycle.compareAndSet(SESSION_DESTROY_PENDING, SESSION_DESTROYED)) {
+                        clearSecrets()
+                        return
+                    }
+                }
+
+                else -> return
+            }
+        }
+    }
+
+    private fun clearSecrets() {
         w.fill(0)
         privateScalar.fill(0)
     }
@@ -270,5 +324,9 @@ private class Spake2Session(
 
     private companion object {
         const val LENGTH_PREFIX_SIZE = 8
+        const val SESSION_ACTIVE = 0
+        const val SESSION_DERIVING = 1
+        const val SESSION_DESTROY_PENDING = 2
+        const val SESSION_DESTROYED = 3
     }
 }

--- a/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/BouncyCastlePakeEcOps.kt
+++ b/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/BouncyCastlePakeEcOps.kt
@@ -8,13 +8,14 @@ import java.math.BigInteger
 import java.security.SecureRandom
 
 /**
- * JVM/Android [PakeEcOps] backed by BouncyCastle low-level P-256 point/scalar ops
- * (ADR D7). No elliptic-curve arithmetic is written here — every operation is a
- * BouncyCastle primitive over the reviewed `secp256r1` implementation.
+ * JVM/Android [PakeEcOps] backed by BouncyCastle low-level P-256 point/scalar ops.
+ * This backend is retained for vectors and cross-platform conformance tests only;
+ * it must not be registered as a production [PakeProvider].
  *
- * Secret scalar multiplication uses BouncyCastle's fixed-comb multiplier. Its
- * loop count is fixed for the curve and its precomputed-point lookup is
- * constant-time with respect to the scalar, unlike the default WNAF multiplier.
+ * [FixedPointCombMultiplier] has a fixed loop and cache-safe lookup, but the
+ * underlying P-256 point addition/doubling formulas contain input-dependent
+ * branches. It therefore cannot satisfy RFC 9382 §7's requirement that every
+ * elliptic-curve point operation take time independent of its inputs.
  *
  * Secret-hygiene limitation: scalars pass through immutable [BigInteger] inside
  * BouncyCastle, which cannot be zeroed; a `w`/private-scalar copy therefore lives

--- a/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/Spake2PakeProviderTest.kt
+++ b/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/Spake2PakeProviderTest.kt
@@ -1,6 +1,11 @@
 package com.crosspaste.pairing.v3
 
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -185,8 +190,49 @@ class Spake2PakeProviderTest {
         runTest {
             val ctx = context()
             val session = provider.createSession(PakeRole.INITIATOR, "620632".toCharArray(), ctx)
+            val peer = provider.createSession(PakeRole.ACCEPTOR, "620632".toCharArray(), ctx)
+            val peerShare = peer.localShare()
             session.destroy()
             assertFailsWith<IllegalStateException> { session.localShare() }
+            assertFailsWith<IllegalStateException> { session.deriveSharedSecret(peerShare) }
+            session.destroy()
+            peer.destroy()
+            peerShare.fill(0)
+        }
+
+    @Test
+    fun destroyDuringDerivationDefersSecretClearingUntilDerivationFinishes() =
+        runBlocking {
+            val blockingOps = BlockingDerivePakeEcOps(BouncyCastlePakeEcOps())
+            val blockingProvider = Spake2PakeProvider(blockingOps)
+            val ctx = context()
+            val initiator = blockingProvider.createSession(PakeRole.INITIATOR, "620632".toCharArray(), ctx)
+            val acceptor = provider.createSession(PakeRole.ACCEPTOR, "620632".toCharArray(), ctx)
+            val acceptorShare = acceptor.localShare()
+            val executor = Executors.newSingleThreadExecutor()
+            try {
+                val derived =
+                    executor.submit<ByteArray> {
+                        runBlocking { initiator.deriveSharedSecret(acceptorShare) }
+                    }
+                assertTrue(blockingOps.deriveEntered.await(5, TimeUnit.SECONDS))
+
+                initiator.destroy()
+                blockingOps.allowDeriveToContinue.countDown()
+
+                val ke = derived.get(5, TimeUnit.SECONDS)
+                assertEquals(Spake2P256.KE_LENGTH, ke.size)
+                ke.fill(0)
+                assertFailsWith<IllegalStateException> { initiator.localShare() }
+                assertFailsWith<IllegalStateException> { initiator.deriveSharedSecret(acceptorShare) }
+            } finally {
+                blockingOps.allowDeriveToContinue.countDown()
+                initiator.destroy()
+                acceptor.destroy()
+                acceptorShare.fill(0)
+                executor.shutdownNow()
+            }
+            Unit
         }
 
     /**
@@ -295,5 +341,27 @@ class Spake2PakeProviderTest {
             delegate.mulPoint(point, scalar).also { result ->
                 lastMultiplication = result
             }
+    }
+
+    private class BlockingDerivePakeEcOps(
+        private val delegate: PakeEcOps,
+    ) : PakeEcOps by delegate {
+
+        val deriveEntered = CountDownLatch(1)
+        val allowDeriveToContinue = CountDownLatch(1)
+        private val multiplicationCount = AtomicInteger()
+
+        override fun mulPoint(
+            point: ByteArray,
+            scalar: ByteArray,
+        ): ByteArray {
+            if (multiplicationCount.incrementAndGet() == 2) {
+                deriveEntered.countDown()
+                check(allowDeriveToContinue.await(5, TimeUnit.SECONDS)) {
+                    "timed out waiting to continue injected PAKE derivation"
+                }
+            }
+            return delegate.mulPoint(point, scalar)
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ yaml = "2.6"
 zxing = "3.5.4"
 
 [libraries]
+atomicfu-lib = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 awesome-brans = { module = "com.composables:icons-font-awesome-brands-cmp", version.ref = "awesome-brans" }
 bouncycastle-prov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }


### PR DESCRIPTION
Closes #4662

## Summary

Post-#4658 hardening from the 2026-07-24 constant-time review of the SPAKE2/P-256 stack. Three fixes:

### 1. Desktop DI fails closed again
BouncyCastle's `FixedPointCombMultiplier` has a fixed loop and cache-safe table lookup, but the underlying P-256 point addition/doubling formulas contain input-dependent branches, so the backend cannot satisfy RFC 9382 §7 (EC point operations must take time independent of their inputs). `DesktopNetworkModule` registers `UnavailablePakeProvider` again; `BouncyCastlePakeEcOps` is downgraded (KDoc) to RFC 9382 vectors and cross-platform conformance tests only. No user-visible change: production `PAIRING_VERSION` is still 2, so v3 was never reachable.

### 2. `Spake2Session` lifecycle state machine
The plain `destroyed` boolean allowed `destroy()` during a concurrent `deriveSharedSecret` to zero `w` and the private scalar mid-use, and did not exclude concurrent derives. Replaced with an atomicfu CAS state machine (`ACTIVE → DERIVING → DESTROY_PENDING → DESTROYED`): concurrent derives are rejected, and `destroy()` during derivation defers secret zeroing until the derivation finishes. `core` gains the `kotlinx.atomicfu` runtime dependency (`transformJvm = false`, class-property usage only).

### 3. Acceptor generation-material cleanup
In `PairingProtocolV3Service.createGenerationMaterial`, only a `localShare()` failure destroyed the PAKE session and cleared the PIN; failures at later steps (offer signing/hashing) leaked the live session and PIN chars. Now uses an ownership-transfer pattern: unless the material is fully constructed and handed off, the PIN, local share, and session are cleaned up on any failure path.

## Testing

- `./gradlew ktlintFormat` — no changes.
- `core:desktopTest` `Spake2PakeProviderTest` — 12/12 passing, including new `destroyDuringDerivationDefersSecretClearingUntilDerivationFinishes` (blocking EC-ops injection).
- `app:desktopTest` `PairingV3IntegrationTest` — all passing, including new `testGenerationFailureDuringSessionCreationClearsPin` and `testGenerationFailureDuringLocalShareClearsPinAndDestroysSession`.

## Notes

- Independent of #4661 (transport seam); touches the same files in different regions. Merge order does not matter functionally; a trivial import-block conflict may need resolution in whichever merges second.
- The real provider returns to production DI once a reviewed constant-time backend lands (Phase 5 K/N OpenSSL work / a reviewed JVM backend).