### PR TITLE
:bug: release the responder's pending v2 exchange when the initiator abandons pairing

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenApi.kt
@@ -26,5 +26,20 @@ interface AppTokenApi {
 
     fun removePendingVerifier(appInstanceId: String)
 
+    /**
+     * Atomically releases the token-refresh count owned by [appInstanceId]'s
+     * pending-verifier entry: the count is decremented ONLY when the verifier
+     * was still pending, so the unified server release path and the UI reap can
+     * both call this without double-decrementing (a second decrement would
+     * steal a count held by another concurrently pairing device). This is the
+     * single release primitive — callers must not hand-compose
+     * [removePendingVerifier] with [stopRefresh]. [hideToken] additionally
+     * hides the token overlay (user-facing dismissal).
+     */
+    fun releaseVerifier(
+        appInstanceId: String,
+        hideToken: Boolean = false,
+    )
+
     fun showPairingCode()
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
@@ -2,17 +2,14 @@ package com.crosspaste.app
 
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.getAndUpdate
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -20,7 +17,14 @@ abstract class AppTokenService : AppTokenApi {
 
     private val scope = namedScope(ioDispatcher, "AppTokenService")
 
-    private val lock = Mutex()
+    // Every state mutation (verifier set, refresh counter, overlay visibility,
+    // SAS mode) runs on ONE consumer coroutine in submission order. Callers
+    // enqueue synchronously (trySend on an UNLIMITED channel never fails), so
+    // each caller's own call sequence is executed in that order — a verifier
+    // release can never be processed before the startRefresh that funded it,
+    // which is what previously allowed an orphaned count to keep the refresh
+    // loop alive forever (#4684 / #4690 review).
+    private val commands = Channel<() -> Unit>(Channel.UNLIMITED)
 
     private val _refreshProgress = MutableStateFlow(0f)
 
@@ -30,6 +34,7 @@ abstract class AppTokenService : AppTokenApi {
 
     override val refresh: StateFlow<Boolean> = _refresh.asStateFlow()
 
+    // Confined to the command consumer coroutine.
     private var refreshCounter = 0
 
     private val _showToken = MutableStateFlow(false)
@@ -40,6 +45,8 @@ abstract class AppTokenService : AppTokenApi {
 
     override val pendingVerifiers: StateFlow<Set<String>> = _pendingVerifiers.asStateFlow()
 
+    // Written only on the command consumer coroutine; also read by the refresh
+    // loop (a stale read at worst regenerates one random token — benign).
     private var _sasMode = false
 
     private val _token = MutableStateFlow(charArrayOf('0', '0', '0', '0', '0', '0'))
@@ -47,6 +54,11 @@ abstract class AppTokenService : AppTokenApi {
     override val token: StateFlow<CharArray> = _token.asStateFlow()
 
     init {
+        scope.launch {
+            for (command in commands) {
+                command()
+            }
+        }
         scope.launch {
             refresh.collectLatest { isShowing ->
                 if (isShowing) {
@@ -69,6 +81,10 @@ abstract class AppTokenService : AppTokenApi {
 
     abstract fun preShowPairingCode()
 
+    private fun submit(command: () -> Unit) {
+        commands.trySend(command)
+    }
+
     override fun sameToken(token: Int): Boolean =
         token ==
             this.token.value
@@ -76,32 +92,30 @@ abstract class AppTokenService : AppTokenApi {
                 .toInt()
 
     override fun setSASToken(sas: Int) {
-        val padded = sas.toString().padStart(6, '0')
-        _token.value = padded.toCharArray()
-        _sasMode = true
+        submit {
+            val padded = sas.toString().padStart(6, '0')
+            _token.value = padded.toCharArray()
+            _sasMode = true
+        }
     }
 
     override fun startRefresh(showToken: Boolean) {
-        scope.launch {
-            lock.withLock {
-                if (showToken) {
-                    _showToken.value = true
-                    preShowToken()
-                }
-                _refresh.value = true
-                refreshCounter += 1
+        submit {
+            if (showToken) {
+                _showToken.value = true
+                preShowToken()
             }
+            _refresh.value = true
+            refreshCounter += 1
         }
     }
 
     override fun stopRefresh(hideToken: Boolean) {
-        scope.launch {
-            lock.withLock {
-                if (hideToken) {
-                    _showToken.value = false
-                }
-                decrementRefreshLocked()
+        submit {
+            if (hideToken) {
+                _showToken.value = false
             }
+            decrementRefresh()
         }
     }
 
@@ -109,33 +123,39 @@ abstract class AppTokenService : AppTokenApi {
         appInstanceId: String,
         hideToken: Boolean,
     ) {
-        // Remove the verifier SYNCHRONOUSLY (same semantics as
-        // removePendingVerifier): callers such as the v2 exchange route release
-        // a superseded peer and immediately re-add it, so deferring the removal
-        // into the async block would erase the re-added verifier. The atomic
-        // getAndUpdate makes concurrent releases race safely — only the caller
-        // that actually removed the entry gets to decrement.
-        val hadVerifier =
-            appInstanceId in
-                _pendingVerifiers.getAndUpdate { currentSet ->
-                    currentSet - appInstanceId
-                }
-        scope.launch {
-            lock.withLock {
-                if (hideToken) {
-                    _showToken.value = false
-                }
-                // Decrement only for the verifier we actually removed — an
-                // already-released verifier must not consume a count owned by
-                // another pairing in flight.
-                if (hadVerifier) {
-                    decrementRefreshLocked()
-                }
+        submit {
+            val hadVerifier = appInstanceId in _pendingVerifiers.value
+            _pendingVerifiers.value -= appInstanceId
+            if (hideToken) {
+                _showToken.value = false
+            }
+            // Decrement only for the verifier we actually removed — an
+            // already-released verifier must not consume a count owned by
+            // another pairing in flight.
+            if (hadVerifier) {
+                decrementRefresh()
             }
         }
     }
 
-    private fun decrementRefreshLocked() {
+    override fun addPendingVerifier(appInstanceId: String) {
+        submit {
+            _pendingVerifiers.value += appInstanceId
+        }
+    }
+
+    override fun removePendingVerifier(appInstanceId: String) {
+        submit {
+            _pendingVerifiers.value -= appInstanceId
+        }
+    }
+
+    override fun showPairingCode() {
+        preShowPairingCode()
+    }
+
+    // Runs on the command consumer coroutine only.
+    private fun decrementRefresh() {
         if (refreshCounter > 0) {
             refreshCounter -= 1
         }
@@ -144,22 +164,6 @@ abstract class AppTokenService : AppTokenApi {
             _showToken.value = false
             _sasMode = false
         }
-    }
-
-    override fun addPendingVerifier(appInstanceId: String) {
-        _pendingVerifiers.update { currentSet ->
-            currentSet + appInstanceId
-        }
-    }
-
-    override fun removePendingVerifier(appInstanceId: String) {
-        _pendingVerifiers.update { currentSet ->
-            currentSet - appInstanceId
-        }
-    }
-
-    override fun showPairingCode() {
-        preShowPairingCode()
     }
 
     private fun refreshToken() {

--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -99,15 +100,49 @@ abstract class AppTokenService : AppTokenApi {
                 if (hideToken) {
                     _showToken.value = false
                 }
-                if (refreshCounter > 0) {
-                    refreshCounter -= 1
+                decrementRefreshLocked()
+            }
+        }
+    }
+
+    override fun releaseVerifier(
+        appInstanceId: String,
+        hideToken: Boolean,
+    ) {
+        // Remove the verifier SYNCHRONOUSLY (same semantics as
+        // removePendingVerifier): callers such as the v2 exchange route release
+        // a superseded peer and immediately re-add it, so deferring the removal
+        // into the async block would erase the re-added verifier. The atomic
+        // getAndUpdate makes concurrent releases race safely — only the caller
+        // that actually removed the entry gets to decrement.
+        val hadVerifier =
+            appInstanceId in
+                _pendingVerifiers.getAndUpdate { currentSet ->
+                    currentSet - appInstanceId
                 }
-                if (refreshCounter == 0) {
-                    _refresh.value = false
+        scope.launch {
+            lock.withLock {
+                if (hideToken) {
                     _showToken.value = false
-                    _sasMode = false
+                }
+                // Decrement only for the verifier we actually removed — an
+                // already-released verifier must not consume a count owned by
+                // another pairing in flight.
+                if (hadVerifier) {
+                    decrementRefreshLocked()
                 }
             }
+        }
+    }
+
+    private fun decrementRefreshLocked() {
+        if (refreshCounter > 0) {
+            refreshCounter -= 1
+        }
+        if (refreshCounter == 0) {
+            _refresh.value = false
+            _showToken.value = false
+            _sasMode = false
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -171,8 +171,10 @@ open class DefaultServerModule(
      */
     private fun releasePendingKeyExchange(appInstanceId: String) {
         if (pendingKeyExchangeStore.remove(appInstanceId)) {
-            appTokenApi.removePendingVerifier(appInstanceId)
-            appTokenApi.stopRefresh(hideToken = false)
+            // releaseVerifier decrements only when the verifier is still
+            // pending, so a UI reap that already released this peer (device
+            // went offline) cannot be double-counted here.
+            appTokenApi.releaseVerifier(appInstanceId)
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
@@ -143,14 +143,19 @@ class SyncClientApi(
             }
         }
 
+    // [exchangeGeneration] is the caller-generated generation marker for this
+    // exchange (see PendingExchangeLedger): it travels as the signed request
+    // timestamp, the responder stores it with the pending entry, and a later
+    // cancel echoes it so only this exact exchange can be released.
     suspend fun exchangeKeys(
         targetAppInstanceId: String,
+        exchangeGeneration: Long,
         toUrl: URLBuilder.() -> Unit,
     ): ClientApiResult =
         request(logger, exceptionHandler, request = {
             val signPublicKey = secureStore.secureKeyPair.getSignPublicKeyBytes(secureKeyPairSerializer)
             val cryptPublicKey = secureStore.secureKeyPair.getCryptPublicKeyBytes(secureKeyPairSerializer)
-            val timestamp = nowEpochMilliseconds()
+            val timestamp = exchangeGeneration
             val signature =
                 CryptographyUtils.signKeyExchangeRequest(
                     secureStore.secureKeyPair.signKeyPair.privateKey,
@@ -230,13 +235,13 @@ class SyncClientApi(
     // Best-effort release of our pending v2 exchange on the responder (trust
     // dialog dismissed before confirm). The stored exchange owns one of the
     // responder's token-refresh counts, so without this the SAS overlay lingers
-    // until closed manually (#4684). [exchangeTimestamp] is the generation
-    // marker from the exchange response: the responder only releases that exact
+    // until closed manually (#4684). [exchangeGeneration] is the same marker we
+    // sent with the exchange request: the responder only releases that exact
     // exchange, so a stale cancel cannot tear down a newer one. Idempotent
     // server-side; peers older than the route just fail and the caller ignores
     // the result.
     suspend fun trustV2Cancel(
-        exchangeTimestamp: Long,
+        exchangeGeneration: Long,
         toUrl: URLBuilder.() -> Unit,
     ): ClientApiResult =
         request(logger, exceptionHandler, request = {
@@ -244,7 +249,7 @@ class SyncClientApi(
                 "",
                 typeInfo<String>(),
                 headersBuilder = {
-                    append(HEADER_EXCHANGE_TIMESTAMP, exchangeTimestamp.toString())
+                    append(HEADER_EXCHANGE_TIMESTAMP, exchangeGeneration.toString())
                 },
                 urlBuilder = {
                     toUrl()

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
@@ -15,6 +15,7 @@ import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.utils.CryptographyUtils
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
+import com.crosspaste.utils.HEADER_EXCHANGE_TIMESTAMP
 import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.call.*
@@ -229,13 +230,22 @@ class SyncClientApi(
     // Best-effort release of our pending v2 exchange on the responder (trust
     // dialog dismissed before confirm). The stored exchange owns one of the
     // responder's token-refresh counts, so without this the SAS overlay lingers
-    // until closed manually (#4684). Idempotent server-side; peers older than
-    // the route just fail and the caller ignores the result.
-    suspend fun trustV2Cancel(toUrl: URLBuilder.() -> Unit): ClientApiResult =
+    // until closed manually (#4684). [exchangeTimestamp] is the generation
+    // marker from the exchange response: the responder only releases that exact
+    // exchange, so a stale cancel cannot tear down a newer one. Idempotent
+    // server-side; peers older than the route just fail and the caller ignores
+    // the result.
+    suspend fun trustV2Cancel(
+        exchangeTimestamp: Long,
+        toUrl: URLBuilder.() -> Unit,
+    ): ClientApiResult =
         request(logger, exceptionHandler, request = {
             pasteClient.post(
                 "",
                 typeInfo<String>(),
+                headersBuilder = {
+                    append(HEADER_EXCHANGE_TIMESTAMP, exchangeTimestamp.toString())
+                },
                 urlBuilder = {
                     toUrl()
                     buildUrl("sync", "trust", "v2", "cancel")

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
@@ -226,6 +226,23 @@ class SyncClientApi(
             true
         }
 
+    // Best-effort release of our pending v2 exchange on the responder (trust
+    // dialog dismissed before confirm). The stored exchange owns one of the
+    // responder's token-refresh counts, so without this the SAS overlay lingers
+    // until closed manually (#4684). Idempotent server-side; peers older than
+    // the route just fail and the caller ignores the result.
+    suspend fun trustV2Cancel(toUrl: URLBuilder.() -> Unit): ClientApiResult =
+        request(logger, exceptionHandler, request = {
+            pasteClient.post(
+                "",
+                typeInfo<String>(),
+                urlBuilder = {
+                    toUrl()
+                    buildUrl("sync", "trust", "v2", "cancel")
+                },
+            )
+        }) { true }
+
     suspend fun showToken(toUrl: URLBuilder.() -> Unit): ClientApiResult =
         request(logger, exceptionHandler, request = {
             pasteClient.get(urlBuilder = {

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -27,6 +27,7 @@ import com.crosspaste.sync.PendingKeyExchangeStore
 import com.crosspaste.utils.CryptographyUtils
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.HEADER_APP_INSTANCE_ID
+import com.crosspaste.utils.HEADER_EXCHANGE_TIMESTAMP
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
 import com.crosspaste.utils.successResponse
@@ -247,11 +248,11 @@ fun Routing.syncRouting(
                 }.onSuccess { trustResponse ->
                     val host = call.request.headers["crosspaste-host"]
                     val clientSyncInfo = call.clientSyncInfo()
-                    appTokenApi.removePendingVerifier(appInstanceId)
+                    // Atomic release: decrements the refresh count only if this
+                    // verifier was still pending (a QR token-cache trust never
+                    // requested /sync/showToken, so it has nothing to release).
+                    appTokenApi.releaseVerifier(appInstanceId)
                     trustSyncInfo(appInstanceId, host, clientSyncInfo)
-                    if (appTokenApi.showToken.value) {
-                        appTokenApi.stopRefresh(hideToken = false)
-                    }
                     successResponse(call, trustResponse)
                 }.onFailure { e ->
                     logger.error(e) { "Trust request failed for $appInstanceId" }
@@ -421,14 +422,27 @@ fun Routing.syncRouting(
         }
     }
 
-    // Client-side cancellation of a pending v2 exchange (e.g. the browser
-    // extension's pairing dialog was closed). Idempotent: releasing a peer with
-    // no pending entry is a no-op. Older clients simply never call this.
+    // Client-side cancellation of a pending v2 exchange (pairing dialog was
+    // closed before confirm). Idempotent: releasing a peer with no pending
+    // entry is a no-op. When the caller echoes the exchange timestamp it
+    // received (generation marker), only that exact exchange is released — a
+    // cancel delayed past a newer exchange from the same peer must not tear
+    // down the newer one. Callers without the header (older clients, the
+    // browser extension) keep the original unconditional-release semantics.
     post("/sync/trust/v2/cancel") {
         getAppInstanceId(call)?.let { appInstanceId ->
-            releasePendingKeyExchange(appInstanceId)
-            logger.info { "v2 exchange cancelled by $appInstanceId" }
-            successResponse(call)
+            pairingVersionCoordinator.withPeerLock(appInstanceId) {
+                val requestedTimestamp = call.request.headers[HEADER_EXCHANGE_TIMESTAMP]?.toLongOrNull()
+                if (requestedTimestamp == null ||
+                    pendingKeyExchangeStore.timestampMatches(appInstanceId, requestedTimestamp)
+                ) {
+                    releasePendingKeyExchange(appInstanceId)
+                    logger.info { "v2 exchange cancelled by $appInstanceId" }
+                } else {
+                    logger.info { "v2 cancel from $appInstanceId ignored (exchange superseded)" }
+                }
+                successResponse(call)
+            }
         }
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -314,6 +314,9 @@ fun Routing.syncRouting(
                             cryptPublicKey = request.cryptPublicKey,
                             sas = sas,
                             timestamp = currentTimestamp,
+                            // The signed request timestamp is the initiator's
+                            // generation marker; a client cancel must echo it.
+                            generation = request.timestamp,
                         ),
                     )
 
@@ -432,9 +435,9 @@ fun Routing.syncRouting(
     post("/sync/trust/v2/cancel") {
         getAppInstanceId(call)?.let { appInstanceId ->
             pairingVersionCoordinator.withPeerLock(appInstanceId) {
-                val requestedTimestamp = call.request.headers[HEADER_EXCHANGE_TIMESTAMP]?.toLongOrNull()
-                if (requestedTimestamp == null ||
-                    pendingKeyExchangeStore.timestampMatches(appInstanceId, requestedTimestamp)
+                val requestedGeneration = call.request.headers[HEADER_EXCHANGE_TIMESTAMP]?.toLongOrNull()
+                if (requestedGeneration == null ||
+                    pendingKeyExchangeStore.generationMatches(appInstanceId, requestedGeneration)
                 ) {
                     releasePendingKeyExchange(appInstanceId)
                     logger.info { "v2 exchange cancelled by $appInstanceId" }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -221,8 +221,8 @@ class GeneralSyncHandler(
         emitEvent(SyncEvent.ExchangeKeysForPairing(currentSyncRuntimeInfo))
     }
 
-    override suspend fun cancelPairing(requestedAt: Long) {
-        emitEvent(SyncEvent.CancelPairing(currentSyncRuntimeInfo, requestedAt))
+    override suspend fun cancelPairing(generation: Long) {
+        emitEvent(SyncEvent.CancelPairing(currentSyncRuntimeInfo, generation))
     }
 
     override suspend fun showToken() {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -221,6 +221,10 @@ class GeneralSyncHandler(
         emitEvent(SyncEvent.ExchangeKeysForPairing(currentSyncRuntimeInfo))
     }
 
+    override suspend fun cancelPairing() {
+        emitEvent(SyncEvent.CancelPairing(currentSyncRuntimeInfo))
+    }
+
     override suspend fun showToken() {
         emitEvent(SyncEvent.ShowToken(currentSyncRuntimeInfo))
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -221,8 +221,8 @@ class GeneralSyncHandler(
         emitEvent(SyncEvent.ExchangeKeysForPairing(currentSyncRuntimeInfo))
     }
 
-    override suspend fun cancelPairing() {
-        emitEvent(SyncEvent.CancelPairing(currentSyncRuntimeInfo))
+    override suspend fun cancelPairing(requestedAt: Long) {
+        emitEvent(SyncEvent.CancelPairing(currentSyncRuntimeInfo, requestedAt))
     }
 
     override suspend fun showToken() {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -12,7 +12,6 @@ import com.crosspaste.net.filter
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.pairing.v3.PairingCapabilityFlag
 import com.crosspaste.pairing.v3.PairingV3
-import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import com.crosspaste.utils.ioDispatcher
@@ -42,6 +41,7 @@ import kotlin.coroutines.cancellation.CancellationException
 
 class GeneralSyncManager(
     override val realTimeSyncScope: CoroutineScope = namedScope(ioDispatcher, "GeneralSyncManager"),
+    private val pendingExchangeLedger: PendingExchangeLedger,
     private val syncResolver: SyncResolverApi,
     private val syncRuntimeInfoDao: SyncRuntimeInfoDao,
     private val syncClientApi: SyncClientApi,
@@ -326,14 +326,14 @@ class GeneralSyncManager(
     }
 
     override fun cancelPairing(appInstanceId: String) {
-        // Capture the abandon instant synchronously: the UI disposes the old
-        // dialog before a reopened one fires its warm-up exchange, so any
-        // exchange recorded after this timestamp belongs to the newer dialog
-        // and must not be cancelled.
-        val requestedAt = nowEpochMilliseconds()
+        // Capture the generation of the exchange the closing dialog owns,
+        // synchronously: Compose disposes the old dialog before a reopened one
+        // fires its warm-up, so whatever the ledger holds right now is ours to
+        // cancel. No record → nothing we own → no request at all.
+        val generation = pendingExchangeLedger.current(appInstanceId) ?: return
         internalSyncHandlers[appInstanceId]?.let { syncHandler ->
             realTimeSyncScope.launch {
-                syncHandler.cancelPairing(requestedAt)
+                syncHandler.cancelPairing(generation)
             }
         }
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -12,6 +12,7 @@ import com.crosspaste.net.filter
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.pairing.v3.PairingCapabilityFlag
 import com.crosspaste.pairing.v3.PairingV3
+import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import com.crosspaste.utils.ioDispatcher
@@ -325,9 +326,14 @@ class GeneralSyncManager(
     }
 
     override fun cancelPairing(appInstanceId: String) {
+        // Capture the abandon instant synchronously: the UI disposes the old
+        // dialog before a reopened one fires its warm-up exchange, so any
+        // exchange recorded after this timestamp belongs to the newer dialog
+        // and must not be cancelled.
+        val requestedAt = nowEpochMilliseconds()
         internalSyncHandlers[appInstanceId]?.let { syncHandler ->
             realTimeSyncScope.launch {
-                syncHandler.cancelPairing()
+                syncHandler.cancelPairing(requestedAt)
             }
         }
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -324,6 +324,14 @@ class GeneralSyncManager(
         } ?: callback(false)
     }
 
+    override fun cancelPairing(appInstanceId: String) {
+        internalSyncHandlers[appInstanceId]?.let { syncHandler ->
+            realTimeSyncScope.launch {
+                syncHandler.cancelPairing()
+            }
+        }
+    }
+
     override fun updateAllowSend(
         appInstanceId: String,
         allowSend: Boolean,

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
@@ -50,6 +50,9 @@ class MarketingSyncHandler(
     override suspend fun exchangeKeysForPairing() {
     }
 
+    override suspend fun cancelPairing() {
+    }
+
     override suspend fun showToken() {
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
@@ -50,7 +50,7 @@ class MarketingSyncHandler(
     override suspend fun exchangeKeysForPairing() {
     }
 
-    override suspend fun cancelPairing() {
+    override suspend fun cancelPairing(requestedAt: Long) {
     }
 
     override suspend fun showToken() {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
@@ -50,7 +50,7 @@ class MarketingSyncHandler(
     override suspend fun exchangeKeysForPairing() {
     }
 
-    override suspend fun cancelPairing(requestedAt: Long) {
+    override suspend fun cancelPairing(generation: Long) {
     }
 
     override suspend fun showToken() {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
@@ -121,6 +121,9 @@ class MarketingSyncManager : SyncManager {
     ) {
     }
 
+    override fun cancelPairing(appInstanceId: String) {
+    }
+
     override fun refresh(
         ids: List<String>,
         callback: () -> Unit,

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PendingExchangeLedger.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PendingExchangeLedger.kt
@@ -1,0 +1,65 @@
+package com.crosspaste.sync
+
+import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
+import io.ktor.util.collections.ConcurrentMap
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.updateAndGet
+
+/**
+ * Initiator-side ledger of the v2 key exchange we currently own per peer
+ * (#4684 / #4690 review).
+ *
+ * The generation is CLIENT-generated and strictly monotonic — two attempts can
+ * never collide, even inside one millisecond or across a wall-clock rollback —
+ * and it is recorded BEFORE the exchange request is sent, so even when the
+ * request lands on the responder but the response is lost we still hold the
+ * marker needed to cancel the orphaned entry. It travels to the responder as
+ * the signed `KeyExchangeRequest.timestamp` and is echoed back in the cancel
+ * header, so the responder releases exactly the exchange we own and never a
+ * newer one.
+ */
+class PendingExchangeLedger {
+
+    private val lastGeneration = atomic(0L)
+
+    private val generations: MutableMap<String, Long> = ConcurrentMap()
+
+    /**
+     * Strictly monotonic and unique within this process, while still being a
+     * plausible epoch-millisecond timestamp for the signed request field.
+     */
+    fun nextGeneration(): Long =
+        lastGeneration.updateAndGet { previous ->
+            maxOf(nowEpochMilliseconds(), previous + 1)
+        }
+
+    fun record(
+        appInstanceId: String,
+        generation: Long,
+    ) {
+        generations[appInstanceId] = generation
+    }
+
+    /** The generation of the exchange we currently own for the peer, if any. */
+    fun current(appInstanceId: String): Long? = generations[appInstanceId]
+
+    /** Drops the peer's record (a successful confirm consumed the exchange). */
+    fun clear(appInstanceId: String) {
+        generations.remove(appInstanceId)
+    }
+
+    /**
+     * Removes the peer's record ONLY while it still is [generation]. A stale
+     * cancel whose dialog was superseded by a newer exchange consumes nothing.
+     * Mutations for one peer are serialized by the resolver's per-peer mutex,
+     * so the check-then-remove needs no extra atomicity.
+     */
+    fun consume(
+        appInstanceId: String,
+        generation: Long,
+    ): Boolean {
+        if (generations[appInstanceId] != generation) return false
+        generations.remove(appInstanceId)
+        return true
+    }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PendingKeyExchangeStore.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PendingKeyExchangeStore.kt
@@ -84,4 +84,15 @@ class PendingKeyExchangeStore {
 
     /** Removes the peer's entry, reporting whether one existed. */
     fun remove(appInstanceId: String): Boolean = store.remove(appInstanceId) != null
+
+    /**
+     * Generation check for client-initiated cancellation: true when the peer's
+     * stored exchange (live OR expired — an expired entry still owns its
+     * token-refresh count) carries exactly [timestamp]. A stale cancel from a
+     * superseded exchange therefore never matches the current entry.
+     */
+    fun timestampMatches(
+        appInstanceId: String,
+        timestamp: Long,
+    ): Boolean = store[appInstanceId]?.timestamp == timestamp
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PendingKeyExchangeStore.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PendingKeyExchangeStore.kt
@@ -6,7 +6,12 @@ data class PendingKeyExchange(
     val signPublicKey: ByteArray,
     val cryptPublicKey: ByteArray,
     val sas: Int,
+    // Server clock at storage time — drives the TTL only.
     val timestamp: Long,
+    // The INITIATOR-generated marker carried as the signed request timestamp:
+    // a client cancel is honored only when it echoes this exact value, so a
+    // stale cancel can never release a newer exchange (#4684).
+    val generation: Long,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -15,6 +20,7 @@ data class PendingKeyExchange(
         if (!cryptPublicKey.contentEquals(other.cryptPublicKey)) return false
         if (sas != other.sas) return false
         if (timestamp != other.timestamp) return false
+        if (generation != other.generation) return false
         return true
     }
 
@@ -23,6 +29,7 @@ data class PendingKeyExchange(
         result = 31 * result + cryptPublicKey.contentHashCode()
         result = 31 * result + sas
         result = 31 * result + timestamp.hashCode()
+        result = 31 * result + generation.hashCode()
         return result
     }
 }
@@ -88,11 +95,11 @@ class PendingKeyExchangeStore {
     /**
      * Generation check for client-initiated cancellation: true when the peer's
      * stored exchange (live OR expired — an expired entry still owns its
-     * token-refresh count) carries exactly [timestamp]. A stale cancel from a
+     * token-refresh count) carries exactly [generation]. A stale cancel from a
      * superseded exchange therefore never matches the current entry.
      */
-    fun timestampMatches(
+    fun generationMatches(
         appInstanceId: String,
-        timestamp: Long,
-    ): Boolean = store[appInstanceId]?.timestamp == timestamp
+        generation: Long,
+    ): Boolean = store[appInstanceId]?.generation == generation
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
@@ -3,7 +3,6 @@ package com.crosspaste.sync
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
-import com.crosspaste.dto.secure.KeyExchangeResponse
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.ws.WsEnvelope
@@ -14,9 +13,9 @@ import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.util.collections.ConcurrentMap
 
 class SyncDeviceManager(
+    private val pendingExchangeLedger: PendingExchangeLedger,
     private val secureStore: SecureStore,
     private val syncClientApi: SyncClientApi,
     private val syncRuntimeInfoDao: SyncRuntimeInfoDao,
@@ -24,36 +23,6 @@ class SyncDeviceManager(
 ) {
 
     private val logger = KotlinLogging.logger {}
-
-    /**
-     * The v2 exchange we initiated on a peer that has not yet been confirmed
-     * or cancelled: the responder's exchange timestamp (its generation marker)
-     * plus when we recorded it locally. This is what makes cancelPairing both
-     * targeted (the cancel names the exact exchange it releases) and
-     * self-gating (no record → nothing we own → no request), independent of
-     * the peer's connect state (#4684 / #4690 review).
-     */
-    private val pendingExchanges: MutableMap<String, PendingExchangeRecord> = ConcurrentMap()
-
-    data class PendingExchangeRecord(
-        val exchangeTimestamp: Long,
-        val recordedAt: Long,
-    )
-
-    fun rememberPendingExchange(
-        appInstanceId: String,
-        exchangeTimestamp: Long,
-    ) {
-        pendingExchanges[appInstanceId] =
-            PendingExchangeRecord(
-                exchangeTimestamp = exchangeTimestamp,
-                recordedAt = nowEpochMilliseconds(),
-            )
-    }
-
-    fun clearPendingExchange(appInstanceId: String) {
-        pendingExchanges.remove(appInstanceId)
-    }
 
     suspend fun updateAllowSend(
         syncRuntimeInfo: SyncRuntimeInfo,
@@ -80,14 +49,16 @@ class SyncDeviceManager(
         if (syncRuntimeInfo.connectState == SyncState.UNVERIFIED) {
             syncRuntimeInfo.connectHostAddress?.let { host ->
                 val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
+                // Record the generation BEFORE sending: if the request lands
+                // but the response is lost, we still hold the marker needed to
+                // cancel the responder's orphaned entry.
+                val generation = pendingExchangeLedger.nextGeneration()
+                pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, generation)
                 val result =
-                    syncClientApi.exchangeKeys(syncRuntimeInfo.appInstanceId) {
+                    syncClientApi.exchangeKeys(syncRuntimeInfo.appInstanceId, generation) {
                         buildUrl(hostAndPort)
                     }
                 if (result is SuccessResult) {
-                    result.getResult<KeyExchangeResponse>()?.let { response ->
-                        rememberPendingExchange(syncRuntimeInfo.appInstanceId, response.timestamp)
-                    }
                     logger.info { "exchangeKeysForPairing success $host ${syncRuntimeInfo.port}" }
                 } else {
                     logger.warn { "exchangeKeysForPairing failed $host ${syncRuntimeInfo.port}" }
@@ -104,30 +75,26 @@ class SyncDeviceManager(
 
     /**
      * Best-effort release of the pending v2 exchange we opened on the peer
-     * (#4684). Gated by ownership, not connect state: we send exactly when we
-     * hold an unconsumed exchange record for the peer (a confirm clears it, a
-     * successful exchange creates it), so the request is still sent after the
-     * peer dropped to DISCONNECTED, and skipped after a successful pairing.
-     * [requestedAt] is when the user abandoned the dialog — a record written
-     * after that belongs to a newer dialog, so this stale cancel must not
-     * release it. Failures are ignored: pairing is being abandoned anyway, and
+     * (#4684). Gated by ownership, not connect state: [generation] was
+     * captured from the ledger at the abandon instant, and the cancel is only
+     * sent while the ledger still holds that exact generation — a reopened
+     * dialog's newer exchange replaces the record, so a stale cancel consumes
+     * nothing. Failures are ignored: pairing is being abandoned anyway, and
      * the peer's entry self-heals when a later exchange from us replaces it.
      */
     suspend fun cancelPairing(
         syncRuntimeInfo: SyncRuntimeInfo,
-        requestedAt: Long,
+        generation: Long,
     ) {
         val appInstanceId = syncRuntimeInfo.appInstanceId
-        val record = pendingExchanges[appInstanceId] ?: return
-        if (record.recordedAt > requestedAt) {
-            logger.info { "cancelPairing skipped for $appInstanceId (a newer exchange superseded it)" }
+        val host = syncRuntimeInfo.connectHostAddress ?: return
+        if (!pendingExchangeLedger.consume(appInstanceId, generation)) {
+            logger.info { "cancelPairing skipped for $appInstanceId (exchange superseded or consumed)" }
             return
         }
-        val host = syncRuntimeInfo.connectHostAddress ?: return
-        clearPendingExchange(appInstanceId)
         val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
         val result =
-            syncClientApi.trustV2Cancel(record.exchangeTimestamp) {
+            syncClientApi.trustV2Cancel(generation) {
                 buildUrl(hostAndPort)
             }
         if (result is SuccessResult) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
@@ -67,6 +67,29 @@ class SyncDeviceManager(
         }
     }
 
+    /**
+     * Best-effort release of the pending v2 exchange we opened on the peer
+     * (#4684): only meaningful while the peer is still UNVERIFIED — after a
+     * successful confirm the peer has already consumed the exchange, and
+     * without a host there is nothing to notify. Failures are ignored: pairing
+     * is being abandoned anyway, and the peer's entry self-heals when a later
+     * exchange from us replaces it.
+     */
+    suspend fun cancelPairing(syncRuntimeInfo: SyncRuntimeInfo) {
+        if (syncRuntimeInfo.connectState != SyncState.UNVERIFIED) return
+        val host = syncRuntimeInfo.connectHostAddress ?: return
+        val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
+        val result =
+            syncClientApi.trustV2Cancel {
+                buildUrl(hostAndPort)
+            }
+        if (result is SuccessResult) {
+            logger.info { "cancelPairing released pending exchange on $host ${syncRuntimeInfo.port}" }
+        } else {
+            logger.info { "cancelPairing best-effort release failed $host ${syncRuntimeInfo.port}" }
+        }
+    }
+
     suspend fun showToken(syncRuntimeInfo: SyncRuntimeInfo) {
         if (syncRuntimeInfo.connectState == SyncState.UNVERIFIED) {
             syncRuntimeInfo.connectHostAddress?.let { host ->

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
@@ -3,6 +3,7 @@ package com.crosspaste.sync
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
+import com.crosspaste.dto.secure.KeyExchangeResponse
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.ws.WsEnvelope
@@ -13,6 +14,7 @@ import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.util.collections.ConcurrentMap
 
 class SyncDeviceManager(
     private val secureStore: SecureStore,
@@ -22,6 +24,36 @@ class SyncDeviceManager(
 ) {
 
     private val logger = KotlinLogging.logger {}
+
+    /**
+     * The v2 exchange we initiated on a peer that has not yet been confirmed
+     * or cancelled: the responder's exchange timestamp (its generation marker)
+     * plus when we recorded it locally. This is what makes cancelPairing both
+     * targeted (the cancel names the exact exchange it releases) and
+     * self-gating (no record → nothing we own → no request), independent of
+     * the peer's connect state (#4684 / #4690 review).
+     */
+    private val pendingExchanges: MutableMap<String, PendingExchangeRecord> = ConcurrentMap()
+
+    data class PendingExchangeRecord(
+        val exchangeTimestamp: Long,
+        val recordedAt: Long,
+    )
+
+    fun rememberPendingExchange(
+        appInstanceId: String,
+        exchangeTimestamp: Long,
+    ) {
+        pendingExchanges[appInstanceId] =
+            PendingExchangeRecord(
+                exchangeTimestamp = exchangeTimestamp,
+                recordedAt = nowEpochMilliseconds(),
+            )
+    }
+
+    fun clearPendingExchange(appInstanceId: String) {
+        pendingExchanges.remove(appInstanceId)
+    }
 
     suspend fun updateAllowSend(
         syncRuntimeInfo: SyncRuntimeInfo,
@@ -53,6 +85,9 @@ class SyncDeviceManager(
                         buildUrl(hostAndPort)
                     }
                 if (result is SuccessResult) {
+                    result.getResult<KeyExchangeResponse>()?.let { response ->
+                        rememberPendingExchange(syncRuntimeInfo.appInstanceId, response.timestamp)
+                    }
                     logger.info { "exchangeKeysForPairing success $host ${syncRuntimeInfo.port}" }
                 } else {
                     logger.warn { "exchangeKeysForPairing failed $host ${syncRuntimeInfo.port}" }
@@ -69,18 +104,30 @@ class SyncDeviceManager(
 
     /**
      * Best-effort release of the pending v2 exchange we opened on the peer
-     * (#4684): only meaningful while the peer is still UNVERIFIED — after a
-     * successful confirm the peer has already consumed the exchange, and
-     * without a host there is nothing to notify. Failures are ignored: pairing
-     * is being abandoned anyway, and the peer's entry self-heals when a later
-     * exchange from us replaces it.
+     * (#4684). Gated by ownership, not connect state: we send exactly when we
+     * hold an unconsumed exchange record for the peer (a confirm clears it, a
+     * successful exchange creates it), so the request is still sent after the
+     * peer dropped to DISCONNECTED, and skipped after a successful pairing.
+     * [requestedAt] is when the user abandoned the dialog — a record written
+     * after that belongs to a newer dialog, so this stale cancel must not
+     * release it. Failures are ignored: pairing is being abandoned anyway, and
+     * the peer's entry self-heals when a later exchange from us replaces it.
      */
-    suspend fun cancelPairing(syncRuntimeInfo: SyncRuntimeInfo) {
-        if (syncRuntimeInfo.connectState != SyncState.UNVERIFIED) return
+    suspend fun cancelPairing(
+        syncRuntimeInfo: SyncRuntimeInfo,
+        requestedAt: Long,
+    ) {
+        val appInstanceId = syncRuntimeInfo.appInstanceId
+        val record = pendingExchanges[appInstanceId] ?: return
+        if (record.recordedAt > requestedAt) {
+            logger.info { "cancelPairing skipped for $appInstanceId (a newer exchange superseded it)" }
+            return
+        }
         val host = syncRuntimeInfo.connectHostAddress ?: return
+        clearPendingExchange(appInstanceId)
         val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
         val result =
-            syncClientApi.trustV2Cancel {
+            syncClientApi.trustV2Cancel(record.exchangeTimestamp) {
                 buildUrl(hostAndPort)
             }
         if (result is SuccessResult) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -73,6 +73,12 @@ sealed interface SyncEvent {
         override fun toString(): String = "ExchangeKeysForPairing ${syncRuntimeInfo.appInstanceId}"
     }
 
+    data class CancelPairing(
+        override val syncRuntimeInfo: SyncRuntimeInfo,
+    ) : SyncRunTimeInfoEvent {
+        override fun toString(): String = "CancelPairing ${syncRuntimeInfo.appInstanceId}"
+    }
+
     data class ShowToken(
         override val syncRuntimeInfo: SyncRuntimeInfo,
     ) : SyncRunTimeInfoEvent {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -75,6 +75,10 @@ sealed interface SyncEvent {
 
     data class CancelPairing(
         override val syncRuntimeInfo: SyncRuntimeInfo,
+        // Epoch millis of the user's abandon action, captured synchronously at
+        // the UI call site: an exchange recorded after this instant belongs to
+        // a newer pairing dialog and must survive this cancel.
+        val requestedAt: Long,
     ) : SyncRunTimeInfoEvent {
         override fun toString(): String = "CancelPairing ${syncRuntimeInfo.appInstanceId}"
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -75,10 +75,11 @@ sealed interface SyncEvent {
 
     data class CancelPairing(
         override val syncRuntimeInfo: SyncRuntimeInfo,
-        // Epoch millis of the user's abandon action, captured synchronously at
-        // the UI call site: an exchange recorded after this instant belongs to
-        // a newer pairing dialog and must survive this cancel.
-        val requestedAt: Long,
+        // Generation of the exchange the abandoned dialog owned, captured from
+        // the PendingExchangeLedger synchronously at the UI call site: a newer
+        // exchange from a reopened dialog replaces the ledger record, so this
+        // stale cancel consumes nothing.
+        val generation: Long,
     ) : SyncRunTimeInfoEvent {
         override fun toString(): String = "CancelPairing ${syncRuntimeInfo.appInstanceId}"
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
@@ -64,7 +64,9 @@ interface SyncHandler {
 
     // Release the pending v2 exchange we started on the peer when pairing is
     // abandoned before confirm (POST /sync/trust/v2/cancel, best-effort).
-    suspend fun cancelPairing()
+    // [requestedAt] = epoch millis of the abandon action, captured at the UI
+    // call site so a later exchange from a reopened dialog is never cancelled.
+    suspend fun cancelPairing(requestedAt: Long)
 
     suspend fun showToken()
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
@@ -62,6 +62,10 @@ interface SyncHandler {
 
     suspend fun exchangeKeysForPairing()
 
+    // Release the pending v2 exchange we started on the peer when pairing is
+    // abandoned before confirm (POST /sync/trust/v2/cancel, best-effort).
+    suspend fun cancelPairing()
+
     suspend fun showToken()
 
     suspend fun showPairingCode()

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
@@ -64,9 +64,10 @@ interface SyncHandler {
 
     // Release the pending v2 exchange we started on the peer when pairing is
     // abandoned before confirm (POST /sync/trust/v2/cancel, best-effort).
-    // [requestedAt] = epoch millis of the abandon action, captured at the UI
-    // call site so a later exchange from a reopened dialog is never cancelled.
-    suspend fun cancelPairing(requestedAt: Long)
+    // [generation] = the abandoned exchange's ledger generation, captured at
+    // the UI call site so a later exchange from a reopened dialog is never
+    // cancelled.
+    suspend fun cancelPairing(generation: Long)
 
     suspend fun showToken()
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
@@ -58,6 +58,10 @@ interface SyncManager : SyncRoutingApi {
         callback: (Boolean) -> Unit,
     )
 
+    // Best-effort release of the pending v2 exchange on the peer when the user
+    // abandons pairing before confirm. Routes to POST /sync/trust/v2/cancel.
+    fun cancelPairing(appInstanceId: String)
+
     fun refresh(
         ids: List<String> = listOf(),
         callback: () -> Unit = {},

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -39,6 +39,7 @@ class SyncResolver(
     private val localPlatform: Platform,
     private val lazyPasteBonjourService: Lazy<PasteBonjourService>,
     private val networkInterfaceService: NetworkInterfaceService,
+    private val pendingExchangeLedger: PendingExchangeLedger,
     private val ratingPromptManager: RatingPromptManager,
     private val secureKeyPairSerializer: SecureKeyPairSerializer,
     private val secureStore: SecureStore,
@@ -123,7 +124,7 @@ class SyncResolver(
                     }
 
                     is SyncEvent.CancelPairing -> {
-                        syncDeviceManager.cancelPairing(syncRuntimeInfo, event.requestedAt)
+                        syncDeviceManager.cancelPairing(syncRuntimeInfo, event.generation)
                     }
 
                     is SyncEvent.ShowToken -> {
@@ -705,9 +706,14 @@ class SyncResolver(
         connectHostAddress?.let { host ->
             val hostAndPort = HostAndPort(host, port)
 
-            // Step 1: Exchange keys
+            // Step 1: Exchange keys. This exchange supersedes the dialog's
+            // warm-up on the responder; record its generation BEFORE sending so
+            // an abandon after a SAS mismatch or a lost response can still
+            // cancel the exchange that actually exists over there (#4684).
+            val generation = pendingExchangeLedger.nextGeneration()
+            pendingExchangeLedger.record(appInstanceId, generation)
             val exchangeResult =
-                syncClientApi.exchangeKeys(appInstanceId) {
+                syncClientApi.exchangeKeys(appInstanceId, generation) {
                     buildUrl(hostAndPort)
                 }
 
@@ -723,11 +729,6 @@ class SyncResolver(
                 callback(false)
                 return
             }
-
-            // This exchange superseded the dialog's warm-up on the responder;
-            // track it so an abandon after a SAS mismatch or confirm failure
-            // cancels the exchange that actually exists over there (#4684).
-            syncDeviceManager.rememberPendingExchange(appInstanceId, response.timestamp)
 
             // Step 2: Compute local SAS and compare with user-entered token
             val localCryptPublicKey =
@@ -757,7 +758,7 @@ class SyncResolver(
 
             // Step 4: Save remote key locally and send heartbeat. The confirm
             // consumed the responder's pending exchange — nothing left to cancel.
-            syncDeviceManager.clearPendingExchange(appInstanceId)
+            pendingExchangeLedger.clear(appInstanceId)
             secureStore.saveCryptPublicKey(appInstanceId, response.cryptPublicKey)
 
             advertiseAddressViaHeartbeat(host, port, appInstanceId)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -122,6 +122,10 @@ class SyncResolver(
                         syncDeviceManager.exchangeKeysForPairing(syncRuntimeInfo)
                     }
 
+                    is SyncEvent.CancelPairing -> {
+                        syncDeviceManager.cancelPairing(syncRuntimeInfo)
+                    }
+
                     is SyncEvent.ShowToken -> {
                         syncDeviceManager.showToken(syncRuntimeInfo)
                     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -123,7 +123,7 @@ class SyncResolver(
                     }
 
                     is SyncEvent.CancelPairing -> {
-                        syncDeviceManager.cancelPairing(syncRuntimeInfo)
+                        syncDeviceManager.cancelPairing(syncRuntimeInfo, event.requestedAt)
                     }
 
                     is SyncEvent.ShowToken -> {
@@ -724,6 +724,11 @@ class SyncResolver(
                 return
             }
 
+            // This exchange superseded the dialog's warm-up on the responder;
+            // track it so an abandon after a SAS mismatch or confirm failure
+            // cancels the exchange that actually exists over there (#4684).
+            syncDeviceManager.rememberPendingExchange(appInstanceId, response.timestamp)
+
             // Step 2: Compute local SAS and compare with user-entered token
             val localCryptPublicKey =
                 secureStore.secureKeyPair.getCryptPublicKeyBytes(secureKeyPairSerializer)
@@ -750,7 +755,9 @@ class SyncResolver(
                 return
             }
 
-            // Step 4: Save remote key locally and send heartbeat
+            // Step 4: Save remote key locally and send heartbeat. The confirm
+            // consumed the responder's pending exchange — nothing left to cancel.
+            syncDeviceManager.clearPendingExchange(appInstanceId)
             secureStore.saveCryptPublicKey(appInstanceId, response.cryptPublicKey)
 
             advertiseAddressViaHeartbeat(host, port, appInstanceId)

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
@@ -67,8 +67,15 @@ fun TokenView(intOffset: IntOffset) {
     val pairingSessions by pairingV3UiController.sessions.collectAsState()
     val incomingPairingSessions = acceptorPairingSessions(pairingSessions)
 
-    // Auto-close token view when all pending verifiers have completed verification
-    // (either trust succeeded, went offline, or disconnected)
+    // Reap pending verifiers whose device left UNVERIFIED without completing the
+    // handshake here (went offline / disconnected / trusted out-of-band). This is
+    // NOT the success path: a successful trust/confirm removes its verifier and
+    // releases its refresh count server-side before the UI can observe it, so
+    // `pending` is already empty and this effect never fires (#4684). Each
+    // verifier still parked here owns one refresh count (its exchange/showToken
+    // never got a matching release), so release one count per reaped verifier —
+    // a single decrement would hide the overlay but leave the refresh loop
+    // running in the background.
     val pending by appTokenApi.pendingVerifiers.collectAsState()
     val syncRuntimeInfos by syncManager.realTimeSyncRuntimeInfos.collectAsState()
 
@@ -82,8 +89,10 @@ fun TokenView(intOffset: IntOffset) {
 
     LaunchedEffect(allResolved) {
         if (allResolved) {
-            pending.forEach { appTokenApi.removePendingVerifier(it) }
-            appTokenApi.stopRefresh(hideToken = true)
+            pending.forEach {
+                appTokenApi.removePendingVerifier(it)
+                appTokenApi.stopRefresh(hideToken = true)
+            }
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
@@ -72,10 +72,10 @@ fun TokenView(intOffset: IntOffset) {
     // NOT the success path: a successful trust/confirm removes its verifier and
     // releases its refresh count server-side before the UI can observe it, so
     // `pending` is already empty and this effect never fires (#4684). Each
-    // verifier still parked here owns one refresh count (its exchange/showToken
-    // never got a matching release), so release one count per reaped verifier —
-    // a single decrement would hide the overlay but leave the refresh loop
-    // running in the background.
+    // verifier still parked here owns one refresh count, released through the
+    // atomic releaseVerifier — one count per reaped verifier, and a later server
+    // release of the same peer (retry / confirm / cancel finding the leftover
+    // store entry) becomes a no-op instead of a double decrement.
     val pending by appTokenApi.pendingVerifiers.collectAsState()
     val syncRuntimeInfos by syncManager.realTimeSyncRuntimeInfos.collectAsState()
 
@@ -90,8 +90,7 @@ fun TokenView(intOffset: IntOffset) {
     LaunchedEffect(allResolved) {
         if (allResolved) {
             pending.forEach {
-                appTokenApi.removePendingVerifier(it)
-                appTokenApi.stopRefresh(hideToken = true)
+                appTokenApi.releaseVerifier(it, hideToken = true)
             }
         }
     }
@@ -103,7 +102,21 @@ fun TokenView(intOffset: IntOffset) {
                     title = copywriter.getText("token"),
                     token = token.map(Char::toString),
                     progress = progress,
-                    onClose = { appTokenApi.stopRefresh(hideToken = true) },
+                    onClose = {
+                        // Manual dismissal releases each pending verifier's count
+                        // through the atomic primitive, so a later server-side
+                        // release of the same peer cannot double-decrement. With
+                        // no verifiers (degenerate: overlay without a tracked
+                        // requester) fall back to a plain single decrement.
+                        val verifiers = appTokenApi.pendingVerifiers.value
+                        if (verifiers.isEmpty()) {
+                            appTokenApi.stopRefresh(hideToken = true)
+                        } else {
+                            verifiers.forEach {
+                                appTokenApi.releaseVerifier(it, hideToken = true)
+                            }
+                        }
+                    },
                 )
             }
             PairingV3AcceptorTokenCards(

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -133,6 +134,23 @@ fun DeviceScope.TrustDeviceDialog() {
             PairingCredentialType.QR_BEARER_TOKEN -> handler?.showToken()
             PairingCredentialType.V3_PIN -> Unit
             null -> Unit
+        }
+    }
+
+    // The SAS warm-up exchange above parks one token-refresh count on the
+    // responder; if the dialog goes away without a confirm, release it so the
+    // responder's SAS overlay auto-closes (#4684). Keyed like the warm-up
+    // effect so each dismissal path (cancel button, outside click, device
+    // switch, window close) triggers a release; after a successful pairing the
+    // peer is no longer UNVERIFIED and cancelPairing skips the request. Best
+    // effort only: both effects go through the async event pipeline, so a
+    // dismissal racing an in-flight warm-up can release before the exchange
+    // lands — the leftover entry then self-heals on the next exchange.
+    DisposableEffect(appInstanceId, pairingCredentialType) {
+        onDispose {
+            if (pairingCredentialType == PairingCredentialType.SAS_CODE) {
+                syncManager.cancelPairing(appInstanceId)
+            }
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -141,11 +141,12 @@ fun DeviceScope.TrustDeviceDialog() {
     // responder; if the dialog goes away without a confirm, release it so the
     // responder's SAS overlay auto-closes (#4684). Keyed like the warm-up
     // effect so each dismissal path (cancel button, outside click, device
-    // switch, window close) triggers a release; after a successful pairing the
-    // peer is no longer UNVERIFIED and cancelPairing skips the request. Best
-    // effort only: both effects go through the async event pipeline, so a
-    // dismissal racing an in-flight warm-up can release before the exchange
-    // lands — the leftover entry then self-heals on the next exchange.
+    // switch, window close) triggers a release. The cancel is generation-safe:
+    // it names the exact exchange this dialog owns (skipped after a successful
+    // confirm consumes it, or when a reopened dialog's newer exchange
+    // supersedes it — see SyncDeviceManager.cancelPairing). Best effort only:
+    // a dismissal racing an in-flight warm-up finds no recorded exchange and
+    // skips; the responder's leftover entry self-heals on the next exchange.
     DisposableEffect(appInstanceId, pairingCredentialType) {
         onDispose {
             if (pairingCredentialType == PairingCredentialType.SAS_CODE) {

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/ResponseUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/ResponseUtils.kt
@@ -16,6 +16,10 @@ import io.ktor.utils.io.*
 const val HEADER_APP_INSTANCE_ID: String = "appInstanceId"
 const val HEADER_TARGET_APP_INSTANCE_ID: String = "targetAppInstanceId"
 
+// Generation marker for /sync/trust/v2/cancel: the responder's exchange
+// timestamp echoed back so a stale cancel cannot release a newer exchange.
+const val HEADER_EXCHANGE_TIMESTAMP: String = "crosspaste-exchange-timestamp"
+
 suspend inline fun successResponse(call: ApplicationCall) {
     call.respond(status = HttpStatusCode.OK, message = "")
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -61,6 +61,7 @@ import com.crosspaste.sync.GeneralSyncManager
 import com.crosspaste.sync.MarketingNearbyDeviceManager
 import com.crosspaste.sync.MarketingSyncManager
 import com.crosspaste.sync.NearbyDeviceManager
+import com.crosspaste.sync.PendingExchangeLedger
 import com.crosspaste.sync.PendingKeyExchangeStore
 import com.crosspaste.sync.PushSessionManager
 import com.crosspaste.sync.SharePushOrchestrator
@@ -240,6 +241,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 GeneralNearbyDeviceManager(get(), get(), get(), get())
             }
         }
+        single<PendingExchangeLedger> { PendingExchangeLedger() }
         single<PendingKeyExchangeStore> { PendingKeyExchangeStore() }
         single<PushSessionManager> {
             PushSessionManager(
@@ -250,6 +252,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
         single<SharePushOrchestrator> { SharePushOrchestrator(get(), get(), get()) }
         single<SyncDeviceManager> {
             SyncDeviceManager(
+                pendingExchangeLedger = get(),
                 secureStore = get(),
                 syncClientApi = get(),
                 syncRuntimeInfoDao = get(),
@@ -261,6 +264,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 MarketingSyncManager()
             } else {
                 GeneralSyncManager(
+                    pendingExchangeLedger = get(),
                     syncResolver = get(),
                     syncRuntimeInfoDao = get(),
                     syncClientApi = get(),
@@ -275,6 +279,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 localPlatform = get(),
                 lazyPasteBonjourService = lazy { get() },
                 networkInterfaceService = get(),
+                pendingExchangeLedger = get(),
                 ratingPromptManager = get(),
                 secureKeyPairSerializer = get(),
                 secureStore = get(),

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/AppTokenServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/AppTokenServiceTest.kt
@@ -76,6 +76,26 @@ class AppTokenServiceTest {
     }
 
     @Test
+    fun `release enqueued right after acquire cannot orphan the refresh count`() {
+        val service = createService()
+        runBlocking {
+            service.addPendingVerifier("a")
+            service.startRefresh(showToken = true)
+            // Enqueued after the increment, so the single-consumer command
+            // queue can never process it first — the interleaving that
+            // previously left an orphaned count driving the refresh loop.
+            service.releaseVerifier("a")
+            // FIFO marker: once it is visible, every prior command has run.
+            service.addPendingVerifier("marker")
+            withTimeout(5.seconds) {
+                service.pendingVerifiers.first { "marker" in it }
+            }
+            assertFalse(service.refresh.value)
+            assertEquals(setOf("marker"), service.pendingVerifiers.value)
+        }
+    }
+
+    @Test
     fun `releaseVerifier hideToken hides overlay while other counts keep refreshing`() {
         val service = createService()
         runBlocking {

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/AppTokenServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/AppTokenServiceTest.kt
@@ -1,9 +1,15 @@
 package com.crosspaste.app
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class AppTokenServiceTest {
 
@@ -34,5 +40,62 @@ class AppTokenServiceTest {
     fun `token characters are all decimal digits`() {
         val service = createService()
         assertTrue(service.token.value.all { it in '0'..'9' })
+    }
+
+    @Test
+    fun `releaseVerifier releases exactly one count per pending verifier`() {
+        val service = createService()
+        runBlocking {
+            service.addPendingVerifier("a")
+            service.startRefresh(showToken = true)
+            service.addPendingVerifier("b")
+            service.startRefresh(showToken = true)
+            withTimeout(5.seconds) {
+                service.refresh.first { it }
+                service.pendingVerifiers.first { it == setOf("a", "b") }
+            }
+
+            service.releaseVerifier("a")
+            withTimeout(5.seconds) {
+                service.pendingVerifiers.first { "a" !in it }
+            }
+
+            // Releasing an already-released or unknown verifier must not
+            // consume the count still owned by "b".
+            service.releaseVerifier("a")
+            service.releaseVerifier("unknown")
+            delay(200.milliseconds)
+            assertTrue(service.refresh.value)
+
+            service.releaseVerifier("b")
+            withTimeout(5.seconds) {
+                service.refresh.first { !it }
+                service.pendingVerifiers.first { it.isEmpty() }
+            }
+        }
+    }
+
+    @Test
+    fun `releaseVerifier hideToken hides overlay while other counts keep refreshing`() {
+        val service = createService()
+        runBlocking {
+            // One verifier-owned count plus one anonymous count (e.g. the local
+            // pairing-code screen keeping the token rotation alive).
+            service.addPendingVerifier("a")
+            service.startRefresh(showToken = true)
+            service.startRefresh(showToken = false)
+            withTimeout(5.seconds) {
+                service.showToken.first { it }
+                service.refresh.first { it }
+            }
+
+            service.releaseVerifier("a", hideToken = true)
+
+            withTimeout(5.seconds) {
+                service.showToken.first { !it }
+            }
+            // The anonymous count is untouched: the refresh loop keeps running.
+            assertTrue(service.refresh.value)
+        }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
@@ -518,7 +518,7 @@ class PairingV3IntegrationTest {
             a.start()
             b.start()
 
-            assertIs<SuccessResult>(b.syncClientApi.exchangeKeys(a.appInstanceId, urlFor(a)))
+            assertIs<SuccessResult>(b.syncClientApi.exchangeKeys(a.appInstanceId, 2000L, urlFor(a)))
             assertIs<SuccessResult>(
                 b.syncClientApi.trustV2Confirm(a.appInstanceId, "localhost", urlFor(a)),
             )
@@ -554,13 +554,13 @@ class PairingV3IntegrationTest {
             a.pairingAcceptanceWindow.open()
 
             // The v2 exchange completes BEFORE any v3 session exists
-            val exchange = b.syncClientApi.exchangeKeys(a.appInstanceId, urlFor(a))
+            val exchange = b.syncClientApi.exchangeKeys(a.appInstanceId, 3000L, urlFor(a))
             assertIs<SuccessResult>(exchange)
 
             startPairing(b, a)
 
             // With a v3 session in flight, both remaining v2 legs are refused
-            val v2Exchange = b.syncClientApi.exchangeKeys(a.appInstanceId, urlFor(a))
+            val v2Exchange = b.syncClientApi.exchangeKeys(a.appInstanceId, 4000L, urlFor(a))
             assertIs<FailureResult>(v2Exchange)
             assertEquals(
                 PairingV3ErrorCode.PAIRING_VERSION_UNSUPPORTED,
@@ -586,7 +586,7 @@ class PairingV3IntegrationTest {
 
             startPairing(b, a)
 
-            val reverseV2Exchange = a.syncClientApi.exchangeKeys(b.appInstanceId, urlFor(b))
+            val reverseV2Exchange = a.syncClientApi.exchangeKeys(b.appInstanceId, 5000L, urlFor(b))
             assertIs<FailureResult>(reverseV2Exchange)
             assertEquals(
                 PairingV3ErrorCode.PAIRING_VERSION_UNSUPPORTED,

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
@@ -12,7 +12,6 @@ import com.crosspaste.config.TestReadWritePort
 import com.crosspaste.db.secure.MemorySecureIO
 import com.crosspaste.db.secure.SecureIO
 import com.crosspaste.db.sync.HostInfo
-import com.crosspaste.dto.secure.KeyExchangeResponse
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.SuccessResult
@@ -51,7 +50,6 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -276,14 +274,12 @@ class SyncTest : KoinTest {
         runBlocking { pasteServer.stop() }
     }
 
-    private suspend fun exchangeAndAwaitPending(): KeyExchangeResponse {
+    private suspend fun exchangeAndAwaitPending(exchangeGeneration: Long) {
         val exchangeResult =
-            syncClientApi.exchangeKeys(serverAppInfo.appInstanceId) {
+            syncClientApi.exchangeKeys(serverAppInfo.appInstanceId, exchangeGeneration) {
                 buildUrl(HostAndPort("localhost", readWritePort.getValue()))
             }
         assertTrue(exchangeResult is SuccessResult)
-        val response = (exchangeResult as SuccessResult).getResult<KeyExchangeResponse>()
-        assertNotNull(response)
 
         // The exchange parks one token-refresh count and one pending verifier
         // on the responder (both updated asynchronously).
@@ -291,7 +287,6 @@ class SyncTest : KoinTest {
             appTokenApi.refresh.first { it }
             appTokenApi.pendingVerifiers.first { clientAppInfo.appInstanceId in it }
         }
-        return response
     }
 
     @Test
@@ -299,10 +294,10 @@ class SyncTest : KoinTest {
         runBlocking {
             pasteServer.start()
 
-            val response = exchangeAndAwaitPending()
+            exchangeAndAwaitPending(exchangeGeneration = 1000L)
 
             val cancelResult =
-                syncClientApi.trustV2Cancel(response.timestamp) {
+                syncClientApi.trustV2Cancel(1000L) {
                     buildUrl(HostAndPort("localhost", readWritePort.getValue()))
                 }
             assertTrue(cancelResult is SuccessResult)
@@ -330,19 +325,16 @@ class SyncTest : KoinTest {
         runBlocking {
             pasteServer.start()
 
-            val firstResponse = exchangeAndAwaitPending()
+            exchangeAndAwaitPending(exchangeGeneration = 1000L)
 
-            // A second exchange supersedes the first entry; the generation
-            // marker is the responder's epoch-millisecond clock, so a short
-            // delay guarantees it differs from the stale one.
-            delay(10.milliseconds)
-            val secondResponse = exchangeAndAwaitPending()
-            assertTrue(secondResponse.timestamp != firstResponse.timestamp)
+            // A second exchange supersedes the first entry under a distinct
+            // client-generated generation.
+            exchangeAndAwaitPending(exchangeGeneration = 2000L)
 
             // The stale cancel names the superseded exchange: the responder
             // must keep the current one alive.
             val staleCancel =
-                syncClientApi.trustV2Cancel(firstResponse.timestamp) {
+                syncClientApi.trustV2Cancel(1000L) {
                     buildUrl(HostAndPort("localhost", readWritePort.getValue()))
                 }
             assertTrue(staleCancel is SuccessResult)
@@ -352,7 +344,7 @@ class SyncTest : KoinTest {
 
             // Cancelling the current generation releases it.
             val currentCancel =
-                syncClientApi.trustV2Cancel(secondResponse.timestamp) {
+                syncClientApi.trustV2Cancel(2000L) {
                     buildUrl(HostAndPort("localhost", readWritePort.getValue()))
                 }
             assertTrue(currentCancel is SuccessResult)
@@ -370,7 +362,7 @@ class SyncTest : KoinTest {
         runBlocking {
             pasteServer.start()
 
-            exchangeAndAwaitPending()
+            exchangeAndAwaitPending(exchangeGeneration = 1000L)
 
             // Callers without the generation header (older clients, the browser
             // extension) keep the original unconditional-release behaviour.

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
@@ -13,6 +13,7 @@ import com.crosspaste.db.secure.MemorySecureIO
 import com.crosspaste.db.secure.SecureIO
 import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.exception.DesktopExceptionHandler
@@ -35,7 +36,9 @@ import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import com.crosspaste.utils.getPlatformUtils
 import io.ktor.server.netty.*
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.koin.core.context.GlobalContext
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -46,6 +49,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class SyncTest : KoinTest {
 
@@ -263,5 +267,47 @@ class SyncTest : KoinTest {
         assertTrue(result is SuccessResult)
 
         runBlocking { pasteServer.stop() }
+    }
+
+    @Test
+    fun testV2ExchangeCancelReleasesPendingExchange() {
+        runBlocking {
+            pasteServer.start()
+
+            val exchangeResult =
+                syncClientApi.exchangeKeys(serverAppInfo.appInstanceId) {
+                    buildUrl(HostAndPort("localhost", readWritePort.getValue()))
+                }
+            assertTrue(exchangeResult is SuccessResult)
+
+            // The exchange parks one token-refresh count and one pending verifier
+            // on the responder (both updated asynchronously).
+            withTimeout(5.seconds) {
+                appTokenApi.refresh.first { it }
+                appTokenApi.pendingVerifiers.first { clientAppInfo.appInstanceId in it }
+            }
+
+            val cancelResult =
+                syncClientApi.trustV2Cancel {
+                    buildUrl(HostAndPort("localhost", readWritePort.getValue()))
+                }
+            assertTrue(cancelResult is SuccessResult)
+
+            // Cancel funnels through the unified release path: the verifier is
+            // removed and the refresh count drains back to zero (#4684).
+            withTimeout(5.seconds) {
+                appTokenApi.refresh.first { !it }
+                appTokenApi.pendingVerifiers.first { it.isEmpty() }
+            }
+
+            // The pending exchange was consumed, so a late confirm cannot match.
+            val confirmResult =
+                syncClientApi.trustV2Confirm(serverAppInfo.appInstanceId, "localhost") {
+                    buildUrl(HostAndPort("localhost", readWritePort.getValue()))
+                }
+            assertTrue(confirmResult is FailureResult)
+
+            pasteServer.stop()
+        }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
@@ -12,6 +12,7 @@ import com.crosspaste.config.TestReadWritePort
 import com.crosspaste.db.secure.MemorySecureIO
 import com.crosspaste.db.secure.SecureIO
 import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.dto.secure.KeyExchangeResponse
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.SuccessResult
@@ -36,6 +37,8 @@ import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import com.crosspaste.utils.getPlatformUtils
 import io.ktor.server.netty.*
+import io.ktor.util.reflect.*
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -48,7 +51,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class SyncTest : KoinTest {
@@ -68,6 +73,8 @@ class SyncTest : KoinTest {
     private val clientSecureIO by inject<SecureIO>(named("clientSecureIO"))
 
     private val syncClientApi by inject<SyncClientApi>()
+
+    private val pasteClient by inject<PasteClient>()
 
     companion object {
 
@@ -269,26 +276,33 @@ class SyncTest : KoinTest {
         runBlocking { pasteServer.stop() }
     }
 
+    private suspend fun exchangeAndAwaitPending(): KeyExchangeResponse {
+        val exchangeResult =
+            syncClientApi.exchangeKeys(serverAppInfo.appInstanceId) {
+                buildUrl(HostAndPort("localhost", readWritePort.getValue()))
+            }
+        assertTrue(exchangeResult is SuccessResult)
+        val response = (exchangeResult as SuccessResult).getResult<KeyExchangeResponse>()
+        assertNotNull(response)
+
+        // The exchange parks one token-refresh count and one pending verifier
+        // on the responder (both updated asynchronously).
+        withTimeout(5.seconds) {
+            appTokenApi.refresh.first { it }
+            appTokenApi.pendingVerifiers.first { clientAppInfo.appInstanceId in it }
+        }
+        return response
+    }
+
     @Test
     fun testV2ExchangeCancelReleasesPendingExchange() {
         runBlocking {
             pasteServer.start()
 
-            val exchangeResult =
-                syncClientApi.exchangeKeys(serverAppInfo.appInstanceId) {
-                    buildUrl(HostAndPort("localhost", readWritePort.getValue()))
-                }
-            assertTrue(exchangeResult is SuccessResult)
-
-            // The exchange parks one token-refresh count and one pending verifier
-            // on the responder (both updated asynchronously).
-            withTimeout(5.seconds) {
-                appTokenApi.refresh.first { it }
-                appTokenApi.pendingVerifiers.first { clientAppInfo.appInstanceId in it }
-            }
+            val response = exchangeAndAwaitPending()
 
             val cancelResult =
-                syncClientApi.trustV2Cancel {
+                syncClientApi.trustV2Cancel(response.timestamp) {
                     buildUrl(HostAndPort("localhost", readWritePort.getValue()))
                 }
             assertTrue(cancelResult is SuccessResult)
@@ -306,6 +320,73 @@ class SyncTest : KoinTest {
                     buildUrl(HostAndPort("localhost", readWritePort.getValue()))
                 }
             assertTrue(confirmResult is FailureResult)
+
+            pasteServer.stop()
+        }
+    }
+
+    @Test
+    fun testV2StaleCancelDoesNotReleaseNewerExchange() {
+        runBlocking {
+            pasteServer.start()
+
+            val firstResponse = exchangeAndAwaitPending()
+
+            // A second exchange supersedes the first entry; the generation
+            // marker is the responder's epoch-millisecond clock, so a short
+            // delay guarantees it differs from the stale one.
+            delay(10.milliseconds)
+            val secondResponse = exchangeAndAwaitPending()
+            assertTrue(secondResponse.timestamp != firstResponse.timestamp)
+
+            // The stale cancel names the superseded exchange: the responder
+            // must keep the current one alive.
+            val staleCancel =
+                syncClientApi.trustV2Cancel(firstResponse.timestamp) {
+                    buildUrl(HostAndPort("localhost", readWritePort.getValue()))
+                }
+            assertTrue(staleCancel is SuccessResult)
+            delay(200.milliseconds)
+            assertTrue(appTokenApi.refresh.value)
+            assertTrue(clientAppInfo.appInstanceId in appTokenApi.pendingVerifiers.value)
+
+            // Cancelling the current generation releases it.
+            val currentCancel =
+                syncClientApi.trustV2Cancel(secondResponse.timestamp) {
+                    buildUrl(HostAndPort("localhost", readWritePort.getValue()))
+                }
+            assertTrue(currentCancel is SuccessResult)
+            withTimeout(5.seconds) {
+                appTokenApi.refresh.first { !it }
+                appTokenApi.pendingVerifiers.first { it.isEmpty() }
+            }
+
+            pasteServer.stop()
+        }
+    }
+
+    @Test
+    fun testV2CancelWithoutGenerationHeaderKeepsLegacySemantics() {
+        runBlocking {
+            pasteServer.start()
+
+            exchangeAndAwaitPending()
+
+            // Callers without the generation header (older clients, the browser
+            // extension) keep the original unconditional-release behaviour.
+            pasteClient.post(
+                "",
+                typeInfo<String>(),
+                urlBuilder = {
+                    buildUrl(HostAndPort("localhost", readWritePort.getValue()))
+                    buildUrl("sync", "trust", "v2", "cancel")
+                },
+            )
+
+            withTimeout(5.seconds) {
+                appTokenApi.refresh.first { !it }
+                appTokenApi.pendingVerifiers.first { it.isEmpty() }
+            }
 
             pasteServer.stop()
         }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
@@ -64,8 +64,7 @@ class TestServerModule(
                     { _, _, _ -> },
                     { appInstanceId ->
                         if (pendingKeyExchangeStore.remove(appInstanceId)) {
-                            appTokenApi.removePendingVerifier(appInstanceId)
-                            appTokenApi.stopRefresh(hideToken = false)
+                            appTokenApi.releaseVerifier(appInstanceId)
                         }
                     },
                     pairingVersionCoordinator,

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsModuleDependencyTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsModuleDependencyTest.kt
@@ -20,6 +20,7 @@ import com.crosspaste.platform.Platform
 import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.NearbyDeviceManager
+import com.crosspaste.sync.PendingExchangeLedger
 import com.crosspaste.sync.SyncDeviceManager
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.sync.SyncResolver
@@ -125,6 +126,7 @@ class WsModuleDependencyTest : KoinTest {
                         localPlatform = get(),
                         lazyPasteBonjourService = lazy { get() },
                         networkInterfaceService = get(),
+                        pendingExchangeLedger = PendingExchangeLedger(),
                         ratingPromptManager = get(),
                         secureKeyPairSerializer = get(),
                         secureStore = get(),

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
@@ -57,6 +57,7 @@ class GeneralSyncManagerTest {
     ): GeneralSyncManager =
         GeneralSyncManager(
             realTimeSyncScope = scope,
+            pendingExchangeLedger = PendingExchangeLedger(),
             syncResolver = mocks.syncResolver,
             syncRuntimeInfoDao = mocks.syncRuntimeInfoDao,
             syncClientApi = mocks.syncClientApi,

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/PendingExchangeLedgerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/PendingExchangeLedgerTest.kt
@@ -1,0 +1,55 @@
+package com.crosspaste.sync
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PendingExchangeLedgerTest {
+
+    @Test
+    fun `nextGeneration is strictly monotonic even within one millisecond`() {
+        val ledger = PendingExchangeLedger()
+        var previous = ledger.nextGeneration()
+        // Far more calls than can span distinct milliseconds on any machine.
+        repeat(10_000) {
+            val next = ledger.nextGeneration()
+            assertTrue(next > previous)
+            previous = next
+        }
+    }
+
+    @Test
+    fun `record and current round-trip per peer`() {
+        val ledger = PendingExchangeLedger()
+        ledger.record("a", 1L)
+        ledger.record("b", 2L)
+        assertEquals(1L, ledger.current("a"))
+        assertEquals(2L, ledger.current("b"))
+        assertNull(ledger.current("c"))
+    }
+
+    @Test
+    fun `consume removes only the matching generation`() {
+        val ledger = PendingExchangeLedger()
+        ledger.record("a", 1L)
+
+        assertFalse(ledger.consume("a", 2L))
+        assertEquals(1L, ledger.current("a"))
+
+        assertTrue(ledger.consume("a", 1L))
+        assertNull(ledger.current("a"))
+
+        assertFalse(ledger.consume("a", 1L))
+    }
+
+    @Test
+    fun `clear drops the record`() {
+        val ledger = PendingExchangeLedger()
+        ledger.record("a", 1L)
+        ledger.clear("a")
+        assertNull(ledger.current("a"))
+        assertFalse(ledger.consume("a", 1L))
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/PendingKeyExchangeStoreTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/PendingKeyExchangeStoreTest.kt
@@ -10,13 +10,34 @@ import kotlin.test.assertTrue
 
 class PendingKeyExchangeStoreTest {
 
-    private fun exchange(timestamp: Long): PendingKeyExchange =
+    private fun exchange(
+        timestamp: Long,
+        generation: Long = timestamp,
+    ): PendingKeyExchange =
         PendingKeyExchange(
             signPublicKey = byteArrayOf(1),
             cryptPublicKey = byteArrayOf(2),
             sas = 123456,
             timestamp = timestamp,
+            generation = generation,
         )
+
+    @Test
+    fun generationMatchesComparesTheStoredInitiatorMarker() {
+        val store = PendingKeyExchangeStore()
+        val now = DateUtils.nowEpochMilliseconds()
+        assertFalse(store.generationMatches("peer", 42L))
+
+        store.put("peer", exchange(now, generation = 42L))
+        assertTrue(store.generationMatches("peer", 42L))
+        assertFalse(store.generationMatches("peer", 43L))
+
+        // An EXPIRED entry still owns its refresh count, so its generation
+        // remains matchable until the release path removes it.
+        val store2 = PendingKeyExchangeStore()
+        store2.put("stale", exchange(now - 120_000L, generation = 42L))
+        assertTrue(store2.generationMatches("stale", 42L))
+    }
 
     @Test
     fun putReportsWhetherAPreviousEntryWasReplaced() {

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
@@ -86,6 +86,65 @@ class SyncDeviceManagerTest {
             assertEquals("My Device", capturedInfo.captured.noteName)
         }
 
+    // ========== cancelPairing ==========
+
+    @Test
+    fun cancelPairing_unverified_callsTrustV2Cancel() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+            coEvery { deps.syncClientApi.trustV2Cancel(any()) } returns SuccessResult(true)
+
+            manager.cancelPairing(syncRuntimeInfo)
+
+            coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(any()) }
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun cancelPairing_notUnverified_doesNothing() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createConnectedSyncRuntimeInfo()
+
+            manager.cancelPairing(syncRuntimeInfo)
+
+            coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any()) }
+        }
+
+    @Test
+    fun cancelPairing_noConnectHostAddress_doesNothing() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo =
+                createSyncRuntimeInfo(
+                    connectState = SyncState.UNVERIFIED,
+                    connectHostAddress = null,
+                )
+
+            manager.cancelPairing(syncRuntimeInfo)
+
+            coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any()) }
+        }
+
+    @Test
+    fun cancelPairing_failure_isBestEffortWithoutStateChange() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+            coEvery { deps.syncClientApi.trustV2Cancel(any()) } returns ConnectionRefused
+
+            manager.cancelPairing(syncRuntimeInfo)
+
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
     // ========== showToken ==========
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
@@ -3,7 +3,6 @@ package com.crosspaste.sync
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
-import com.crosspaste.dto.secure.KeyExchangeResponse
 import com.crosspaste.net.clientapi.ConnectionRefused
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
@@ -20,11 +19,13 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class SyncDeviceManagerTest {
 
     private class TestDeps {
+        val pendingExchangeLedger: PendingExchangeLedger = PendingExchangeLedger()
         val secureStore: SecureStore = mockk(relaxed = true)
         val syncClientApi: SyncClientApi = mockk(relaxed = true)
         val syncRuntimeInfoDao: SyncRuntimeInfoDao = mockk(relaxed = true)
@@ -33,6 +34,7 @@ class SyncDeviceManagerTest {
 
         fun createManager(): SyncDeviceManager =
             SyncDeviceManager(
+                pendingExchangeLedger = pendingExchangeLedger,
                 secureStore = secureStore,
                 syncClientApi = syncClientApi,
                 syncRuntimeInfoDao = syncRuntimeInfoDao,
@@ -98,8 +100,8 @@ class SyncDeviceManagerTest {
 
             coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns SuccessResult(true)
 
-            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, generation = 42L)
 
             coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(42L, any()) }
             coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
@@ -112,7 +114,7 @@ class SyncDeviceManagerTest {
             val manager = deps.createManager()
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
 
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+            manager.cancelPairing(syncRuntimeInfo, generation = 42L)
 
             coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any(), any()) }
         }
@@ -133,8 +135,8 @@ class SyncDeviceManagerTest {
 
             coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns SuccessResult(true)
 
-            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, generation = 42L)
 
             coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(42L, any()) }
         }
@@ -146,25 +148,27 @@ class SyncDeviceManagerTest {
             val manager = deps.createManager()
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
 
-            // The exchange was recorded AFTER the abandon instant (requestedAt=0):
-            // it belongs to a reopened dialog and must survive the stale cancel.
-            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = 0L)
+            // A reopened dialog's newer exchange replaced the ledger record:
+            // the stale cancel (generation 42) must consume nothing and the
+            // newer record must survive.
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, 43L)
+            manager.cancelPairing(syncRuntimeInfo, generation = 42L)
 
             coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any(), any()) }
+            assertEquals(43L, deps.pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId))
         }
 
     @Test
-    fun cancelPairing_afterClearPendingExchange_doesNothing() =
+    fun cancelPairing_afterLedgerClear_doesNothing() =
         runTest {
             val deps = TestDeps()
             val manager = deps.createManager()
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
 
             // A successful confirm clears the record — nothing left to cancel.
-            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
-            manager.clearPendingExchange(syncRuntimeInfo.appInstanceId)
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, 42L)
+            deps.pendingExchangeLedger.clear(syncRuntimeInfo.appInstanceId)
+            manager.cancelPairing(syncRuntimeInfo, generation = 42L)
 
             coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any(), any()) }
         }
@@ -178,15 +182,15 @@ class SyncDeviceManagerTest {
 
             coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns SuccessResult(true)
 
-            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, generation = 42L)
+            manager.cancelPairing(syncRuntimeInfo, generation = 42L)
 
             coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(any(), any()) }
         }
 
     @Test
-    fun cancelPairing_noConnectHostAddress_doesNothing() =
+    fun cancelPairing_noConnectHostAddress_keepsRecord() =
         runTest {
             val deps = TestDeps()
             val manager = deps.createManager()
@@ -196,10 +200,11 @@ class SyncDeviceManagerTest {
                     connectHostAddress = null,
                 )
 
-            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, generation = 42L)
 
             coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any(), any()) }
+            assertEquals(42L, deps.pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId))
         }
 
     @Test
@@ -211,33 +216,55 @@ class SyncDeviceManagerTest {
 
             coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns ConnectionRefused
 
-            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, generation = 42L)
 
             coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
         }
 
     @Test
-    fun exchangeKeysForPairing_success_recordsExchangeForCancel() =
+    fun exchangeKeysForPairing_recordsGenerationBeforeSending() =
         runTest {
             val deps = TestDeps()
             val manager = deps.createManager()
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
-            val response =
-                KeyExchangeResponse(
-                    signPublicKey = byteArrayOf(1),
-                    cryptPublicKey = byteArrayOf(2),
-                    timestamp = 42L,
-                    signature = byteArrayOf(3),
-                )
 
-            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns SuccessResult(response)
+            val sentGeneration = slot<Long>()
+            coEvery {
+                deps.syncClientApi.exchangeKeys(any(), capture(sentGeneration), any())
+            } returns SuccessResult(null)
+
+            manager.exchangeKeysForPairing(syncRuntimeInfo)
+
+            // The ledger holds exactly the generation that went out with the
+            // signed request, recorded before the response came back.
+            assertEquals(
+                sentGeneration.captured,
+                deps.pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId),
+            )
+        }
+
+    @Test
+    fun exchangeKeysForPairing_responseLost_recordStillEnablesCancel() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+            // The request may have landed on the responder even though we never
+            // saw the response: the pre-send record must survive the failure so
+            // an abandon can still release the responder's orphaned entry.
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any(), any()) } returns ConnectionRefused
             coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns SuccessResult(true)
 
             manager.exchangeKeysForPairing(syncRuntimeInfo)
-            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
 
-            coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(42L, any()) }
+            val generation = deps.pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId)
+            assertNotNull(generation)
+
+            manager.cancelPairing(syncRuntimeInfo, generation)
+
+            coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(generation, any()) }
         }
 
     // ========== showToken ==========

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
@@ -3,6 +3,7 @@ package com.crosspaste.sync
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
+import com.crosspaste.dto.secure.KeyExchangeResponse
 import com.crosspaste.net.clientapi.ConnectionRefused
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
@@ -89,30 +90,99 @@ class SyncDeviceManagerTest {
     // ========== cancelPairing ==========
 
     @Test
-    fun cancelPairing_unverified_callsTrustV2Cancel() =
+    fun cancelPairing_recordedExchange_sendsGenerationMatchedCancel() =
         runTest {
             val deps = TestDeps()
             val manager = deps.createManager()
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
 
-            coEvery { deps.syncClientApi.trustV2Cancel(any()) } returns SuccessResult(true)
+            coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns SuccessResult(true)
 
-            manager.cancelPairing(syncRuntimeInfo)
+            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
 
-            coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(any()) }
+            coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(42L, any()) }
             coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
         }
 
     @Test
-    fun cancelPairing_notUnverified_doesNothing() =
+    fun cancelPairing_noRecordedExchange_doesNothing() =
         runTest {
             val deps = TestDeps()
             val manager = deps.createManager()
-            val syncRuntimeInfo = createConnectedSyncRuntimeInfo()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
 
-            manager.cancelPairing(syncRuntimeInfo)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
 
-            coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any()) }
+            coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any(), any()) }
+        }
+
+    @Test
+    fun cancelPairing_disconnectedPeerWithRecord_stillSends() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            // The exchange request may have landed while its response was lost:
+            // the peer drops to DISCONNECTED but the responder-side entry still
+            // exists, so ownership — not connect state — gates the cancel.
+            val syncRuntimeInfo =
+                createSyncRuntimeInfo(
+                    connectState = SyncState.DISCONNECTED,
+                    connectHostAddress = "192.168.1.100",
+                )
+
+            coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns SuccessResult(true)
+
+            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+
+            coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(42L, any()) }
+        }
+
+    @Test
+    fun cancelPairing_supersededByNewerExchange_skips() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+            // The exchange was recorded AFTER the abandon instant (requestedAt=0):
+            // it belongs to a reopened dialog and must survive the stale cancel.
+            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = 0L)
+
+            coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any(), any()) }
+        }
+
+    @Test
+    fun cancelPairing_afterClearPendingExchange_doesNothing() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+            // A successful confirm clears the record — nothing left to cancel.
+            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
+            manager.clearPendingExchange(syncRuntimeInfo.appInstanceId)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+
+            coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any(), any()) }
+        }
+
+    @Test
+    fun cancelPairing_consumesRecordOnSend() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+            coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns SuccessResult(true)
+
+            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+
+            coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(any(), any()) }
         }
 
     @Test
@@ -126,9 +196,10 @@ class SyncDeviceManagerTest {
                     connectHostAddress = null,
                 )
 
-            manager.cancelPairing(syncRuntimeInfo)
+            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
 
-            coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any()) }
+            coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any(), any()) }
         }
 
     @Test
@@ -138,11 +209,35 @@ class SyncDeviceManagerTest {
             val manager = deps.createManager()
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
 
-            coEvery { deps.syncClientApi.trustV2Cancel(any()) } returns ConnectionRefused
+            coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns ConnectionRefused
 
-            manager.cancelPairing(syncRuntimeInfo)
+            manager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, 42L)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
 
             coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun exchangeKeysForPairing_success_recordsExchangeForCancel() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val response =
+                KeyExchangeResponse(
+                    signPublicKey = byteArrayOf(1),
+                    cryptPublicKey = byteArrayOf(2),
+                    timestamp = 42L,
+                    signature = byteArrayOf(3),
+                )
+
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns SuccessResult(response)
+            coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns SuccessResult(true)
+
+            manager.exchangeKeysForPairing(syncRuntimeInfo)
+            manager.cancelPairing(syncRuntimeInfo, requestedAt = Long.MAX_VALUE)
+
+            coVerify(exactly = 1) { deps.syncClientApi.trustV2Cancel(42L, any()) }
         }
 
     // ========== showToken ==========

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -1311,6 +1311,10 @@ class SyncResolverTest {
             assertEquals(SyncState.CONNECTED, capturedInfo.captured.connectState)
             coVerify { deps.syncClientApi.trustV2Confirm(syncRuntimeInfo.appInstanceId, any(), any()) }
             coVerify { deps.secureStore.saveCryptPublicKey(syncRuntimeInfo.appInstanceId, remoteKey) }
+            // The confirm consumed the responder's exchange: the tracked record
+            // must be cleared so a later dialog dismissal cancels nothing.
+            verify { deps.syncDeviceManager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, response.timestamp) }
+            verify { deps.syncDeviceManager.clearPendingExchange(syncRuntimeInfo.appInstanceId) }
             verify { deps.ratingPromptManager.trackSignificantAction() }
         }
 
@@ -1341,6 +1345,10 @@ class SyncResolverTest {
             assertEquals(false, callbackResult)
             coVerify(exactly = 0) { deps.syncClientApi.trustV2Confirm(any(), any(), any()) }
             coVerify(exactly = 0) { deps.secureStore.saveCryptPublicKey(any(), any()) }
+            // The mismatched exchange still exists on the responder: keep its
+            // record so abandoning the dialog can cancel it.
+            verify { deps.syncDeviceManager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, any()) }
+            verify(exactly = 0) { deps.syncDeviceManager.clearPendingExchange(any()) }
         }
 
     @Test
@@ -1400,9 +1408,9 @@ class SyncResolverTest {
 
             deps.stubDbRead(syncRuntimeInfo)
 
-            resolver.emitEvent(SyncEvent.CancelPairing(syncRuntimeInfo))
+            resolver.emitEvent(SyncEvent.CancelPairing(syncRuntimeInfo, requestedAt = 123L))
 
-            coVerify(exactly = 1) { deps.syncDeviceManager.cancelPairing(syncRuntimeInfo) }
+            coVerify(exactly = 1) { deps.syncDeviceManager.cancelPairing(syncRuntimeInfo, 123L) }
         }
 
     // ========== G. Event dispatch and callback ==========

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -62,6 +62,7 @@ class SyncResolverTest {
                 every { getCurrentUseNetworkInterfaces() } returns
                     listOf(NetworkInterfaceInfo("en0", 24, "192.168.1.2"))
             }
+        val pendingExchangeLedger: PendingExchangeLedger = PendingExchangeLedger()
         val ratingPromptManager: RatingPromptManager = mockk(relaxed = true)
         val secureKeyPairSerializer: com.crosspaste.secure.SecureKeyPairSerializer = mockk(relaxed = true)
         val secureStore: SecureStore = mockk(relaxed = true)
@@ -92,6 +93,7 @@ class SyncResolverTest {
                 localPlatform = localPlatform,
                 lazyPasteBonjourService = lazy { pasteBonjourService },
                 networkInterfaceService = networkInterfaceService,
+                pendingExchangeLedger = pendingExchangeLedger,
                 ratingPromptManager = ratingPromptManager,
                 secureKeyPairSerializer = secureKeyPairSerializer,
                 secureStore = secureStore,
@@ -1293,7 +1295,7 @@ class SyncResolverTest {
             deps.stubDbRead(syncRuntimeInfo)
             every { deps.secureStore.secureKeyPair } returns secureKeyPair
             coEvery { secureKeyPair.getCryptPublicKeyBytes(any()) } returns localKey
-            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns SuccessResult(response)
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any(), any()) } returns SuccessResult(response)
             coEvery { deps.syncClientApi.trustV2Confirm(any(), any(), any()) } returns SuccessResult(true)
             coEvery { deps.syncInfoFactory.createSyncInfo(any()) } returns SyncTestFixtures.createSyncInfo()
             coEvery { deps.syncClientApi.heartbeat(any(), any(), any()) } returns
@@ -1311,10 +1313,9 @@ class SyncResolverTest {
             assertEquals(SyncState.CONNECTED, capturedInfo.captured.connectState)
             coVerify { deps.syncClientApi.trustV2Confirm(syncRuntimeInfo.appInstanceId, any(), any()) }
             coVerify { deps.secureStore.saveCryptPublicKey(syncRuntimeInfo.appInstanceId, remoteKey) }
-            // The confirm consumed the responder's exchange: the tracked record
+            // The confirm consumed the responder's exchange: the ledger record
             // must be cleared so a later dialog dismissal cancels nothing.
-            verify { deps.syncDeviceManager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, response.timestamp) }
-            verify { deps.syncDeviceManager.clearPendingExchange(syncRuntimeInfo.appInstanceId) }
+            assertNull(deps.pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId))
             verify { deps.ratingPromptManager.trackSignificantAction() }
         }
 
@@ -1332,7 +1333,7 @@ class SyncResolverTest {
             deps.stubDbRead(syncRuntimeInfo)
             every { deps.secureStore.secureKeyPair } returns secureKeyPair
             coEvery { secureKeyPair.getCryptPublicKeyBytes(any()) } returns localKey
-            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any(), any()) } returns
                 SuccessResult(createKeyExchangeResponse(remoteKey))
 
             var callbackResult: Boolean? = null
@@ -1346,9 +1347,8 @@ class SyncResolverTest {
             coVerify(exactly = 0) { deps.syncClientApi.trustV2Confirm(any(), any(), any()) }
             coVerify(exactly = 0) { deps.secureStore.saveCryptPublicKey(any(), any()) }
             // The mismatched exchange still exists on the responder: keep its
-            // record so abandoning the dialog can cancel it.
-            verify { deps.syncDeviceManager.rememberPendingExchange(syncRuntimeInfo.appInstanceId, any()) }
-            verify(exactly = 0) { deps.syncDeviceManager.clearPendingExchange(any()) }
+            // ledger record so abandoning the dialog can cancel it.
+            assertNotNull(deps.pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId))
         }
 
     @Test
@@ -1359,7 +1359,7 @@ class SyncResolverTest {
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
 
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any(), any()) } returns
                 FailureResult(PasteException(StandardErrorCode.EXCHANGE_FAIL.toErrorCode(), "exchange failed"))
 
             var callbackResult: Boolean? = null
@@ -1385,7 +1385,7 @@ class SyncResolverTest {
             deps.stubDbRead(syncRuntimeInfo)
             every { deps.secureStore.secureKeyPair } returns secureKeyPair
             coEvery { secureKeyPair.getCryptPublicKeyBytes(any()) } returns localKey
-            coEvery { deps.syncClientApi.exchangeKeys(any(), any()) } returns
+            coEvery { deps.syncClientApi.exchangeKeys(any(), any(), any()) } returns
                 SuccessResult(createKeyExchangeResponse(remoteKey))
             coEvery { deps.syncClientApi.trustV2Confirm(any(), any(), any()) } returns
                 FailureResult(PasteException(StandardErrorCode.TRUST_FAIL.toErrorCode(), "confirm failed"))
@@ -1408,7 +1408,7 @@ class SyncResolverTest {
 
             deps.stubDbRead(syncRuntimeInfo)
 
-            resolver.emitEvent(SyncEvent.CancelPairing(syncRuntimeInfo, requestedAt = 123L))
+            resolver.emitEvent(SyncEvent.CancelPairing(syncRuntimeInfo, generation = 123L))
 
             coVerify(exactly = 1) { deps.syncDeviceManager.cancelPairing(syncRuntimeInfo, 123L) }
         }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -1391,6 +1391,20 @@ class SyncResolverTest {
             coVerify(exactly = 0) { deps.secureStore.saveCryptPublicKey(any(), any()) }
         }
 
+    @Test
+    fun cancelPairing_dispatchesToSyncDeviceManager() =
+        runTest {
+            val deps = TestDeps()
+            val resolver = deps.createResolver()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+
+            deps.stubDbRead(syncRuntimeInfo)
+
+            resolver.emitEvent(SyncEvent.CancelPairing(syncRuntimeInfo))
+
+            coVerify(exactly = 1) { deps.syncDeviceManager.cancelPairing(syncRuntimeInfo) }
+        }
+
     // ========== G. Event dispatch and callback ==========
 
     @Test

--- a/web/src/background/service-worker.ts
+++ b/web/src/background/service-worker.ts
@@ -125,8 +125,9 @@ interface ConnectingAttempt {
    * The warm-up key-exchange response (pairingMode 2 only). Reused at confirm
    * time so each pairing performs exactly ONE exchange — the desktop's token
    * refresh is counted per exchange and released once per confirm.
+   * `requestTimestamp` is the generation marker for a targeted cancel.
    */
-  v2Exchange?: KeyExchangeResponse;
+  v2Exchange?: KeyExchangeResponse & { requestTimestamp: number };
   /**
    * True while the trust round-trip that makes the DESKTOP persist keys is in
    * flight (v1 trust / v2 confirm / v3 commit). Cancelling in this window
@@ -762,7 +763,7 @@ async function beginPairing(
   const pairingMode = selectPairingMode(syncInfo.appInfo.pairingVersion);
 
   let v3: PairingV3Initiator | undefined;
-  let v2Exchange: KeyExchangeResponse | undefined;
+  let v2Exchange: (KeyExchangeResponse & { requestTimestamp: number }) | undefined;
   if (pairingMode === 3) {
     v3 = await startV3Session(appInstanceId, targetAppInstanceId, config);
     // The desktop is now showing this session's PIN card.
@@ -881,11 +882,14 @@ async function releaseAttempt(attempt: ConnectingAttempt): Promise<void> {
       v3.destroy();
     }
   }
-  if (attempt.v2Exchange) {
+  const v2Exchange = attempt.v2Exchange;
+  if (v2Exchange) {
     attempt.v2Exchange = undefined;
-    // Release the desktop's pending exchange (refresh count + SAS overlay).
-    // Desktops predating the cancel route just fail; nothing else to do.
-    await SyncApi.cancelV2(config).catch(() => {});
+    // Release the desktop's pending exchange (refresh count + SAS overlay),
+    // naming its generation so a cancel that arrives after a newer exchange
+    // (fast reconnect) releases nothing. Desktops predating the cancel route
+    // just fail; ones predating the header ignore it.
+    await SyncApi.cancelV2(config, v2Exchange.requestTimestamp).catch(() => {});
   }
 }
 

--- a/web/src/shared/api/__tests__/sync-v2v3.test.ts
+++ b/web/src/shared/api/__tests__/sync-v2v3.test.ts
@@ -118,6 +118,10 @@ describe("SyncApi.exchangeV2", () => {
     expect(typeof sent.signPublicKey).toBe("string");
     expect(typeof sent.signature).toBe("string");
     expect(typeof sent.timestamp).toBe("number");
+
+    // The generation marker surfaced to the caller IS the signed request
+    // timestamp — the value a targeted cancelV2 must echo.
+    expect(result.requestTimestamp).toBe(sent.timestamp);
   });
 
   it("rejects a tampered exchange response", async () => {
@@ -129,6 +133,30 @@ describe("SyncApi.exchangeV2", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(jsonResponse(responseBody)));
 
     await expect(SyncApi.exchangeV2(CONFIG)).rejects.toThrow(/verification/);
+  });
+});
+
+describe("SyncApi.cancelV2", () => {
+  it("sends the exchange generation header when provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(""));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await SyncApi.cancelV2(CONFIG, 1234567890);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://192.168.1.10:13129/sync/trust/v2/cancel");
+    expect(init.method).toBe("POST");
+    expect(init.headers["crosspaste-exchange-timestamp"]).toBe("1234567890");
+  });
+
+  it("omits the generation header when not provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(""));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await SyncApi.cancelV2(CONFIG);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers["crosspaste-exchange-timestamp"]).toBeUndefined();
   });
 });
 

--- a/web/src/shared/api/sync.ts
+++ b/web/src/shared/api/sync.ts
@@ -96,30 +96,33 @@ export const SyncApi = {
    * v2 SAS pairing, step 1 — POST /sync/trust/v2/exchange.
    * Sends our signed public keys; the desktop computes and DISPLAYS the SAS.
    * Returns the desktop's verified key-exchange response, or throws when the
-   * response signature/keys don't verify.
+   * response signature/keys don't verify. `requestTimestamp` is our signed
+   * request timestamp — the generation marker the desktop stores with the
+   * pending exchange; pass it to [cancelV2] so only THIS exchange is released.
    */
   async exchangeV2(config: {
     host: string;
     port: number;
     appInstanceId: string;
     targetAppInstanceId: string;
-  }): Promise<KeyExchangeResponse> {
+  }): Promise<KeyExchangeResponse & { requestTimestamp: number }> {
     const keys = await ensureKeys();
     const requestJson = await CrossPasteCrypto.buildKeyExchangeRequest(
       toInt8Array(keys.signPrivateKey),
       toInt8Array(keys.signPublicKey),
       toInt8Array(keys.cryptPublicKey),
     );
+    const request = JSON.parse(requestJson) as { timestamp: number };
     const response = await apiPost<KeyExchangeResponse>(
       toRequestConfig(config),
       "/sync/trust/v2/exchange",
-      JSON.parse(requestJson),
+      request,
     );
     const valid = await CrossPasteCrypto.verifyKeyExchangeResponse(JSON.stringify(response));
     if (!valid) {
       throw new Error("Key exchange response failed verification");
     }
-    return response;
+    return { ...response, requestTimestamp: request.timestamp };
   },
 
   /**
@@ -175,15 +178,26 @@ export const SyncApi = {
   /**
    * Release our pending v2 exchange on the desktop (dialog closed before
    * confirm) — POST /sync/trust/v2/cancel. Idempotent; desktops older than
-   * this route simply fail and the caller swallows it.
+   * this route simply fail and the caller swallows it. `exchangeGeneration`
+   * is [exchangeV2]'s requestTimestamp: desktops that understand the header
+   * release only that exact exchange, so a cancel delayed past a newer
+   * exchange (fast reconnect) can never tear the newer one down. Older
+   * desktops ignore the header and keep unconditional-release semantics.
    */
-  async cancelV2(config: {
-    host: string;
-    port: number;
-    appInstanceId: string;
-    targetAppInstanceId: string;
-  }): Promise<void> {
-    await apiPost<unknown>(toRequestConfig(config), "/sync/trust/v2/cancel");
+  async cancelV2(
+    config: {
+      host: string;
+      port: number;
+      appInstanceId: string;
+      targetAppInstanceId: string;
+    },
+    exchangeGeneration?: number,
+  ): Promise<void> {
+    const extraHeaders =
+      exchangeGeneration === undefined
+        ? undefined
+        : { "crosspaste-exchange-timestamp": String(exchangeGeneration) };
+    await apiPost<unknown>(toRequestConfig(config), "/sync/trust/v2/cancel", undefined, extraHeaders);
   },
 
   /**


### PR DESCRIPTION
Closes #4684 (remaining items after the counter-balancing fix that shipped inside #4683).

## Problem

Two leftovers from #4684:

1. **Abandoned exchange parked one refresh count.** The v2 SAS initiator's trust dialog fires a warm-up key exchange on open, which parks one token-refresh count and one pending verifier on the responder. The release endpoint `POST /sync/trust/v2/cancel` already existed (added in #4683 for the browser extension), but the desktop initiator never called it — dismissing the dialog without confirming left the responder's SAS overlay up until closed manually.
2. **`TokenView`'s `allResolved` auto-close.** Its success path is dead (the confirm handler removes the pending verifier server-side before the UI can observe resolution), and the surviving offline-reap path released only a single refresh count no matter how many verifiers it reaped — hiding the overlay while the 300 ms refresh loop kept running in the background.

## Changes

**Generation-exact cancellation (client-generated, recorded before sending).**
- New `PendingExchangeLedger`: for every v2 exchange we initiate (the dialog warm-up in `SyncDeviceManager` and the confirm-time exchange in `SyncResolver.trustBySasCode`), the initiator generates a strictly monotonic generation — unique even within one millisecond or across a wall-clock rollback — and records it BEFORE the request goes out, so a lost response still leaves us the marker needed to cancel the responder's orphaned entry. The generation travels as the signed `KeyExchangeRequest.timestamp`; the responder stores it with the pending entry (`PendingKeyExchange.generation`, separate from the server-clock TTL timestamp).
- A cancel echoes the generation in a `crosspaste-exchange-timestamp` header; the server — inside the per-peer pairing lock — releases only an exactly matching entry. Header-less cancels (older clients) keep unconditional-release semantics.
- Initiator-side supersede safety without wall-clock comparison: `SyncManager.cancelPairing` captures the ledger's current generation synchronously at the abandon instant (Compose disposes the old dialog before a reopened one fires its warm-up), and `SyncDeviceManager.cancelPairing` consumes the record only while it still holds that exact generation. Sending is gated by ownership plus a host address — not connect state — so a DISCONNECTED peer with a live record is still cancelled; a successful confirm clears the record and no request is made.
- The browser extension now passes its exchange's request timestamp to `cancelV2`, so the extension path gets the same protection on fast reconnects.

**Serialized token-refresh accounting.**
- `AppTokenService` now runs every state mutation (verifier set, refresh counter, overlay visibility, SAS mode) on a single consumer command queue; callers enqueue synchronously, so each caller's sequence executes in order. The previous mix of synchronous `StateFlow` writes and independent `scope.launch` counter updates could process a release before the `startRefresh` that funded it, permanently orphaning a count into a forever-running refresh loop.
- New `AppTokenApi.releaseVerifier(appInstanceId, hideToken)` decrements the counter only when the verifier was actually still pending. All release sites converge on it (server's `releasePendingKeyExchange`, v1 `/sync/trust` confirm, `TokenView` offline reap and manual close); no caller hand-composes `removePendingVerifier` + `stopRefresh` anymore.

## Tests

- `PendingExchangeLedgerTest`: strict monotonicity (10k same-ms calls), record/current/clear, consume-only-matching.
- `SyncDeviceManagerTest`: generation-matched send; ownership gating (no record / cleared / superseded / consumed-on-send / no-host keeps record); DISCONNECTED-with-record still sends; **response-lost: the pre-send record survives a failed exchange and still enables a targeted cancel**; the sent generation equals the recorded one.
- `SyncResolverTest`: `CancelPairing` dispatch; `trustBySasCode` clears the ledger on success and keeps it on SAS mismatch.
- `SyncTest` (end-to-end): cancel releases count + verifier and a late confirm fails; a stale-generation cancel does not release a newer exchange while the current generation's does; a header-less cancel keeps legacy semantics.
- `AppTokenServiceTest`: one count released per pending verifier; double/unknown release is a no-op; **a release enqueued immediately after acquire (before the increment was ever observable) cannot orphan the count**; `hideToken` hides the overlay without touching counts owned by others.
- Web (`sync-v2v3.test.ts`): `exchangeV2` surfaces the signed request timestamp as the generation; `cancelV2` sends the header when given and omits it otherwise.
- Full `app:desktopTest` (Kotlin) and vitest (web, 100 tests) suites pass; `tsc --noEmit` clean.

## Notes

- The residual unreachable case is now only "the exchange request itself never observably started" (dialog closed while the warm-up event was still queued): no record exists yet, the cancel skips, and the responder's entry self-heals when a later exchange from the same peer replaces it.
- The equivalent v1 QR (`QR_BEARER_TOKEN`) abandonment leak is pre-existing and out of scope; the v1 flow is on its way out.