### PR TITLE
:hammer: Harden pairing v3 interop handshake and trust dialog UX

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -123,6 +123,7 @@ open class DefaultServerModule(
                     ::trustSyncInfo,
                     pairingVersionCoordinator,
                     pairingProtocolV3Service::hasActiveSession,
+                    pairingProtocolV3Service.acceptanceWindow::open,
                 )
                 pairingV3Routing(
                     pairingProtocolV3Service,

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -52,6 +52,7 @@ fun Routing.syncRouting(
     // No-downgrade rule (pairing v3 design §17.2): while a v3 pairing session is
     // active for a peer, that peer must not be able to fall back to v2 trust.
     hasActivePairingV3Session: (String) -> Boolean = { false },
+    openPairingV3AcceptanceWindow: () -> Unit = {},
 ) {
     val logger = KotlinLogging.logger {}
 
@@ -144,6 +145,7 @@ fun Routing.syncRouting(
             return@get
         }
         appTokenApi.showPairingCode()
+        openPairingV3AcceptanceWindow()
         logger.info { "show pairing code requested from $host" }
         successResponse(call)
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
@@ -152,6 +152,24 @@ class PairingProtocolV3Service(
             return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_IDENTITY_INVALID)
         }
         val fingerprint = PairingKeyFingerprint.of(intent.initiatorSignPublicKey)
+        val intentHash = PairingTranscriptCodec.intentHash(intent)
+        val duplicateSession =
+            sessionStore.findActiveAcceptorSessionForIntent(
+                peerKeyFingerprint = fingerprint,
+                requestId = toHex(intent.requestId),
+                intentHash = intentHash,
+            )
+        val duplicateOffer =
+            duplicateSession?.let { session ->
+                acceptorRuntimes[session.sessionId]?.let { runtime ->
+                    runtime.offerMutex.withLock {
+                        runtime.currentOffer
+                    }
+                }
+            }
+        if (duplicateOffer != null) {
+            return PairingV3ServerResult.Ok(duplicateOffer)
+        }
         val source =
             PairingAttemptSource(
                 peerKeyFingerprint = fingerprint,
@@ -161,7 +179,6 @@ class PairingProtocolV3Service(
         if (!rateLimiter.tryAcquire(source)) {
             return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_RATE_LIMITED)
         }
-        val intentHash = PairingTranscriptCodec.intentHash(intent)
         return createAcceptorSession(intent, intentHash, fingerprint)
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingRateLimiter.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingRateLimiter.kt
@@ -68,8 +68,8 @@ class PairingRateLimiter(
         }
 
     companion object {
-        const val DEFAULT_MAX_PER_KEY: Int = 5
-        const val DEFAULT_MAX_GLOBAL: Int = 20
+        const val DEFAULT_MAX_PER_KEY: Int = 10
+        const val DEFAULT_MAX_GLOBAL: Int = 100
         const val DEFAULT_WINDOW_MILLIS: Long = 60_000L
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingSessionStore.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingSessionStore.kt
@@ -193,6 +193,26 @@ class PairingSessionStore(
     fun activeSessions(): List<PairingSession> = snapshot().filter { session -> session.isActive }
 
     /**
+     * Finds an exact, still-active signed intent retry. The protocol service uses
+     * this only after validating the intent shape, keys, and signature, so a
+     * legitimate offer refresh does not consume the budget for a new pairing.
+     */
+    internal fun findActiveAcceptorSessionForIntent(
+        peerKeyFingerprint: String,
+        requestId: String,
+        intentHash: ByteArray,
+    ): PairingSession? =
+        sessions.values
+            .map { stored -> stored.session }
+            .firstOrNull { session ->
+                session.isActive &&
+                    session.role == PakeRole.ACCEPTOR &&
+                    session.peerKeyFingerprint == peerKeyFingerprint &&
+                    session.requestId == requestId &&
+                    session.intentHash?.contentEquals(intentHash) == true
+            }
+
+    /**
      * Applies capacity and deduplication policy for incoming (acceptor-role) sessions.
      * Peer identity comparisons use the FULL signing-key fingerprint. Initiator-role
      * sessions bypass the peer policies but never an existing session id: a session

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -226,7 +226,15 @@ class GeneralSyncHandler(
     }
 
     override suspend fun showPairingCode() {
-        emitEvent(SyncEvent.ShowPairingCode(currentSyncRuntimeInfo))
+        val event = SyncEvent.ShowPairingCode(currentSyncRuntimeInfo)
+        emitEvent(event)
+        val pairingCodeShown =
+            withTimeoutOrNull(5.seconds) {
+                event.completionSignal.await()
+            } ?: false
+        check(pairingCodeShown) {
+            "Unable to process remote pairing-code request for ${currentSyncRuntimeInfo.appInstanceId}"
+        }
     }
 
     override suspend fun notifyExit() {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
@@ -89,25 +89,25 @@ class SyncDeviceManager(
         }
     }
 
-    suspend fun showPairingCode(syncRuntimeInfo: SyncRuntimeInfo) {
-        if (syncRuntimeInfo.connectState == SyncState.UNVERIFIED) {
-            syncRuntimeInfo.connectHostAddress?.let { host ->
-                val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
-                val result =
-                    syncClientApi.showPairingCode {
-                        buildUrl(hostAndPort)
-                    }
-                if (result is SuccessResult) {
-                    logger.info { "showPairingCode success $host ${syncRuntimeInfo.port}" }
-                } else {
-                    syncRuntimeInfoDao.updateConnectInfo(
-                        syncRuntimeInfo.copy(
-                            connectState = SyncState.DISCONNECTED,
-                            modifyTime = nowEpochMilliseconds(),
-                        ),
-                    )
-                }
+    suspend fun showPairingCode(syncRuntimeInfo: SyncRuntimeInfo): Boolean {
+        if (syncRuntimeInfo.connectState != SyncState.UNVERIFIED) return false
+        val host = syncRuntimeInfo.connectHostAddress ?: return false
+        val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
+        val result =
+            syncClientApi.showPairingCode {
+                buildUrl(hostAndPort)
             }
+        return if (result is SuccessResult) {
+            logger.info { "showPairingCode success $host ${syncRuntimeInfo.port}" }
+            true
+        } else {
+            syncRuntimeInfoDao.updateConnectInfo(
+                syncRuntimeInfo.copy(
+                    connectState = SyncState.DISCONNECTED,
+                    modifyTime = nowEpochMilliseconds(),
+                ),
+            )
+            false
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -81,6 +81,7 @@ sealed interface SyncEvent {
 
     data class ShowPairingCode(
         override val syncRuntimeInfo: SyncRuntimeInfo,
+        val completionSignal: CompletableDeferred<Boolean> = CompletableDeferred(),
     ) : SyncRunTimeInfoEvent {
         override fun toString(): String = "ShowPairingCode ${syncRuntimeInfo.appInstanceId}"
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -127,7 +127,9 @@ class SyncResolver(
                     }
 
                     is SyncEvent.ShowPairingCode -> {
-                        syncDeviceManager.showPairingCode(syncRuntimeInfo)
+                        event.completionSignal.complete(
+                            syncDeviceManager.showPairingCode(syncRuntimeInfo),
+                        )
                     }
 
                     is SyncEvent.NotifyExit -> {
@@ -170,6 +172,9 @@ class SyncResolver(
         } finally {
             if (event is SyncEvent.CallbackEvent) {
                 event.callback.onComplete()
+            }
+            if (event is SyncEvent.ShowPairingCode) {
+                event.completionSignal.complete(false)
             }
         }
     }
@@ -386,6 +391,13 @@ class SyncResolver(
      */
     private suspend fun SyncRuntimeInfo.resolveUnverified(callback: ResolveCallback) {
         connectHostAddress?.let { host ->
+            // Pairing v3 persists the peer key outside the legacy resolver event path.
+            // A forced refresh then arrives while this row is still UNVERIFIED, so
+            // authenticate with the newly stored key before falling back to QR tokens.
+            if (secureStore.existCryptPublicKey(appInstanceId)) {
+                authenticate(host, connectNetworkPrefixLength, callback)
+                return
+            }
             // Check token cache first — user may have scanned QR while waiting
             if (trustByTokenCache()) {
                 logger.info { "trustByTokenCache success (from unverified) $host $port" }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3TrustDeviceDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,10 +46,14 @@ import com.crosspaste.ui.theme.AppUISize.tiny
 import com.crosspaste.ui.theme.AppUISize.xLarge
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 private const val PAIRING_PIN_LENGTH = 6
+private val INCORRECT_PIN_FEEDBACK_DURATION = 1.seconds
 
 @Composable
 fun DeviceScope.PairingV3TrustDeviceDialog() {
@@ -133,6 +138,12 @@ private fun PairingV3DialogLifecycle(
     LaunchedEffect(session?.sessionId, session?.tokenGeneration) {
         resetInput()
         dialogState.resetFeedback()
+    }
+
+    LaunchedEffect(dialogState.inputResetGeneration) {
+        if (dialogState.inputResetGeneration > 0) {
+            resetInput()
+        }
     }
 
     DisposableEffect(appInstanceId) {
@@ -385,11 +396,12 @@ internal data class PairingV3DialogModel(
                 recovery != PairingV3Recovery.NONE
 }
 
-private class PairingV3DialogState(
+internal class PairingV3DialogState(
     private val appInstanceId: String,
     private val controller: PairingV3UiController,
     private val syncManager: SyncManager,
     private val coroutineScope: CoroutineScope,
+    private val incorrectPinFeedbackDuration: Duration = INCORRECT_PIN_FEEDBACK_DURATION,
 ) {
     var isLoading by mutableStateOf(false)
         private set
@@ -398,6 +410,9 @@ private class PairingV3DialogState(
         private set
 
     var recovery by mutableStateOf(PairingV3Recovery.NONE)
+        private set
+
+    var inputResetGeneration by mutableIntStateOf(0)
         private set
 
     fun resetFeedback() {
@@ -415,7 +430,7 @@ private class PairingV3DialogState(
         sessionId: String,
         pin: String,
     ) {
-        launchAction {
+        launchAction(autoRefreshIncorrectPinSessionId = sessionId) {
             controller.submitPin(sessionId, V3Pin(pin))
         }
     }
@@ -445,23 +460,57 @@ private class PairingV3DialogState(
         }
     }
 
-    private fun launchAction(action: suspend () -> PairingV3UiResult) {
+    private fun launchAction(
+        autoRefreshIncorrectPinSessionId: String? = null,
+        action: suspend () -> PairingV3UiResult,
+    ) {
         if (isLoading) return
         isLoading = true
         uiError = null
         coroutineScope.launch {
-            runAction(action)
+            runAction(
+                action = action,
+                autoRefreshIncorrectPinSessionId = autoRefreshIncorrectPinSessionId,
+            )
         }
     }
 
-    private suspend fun runAction(action: suspend () -> PairingV3UiResult) {
+    private suspend fun runAction(
+        action: suspend () -> PairingV3UiResult,
+        autoRefreshIncorrectPinSessionId: String?,
+    ) {
+        val result = executeAction(action)
+        if (
+            autoRefreshIncorrectPinSessionId != null &&
+            result is PairingV3UiResult.Error &&
+            result.reason == PairingV3UiError.INCORRECT_PIN &&
+            result.recovery == PairingV3Recovery.REFRESH_OFFER
+        ) {
+            autoRefreshAfterIncorrectPin(autoRefreshIncorrectPinSessionId)
+        } else {
+            applyResult(result)
+        }
+    }
+
+    private suspend fun executeAction(action: suspend () -> PairingV3UiResult): PairingV3UiResult =
         try {
-            applyResult(action())
+            action()
         } catch (error: CancellationException) {
             throw error
         } catch (_: Exception) {
-            applyResult(PairingV3UiResult.Error(PairingV3UiError.FAILED))
+            PairingV3UiResult.Error(PairingV3UiError.FAILED)
         }
+
+    private suspend fun autoRefreshAfterIncorrectPin(sessionId: String) {
+        uiError = PairingV3UiError.INCORRECT_PIN
+        recovery = PairingV3Recovery.NONE
+
+        delay(incorrectPinFeedbackDuration)
+
+        uiError = null
+        val result = executeAction { controller.recover(sessionId) }
+        inputResetGeneration += 1
+        applyResult(result)
     }
 
     private fun applyResult(result: PairingV3UiResult) {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
@@ -123,6 +123,7 @@ class DefaultPairingV3UiController(
                         PairingV3UiError.NETWORK_FAILURE,
                         PairingV3Recovery.RETRY_START,
                     )
+            target.showPairingCode()
             pairingProtocolV3Service
                 .startPairing(
                     targetAppInstanceId = peerAppInstanceId,
@@ -194,6 +195,7 @@ class DefaultPairingV3UiController(
         val runtimeInfo = handler.currentSyncRuntimeInfo
         return PairingTarget(
             displayName = runtimeInfo.getDeviceDisplayName(),
+            showPairingCode = handler::showPairingCode,
             toUrl = {
                 buildUrl(HostAndPort(host, runtimeInfo.port))
             },
@@ -202,6 +204,7 @@ class DefaultPairingV3UiController(
 
     private data class PairingTarget(
         val displayName: String,
+        val showPairingCode: suspend () -> Unit,
         val toUrl: io.ktor.http.URLBuilder.() -> Unit,
     )
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
@@ -54,8 +54,9 @@ fun TokenView(intOffset: IntOffset) {
     val appTokenApi = koinInject<AppTokenApi>()
     val syncManager = koinInject<SyncManager>()
     val copywriter = koinInject<GlobalCopywriter>()
-    val appSizeValue = LocalAppSizeValueState.current
     val showToken by appTokenApi.showToken.collectAsState()
+    val progress by appTokenApi.refreshProgress.collectAsState()
+    val token by appTokenApi.token.collectAsState()
 
     // Auto-close token view when all pending verifiers have completed verification
     // (either trust succeeded, went offline, or disconnected)
@@ -78,69 +79,122 @@ fun TokenView(intOffset: IntOffset) {
     }
 
     if (showToken) {
-        Popup(
-            alignment = Alignment.TopCenter,
-            offset = intOffset,
-            properties = PopupProperties(clippingEnabled = false),
+        TokenPopup(
+            intOffset = intOffset,
+            title = copywriter.getText("token"),
+            token = token.map(Char::toString),
+            progress = progress,
+            onClose = { appTokenApi.stopRefresh(hideToken = true) },
+        )
+    }
+}
+
+@Composable
+fun TokenPopup(
+    intOffset: IntOffset,
+    title: String,
+    token: List<String>,
+    progress: Float,
+    onClose: () -> Unit,
+    deviceDisplayName: String? = null,
+    statusText: String? = null,
+) {
+    Popup(
+        alignment = Alignment.TopCenter,
+        offset = intOffset,
+        properties = PopupProperties(clippingEnabled = false),
+    ) {
+        TokenPopupCard(
+            title = title,
+            token = token,
+            progress = progress,
+            onClose = onClose,
+            deviceDisplayName = deviceDisplayName,
+            statusText = statusText,
+        )
+    }
+}
+
+@Composable
+fun TokenPopupCard(
+    title: String,
+    token: List<String>,
+    progress: Float,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    deviceDisplayName: String? = null,
+    statusText: String? = null,
+) {
+    val appSizeValue = LocalAppSizeValueState.current
+
+    Surface(
+        modifier =
+            modifier
+                .width(appSizeValue.tokenViewWidth)
+                .wrapContentHeight(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = small,
+        shadowElevation = small,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = small2X),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Surface(
+            Box(
                 modifier =
                     Modifier
-                        .width(appSizeValue.tokenViewWidth)
-                        .wrapContentHeight(),
-                shape = MaterialTheme.shapes.large,
-                color = MaterialTheme.colorScheme.surfaceContainer,
-                tonalElevation = small,
-                shadowElevation = small,
+                        .fillMaxWidth()
+                        .padding(top = small, start = small2X, end = tiny),
+                contentAlignment = Alignment.Center,
             ) {
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = small2X),
-                    horizontalAlignment = Alignment.CenterHorizontally,
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                IconButton(
+                    onClick = onClose,
+                    modifier = Modifier.align(Alignment.CenterEnd),
                 ) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(top = small, start = small2X, end = tiny),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = copywriter.getText("token"),
-                            style = MaterialTheme.typography.titleLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-
-                        // Close Button aligned to the end
-                        IconButton(
-                            onClick = { appTokenApi.stopRefresh(hideToken = true) },
-                            modifier = Modifier.align(Alignment.CenterEnd),
-                        ) {
-                            Icon(
-                                imageVector = MaterialSymbols.Rounded.Close,
-                                contentDescription = "Close",
-                                modifier = Modifier.size(medium),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-
-                    // Token Display Section
-                    OTPCodeBox()
+                    Icon(
+                        imageVector = MaterialSymbols.Rounded.Close,
+                        contentDescription = "Close",
+                        modifier = Modifier.size(medium),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
+
+            deviceDisplayName?.let { displayName ->
+                Text(
+                    text = displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            statusText?.let { status ->
+                Text(
+                    text = status,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            OTPCodeBox(token = token, progress = progress)
         }
     }
 }
 
 @Composable
-private fun OTPCodeBox() {
-    val appTokenApi = koinInject<AppTokenApi>()
-    val progress by appTokenApi.refreshProgress.collectAsState()
-    val token by appTokenApi.token.collectAsState()
-
+private fun OTPCodeBox(
+    token: List<String>,
+    progress: Float,
+) {
     Column(
         modifier =
             Modifier
@@ -152,8 +206,8 @@ private fun OTPCodeBox() {
             horizontalArrangement = Arrangement.spacedBy(small),
             modifier = Modifier.padding(vertical = small2X),
         ) {
-            token.forEach { char ->
-                TokenDisplayBox(char = char.toString())
+            token.forEach { value ->
+                TokenDisplayBox(char = value)
             }
         }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/config/DevConfig.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/config/DevConfig.kt
@@ -13,5 +13,13 @@ object DevConfig {
     val marketingMode: Boolean = development.getProperty("marketingMode")?.toBoolean() == true
 
     val pairingV3InteropEnabled: Boolean =
-        development.getProperty("pairingV3InteropEnabled")?.toBoolean() == true
+        developmentPairingV3InteropEnabled(
+            development.getProperty("pairingV3InteropEnabled"),
+        )
 }
+
+internal fun developmentPairingV3InteropEnabled(configuredValue: String?): Boolean =
+    when (configuredValue) {
+        null -> true
+        else -> configuredValue.toBooleanStrictOrNull() ?: false
+    }

--- a/app/src/desktopTest/kotlin/com/crosspaste/DesktopPairingCapabilityTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/DesktopPairingCapabilityTest.kt
@@ -1,6 +1,7 @@
 package com.crosspaste
 
 import com.crosspaste.app.AppEnv
+import com.crosspaste.config.developmentPairingV3InteropEnabled
 import com.crosspaste.pairing.v3.PairingCapabilityFlag
 import com.crosspaste.pairing.v3.Spake2PakeProvider
 import com.crosspaste.pairing.v3.UnavailablePakeProvider
@@ -12,6 +13,13 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DesktopPairingCapabilityTest {
+
+    @Test
+    fun developmentConfigurationDefaultsToV3AndSupportsExplicitV2Override() {
+        assertTrue(developmentPairingV3InteropEnabled(null))
+        assertFalse(developmentPairingV3InteropEnabled("false"))
+        assertFalse(developmentPairingV3InteropEnabled("invalid"))
+    }
 
     @Test
     fun developmentInteropOptInEnablesV3() {
@@ -29,7 +37,7 @@ class DesktopPairingCapabilityTest {
     }
 
     @Test
-    fun developmentDefaultsToV2() {
+    fun developmentInteropOptOutUsesV2() {
         val capability =
             createDesktopPairingCapabilityFlag(
                 appEnv = AppEnv.DEVELOPMENT,

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
@@ -11,6 +11,7 @@ import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.pairing.v3.BouncyCastlePakeEcOps
 import com.crosspaste.pairing.v3.PairingKeySchedule
+import com.crosspaste.pairing.v3.PairingRateLimiter
 import com.crosspaste.pairing.v3.PairingSessionState
 import com.crosspaste.pairing.v3.PairingSessionUiState
 import com.crosspaste.pairing.v3.PairingTranscript
@@ -57,6 +58,7 @@ class PairingV3IntegrationTest {
         id: String,
         pinLifetime: kotlin.time.Duration = PairingV3.DEFAULT_PIN_LIFETIME,
         generationGrace: kotlin.time.Duration = PairingV3.DEFAULT_GENERATION_GRACE,
+        pairingRateLimiter: PairingRateLimiter = PairingRateLimiter(),
         pakeProvider: PakeProvider = TestPakeProvider(),
         pairingV3Enabled: Boolean = true,
     ): TestInstance =
@@ -64,6 +66,7 @@ class PairingV3IntegrationTest {
             appInstanceId = id,
             pairingPinLifetime = pinLifetime,
             pairingGenerationGrace = generationGrace,
+            pairingRateLimiter = pairingRateLimiter,
             pakeProvider = pakeProvider,
             pairingV3Enabled = pairingV3Enabled,
         ).also { instances.add(it) }
@@ -771,11 +774,11 @@ class PairingV3IntegrationTest {
             b.start()
             a.pairingAcceptanceWindow.open()
 
-            val manual = ManualInitiator(b, a)
-            manual.buildIntent()
             var limited = false
-            repeat(10) {
-                val result = b.pairingV3ClientApi.sendIntent(manual.intent, urlFor(a))
+            repeat(11) {
+                val attempt = ManualInitiator(b, a)
+                attempt.buildIntent()
+                val result = b.pairingV3ClientApi.sendIntent(attempt.intent, urlFor(a))
                 if (result is FailureResult &&
                     pairingV3ErrorCodeOf(result.exception.getErrorCode().code) ==
                     PairingV3ErrorCode.PAIRING_RATE_LIMITED
@@ -784,6 +787,28 @@ class PairingV3IntegrationTest {
                 }
             }
             assertTrue(limited, "expected the per-key rate limit to trigger")
+        }
+
+    @Test
+    fun testDuplicateIntentRefreshDoesNotConsumeNewPairingBudget() =
+        runBlocking {
+            val limiter = PairingRateLimiter(maxPerKey = 1, maxGlobal = 1)
+            val a = createInstance("refresh-a", pairingRateLimiter = limiter)
+            val b = createInstance("refresh-b")
+            a.start()
+            b.start()
+            a.pairingAcceptanceWindow.open()
+
+            val manual = ManualInitiator(b, a)
+            val firstOffer = manual.requestOffer(urlFor(a))
+            val refreshedOffer = manual.requestOffer(urlFor(a))
+
+            assertContentEquals(firstOffer.sessionId, refreshedOffer.sessionId)
+
+            val newAttempt = ManualInitiator(b, a)
+            newAttempt.buildIntent()
+            val refused = b.pairingV3ClientApi.sendIntent(newAttempt.intent, urlFor(a))
+            assertPairingFailure(refused, PairingV3ErrorCode.PAIRING_RATE_LIMITED)
         }
 
     private fun assertPairingFailure(

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
@@ -66,6 +66,7 @@ class TestServerModule(
                     { appInstanceId ->
                         pairingProtocolV3Service?.hasActiveSession(appInstanceId) ?: false
                     },
+                    { pairingProtocolV3Service?.acceptanceWindow?.open() },
                 )
                 pairingProtocolV3Service?.let { service ->
                     pairingV3Routing(

--- a/app/src/desktopTest/kotlin/com/crosspaste/pairing/v3/PairingRateLimiterTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/pairing/v3/PairingRateLimiterTest.kt
@@ -21,6 +21,32 @@ class PairingRateLimiterTest {
     )
 
     @Test
+    fun testDefaultProductBudgetsAllowTenPerPeerAndOneHundredGlobal() =
+        runTest {
+            val perPeerLimiter = PairingRateLimiter(nowEpochMillis = { now })
+            val peer = PairingAttemptSource(peerKeyFingerprint = "fp-a")
+
+            repeat(10) {
+                assertTrue(perPeerLimiter.tryAcquire(peer))
+            }
+            assertFalse(perPeerLimiter.tryAcquire(peer))
+
+            val globalLimiter = PairingRateLimiter(nowEpochMillis = { now })
+            repeat(100) { index ->
+                assertTrue(
+                    globalLimiter.tryAcquire(
+                        PairingAttemptSource(peerKeyFingerprint = "fp-$index"),
+                    ),
+                )
+            }
+            assertFalse(
+                globalLimiter.tryAcquire(
+                    PairingAttemptSource(peerKeyFingerprint = "fp-over-global-budget"),
+                ),
+            )
+        }
+
+    @Test
     fun testPerFingerprintLimit() =
         runTest {
             val limiter = newLimiter()

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
@@ -9,11 +9,14 @@ import com.crosspaste.sync.SyncTestFixtures.createUnverifiedSyncRuntimeInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -580,6 +583,58 @@ class GeneralSyncHandlerTest {
             assertTrue(emitter.events.any { it is SyncEvent.Resolve })
             assertNull(address)
             childScope.cancel()
+        }
+
+    @Test
+    fun showPairingCode_waitsUntilRemoteRequestCompletes() =
+        runTest {
+            val emitter = TestEmitter()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val handler = GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
+            advanceTimeBy(SMALL_ADVANCE_MS)
+            emitter.events.clear()
+
+            try {
+                val request = async { handler.showPairingCode() }
+                runCurrent()
+
+                val event = emitter.events.filterIsInstance<SyncEvent.ShowPairingCode>().single()
+                assertFalse(request.isCompleted)
+
+                event.completionSignal.complete(true)
+                runCurrent()
+
+                assertTrue(request.isCompleted)
+            } finally {
+                childScope.cancel()
+            }
+        }
+
+    @Test
+    fun showPairingCode_timesOutWhenRemoteRequestIsNeverProcessed() =
+        runTest {
+            val emitter = TestEmitter()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val handler = GeneralSyncHandler(syncRuntimeInfo, emitter.emitEvent, childScope)
+            advanceTimeBy(SMALL_ADVANCE_MS)
+            emitter.events.clear()
+
+            try {
+                val request = async { runCatching { handler.showPairingCode() } }
+                runCurrent()
+
+                assertFalse(request.isCompleted)
+
+                advanceTimeBy(5_000)
+                runCurrent()
+
+                assertTrue(request.isCompleted)
+                assertTrue(request.await().isFailure)
+            } finally {
+                childScope.cancel()
+            }
         }
 
     // ========== X. callback wiring (polling vs force) ==========

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
@@ -18,6 +18,8 @@ import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class SyncDeviceManagerTest {
 
@@ -128,6 +130,49 @@ class SyncDeviceManagerTest {
             manager.showToken(syncRuntimeInfo)
 
             coVerify(exactly = 0) { deps.syncClientApi.showToken(any()) }
+        }
+
+    // ========== showPairingCode ==========
+
+    @Test
+    fun showPairingCode_unverifiedAndSuccess_returnsTrue() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            coEvery { deps.syncClientApi.showPairingCode(any()) } returns SuccessResult(true)
+
+            assertTrue(manager.showPairingCode(syncRuntimeInfo))
+
+            coVerify(exactly = 1) { deps.syncClientApi.showPairingCode(any()) }
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun showPairingCode_unverifiedAndFails_returnsFalseAndDisconnects() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            coEvery { deps.syncClientApi.showPairingCode(any()) } returns ConnectionRefused
+            val capturedInfo = slot<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
+
+            assertFalse(manager.showPairingCode(syncRuntimeInfo))
+
+            assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
+        }
+
+    @Test
+    fun showPairingCode_notUnverified_returnsFalseWithoutRequest() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo()
+
+            assertFalse(manager.showPairingCode(syncRuntimeInfo))
+
+            coVerify(exactly = 0) { deps.syncClientApi.showPairingCode(any()) }
         }
 
     // ========== notifyExit ==========

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -45,6 +45,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -1254,6 +1255,27 @@ class SyncResolverTest {
             assertEquals(false, callbackResult)
         }
 
+    @Test
+    fun resolveUnverified_cryptoKeyAddedByPairing_authenticatesAndConnects() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.secureStore.existCryptPublicKey(syncRuntimeInfo.appInstanceId) } returns true
+            coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
+                SuccessResult(VersionRelation.EQUAL_TO)
+
+            val capturedInfo = slot<SyncRuntimeInfo>()
+            coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
+
+            resolver.emitEvent(SyncEvent.Resolve(syncRuntimeInfo, createTestCallback()))
+
+            assertEquals(SyncState.CONNECTED, capturedInfo.captured.connectState)
+            coVerify { deps.syncClientApi.heartbeat(any(), syncRuntimeInfo.appInstanceId, any()) }
+        }
+
     // ========== F. trustBySasCode ==========
 
     @Test
@@ -1655,6 +1677,73 @@ class SyncResolverTest {
             assertEquals(0, failureCalls)
             coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
             coVerify(exactly = 0) { deps.wsSessionManager.probe(any()) }
+        }
+
+    @Test
+    fun showPairingCode_completesAfterRemoteRequestIsProcessed() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val event = SyncEvent.ShowPairingCode(syncRuntimeInfo)
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.syncDeviceManager.showPairingCode(syncRuntimeInfo) } returns true
+
+            resolver.emitEvent(event)
+
+            coVerify(exactly = 1) { deps.syncDeviceManager.showPairingCode(syncRuntimeInfo) }
+            assertTrue(event.completionSignal.await())
+        }
+
+    @Test
+    fun showPairingCode_reportsFailureWhenRemoteWindowWasNotOpened() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val event = SyncEvent.ShowPairingCode(syncRuntimeInfo)
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery { deps.syncDeviceManager.showPairingCode(syncRuntimeInfo) } returns false
+
+            resolver.emitEvent(event)
+
+            assertFalse(event.completionSignal.await())
+        }
+
+    @Test
+    fun showPairingCode_resolverCancellationCompletesFalseWithoutCancellingCaller() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val event = SyncEvent.ShowPairingCode(syncRuntimeInfo)
+            deps.stubDbRead(syncRuntimeInfo)
+            coEvery {
+                deps.syncDeviceManager.showPairingCode(syncRuntimeInfo)
+            } throws CancellationException("resolver cancelled")
+
+            assertFailsWith<CancellationException> {
+                resolver.emitEvent(event)
+            }
+
+            assertFalse(event.completionSignal.await())
+        }
+
+    @Test
+    fun showPairingCode_reportsIncompleteWhenPeerRecordDisappears() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val event = SyncEvent.ShowPairingCode(syncRuntimeInfo)
+            coEvery {
+                deps.syncRuntimeInfoDao.getSyncRuntimeInfo(syncRuntimeInfo.appInstanceId)
+            } returns null
+
+            resolver.emitEvent(event)
+
+            coVerify(exactly = 0) { deps.syncDeviceManager.showPairingCode(any()) }
+            assertFalse(event.completionSignal.await())
         }
 
     private fun extensionPlatform(): Platform =

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3DialogStateTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3DialogStateTest.kt
@@ -1,0 +1,123 @@
+package com.crosspaste.ui.devices
+
+import com.crosspaste.pairing.v3.PairingSessionState
+import com.crosspaste.pairing.v3.PairingSessionUiState
+import com.crosspaste.pairing.v3.PakeRole
+import com.crosspaste.sync.SyncManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PairingV3DialogStateTest {
+
+    @Test
+    fun incorrectPin_autoRefreshesOfferAndRequestsFreshInput() =
+        runTest {
+            val controller = mockk<PairingV3UiController>()
+            val state =
+                PairingV3DialogState(
+                    appInstanceId = "peer",
+                    controller = controller,
+                    syncManager = mockk<SyncManager>(relaxed = true),
+                    coroutineScope = this,
+                    incorrectPinFeedbackDuration = 1.seconds,
+                )
+            coEvery {
+                controller.submitPin("session", any())
+            } returns
+                PairingV3UiResult.Error(
+                    PairingV3UiError.INCORRECT_PIN,
+                    PairingV3Recovery.REFRESH_OFFER,
+                )
+            coEvery {
+                controller.recover("session")
+            } returns
+                PairingV3UiResult.SessionReady(
+                    sessionId = "session",
+                    tokenGeneration = 2,
+                    pinExpiresAt = 60_000,
+                    peerKeyFingerprintDisplay = "aabbccdd",
+                )
+            coEvery { controller.cancel("session") } returns true
+
+            state.submitPin("session", "123456")
+            runCurrent()
+
+            assertEquals(PairingV3UiError.INCORRECT_PIN, state.uiError)
+            assertEquals(PairingV3Recovery.NONE, state.recovery)
+            assertTrue(state.isLoading)
+            assertEquals(0, state.inputResetGeneration)
+
+            state.cancel(
+                PairingSessionUiState(
+                    sessionId = "session",
+                    role = PakeRole.INITIATOR,
+                    peerDisplayName = "Peer",
+                    peerAppInstanceId = "peer",
+                    peerKeyFingerprintDisplay = "aabbccdd",
+                    pin = null,
+                    pinExpiresAt = 60_000,
+                    tokenGeneration = 1,
+                    state = PairingSessionState.PIN_AVAILABLE,
+                    createdAt = 0,
+                ),
+            )
+            runCurrent()
+            coVerify(exactly = 0) { controller.cancel("session") }
+
+            advanceTimeBy(1_000)
+            runCurrent()
+
+            coVerify(exactly = 1) { controller.recover("session") }
+            assertEquals(1, state.inputResetGeneration)
+            assertFalse(state.isLoading)
+            assertEquals(null, state.uiError)
+        }
+
+    @Test
+    fun incorrectPin_autoRefreshFailureLeavesManualRetryPath() =
+        runTest {
+            val controller = mockk<PairingV3UiController>()
+            val state =
+                PairingV3DialogState(
+                    appInstanceId = "peer",
+                    controller = controller,
+                    syncManager = mockk<SyncManager>(relaxed = true),
+                    coroutineScope = this,
+                    incorrectPinFeedbackDuration = 1.seconds,
+                )
+            coEvery {
+                controller.submitPin("session", any())
+            } returns
+                PairingV3UiResult.Error(
+                    PairingV3UiError.INCORRECT_PIN,
+                    PairingV3Recovery.REFRESH_OFFER,
+                )
+            coEvery {
+                controller.recover("session")
+            } returns
+                PairingV3UiResult.Error(
+                    PairingV3UiError.NETWORK_FAILURE,
+                    PairingV3Recovery.REFRESH_OFFER,
+                )
+
+            state.submitPin("session", "123456")
+            advanceTimeBy(1_000)
+            runCurrent()
+
+            assertEquals(1, state.inputResetGeneration)
+            assertEquals(PairingV3UiError.NETWORK_FAILURE, state.uiError)
+            assertEquals(PairingV3Recovery.REFRESH_OFFER, state.recovery)
+            assertTrue(state.recovery != PairingV3Recovery.NONE)
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3UiControllerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3UiControllerTest.kt
@@ -2,12 +2,63 @@ package com.crosspaste.ui.devices
 
 import com.crosspaste.dto.pairing.v3.PairingV3ErrorCode
 import com.crosspaste.net.clientapi.UnknownError
+import com.crosspaste.pairing.v3.PairingAcceptanceWindow
+import com.crosspaste.pairing.v3.PairingProtocolV3Service
 import com.crosspaste.pairing.v3.PairingV3PinResult
 import com.crosspaste.pairing.v3.PairingV3StartResult
+import com.crosspaste.sync.SyncHandler
+import com.crosspaste.sync.SyncManager
+import com.crosspaste.sync.SyncTestFixtures.createUnverifiedSyncRuntimeInfo
+import io.mockk.coEvery
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PairingV3UiControllerTest {
+
+    @Test
+    fun startPairingRequestsRemotePairingScreenBeforeSendingIntent() =
+        runTest {
+            val peerAppInstanceId = "peer-app"
+            val syncRuntimeInfo =
+                createUnverifiedSyncRuntimeInfo(
+                    appInstanceId = peerAppInstanceId,
+                    hostAddress = "192.168.1.10",
+                )
+            val syncHandler = mockk<SyncHandler>()
+            val syncManager = mockk<SyncManager>()
+            val pairingProtocolV3Service = mockk<PairingProtocolV3Service>()
+
+            every { syncManager.getSyncHandler(peerAppInstanceId) } returns syncHandler
+            every { syncHandler.currentSyncRuntimeInfo } returns syncRuntimeInfo
+            coEvery { syncHandler.getConnectHostAddress() } returns "192.168.1.10"
+            coEvery { syncHandler.showPairingCode() } returns Unit
+            every { pairingProtocolV3Service.uiSessionsFlow } returns MutableStateFlow(emptyList())
+            every { pairingProtocolV3Service.acceptanceWindow } returns PairingAcceptanceWindow()
+            coEvery {
+                pairingProtocolV3Service.startPairing(
+                    targetAppInstanceId = peerAppInstanceId,
+                    targetDisplayName = any(),
+                    toUrl = any(),
+                )
+            } returns PairingV3StartResult.NetworkError(UnknownError)
+
+            DefaultPairingV3UiController(pairingProtocolV3Service, syncManager)
+                .startPairing(peerAppInstanceId)
+
+            coVerifyOrder {
+                syncHandler.showPairingCode()
+                pairingProtocolV3Service.startPairing(
+                    targetAppInstanceId = peerAppInstanceId,
+                    targetDisplayName = any(),
+                    toUrl = any(),
+                )
+            }
+        }
 
     @Test
     fun proofFailureIsPresentedAsIncorrectPinWithOfferRefresh() {


### PR DESCRIPTION
Closes #4668

Hardens the development pairing v3 interop handshake and trust dialog UX.
Production still advertises pairing version 2; all v3 behavior stays gated to
development/interop and non-development builds remain fail-closed.

## Handshake correctness
- The initiator asks the peer to open its pairing screen **before** sending the
  intent and awaits completion (bounded by a 5s timeout), so the intent no
  longer races the acceptance-window opening. `showPairingCode` propagates the
  real result (opened vs. not-UNVERIFIED / unreachable) instead of reporting
  unconditional success.
- The acceptor opens its v3 acceptance window when a peer requests the pairing
  code, so a legacy `showPairingCode` request also arms v3 acceptance.
- A duplicate, already-validated signed intent (same peer key, request id, and
  intent hash) returns the cached offer instead of consuming rate-limit budget
  or creating a second session.

## Reconnect
- `SyncResolver.resolveUnverified` authenticates with a freshly persisted peer
  key before falling back to QR tokens, so a v3-paired device still marked
  UNVERIFIED reconnects without manual re-entry.

## UX
- After an incorrect PIN the dialog shows feedback, then auto-refreshes the
  offer and clears the input. Loading state is held for the whole feedback
  window so cancel/dismiss cannot interleave with the pending refresh.
- `TokenView` is refactored into reusable `TokenPopup` / `TokenPopupCard`
  components.

## Config & limits
- Development builds default pairing v3 interop to enabled (explicit `false`
  opts back to v2).
- Per-key / global pairing attempt budgets relaxed (10 / 100).

## Testing
New/updated tests across `SyncDeviceManagerTest`, `GeneralSyncHandlerTest`,
`SyncResolverTest`, `PairingV3DialogStateTest`, `PairingV3UiControllerTest`,
`PairingV3IntegrationTest`, `PairingRateLimiterTest`, and
`DesktopPairingCapabilityTest`. All passing.