### PR TITLE
:hammer: Scale side paste title bar proportionally with card size

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
@@ -39,6 +39,10 @@ class DesktopAppSize(
         const val MIN_SEARCH_WINDOW_HEIGHT: Int = 250
         const val MAX_SEARCH_WINDOW_HEIGHT: Int = 420
 
+        // Title bar height as a fixed proportion of the square paste card,
+        // matching the original 60dp title on a 252dp card at the 332dp default
+        private const val SIDE_TITLE_HEIGHT_RATIO: Float = 60f / 252f
+
         private fun createAppSizeValue(searchWindowHeight: Int): DesktopAppSizeValue {
             // --- Basic Constants ---
             val deviceHeight: Dp = huge
@@ -71,7 +75,6 @@ class DesktopAppSize(
                     .dp
             val sideSearchTopBarHeight: Dp = 64.dp
             val sideSearchPaddingSize: Dp = 16.dp
-            val sideTitleHeight: Dp = huge
 
             // --- Bubble Window ---
             val bubbleBodySize = DpSize(480.dp, 360.dp)
@@ -85,6 +88,8 @@ class DesktopAppSize(
                     val size = sideSearchWindowHeight - sideSearchTopBarHeight - sideSearchPaddingSize
                     DpSize(width = size, height = size)
                 }
+
+            val sideTitleHeight: Dp = sidePasteSize.height * SIDE_TITLE_HEIGHT_RATIO
 
             val sidePasteContentSize =
                 DpSize(


### PR DESCRIPTION
Closes #4675
Follow-up to #4674 (customizable search window height)

## Summary

`sideTitleHeight` was still hardcoded to 60dp while the square paste preview cards (`sidePasteSize`) scale with the customizable search window height, making the title bar look disproportionate at non-default heights.

It is now derived from the card size with a fixed ratio taken from the original design (60dp title on a 252dp card at the 332dp default), so the default appearance is pixel-identical:

| Window height | Card edge | Title bar |
|---|---|---|
| 250dp (min) | 170dp | ~40.5dp |
| 332dp (default) | 252dp | 60dp (unchanged) |
| 420dp (max) | 340dp | ~81dp |

`sidePasteContentSize` (card minus title) and `SideAppSourceIcon` (pixel size read from `sideTitleHeight`) follow automatically.

## Tests

- `./gradlew app:desktopTest` passes.
- Manually verified on macOS across the full 250–420dp range using the appearance settings live preview: title text (name + relative time) still fits at the minimum height, and proportions stay consistent at the maximum.