### PR TITLE
:sparkles: Add pairing v3 scenarios (pair-v3, all-v3) to the e2e harness

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -150,6 +150,44 @@ class SyncResolverTest {
         }
 
     @Test
+    fun resolveDisconnected_existingV2TrustSurvivesPeerCapabilityUpgrade() =
+        runTest {
+            // Pairing capability selects how NEW trust is established. A peer that was
+            // paired under v2 already has a long-term crypt key, so an app upgrade must
+            // authenticate that key directly instead of forcing a v3 pairing ceremony.
+            // SyncRuntimeInfo intentionally has no pairing capability field: this pins
+            // the resolver-layer invariant that persisted trust is capability-agnostic.
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo =
+                createSyncRuntimeInfo(
+                    hostInfoList = listOf(HostInfo(24, "192.168.1.100")),
+                )
+            val hostInfo = HostInfo(24, "192.168.1.100")
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.telnetHelper.switchHost(any(), any(), any(), any()) } returns
+                Pair(hostInfo, TelnetResult(VersionRelation.EQUAL_TO, syncRuntimeInfo.appInstanceId))
+            coEvery { deps.secureStore.existCryptPublicKey(syncRuntimeInfo.appInstanceId) } returns true
+            coEvery { deps.syncClientApi.heartbeat(any(), syncRuntimeInfo.appInstanceId, any()) } returns
+                SuccessResult(VersionRelation.EQUAL_TO)
+
+            val capturedInfos = mutableListOf<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfos)) } returns
+                syncRuntimeInfo.appInstanceId
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(SyncState.CONNECTED, capturedInfos.last().connectState)
+            coVerify(exactly = 1) {
+                deps.syncClientApi.heartbeat(any(), syncRuntimeInfo.appInstanceId, any())
+            }
+            coVerify(exactly = 0) {
+                deps.secureStore.deleteCryptPublicKey(syncRuntimeInfo.appInstanceId)
+            }
+        }
+
+    @Test
     fun resolveDisconnected_fastProbeIdentityMismatch_fallsThroughToCorrectHost() =
         runTest {
             // #4499 Phase A: a ghost squats on our last address (.108) advertising a

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
@@ -3,6 +3,7 @@ package com.crosspaste.e2e.cli
 import com.crosspaste.e2e.peer.HeadlessPeer
 import com.crosspaste.e2e.scenario.DiscoveryScenario
 import com.crosspaste.e2e.scenario.PairScenario
+import com.crosspaste.e2e.scenario.PairV3Scenario
 import com.crosspaste.e2e.scenario.PullIconScenario
 import com.crosspaste.e2e.scenario.PushColorScenario
 import com.crosspaste.e2e.scenario.PushHtmlScenario
@@ -15,6 +16,8 @@ import com.crosspaste.e2e.scenario.ScenarioResult
 import com.crosspaste.e2e.scenario.TargetSpec
 import com.crosspaste.e2e.scenario.TelnetScenario
 import com.crosspaste.e2e.scenario.WrongTokenScenario
+import com.crosspaste.net.SyncApi
+import com.crosspaste.pairing.v3.PairingV3
 import com.crosspaste.utils.getDateUtils
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.main
@@ -31,7 +34,7 @@ class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
         "-s",
         help =
             "Scenario to run: discovery, pair, wrong-token, telnet, push-text, push-url, " +
-                "push-html, push-rtf, push-color, pull-icon, or all.",
+                "push-html, push-rtf, push-color, pull-icon, pair-v3, all-v3, or all.",
     ).default("discovery")
 
     private val target by option(
@@ -90,8 +93,16 @@ class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
     )
 
     override fun run() {
+        val pairingVersion =
+            if (scenario.lowercase() in V3_SCENARIOS) {
+                PairingV3.PROTOCOL_VERSION
+            } else {
+                SyncApi.PAIRING_VERSION
+            }
         val peer =
-            appInstanceId?.let { HeadlessPeer(appInstanceId = it) } ?: HeadlessPeer()
+            appInstanceId?.let {
+                HeadlessPeer(appInstanceId = it, pairingVersion = pairingVersion)
+            } ?: HeadlessPeer(pairingVersion = pairingVersion)
         try {
             val ctx =
                 ScenarioContext(
@@ -100,6 +111,8 @@ class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
                     targetAppInstanceId = targetAppId,
                     discoveryTimeoutMs = discoveryTimeout * 1000,
                     tokenProvider = ::promptToken,
+                    pinProvider = ::promptPin,
+                    allowLegacyPairing = scenario.lowercase() !in V3_SCENARIOS,
                 )
 
             val now = getDateUtils().nowEpochMilliseconds()
@@ -164,6 +177,7 @@ private fun selectScenarios(
     when (name.lowercase()) {
         "discovery" -> listOf(DiscoveryScenario())
         "pair" -> listOf(PairScenario())
+        "pair-v3" -> listOf(PairV3Scenario())
         "wrong-token" -> listOf(WrongTokenScenario())
         "telnet" -> listOf(TelnetScenario())
         "push-text" -> listOf(PushTextScenario(payloads.text))
@@ -180,6 +194,17 @@ private fun selectScenarios(
                 PairScenario(),
                 // After pair: peer is trusted, so telnet's address-push exercises the gated
                 // server merge path; its identity-header check needs no trust.
+                TelnetScenario(),
+                PushTextScenario(payloads.text),
+                PushUrlScenario(payloads.url),
+                PushHtmlScenario(payloads.html),
+                PushRtfScenario(payloads.rtf),
+                PushColorScenario(payloads.color),
+            )
+        "all-v3" ->
+            listOf(
+                DiscoveryScenario(),
+                PairV3Scenario(),
                 TelnetScenario(),
                 PushTextScenario(payloads.text),
                 PushUrlScenario(payloads.url),
@@ -218,6 +243,22 @@ private fun promptToken(): Int {
     System.out.flush()
     val line = readlnOrNull()?.trim() ?: error("No token entered.")
     return line.toIntOrNull() ?: error("Invalid token: '$line' (must be an integer).")
+}
+
+private fun promptPin(): CharArray {
+    val pin =
+        System.console()?.readPassword("Enter the six-digit PIN shown on the target device: ")
+            ?: run {
+                print("Enter the six-digit PIN shown on the target device: ")
+                System.out.flush()
+                readlnOrNull()?.trim()?.toCharArray()
+            }
+            ?: error("No PIN entered.")
+    if (pin.size != PairingV3.PIN_LENGTH || pin.any { it !in '0'..'9' }) {
+        pin.fill('\u0000')
+        error("Invalid PIN (must be exactly six decimal digits).")
+    }
+    return pin
 }
 
 private fun printSummary(
@@ -292,5 +333,6 @@ private fun xmlText(value: String): String =
         .replace(">", "&gt;")
 
 private const val DEFAULT_PORT = 13129
+private val V3_SCENARIOS = setOf("pair-v3", "all-v3")
 
 fun main(args: Array<String>) = E2eCommand().main(args)

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
@@ -4,6 +4,7 @@ import com.crosspaste.app.AppInfo
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.net.PasteClient
 import com.crosspaste.net.SyncApi
+import com.crosspaste.net.clientapi.PairingV3ClientApi
 import com.crosspaste.net.clientapi.PasteClientApi
 import com.crosspaste.net.clientapi.PullClientApi
 import com.crosspaste.net.clientapi.SyncClientApi
@@ -11,12 +12,24 @@ import com.crosspaste.net.exception.DesktopExceptionHandler
 import com.crosspaste.net.exception.ExceptionHandler
 import com.crosspaste.net.plugin.ClientDecryptPlugin
 import com.crosspaste.net.plugin.ClientEncryptPlugin
+import com.crosspaste.pairing.v3.BouncyCastlePakeEcOps
+import com.crosspaste.pairing.v3.PairingAcceptanceWindow
+import com.crosspaste.pairing.v3.PairingProtocolV3Service
+import com.crosspaste.pairing.v3.PairingRateLimiter
+import com.crosspaste.pairing.v3.PairingReceiptCache
+import com.crosspaste.pairing.v3.PairingSessionStore
+import com.crosspaste.pairing.v3.PairingV3
+import com.crosspaste.pairing.v3.Spake2PakeProvider
 import com.crosspaste.secure.GeneralSecureStore
 import com.crosspaste.secure.SecureKeyPair
 import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.utils.CryptographyUtils.generateSecureKeyPair
 import com.crosspaste.utils.getJsonUtils
+import com.crosspaste.utils.ioDispatcher
+import com.crosspaste.utils.namedScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import java.util.UUID
 
@@ -25,6 +38,7 @@ class HeadlessPeer(
     userName: String = "e2e-peer",
     appVersion: String = "0.0.0-e2e",
     appRevision: String = "Unknown",
+    pairingVersion: Int = SyncApi.PAIRING_VERSION,
 ) {
     // Force JsonUtils to fully initialize before anything else touches PasteItem
     // serializer registration. See MEMORY.md "PasteItem / JsonUtils Circular Class
@@ -38,6 +52,7 @@ class HeadlessPeer(
             appVersion = appVersion,
             appRevision = appRevision,
             userName = userName,
+            pairingVersion = pairingVersion,
         )
 
     val secureKeyPairSerializer: SecureKeyPairSerializer = SecureKeyPairSerializer()
@@ -69,6 +84,34 @@ class HeadlessPeer(
             syncApi,
         )
 
+    private val pairingV3Scope: CoroutineScope? =
+        if (pairingVersion >= PairingV3.PROTOCOL_VERSION) {
+            namedScope(ioDispatcher, "E2ePairingV3")
+        } else {
+            null
+        }
+
+    val pairingProtocolV3Service: PairingProtocolV3Service? =
+        if (pairingVersion >= PairingV3.PROTOCOL_VERSION) {
+            PairingProtocolV3Service(
+                appInfo = appInfo,
+                pairingV3ClientApi = PairingV3ClientApi(pasteClient, exceptionHandler),
+                // Conformance/E2E only. Production intentionally registers
+                // UnavailablePakeProvider pending constant-time EC review.
+                pakeProvider = Spake2PakeProvider(BouncyCastlePakeEcOps()),
+                receiptCache = PairingReceiptCache(),
+                rateLimiter = PairingRateLimiter(),
+                secureKeyPairSerializer = secureKeyPairSerializer,
+                secureStore = secureStore,
+                sessionStore = PairingSessionStore(),
+                acceptanceWindow = PairingAcceptanceWindow(),
+                isPairingV3Enabled = { true },
+                scope = checkNotNull(pairingV3Scope),
+            )
+        } else {
+            null
+        }
+
     val pasteClientApi: PasteClientApi = PasteClientApi(pasteClient, configManager)
 
     val pullClientApi: PullClientApi = PullClientApi(pasteClient, configManager, exceptionHandler)
@@ -76,6 +119,7 @@ class HeadlessPeer(
     val bonjourAdvertiser: BonjourAdvertiser = BonjourAdvertiser(appInfo).also { it.start() }
 
     fun close() {
+        pairingV3Scope?.cancel()
         bonjourAdvertiser.close()
         pasteClient.close()
     }

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairScenario.kt
@@ -71,6 +71,11 @@ internal suspend fun ensureTrust(
 ): ScenarioResult? {
     val id = target.appInstanceId ?: return ScenarioResult.Fail("Target has no appInstanceId.")
     if (ctx.peer.secureIO.existCryptPublicKey(id)) return null
+    if (!ctx.allowLegacyPairing) {
+        return ScenarioResult.Fail(
+            "No trusted key for $id; legacy pairing fallback is disabled for this v3 scenario.",
+        )
+    }
     println("[ensureTrust] Not paired with $id yet — pairing first.")
     requestShowToken(ctx, target)?.let { return it }
     val token = ctx.tokenProvider()

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairV3Scenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairV3Scenario.kt
@@ -1,0 +1,123 @@
+package com.crosspaste.e2e.scenario
+
+import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.e2e.net.NetworkUtils
+import com.crosspaste.e2e.peer.BonjourAdvertiser
+import com.crosspaste.e2e.peer.buildPeerSyncInfo
+import com.crosspaste.net.SyncApi
+import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.pairing.v3.PairingV3PinResult
+import com.crosspaste.pairing.v3.PairingV3StartResult
+import com.crosspaste.utils.HostAndPort
+import com.crosspaste.utils.buildUrl
+import io.ktor.http.URLBuilder
+
+/**
+ * Drives the production pairing-v3 protocol service and real HTTP transport from
+ * a headless initiator. The harness uses the BC backend for interoperability
+ * validation only; the desktop application's production DI remains fail closed.
+ */
+class PairV3Scenario : Scenario {
+    override val name: String = "pair-v3"
+
+    override suspend fun run(ctx: ScenarioContext): ScenarioResult {
+        val target = resolveOrDiscover(ctx) ?: return ScenarioResult.Fail("Could not resolve target.")
+        val targetAppId = target.appInstanceId ?: return ScenarioResult.Fail("Target has no appInstanceId.")
+        if (target.pairingVersion != null && !SyncApi.supportsPairingV3(target.pairingVersion)) {
+            return ScenarioResult.Fail(
+                "Target advertises pairing version ${target.pairingVersion}; " +
+                    "pair-v3 never falls back to legacy pairing.",
+            )
+        }
+        val service =
+            ctx.peer.pairingProtocolV3Service
+                ?: return ScenarioResult.Fail("The E2E peer is not configured for pairing v3.")
+        val toTarget: URLBuilder.() -> Unit = {
+            buildUrl(HostAndPort(target.host, target.port))
+        }
+
+        println("[pair-v3] Target: $targetAppId at ${target.host}:${target.port}")
+        val started =
+            when (
+                val result =
+                    service.startPairing(
+                        targetAppInstanceId = targetAppId,
+                        targetDisplayName = target.displayName ?: targetAppId,
+                        toUrl = toTarget,
+                    )
+            ) {
+                is PairingV3StartResult.Started -> result
+                is PairingV3StartResult.Refused ->
+                    return ScenarioResult.Fail("Pairing v3 intent refused: ${result.code}")
+                is PairingV3StartResult.NetworkError ->
+                    return ScenarioResult.Fail(
+                        "Pairing v3 intent failed: ${describeFailure(result.failure)}",
+                    )
+            }
+
+        println(
+            "[pair-v3] Session ready; target signing-key fingerprint " +
+                started.peerKeyFingerprintDisplay,
+        )
+        val pin =
+            try {
+                ctx.pinProvider()
+            } catch (e: Exception) {
+                service.cancelSession(started.sessionId, toTarget)
+                throw e
+            }
+        val paired =
+            try {
+                service.submitPin(started.sessionId, pin, toTarget)
+            } finally {
+                pin.fill('\u0000')
+            }
+        when (paired) {
+            is PairingV3PinResult.Paired -> Unit
+            is PairingV3PinResult.Refused -> {
+                service.cancelSession(started.sessionId, toTarget)
+                return ScenarioResult.Fail("Pairing v3 proof/commit refused: ${paired.code}")
+            }
+            is PairingV3PinResult.NetworkError -> {
+                service.cancelSession(started.sessionId, toTarget)
+                return ScenarioResult.Fail(
+                    "Pairing v3 proof/commit failed " +
+                        "(commitPending=${paired.commitPending}): ${describeFailure(paired.failure)}",
+                )
+            }
+        }
+
+        if (!ctx.peer.secureIO.existCryptPublicKey(targetAppId)) {
+            return ScenarioResult.Fail(
+                "Pairing v3 completed but the target crypt public key was not persisted.",
+            )
+        }
+        val heartbeat =
+            ctx.peer.syncClientApi.heartbeat(
+                syncInfo = heartbeatSyncInfo(ctx),
+                targetAppInstanceId = targetAppId,
+                toUrl = toTarget,
+            )
+        if (heartbeat !is SuccessResult) {
+            return ScenarioResult.Fail(
+                "Encrypted heartbeat after pairing v3 failed: ${describeFailure(heartbeat)}",
+            )
+        }
+        return ScenarioResult.Pass(
+            "Paired with $targetAppId via v3; peer key persisted and encrypted heartbeat succeeded.",
+        )
+    }
+
+    private fun heartbeatSyncInfo(ctx: ScenarioContext) =
+        buildPeerSyncInfo(
+            appInfo = ctx.peer.appInfo,
+            hostInfoList =
+                NetworkUtils.enumerateLanInet4().map { (address, prefixLength) ->
+                    HostInfo(
+                        networkPrefixLength = prefixLength,
+                        hostAddress = address.hostAddress,
+                    )
+                },
+            port = BonjourAdvertiser.ADVERTISED_PORT,
+        )
+}

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/Scenario.kt
@@ -32,6 +32,8 @@ data class TargetSpec(
     val host: String,
     val port: Int,
     val appInstanceId: String?,
+    val displayName: String? = null,
+    val pairingVersion: Int? = null,
 )
 
 /**
@@ -50,6 +52,8 @@ data class ScenarioContext(
     val targetAppInstanceId: String?,
     val discoveryTimeoutMs: Long,
     val tokenProvider: suspend () -> Int,
+    val pinProvider: suspend () -> CharArray,
+    val allowLegacyPairing: Boolean = true,
     val targetCache: TargetCache = TargetCache(),
 )
 
@@ -75,6 +79,8 @@ fun resolveTarget(
         host = host,
         port = match.endpointInfo.port,
         appInstanceId = match.appInfo.appInstanceId,
+        displayName = match.appInfo.userName,
+        pairingVersion = match.appInfo.pairingVersion,
     )
 }
 


### PR DESCRIPTION
## Summary

Extends the `:e2e` real-device harness with pairing v3 coverage, driving the production `PairingProtocolV3Service` and real HTTP transport from a headless initiator.

- **`pair-v3` scenario**: sends a signed intent, prints the acceptor signing-key fingerprint, prompts for the six-digit PIN (`readPassword` when a console is available), runs SPAKE2 proof/commit, then verifies both sides: the local store must hold the target crypt public key, and an **encrypted** heartbeat (`POST /sync/heartbeat/syncInfo` with `secure: 1`) must succeed — proving the exchanged keys actually interoperate, not just that they were persisted.
- **`all-v3` batch**: discovery → pair-v3 → telnet → all push scenarios, with legacy pairing fallback disabled (`ensureTrust` fails instead of silently falling back to v2 token pairing).
- **HeadlessPeer**: optional `pairingVersion` knob; when >= 3 it advertises v3 capability and wires a `PairingProtocolV3Service` with the BC SPAKE2 backend on a dedicated scope that `close()` cancels. Conformance/E2E only — production DI keeps the fail-closed `UnavailablePakeProvider` pending constant-time EC review.
- **`pair-v3` never downgrades**: a target advertising pairing version < 3 fails the scenario instead of falling back to legacy pairing.
- **SyncResolverTest**: pins the invariant that existing v2 trust survives a peer capability upgrade — the resolver authenticates the stored crypt key directly (single heartbeat, no `deleteCryptPublicKey`) instead of forcing a v3 ceremony.

## Testing

- `./gradlew e2e:compileKotlinDesktop` passes
- `./gradlew app:desktopTest --tests "com.crosspaste.sync.SyncResolverTest"` passes
- `./gradlew ktlintCheck`-clean (formatted via ktlintFormat)