### PR TITLE
Replace contact email with support@crosspaste.com

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppUrls.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppUrls.kt
@@ -9,4 +9,6 @@ interface AppUrls {
     val checkMetadataUrl: String
 
     val issueTrackerUrl: String
+
+    val supportEmail: String
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUrls.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppUrls.kt
@@ -18,4 +18,6 @@ object DesktopAppUrls : AppUrls {
     val versionApiUrl: String = appUrlsProperties.getProperty("version-api-url")
 
     override val issueTrackerUrl: String = appUrlsProperties.getProperty("issue-tracker-url")
+
+    override val supportEmail: String = appUrlsProperties.getProperty("support-email")
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/AboutContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/AboutContentView.kt
@@ -203,7 +203,7 @@ fun AboutContentView() {
                     subtitle = "contact_us_desc",
                     icon = IconData(MaterialSymbols.Rounded.Mail, themeExt.cyanIconColor),
                 ) {
-                    uiSupport.openEmailClient("support@crosspaste.com")
+                    uiSupport.openEmailClient(appUrls.supportEmail)
                 }
             }
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/AboutContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/AboutContentView.kt
@@ -203,7 +203,7 @@ fun AboutContentView() {
                     subtitle = "contact_us_desc",
                     icon = IconData(MaterialSymbols.Rounded.Mail, themeExt.cyanIconColor),
                 ) {
-                    uiSupport.openEmailClient("compile.future@gmail.com")
+                    uiSupport.openEmailClient("support@crosspaste.com")
                 }
             }
         }

--- a/app/src/desktopMain/resources/app-urls.properties
+++ b/app/src/desktopMain/resources/app-urls.properties
@@ -3,3 +3,4 @@ change-log-url=https://github.com/crosspaste/crosspaste-desktop/blob/main/CHANGE
 check-metadata-url=https://oss.crosspaste.com/site/metadata.properties
 version-api-url=https://crosspaste.com/api/desktop.json
 issue-tracker-url=https://github.com/CrossPaste/crosspaste-desktop/issues
+support-email=support@crosspaste.com

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -4,7 +4,7 @@ include file("extract-native-libraries.conf")
 
 app {
   compression-level = high
-  contact-email = "compile.future@gmail.com"
+  contact-email = "support@crosspaste.com"
   license = "AGPL-3.0-or-later"
   display-name = "CrossPaste"
   rdns-name = "com.crosspaste"

--- a/doc/en/Contributing.md
+++ b/doc/en/Contributing.md
@@ -36,5 +36,5 @@ To ensure high-quality code, we have the following pull request guidelines:
 ## Contact Information
 If you have any questions or need further assistance, please contact us:
 
-- Email: compile.future@gmail.com
+- Email: support@crosspaste.com
 - GitHub Issues: [link to issues](https://github.com/CrossPaste/crosspaste-desktop/issues)

--- a/doc/zh/Contributing.md
+++ b/doc/zh/Contributing.md
@@ -36,5 +36,5 @@
 ## 联系信息
 如果您有任何问题或需要进一步的帮助，请联系我们：
 
-- 邮件：compile.future@gmail.com
+- 邮件：support@crosspaste.com
 - GitHub Issues: [问题链接](https://github.com/CrossPaste/crosspaste-desktop/issues)

--- a/web/src/components/settings/AboutView.tsx
+++ b/web/src/components/settings/AboutView.tsx
@@ -15,7 +15,7 @@ const LINKS = {
   tutorial: "https://crosspaste.com/tutorial",
   changelog: "https://crosspaste.com/changelog",
   feedback: "https://github.com/CrossPaste/crosspaste-desktop/issues",
-  email: "mailto:compile.future@gmail.com",
+  email: "mailto:support@crosspaste.com",
 };
 
 function openUrl(url: string) {


### PR DESCRIPTION
Closes #4670

Replace the legacy contact email `compile.future@gmail.com` with the dedicated `support@crosspaste.com` address across all user-facing surfaces:

- Desktop About page contact button (`AboutContentView.kt`)
- Conveyor packaging config (`conveyor.conf`)
- Web settings About view (`AboutView.tsx`)
- Contributing docs (EN/ZH)