### PR TITLE
:sparkles: Add development-only pairing v3 interop flag

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/SyncApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/SyncApi.kt
@@ -7,11 +7,14 @@ object SyncApi {
     const val VERSION: Int = 3
 
     /**
-     * The advertised pairing capability. Still 2: the v3 protocol surface exists
-     * (see `PairingProtocolV3Service`) but stays unadvertised until the reviewed
-     * SPAKE2 provider and the v3 UI ship (design doc §19 Phase 6 rollout flag).
+     * The production rollout version. Still 2: the v3 protocol surface exists,
+     * but production stays unadvertised until every shipping platform has a
+     * reviewed constant-time backend.
      */
     const val PAIRING_VERSION: Int = 2
+
+    /** Highest pairing protocol implemented by this source revision. */
+    const val MAX_IMPLEMENTED_PAIRING_VERSION: Int = PairingV3.PROTOCOL_VERSION
 
     fun supportsSASPairing(remotePairingVersion: Int?): Boolean =
         remotePairingVersion != null && remotePairingVersion >= 2

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingCapabilityFlag.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingCapabilityFlag.kt
@@ -1,0 +1,23 @@
+package com.crosspaste.pairing.v3
+
+/**
+ * Immutable pairing capability snapshot for one application process.
+ *
+ * All capability consumers must share the same instance so discovery,
+ * credential selection, server routing, and provider registration cannot
+ * disagree while the process is running. Remote rollout changes should take
+ * effect after restart rather than changing an active pairing session.
+ */
+data class PairingCapabilityFlag(
+    val advertisedPairingVersion: Int,
+) {
+
+    init {
+        require(advertisedPairingVersion > 0) {
+            "advertised pairing version must be positive"
+        }
+    }
+
+    val isPairingV3Enabled: Boolean =
+        advertisedPairingVersion >= PairingV3.PROTOCOL_VERSION
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -10,6 +10,7 @@ import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.filter
 import com.crosspaste.net.ws.WsSessionManager
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
 import com.crosspaste.pairing.v3.PairingV3
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
@@ -44,6 +45,7 @@ class GeneralSyncManager(
     private val syncRuntimeInfoDao: SyncRuntimeInfoDao,
     private val syncClientApi: SyncClientApi,
     private val wsSessionManager: WsSessionManager,
+    private val pairingCapabilityFlag: PairingCapabilityFlag,
 ) : SyncManager {
 
     private val logger = KotlinLogging.logger {}
@@ -237,7 +239,7 @@ class GeneralSyncManager(
 
     private fun pairingCredentialType(syncInfo: SyncInfo): PairingCredentialType =
         selectPairingCredentialType(
-            localPairingVersion = SyncApi.PAIRING_VERSION,
+            localPairingVersion = pairingCapabilityFlag.advertisedPairingVersion,
             remotePairingVersion = syncInfo.appInfo.pairingVersion,
         )
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
@@ -59,6 +59,7 @@ import com.crosspaste.module.ModuleDownloadManager
 import com.crosspaste.module.ModuleManager
 import com.crosspaste.net.Server
 import com.crosspaste.net.SyncInfoFactory
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
 import com.crosspaste.paste.CacheManager
 import com.crosspaste.paste.DesktopCacheManager
 import com.crosspaste.path.AppPathProvider
@@ -92,6 +93,7 @@ fun desktopAppModule(
     deviceUtils: DeviceUtils,
     klogger: KLogger,
     platform: Platform,
+    pairingCapabilityFlag: PairingCapabilityFlag,
 ): Module =
     module {
         // region App
@@ -99,7 +101,7 @@ fun desktopAppModule(
         single<AppEnv> { appEnv }
         single<AppExitService> { DesktopAppExitService }
         single<AppInfo> { get<AppInfoFactory>().createAppInfo() }
-        single<AppInfoFactory> { DesktopAppInfoFactory(get()) }
+        single<AppInfoFactory> { DesktopAppInfoFactory(get(), get()) }
         single<AppLaunchState> { get<DesktopAppLaunchState>() }
         single<AppLock> { get<DesktopAppLaunch>() }
         single<AppRestartService> { DesktopAppRestartService(get(), get()) }
@@ -121,6 +123,7 @@ fun desktopAppModule(
         single<AppMetadataRepository> { appMetadataRepository }
         single<CommonConfigManager> { configManager as CommonConfigManager }
         single<DesktopConfigManager> { configManager }
+        single<PairingCapabilityFlag> { pairingCapabilityFlag }
         single<ReadWriteConfig<Int>>(named("readWritePort")) { ReadWritePort(get()) }
         single<SimpleConfigFactory> { DesktopSimpleConfigFactory(get()) }
         // endregion

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -24,10 +24,13 @@ import com.crosspaste.headless.headlessViewModelModule
 import com.crosspaste.image.OCRModule
 import com.crosspaste.log.CrossPasteLogger
 import com.crosspaste.module.ocr.DesktopOCRModule
+import com.crosspaste.net.SyncApi
 import com.crosspaste.net.plugin.ClientDecryptPlugin
 import com.crosspaste.net.plugin.ClientEncryptPlugin
 import com.crosspaste.net.plugin.ServerDecryptionPluginFactory
 import com.crosspaste.net.plugin.ServerEncryptPluginFactory
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
+import com.crosspaste.pairing.v3.PairingV3
 import com.crosspaste.paste.plugin.type.ColorTypePlugin
 import com.crosspaste.paste.plugin.type.DesktopColorTypePlugin
 import com.crosspaste.paste.plugin.type.DesktopFilesTypePlugin
@@ -75,6 +78,13 @@ class DesktopModule(
 
     val marketingMode = getAppEnvUtils().isDevelopment() && DevConfig.marketingMode
 
+    private val pairingCapabilityFlag =
+        createDesktopPairingCapabilityFlag(
+            appEnv = appEnv,
+            developmentV3InteropEnabled =
+                appEnv == AppEnv.DEVELOPMENT && DevConfig.pairingV3InteropEnabled,
+        )
+
     override fun appModule() =
         desktopAppModule(
             appEnv,
@@ -85,6 +95,7 @@ class DesktopModule(
             deviceUtils,
             klogger,
             platform,
+            pairingCapabilityFlag,
         )
 
     override fun extensionModule() =
@@ -187,4 +198,22 @@ class DesktopModule(
                 )
             }
         }
+}
+
+internal fun createDesktopPairingCapabilityFlag(
+    appEnv: AppEnv,
+    developmentV3InteropEnabled: Boolean,
+): PairingCapabilityFlag {
+    val pairingVersion =
+        if (appEnv == AppEnv.DEVELOPMENT && developmentV3InteropEnabled) {
+            SyncApi.MAX_IMPLEMENTED_PAIRING_VERSION
+        } else {
+            // Keep non-development builds fail-closed even if the rollout
+            // constant is changed before a reviewed provider is registered.
+            minOf(
+                SyncApi.PAIRING_VERSION,
+                PairingV3.PROTOCOL_VERSION - 1,
+            )
+        }
+    return PairingCapabilityFlag(pairingVersion)
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -1,5 +1,6 @@
 package com.crosspaste
 
+import com.crosspaste.app.AppEnv
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.image.DesktopFaviconLoader
 import com.crosspaste.image.FaviconLoader
@@ -42,14 +43,16 @@ import com.crosspaste.net.ws.WsClientConnector
 import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsPendingRequests
 import com.crosspaste.net.ws.WsSessionManager
+import com.crosspaste.pairing.v3.BouncyCastlePakeEcOps
 import com.crosspaste.pairing.v3.PairingAcceptanceWindow
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
 import com.crosspaste.pairing.v3.PairingProtocolV3Service
 import com.crosspaste.pairing.v3.PairingRateLimiter
 import com.crosspaste.pairing.v3.PairingReceiptCache
 import com.crosspaste.pairing.v3.PairingSessionStore
-import com.crosspaste.pairing.v3.PairingV3
 import com.crosspaste.pairing.v3.PairingVersionCoordinator
 import com.crosspaste.pairing.v3.PakeProvider
+import com.crosspaste.pairing.v3.Spake2PakeProvider
 import com.crosspaste.pairing.v3.UnavailablePakeProvider
 import com.crosspaste.platform.Platform
 import com.crosspaste.sync.FilePushService
@@ -165,6 +168,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
         // region Pairing v3
         single<PairingAcceptanceWindow> { PairingAcceptanceWindow() }
         single<PairingProtocolV3Service> {
+            val pairingCapabilityFlag = get<PairingCapabilityFlag>()
             PairingProtocolV3Service(
                 appInfo = get(),
                 pairingV3ClientApi = get(),
@@ -175,16 +179,14 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 secureStore = get(),
                 sessionStore = get(),
                 acceptanceWindow = get(),
-                isPairingV3Enabled = { SyncApi.PAIRING_VERSION >= PairingV3.PROTOCOL_VERSION },
+                isPairingV3Enabled = { pairingCapabilityFlag.isPairingV3Enabled },
             )
         }
         single<PairingRateLimiter> { PairingRateLimiter() }
         single<PairingReceiptCache> { PairingReceiptCache() }
         single<PairingSessionStore> { PairingSessionStore() }
         single<PairingVersionCoordinator> { PairingVersionCoordinator() }
-        // BouncyCastle's P-256 point formulas are not guaranteed constant-time
-        // for every input. Fail closed until a reviewed production backend lands.
-        single<PakeProvider> { UnavailablePakeProvider }
+        single<PakeProvider> { createDesktopPakeProvider(get(), get()) }
         // endregion
 
         // region WebSocket
@@ -263,6 +265,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                     syncRuntimeInfoDao = get(),
                     syncClientApi = get(),
                     wsSessionManager = get(),
+                    pairingCapabilityFlag = get(),
                 )
             }
         }
@@ -286,4 +289,16 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
             )
         }
         // endregion
+    }
+
+internal fun createDesktopPakeProvider(
+    appEnv: AppEnv,
+    pairingCapabilityFlag: PairingCapabilityFlag,
+): PakeProvider =
+    if (appEnv == AppEnv.DEVELOPMENT && pairingCapabilityFlag.isPairingV3Enabled) {
+        // DEVELOPMENT interoperability only. BouncyCastle's P-256 point
+        // formulas are not approved for production SPAKE2 operations.
+        Spake2PakeProvider(BouncyCastlePakeEcOps())
+    } else {
+        UnavailablePakeProvider
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppInfoFactory.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppInfoFactory.kt
@@ -1,7 +1,7 @@
 package com.crosspaste.app
 
 import com.crosspaste.config.AppMetadataRepository
-import com.crosspaste.net.SyncApi
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
 import com.crosspaste.utils.getAppEnvUtils
 import com.crosspaste.utils.getSystemProperty
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -10,6 +10,7 @@ import java.util.Properties
 
 class DesktopAppInfoFactory(
     private val appMetadataRepository: AppMetadataRepository,
+    private val pairingCapabilityFlag: PairingCapabilityFlag,
 ) : AppInfoFactory {
 
     private val logger = KotlinLogging.logger {}
@@ -36,7 +37,7 @@ class DesktopAppInfoFactory(
             appVersion = getVersion(),
             appRevision = getRevision(),
             userName = getUserName(),
-            pairingVersion = SyncApi.PAIRING_VERSION,
+            pairingVersion = pairingCapabilityFlag.advertisedPairingVersion,
         )
 
     override fun getVersion(): String = getVersion(appEnvUtils.getCurrentAppEnv(), properties)

--- a/app/src/desktopMain/kotlin/com/crosspaste/config/DevConfig.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/config/DevConfig.kt
@@ -11,4 +11,7 @@ object DevConfig {
     val pasteUserPath: String? = development.getProperty("pasteUserPath")
 
     val marketingMode: Boolean = development.getProperty("marketingMode")?.toBoolean() == true
+
+    val pairingV3InteropEnabled: Boolean =
+        development.getProperty("pairingV3InteropEnabled")?.toBoolean() == true
 }

--- a/app/src/desktopMain/resources/development.properties.template
+++ b/app/src/desktopMain/resources/development.properties.template
@@ -1,2 +1,3 @@
 pasteAppPath=.
 pasteUserPath=.user
+pairingV3InteropEnabled=false

--- a/app/src/desktopTest/kotlin/com/crosspaste/DesktopPairingCapabilityTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/DesktopPairingCapabilityTest.kt
@@ -1,0 +1,74 @@
+package com.crosspaste
+
+import com.crosspaste.app.AppEnv
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
+import com.crosspaste.pairing.v3.Spake2PakeProvider
+import com.crosspaste.pairing.v3.UnavailablePakeProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class DesktopPairingCapabilityTest {
+
+    @Test
+    fun developmentInteropOptInEnablesV3() {
+        val capability =
+            createDesktopPairingCapabilityFlag(
+                appEnv = AppEnv.DEVELOPMENT,
+                developmentV3InteropEnabled = true,
+            )
+
+        assertEquals(3, capability.advertisedPairingVersion)
+        assertTrue(capability.isPairingV3Enabled)
+        assertIs<Spake2PakeProvider>(
+            createDesktopPakeProvider(AppEnv.DEVELOPMENT, capability),
+        )
+    }
+
+    @Test
+    fun developmentDefaultsToV2() {
+        val capability =
+            createDesktopPairingCapabilityFlag(
+                appEnv = AppEnv.DEVELOPMENT,
+                developmentV3InteropEnabled = false,
+            )
+
+        assertEquals(2, capability.advertisedPairingVersion)
+        assertFalse(capability.isPairingV3Enabled)
+        assertSame(
+            UnavailablePakeProvider,
+            createDesktopPakeProvider(AppEnv.DEVELOPMENT, capability),
+        )
+    }
+
+    @Test
+    fun nonDevelopmentBuildsIgnoreInteropOptIn() {
+        listOf(AppEnv.PRODUCTION, AppEnv.BETA, AppEnv.TEST).forEach { appEnv ->
+            val capability =
+                createDesktopPairingCapabilityFlag(
+                    appEnv = appEnv,
+                    developmentV3InteropEnabled = true,
+                )
+
+            assertEquals(2, capability.advertisedPairingVersion)
+            assertFalse(capability.isPairingV3Enabled)
+            assertSame(
+                UnavailablePakeProvider,
+                createDesktopPakeProvider(appEnv, capability),
+            )
+        }
+    }
+
+    @Test
+    fun providerStillFailsClosedForMisinjectedProductionCapability() {
+        val capability = PairingCapabilityFlag(advertisedPairingVersion = 3)
+
+        assertSame(
+            UnavailablePakeProvider,
+            createDesktopPakeProvider(AppEnv.PRODUCTION, capability),
+        )
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/AppInfoFactoryTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/AppInfoFactoryTest.kt
@@ -1,10 +1,28 @@
 package com.crosspaste.app
 
+import com.crosspaste.config.AppMetadataRepository
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
+import io.mockk.every
+import io.mockk.mockk
 import java.util.Properties
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class AppInfoFactoryTest {
+
+    @Test
+    fun createAppInfo_usesRuntimePairingCapability() {
+        val appMetadataRepository = mockk<AppMetadataRepository>()
+        every { appMetadataRepository.appInstanceId } returns "test-instance"
+
+        val appInfo =
+            DesktopAppInfoFactory(
+                appMetadataRepository,
+                PairingCapabilityFlag(advertisedPairingVersion = 3),
+            ).createAppInfo()
+
+        assertEquals(3, appInfo.pairingVersion)
+    }
 
     @Test
     fun testAppVersion() {

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
@@ -8,6 +8,7 @@ import com.crosspaste.net.clientapi.RequestTimeout
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.ws.WsSessionManager
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
 import com.crosspaste.platform.Platform
 import com.crosspaste.ui.devices.DeviceScopeFactory
 import io.mockk.coEvery
@@ -52,6 +53,7 @@ class GeneralSyncManagerTest {
     private fun createSyncManager(
         mocks: Mocks,
         scope: CoroutineScope,
+        localPairingVersion: Int = 2,
     ): GeneralSyncManager =
         GeneralSyncManager(
             realTimeSyncScope = scope,
@@ -59,6 +61,7 @@ class GeneralSyncManagerTest {
             syncRuntimeInfoDao = mocks.syncRuntimeInfoDao,
             syncClientApi = mocks.syncClientApi,
             wsSessionManager = WsSessionManager(),
+            pairingCapabilityFlag = PairingCapabilityFlag(localPairingVersion),
         )
 
     private fun createTestSyncRuntimeInfo(
@@ -197,6 +200,22 @@ class GeneralSyncManagerTest {
             advanceUntilIdle()
 
             coVerify { mocks.syncRuntimeInfoDao.insertOrUpdateSyncInfo(syncInfo) }
+        }
+
+    @Test
+    fun updateSyncInfo_v3PeerUsesPinWhenLocalCapabilityIsEnabled() =
+        runTest {
+            val mocks = createMocks()
+            val syncInfo = SyncTestFixtures.createSyncInfo(pairingVersion = 3)
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager = createSyncManager(mocks, childScope, localPairingVersion = 3)
+
+            syncManager.updateSyncInfo(syncInfo)
+
+            assertEquals(
+                PairingCredentialType.V3_PIN,
+                syncManager.pairingCredentialTypes.value[syncInfo.appInfo.appInstanceId],
+            )
         }
 
     @Test


### PR DESCRIPTION
Closes #4666

## Summary

Introduces `PairingCapabilityFlag`, an immutable process-wide snapshot of the advertised pairing capability, and a development-only opt-in (`pairingV3InteropEnabled` in `development.properties`) that lets a DEVELOPMENT desktop build advertise pairing v3 and register the BouncyCastle SPAKE2 backend — giving the `pair-v3` / `all-v3` e2e scenarios (#4665) a real acceptor to pair against.

- **`PairingCapabilityFlag`** (app commonMain): single source of truth shared by every capability consumer — discovery advertisement (`DesktopAppInfoFactory`), credential selection (`GeneralSyncManager`), `PairingProtocolV3Service` enablement, and PAKE provider registration — so they cannot disagree while the process runs. Remote rollout changes take effect after restart rather than mid-session.
- **`SyncApi.MAX_IMPLEMENTED_PAIRING_VERSION`**: the highest protocol implemented by this revision (3), distinct from the production rollout constant `PAIRING_VERSION` (still 2).
- **Development opt-in**: `AppEnv.DEVELOPMENT` + `pairingV3InteropEnabled=true` → advertise v3 and register `Spake2PakeProvider(BouncyCastlePakeEcOps())` (interop only; BC P-256 remains unapproved for production SPAKE2).
- **Fail-closed double gate for non-development builds**: advertised version is clamped to `min(PAIRING_VERSION, PROTOCOL_VERSION - 1)` and the PAKE provider stays `UnavailablePakeProvider`, so even an accidental early bump of the rollout constant cannot expose the unreviewed backend. Production behavior is unchanged.

## Testing

- New `DesktopPairingCapabilityTest` covers the flag matrix (dev on/off, non-dev clamp, provider selection)
- `AppInfoFactoryTest` / `GeneralSyncManagerTest` updated for the injected flag; all three classes pass via `./gradlew app:desktopTest`
- `./gradlew app:compileKotlinDesktop` and ktlint clean