### PR TITLE
:bug: allocate v2 exchange generations before async dispatch and make verifier acquisition atomic

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenApi.kt
@@ -22,19 +22,23 @@ interface AppTokenApi {
 
     fun stopRefresh(hideToken: Boolean)
 
-    fun addPendingVerifier(appInstanceId: String)
-
-    fun removePendingVerifier(appInstanceId: String)
+    /**
+     * Atomically registers [appInstanceId] as a verifier owner and starts one
+     * refresh count. Repeated acquisition by the same verifier only reopens the
+     * overlay; it never increments the count twice.
+     */
+    fun acquireVerifier(
+        appInstanceId: String,
+        showToken: Boolean = true,
+    )
 
     /**
      * Atomically releases the token-refresh count owned by [appInstanceId]'s
      * pending-verifier entry: the count is decremented ONLY when the verifier
      * was still pending, so the unified server release path and the UI reap can
      * both call this without double-decrementing (a second decrement would
-     * steal a count held by another concurrently pairing device). This is the
-     * single release primitive — callers must not hand-compose
-     * [removePendingVerifier] with [stopRefresh]. [hideToken] additionally
-     * hides the token overlay (user-facing dismissal).
+     * steal a count held by another concurrently pairing device). [hideToken]
+     * additionally hides the token overlay (user-facing dismissal).
      */
     fun releaseVerifier(
         appInstanceId: String,

--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
@@ -129,13 +129,16 @@ abstract class AppTokenService : AppTokenApi {
         submit {
             val isNewVerifier = appInstanceId !in _pendingVerifiers.value
             _pendingVerifiers.value += appInstanceId
-            if (showToken) {
-                _showToken.value = true
-                preShowToken()
-            }
+            // Fund the refresh count before the overlay callback: preShowToken
+            // is platform code that may throw, and a registered verifier whose
+            // count was never taken would later release someone else's.
             if (isNewVerifier) {
                 _refresh.value = true
                 refreshCounter += 1
+            }
+            if (showToken) {
+                _showToken.value = true
+                preShowToken()
             }
         }
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/AppTokenService.kt
@@ -2,6 +2,7 @@ package com.crosspaste.app
 
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,15 +16,13 @@ import kotlin.time.Duration.Companion.milliseconds
 
 abstract class AppTokenService : AppTokenApi {
 
+    private val logger = KotlinLogging.logger {}
+
     private val scope = namedScope(ioDispatcher, "AppTokenService")
 
     // Every state mutation (verifier set, refresh counter, overlay visibility,
-    // SAS mode) runs on ONE consumer coroutine in submission order. Callers
-    // enqueue synchronously (trySend on an UNLIMITED channel never fails), so
-    // each caller's own call sequence is executed in that order — a verifier
-    // release can never be processed before the startRefresh that funded it,
-    // which is what previously allowed an orphaned count to keep the refresh
-    // loop alive forever (#4684 / #4690 review).
+    // SAS mode) runs on one consumer coroutine in submission order. Verifier
+    // acquire/release commands update ownership and its counter together.
     private val commands = Channel<() -> Unit>(Channel.UNLIMITED)
 
     private val _refreshProgress = MutableStateFlow(0f)
@@ -56,7 +55,9 @@ abstract class AppTokenService : AppTokenApi {
     init {
         scope.launch {
             for (command in commands) {
-                command()
+                runCatching(command).onFailure { e ->
+                    logger.error(e) { "App token command failed" }
+                }
             }
         }
         scope.launch {
@@ -82,7 +83,9 @@ abstract class AppTokenService : AppTokenApi {
     abstract fun preShowPairingCode()
 
     private fun submit(command: () -> Unit) {
-        commands.trySend(command)
+        if (commands.trySend(command).isFailure) {
+            logger.warn { "App token command rejected" }
+        }
     }
 
     override fun sameToken(token: Int): Boolean =
@@ -119,6 +122,24 @@ abstract class AppTokenService : AppTokenApi {
         }
     }
 
+    override fun acquireVerifier(
+        appInstanceId: String,
+        showToken: Boolean,
+    ) {
+        submit {
+            val isNewVerifier = appInstanceId !in _pendingVerifiers.value
+            _pendingVerifiers.value += appInstanceId
+            if (showToken) {
+                _showToken.value = true
+                preShowToken()
+            }
+            if (isNewVerifier) {
+                _refresh.value = true
+                refreshCounter += 1
+            }
+        }
+    }
+
     override fun releaseVerifier(
         appInstanceId: String,
         hideToken: Boolean,
@@ -135,18 +156,6 @@ abstract class AppTokenService : AppTokenApi {
             if (hadVerifier) {
                 decrementRefresh()
             }
-        }
-    }
-
-    override fun addPendingVerifier(appInstanceId: String) {
-        submit {
-            _pendingVerifiers.value += appInstanceId
-        }
-    }
-
-    override fun removePendingVerifier(appInstanceId: String) {
-        submit {
-            _pendingVerifiers.value -= appInstanceId
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -133,9 +133,10 @@ fun Routing.syncRouting(
         val appInstanceId = call.request.headers["appInstanceId"]
         val host = call.request.host()
         if (appInstanceId != null) {
-            appTokenApi.addPendingVerifier(appInstanceId)
+            appTokenApi.acquireVerifier(appInstanceId)
+        } else {
+            appTokenApi.startRefresh(showToken = true)
         }
-        appTokenApi.startRefresh(showToken = true)
         logger.info { "show token requested from $host" }
         successResponse(call)
     }
@@ -321,8 +322,7 @@ fun Routing.syncRouting(
                     )
 
                     appTokenApi.setSASToken(sas)
-                    appTokenApi.addPendingVerifier(appInstanceId)
-                    appTokenApi.startRefresh(showToken = true)
+                    appTokenApi.acquireVerifier(appInstanceId)
 
                     val signature =
                         CryptographyUtils.signKeyExchangeResponse(
@@ -430,8 +430,8 @@ fun Routing.syncRouting(
     // entry is a no-op. When the caller echoes the exchange timestamp it
     // received (generation marker), only that exact exchange is released — a
     // cancel delayed past a newer exchange from the same peer must not tear
-    // down the newer one. Callers without the header (older clients, the
-    // browser extension) keep the original unconditional-release semantics.
+    // down the newer one. Callers without the header (older extension versions)
+    // keep the original unconditional-release semantics.
     post("/sync/trust/v2/cancel") {
         getAppInstanceId(call)?.let { appInstanceId ->
             pairingVersionCoordinator.withPeerLock(appInstanceId) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -217,8 +217,8 @@ class GeneralSyncHandler(
         emitEvent(SyncEvent.TrustBySasCode(currentSyncRuntimeInfo, code, callback))
     }
 
-    override suspend fun exchangeKeysForPairing() {
-        emitEvent(SyncEvent.ExchangeKeysForPairing(currentSyncRuntimeInfo))
+    override suspend fun exchangeKeysForPairing(generation: Long) {
+        emitEvent(SyncEvent.ExchangeKeysForPairing(currentSyncRuntimeInfo, generation))
     }
 
     override suspend fun cancelPairing(generation: Long) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -325,6 +325,20 @@ class GeneralSyncManager(
         } ?: callback(false)
     }
 
+    override fun exchangeKeysForPairing(appInstanceId: String) {
+        internalSyncHandlers[appInstanceId]?.let { syncHandler ->
+            // Allocate before launching or entering the event channel. A dialog
+            // disposed while the resolver is busy can now capture this exact
+            // generation, and a cancel processed first prevents the queued
+            // exchange from being sent.
+            val generation = pendingExchangeLedger.nextGeneration()
+            pendingExchangeLedger.record(appInstanceId, generation)
+            realTimeSyncScope.launch {
+                syncHandler.exchangeKeysForPairing(generation)
+            }
+        }
+    }
+
     override fun cancelPairing(appInstanceId: String) {
         // Capture the generation of the exchange the closing dialog owns,
         // synchronously: Compose disposes the old dialog before a reopened one

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
@@ -47,7 +47,7 @@ class MarketingSyncHandler(
     ) {
     }
 
-    override suspend fun exchangeKeysForPairing() {
+    override suspend fun exchangeKeysForPairing(generation: Long) {
     }
 
     override suspend fun cancelPairing(generation: Long) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncManager.kt
@@ -121,6 +121,9 @@ class MarketingSyncManager : SyncManager {
     ) {
     }
 
+    override fun exchangeKeysForPairing(appInstanceId: String) {
+    }
+
     override fun cancelPairing(appInstanceId: String) {
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PendingExchangeLedger.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PendingExchangeLedger.kt
@@ -1,8 +1,8 @@
 package com.crosspaste.sync
 
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
-import io.ktor.util.collections.ConcurrentMap
 import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
 import kotlinx.atomicfu.updateAndGet
 
 /**
@@ -22,7 +22,7 @@ class PendingExchangeLedger {
 
     private val lastGeneration = atomic(0L)
 
-    private val generations: MutableMap<String, Long> = ConcurrentMap()
+    private val generations = atomic<Map<String, Long>>(emptyMap())
 
     /**
      * Strictly monotonic and unique within this process, while still being a
@@ -37,29 +37,30 @@ class PendingExchangeLedger {
         appInstanceId: String,
         generation: Long,
     ) {
-        generations[appInstanceId] = generation
+        generations.update { current ->
+            current + (appInstanceId to generation)
+        }
     }
 
     /** The generation of the exchange we currently own for the peer, if any. */
-    fun current(appInstanceId: String): Long? = generations[appInstanceId]
-
-    /** Drops the peer's record (a successful confirm consumed the exchange). */
-    fun clear(appInstanceId: String) {
-        generations.remove(appInstanceId)
-    }
+    fun current(appInstanceId: String): Long? = generations.value[appInstanceId]
 
     /**
      * Removes the peer's record ONLY while it still is [generation]. A stale
      * cancel whose dialog was superseded by a newer exchange consumes nothing.
-     * Mutations for one peer are serialized by the resolver's per-peer mutex,
-     * so the check-then-remove needs no extra atomicity.
+     * The compare-and-set also protects against synchronous manager-side
+     * records racing resolver-side cancel or confirm handling.
      */
     fun consume(
         appInstanceId: String,
         generation: Long,
     ): Boolean {
-        if (generations[appInstanceId] != generation) return false
-        generations.remove(appInstanceId)
-        return true
+        while (true) {
+            val current = generations.value
+            if (current[appInstanceId] != generation) return false
+            if (generations.compareAndSet(current, current - appInstanceId)) {
+                return true
+            }
+        }
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
@@ -45,15 +45,23 @@ class SyncDeviceManager(
         syncRuntimeInfoDao.updateNoteName(syncRuntimeInfo.copy(noteName = noteName))
     }
 
-    suspend fun exchangeKeysForPairing(syncRuntimeInfo: SyncRuntimeInfo) {
+    suspend fun exchangeKeysForPairing(
+        syncRuntimeInfo: SyncRuntimeInfo,
+        generation: Long,
+    ) {
         if (syncRuntimeInfo.connectState == SyncState.UNVERIFIED) {
             syncRuntimeInfo.connectHostAddress?.let { host ->
+                // The dialog may have been dismissed while this event waited in
+                // the resolver queue. Its cancel consumes the ledger entry, so
+                // a late warm-up must not create a new responder-side exchange.
+                if (pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId) != generation) {
+                    logger.info {
+                        "exchangeKeysForPairing skipped for ${syncRuntimeInfo.appInstanceId} " +
+                            "(exchange cancelled or superseded)"
+                    }
+                    return
+                }
                 val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
-                // Record the generation BEFORE sending: if the request lands
-                // but the response is lost, we still hold the marker needed to
-                // cancel the responder's orphaned entry.
-                val generation = pendingExchangeLedger.nextGeneration()
-                pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, generation)
                 val result =
                     syncClientApi.exchangeKeys(syncRuntimeInfo.appInstanceId, generation) {
                         buildUrl(hostAndPort)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -69,6 +69,7 @@ sealed interface SyncEvent {
 
     data class ExchangeKeysForPairing(
         override val syncRuntimeInfo: SyncRuntimeInfo,
+        val generation: Long,
     ) : SyncRunTimeInfoEvent {
         override fun toString(): String = "ExchangeKeysForPairing ${syncRuntimeInfo.appInstanceId}"
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
@@ -60,7 +60,7 @@ interface SyncHandler {
         callback: (Boolean) -> Unit,
     )
 
-    suspend fun exchangeKeysForPairing()
+    suspend fun exchangeKeysForPairing(generation: Long)
 
     // Release the pending v2 exchange we started on the peer when pairing is
     // abandoned before confirm (POST /sync/trust/v2/cancel, best-effort).

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncManager.kt
@@ -58,6 +58,10 @@ interface SyncManager : SyncRoutingApi {
         callback: (Boolean) -> Unit,
     )
 
+    // Starts the v2 warm-up exchange for the pairing dialog. The implementation
+    // records its generation before crossing an asynchronous event boundary.
+    fun exchangeKeysForPairing(appInstanceId: String)
+
     // Best-effort release of the pending v2 exchange on the peer when the user
     // abandons pairing before confirm. Routes to POST /sync/trust/v2/cancel.
     fun cancelPairing(appInstanceId: String)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -120,7 +120,7 @@ class SyncResolver(
                     }
 
                     is SyncEvent.ExchangeKeysForPairing -> {
-                        syncDeviceManager.exchangeKeysForPairing(syncRuntimeInfo)
+                        syncDeviceManager.exchangeKeysForPairing(syncRuntimeInfo, event.generation)
                     }
 
                     is SyncEvent.CancelPairing -> {
@@ -758,7 +758,7 @@ class SyncResolver(
 
             // Step 4: Save remote key locally and send heartbeat. The confirm
             // consumed the responder's pending exchange — nothing left to cancel.
-            pendingExchangeLedger.clear(appInstanceId)
+            pendingExchangeLedger.consume(appInstanceId, generation)
             secureStore.saveCryptPublicKey(appInstanceId, response.cryptPublicKey)
 
             advertiseAddressViaHeartbeat(host, port, appInstanceId)

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -145,8 +145,11 @@ fun DeviceScope.TrustDeviceDialog() {
     // it names the exact exchange this dialog owns (skipped after a successful
     // confirm consumes it, or when a reopened dialog's newer exchange
     // supersedes it). The generation is recorded before asynchronous dispatch;
-    // if dismissal wins the race, the queued warm-up observes the consumed
-    // generation and sends no request.
+    // if dismissal wins the local race, the queued warm-up observes the
+    // consumed generation and sends no request. On the wire the release stays
+    // best effort: warm-up and cancel travel as independent requests, so a
+    // cancel arriving before its exchange is a responder-side no-op and the
+    // leftover entry self-heals on the next exchange.
     DisposableEffect(appInstanceId, pairingCredentialType) {
         onDispose {
             if (pairingCredentialType == PairingCredentialType.SAS_CODE) {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -130,7 +130,7 @@ fun DeviceScope.TrustDeviceDialog() {
     LaunchedEffect(appInstanceId, pairingCredentialType) {
         val handler = syncManager.getSyncHandlers()[appInstanceId]
         when (pairingCredentialType) {
-            PairingCredentialType.SAS_CODE -> handler?.exchangeKeysForPairing()
+            PairingCredentialType.SAS_CODE -> syncManager.exchangeKeysForPairing(appInstanceId)
             PairingCredentialType.QR_BEARER_TOKEN -> handler?.showToken()
             PairingCredentialType.V3_PIN -> Unit
             null -> Unit
@@ -144,9 +144,9 @@ fun DeviceScope.TrustDeviceDialog() {
     // switch, window close) triggers a release. The cancel is generation-safe:
     // it names the exact exchange this dialog owns (skipped after a successful
     // confirm consumes it, or when a reopened dialog's newer exchange
-    // supersedes it — see SyncDeviceManager.cancelPairing). Best effort only:
-    // a dismissal racing an in-flight warm-up finds no recorded exchange and
-    // skips; the responder's leftover entry self-heals on the next exchange.
+    // supersedes it). The generation is recorded before asynchronous dispatch;
+    // if dismissal wins the race, the queued warm-up observes the consumed
+    // generation and sends no request.
     DisposableEffect(appInstanceId, pairingCredentialType) {
         onDispose {
             if (pairingCredentialType == PairingCredentialType.SAS_CODE) {

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/AppTokenServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/AppTokenServiceTest.kt
@@ -46,10 +46,8 @@ class AppTokenServiceTest {
     fun `releaseVerifier releases exactly one count per pending verifier`() {
         val service = createService()
         runBlocking {
-            service.addPendingVerifier("a")
-            service.startRefresh(showToken = true)
-            service.addPendingVerifier("b")
-            service.startRefresh(showToken = true)
+            service.acquireVerifier("a")
+            service.acquireVerifier("b")
             withTimeout(5.seconds) {
                 service.refresh.first { it }
                 service.pendingVerifiers.first { it == setOf("a", "b") }
@@ -79,19 +77,32 @@ class AppTokenServiceTest {
     fun `release enqueued right after acquire cannot orphan the refresh count`() {
         val service = createService()
         runBlocking {
-            service.addPendingVerifier("a")
-            service.startRefresh(showToken = true)
-            // Enqueued after the increment, so the single-consumer command
-            // queue can never process it first — the interleaving that
-            // previously left an orphaned count driving the refresh loop.
+            service.acquireVerifier("a")
             service.releaseVerifier("a")
             // FIFO marker: once it is visible, every prior command has run.
-            service.addPendingVerifier("marker")
+            service.acquireVerifier("marker")
             withTimeout(5.seconds) {
                 service.pendingVerifiers.first { "marker" in it }
             }
-            assertFalse(service.refresh.value)
             assertEquals(setOf("marker"), service.pendingVerifiers.value)
+            service.releaseVerifier("marker")
+            withTimeout(5.seconds) {
+                service.refresh.first { !it }
+            }
+        }
+    }
+
+    @Test
+    fun `repeated acquire by one verifier owns only one refresh count`() {
+        val service = createService()
+        runBlocking {
+            service.acquireVerifier("a")
+            service.acquireVerifier("a")
+            service.releaseVerifier("a")
+            withTimeout(5.seconds) {
+                service.refresh.first { !it }
+                service.pendingVerifiers.first { it.isEmpty() }
+            }
         }
     }
 
@@ -101,8 +112,7 @@ class AppTokenServiceTest {
         runBlocking {
             // One verifier-owned count plus one anonymous count (e.g. the local
             // pairing-code screen keeping the token rotation alive).
-            service.addPendingVerifier("a")
-            service.startRefresh(showToken = true)
+            service.acquireVerifier("a")
             service.startRefresh(showToken = false)
             withTimeout(5.seconds) {
                 service.showToken.first { it }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
@@ -364,8 +364,8 @@ class SyncTest : KoinTest {
 
             exchangeAndAwaitPending(exchangeGeneration = 1000L)
 
-            // Callers without the generation header (older clients, the browser
-            // extension) keep the original unconditional-release behaviour.
+            // Older extension versions without the generation header keep the
+            // original unconditional-release behaviour.
             pasteClient.post(
                 "",
                 typeInfo<String>(),

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
@@ -79,8 +79,7 @@ class TestServerModule(
                         pairingVersionCoordinator,
                         { appInstanceId ->
                             if (pendingKeyExchangeStore.remove(appInstanceId)) {
-                                appTokenApi.removePendingVerifier(appInstanceId)
-                                appTokenApi.stopRefresh(hideToken = false)
+                                appTokenApi.releaseVerifier(appInstanceId)
                             }
                         },
                     ) { _, _, _ -> }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
@@ -54,16 +54,54 @@ class GeneralSyncManagerTest {
         mocks: Mocks,
         scope: CoroutineScope,
         localPairingVersion: Int = 2,
+        pendingExchangeLedger: PendingExchangeLedger = PendingExchangeLedger(),
     ): GeneralSyncManager =
         GeneralSyncManager(
             realTimeSyncScope = scope,
-            pendingExchangeLedger = PendingExchangeLedger(),
+            pendingExchangeLedger = pendingExchangeLedger,
             syncResolver = mocks.syncResolver,
             syncRuntimeInfoDao = mocks.syncRuntimeInfoDao,
             syncClientApi = mocks.syncClientApi,
             wsSessionManager = WsSessionManager(),
             pairingCapabilityFlag = PairingCapabilityFlag(localPairingVersion),
         )
+
+    @Test
+    fun exchangeKeysForPairing_recordsGenerationBeforeAsyncDispatch() =
+        runTest {
+            val mocks = createMocks()
+            val syncRuntimeInfo =
+                createTestSyncRuntimeInfo(
+                    connectState = SyncState.UNVERIFIED,
+                )
+            every { mocks.syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow() } returns
+                MutableStateFlow(listOf(syncRuntimeInfo))
+            coEvery { mocks.syncResolver.emitEvent(any()) } just runs
+            val ledger = PendingExchangeLedger()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager =
+                createSyncManager(
+                    mocks = mocks,
+                    scope = childScope,
+                    pendingExchangeLedger = ledger,
+                )
+            syncManager.start()
+            advanceUntilIdle()
+
+            syncManager.exchangeKeysForPairing(syncRuntimeInfo.appInstanceId)
+
+            val generation = ledger.current(syncRuntimeInfo.appInstanceId)
+            assertNotNull(generation)
+            advanceUntilIdle()
+            coVerify(exactly = 1) {
+                mocks.syncResolver.emitEvent(
+                    match {
+                        it is SyncEvent.ExchangeKeysForPairing &&
+                            it.generation == generation
+                    },
+                )
+            }
+        }
 
     private fun createTestSyncRuntimeInfo(
         appInstanceId: String = "test-app-1",

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/PendingExchangeLedgerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/PendingExchangeLedgerTest.kt
@@ -1,5 +1,10 @@
 package com.crosspaste.sync
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -45,11 +50,39 @@ class PendingExchangeLedgerTest {
     }
 
     @Test
-    fun `clear drops the record`() {
+    fun `successful consume drops the record`() {
         val ledger = PendingExchangeLedger()
         ledger.record("a", 1L)
-        ledger.clear("a")
+        assertTrue(ledger.consume("a", 1L))
         assertNull(ledger.current("a"))
         assertFalse(ledger.consume("a", 1L))
     }
+
+    @Test
+    fun `concurrent stale consume never removes replacement generation`() =
+        runBlocking {
+            val ledger = PendingExchangeLedger()
+            repeat(1_000) { attempt ->
+                val oldGeneration = attempt.toLong() * 2
+                val newGeneration = oldGeneration + 1
+                ledger.record("a", oldGeneration)
+                val start = CompletableDeferred<Unit>()
+                val operations =
+                    listOf(
+                        async(Dispatchers.Default) {
+                            start.await()
+                            ledger.consume("a", oldGeneration)
+                        },
+                        async(Dispatchers.Default) {
+                            start.await()
+                            ledger.record("a", newGeneration)
+                        },
+                    )
+
+                start.complete(Unit)
+                operations.awaitAll()
+
+                assertEquals(newGeneration, ledger.current("a"))
+            }
+        }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class SyncDeviceManagerTest {
@@ -167,7 +166,7 @@ class SyncDeviceManagerTest {
 
             // A successful confirm clears the record — nothing left to cancel.
             deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, 42L)
-            deps.pendingExchangeLedger.clear(syncRuntimeInfo.appInstanceId)
+            deps.pendingExchangeLedger.consume(syncRuntimeInfo.appInstanceId, 42L)
             manager.cancelPairing(syncRuntimeInfo, generation = 42L)
 
             coVerify(exactly = 0) { deps.syncClientApi.trustV2Cancel(any(), any()) }
@@ -223,25 +222,38 @@ class SyncDeviceManagerTest {
         }
 
     @Test
-    fun exchangeKeysForPairing_recordsGenerationBeforeSending() =
+    fun exchangeKeysForPairing_matchingGeneration_sendsRequest() =
         runTest {
             val deps = TestDeps()
             val manager = deps.createManager()
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val generation = 42L
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, generation)
 
             val sentGeneration = slot<Long>()
             coEvery {
                 deps.syncClientApi.exchangeKeys(any(), capture(sentGeneration), any())
             } returns SuccessResult(null)
 
-            manager.exchangeKeysForPairing(syncRuntimeInfo)
+            manager.exchangeKeysForPairing(syncRuntimeInfo, generation)
 
-            // The ledger holds exactly the generation that went out with the
-            // signed request, recorded before the response came back.
-            assertEquals(
-                sentGeneration.captured,
-                deps.pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId),
-            )
+            assertEquals(generation, sentGeneration.captured)
+            assertEquals(generation, deps.pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId))
+        }
+
+    @Test
+    fun exchangeKeysForPairing_cancelledBeforeDispatch_doesNotSendRequest() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            val generation = 42L
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, generation)
+            assertTrue(deps.pendingExchangeLedger.consume(syncRuntimeInfo.appInstanceId, generation))
+
+            manager.exchangeKeysForPairing(syncRuntimeInfo, generation)
+
+            coVerify(exactly = 0) { deps.syncClientApi.exchangeKeys(any(), any(), any()) }
         }
 
     @Test
@@ -256,11 +268,10 @@ class SyncDeviceManagerTest {
             // an abandon can still release the responder's orphaned entry.
             coEvery { deps.syncClientApi.exchangeKeys(any(), any(), any()) } returns ConnectionRefused
             coEvery { deps.syncClientApi.trustV2Cancel(any(), any()) } returns SuccessResult(true)
+            val generation = 42L
+            deps.pendingExchangeLedger.record(syncRuntimeInfo.appInstanceId, generation)
 
-            manager.exchangeKeysForPairing(syncRuntimeInfo)
-
-            val generation = deps.pendingExchangeLedger.current(syncRuntimeInfo.appInstanceId)
-            assertNotNull(generation)
+            manager.exchangeKeysForPairing(syncRuntimeInfo, generation)
 
             manager.cancelPairing(syncRuntimeInfo, generation)
 

--- a/core/src/jsMain/kotlin/com/crosspaste/web/CrossPasteApi.kt
+++ b/core/src/jsMain/kotlin/com/crosspaste/web/CrossPasteApi.kt
@@ -25,6 +25,8 @@ import com.crosspaste.utils.CryptographyUtils
 import com.crosspaste.utils.getCodecsUtils
 import com.crosspaste.utils.getJsonUtils
 import dev.whyoleg.cryptography.CryptographyProvider
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.updateAndGet
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.promise
 import kotlin.js.Promise
@@ -97,6 +99,8 @@ data class JsKeyPair(
  */
 @JsExport
 object CrossPasteCrypto {
+
+    private val lastV2ExchangeGeneration = atomic(0L)
 
     /** Generate ECDSA P-256 sign keypair + ECDH P-256 crypt keypair. */
     @Suppress("OPT_IN_USAGE")
@@ -199,9 +203,14 @@ object CrossPasteCrypto {
             val serializer = SecureKeyPairSerializer()
             val privateKey = serializer.decodeSignPrivateKey(signPrivateKeyDer)
             val timestamp =
-                kotlin.time.Clock.System
-                    .now()
-                    .toEpochMilliseconds()
+                lastV2ExchangeGeneration.updateAndGet { previous ->
+                    maxOf(
+                        kotlin.time.Clock.System
+                            .now()
+                            .toEpochMilliseconds(),
+                        previous + 1,
+                    )
+                }
             val request =
                 KeyExchangeRequest(
                     signPublicKey = signPublicKeyDer,

--- a/web/src/shared/api/__tests__/sync-v2v3.test.ts
+++ b/web/src/shared/api/__tests__/sync-v2v3.test.ts
@@ -130,9 +130,50 @@ describe("SyncApi.exchangeV2", () => {
     // Flip the timestamp after signing — the signature must no longer verify.
     responseBody.timestamp += 1;
 
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(jsonResponse(responseBody)));
+    const fetchMock =
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse(responseBody))
+        .mockResolvedValueOnce(jsonResponse(""));
+    vi.stubGlobal("fetch", fetchMock);
 
     await expect(SyncApi.exchangeV2(CONFIG)).rejects.toThrow(/verification/);
+
+    const exchangeRequest = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(fetchMock.mock.calls[1][0]).toContain("/sync/trust/v2/cancel");
+    expect(fetchMock.mock.calls[1][1].headers["crosspaste-exchange-timestamp"])
+      .toBe(String(exchangeRequest.timestamp));
+  });
+
+  it("cancels its exact generation when the exchange response is lost", async () => {
+    const fetchMock =
+      vi.fn()
+        .mockRejectedValueOnce(new Error("response lost"))
+        .mockResolvedValueOnce(jsonResponse(""));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(SyncApi.exchangeV2(CONFIG)).rejects.toThrow(/response lost/);
+
+    const exchangeRequest = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(fetchMock.mock.calls[1][0]).toContain("/sync/trust/v2/cancel");
+    expect(fetchMock.mock.calls[1][1].headers["crosspaste-exchange-timestamp"])
+      .toBe(String(exchangeRequest.timestamp));
+  });
+
+  it("generates distinct generations for concurrent exchange requests", async () => {
+    const keys = await KeyStore.generateAndStore();
+    const requests = await Promise.all(
+      Array.from({ length: 32 }, async () => {
+        const json = await CrossPasteCrypto.buildKeyExchangeRequest(
+          toInt8Array(keys.signPrivateKey),
+          toInt8Array(keys.signPublicKey),
+          toInt8Array(keys.cryptPublicKey),
+        );
+        return JSON.parse(json) as { timestamp: number };
+      }),
+    );
+
+    const generations = requests.map((request) => request.timestamp);
+    expect(new Set(generations).size).toBe(generations.length);
   });
 });
 

--- a/web/src/shared/api/sync.ts
+++ b/web/src/shared/api/sync.ts
@@ -113,16 +113,24 @@ export const SyncApi = {
       toInt8Array(keys.cryptPublicKey),
     );
     const request = JSON.parse(requestJson) as { timestamp: number };
-    const response = await apiPost<KeyExchangeResponse>(
-      toRequestConfig(config),
-      "/sync/trust/v2/exchange",
-      request,
-    );
-    const valid = await CrossPasteCrypto.verifyKeyExchangeResponse(JSON.stringify(response));
-    if (!valid) {
-      throw new Error("Key exchange response failed verification");
+    try {
+      const response = await apiPost<KeyExchangeResponse>(
+        toRequestConfig(config),
+        "/sync/trust/v2/exchange",
+        request,
+      );
+      const valid = await CrossPasteCrypto.verifyKeyExchangeResponse(JSON.stringify(response));
+      if (!valid) {
+        throw new Error("Key exchange response failed verification");
+      }
+      return { ...response, requestTimestamp: request.timestamp };
+    } catch (error) {
+      // The request may have reached the desktop even when its response was
+      // lost or invalid. Release the exact signed generation before surfacing
+      // the original exchange failure.
+      await SyncApi.cancelV2(config, request.timestamp).catch(() => {});
+      throw error;
     }
-    return { ...response, requestTimestamp: request.timestamp };
   },
 
   /**


### PR DESCRIPTION
Closes #4692. Stacked on #4690 (base is its branch; retargets to `main` once #4690 merges).

## Changes

**1. Generation allocation moved ahead of the async event boundary.**
- New `SyncManager.exchangeKeysForPairing(appInstanceId)`: the warm-up's generation is allocated and recorded in the ledger synchronously at the UI call site, before the event enters the resolver queue; `SyncEvent.ExchangeKeysForPairing`, `SyncHandler`, and `SyncDeviceManager` carry it through.
- `SyncDeviceManager.exchangeKeysForPairing` sends only while the ledger still holds that exact generation: a dialog dismissed while the warm-up event was still queued now captures the generation, its cancel consumes the ledger entry first, and the late warm-up sends nothing. This closes the last residual window from #4690 (previously the cancel found an empty ledger and the orphaned responder entry had to self-heal).

**2. Atomic verifier acquisition.**
- `AppTokenApi.acquireVerifier(appInstanceId, showToken)` replaces the hand-composed `addPendingVerifier` + `startRefresh` pair. Acquisition is idempotent per verifier: repeated acquisition (v1 dialog reopened, repeated `/sync/showToken`) reopens the overlay without incrementing the refresh count twice — fixing the historical v1 accumulation where reopening the dialog n times leaked n−1 counts past the confirm.

**3. Lock-free CAS ledger.**
- `PendingExchangeLedger` now keeps its per-peer map in an atomicfu atomic reference; `consume` is a true compare-and-set loop, so a stale consume racing a replacement `record` for the same peer can never drop the newer generation. Covered by a 1000-round concurrent stress test.

**4. Extension parity.**
- The core JS `buildKeyExchangeRequest` emits strictly monotonic timestamps (`maxOf(now, prev + 1)`), so same-millisecond attempts can no longer collide as generations.
- `exchangeV2` cancels its exact signed generation when the exchange fails after the request may have reached the desktop (lost or invalid response), before surfacing the original failure.

## Tests

- `GeneralSyncManagerTest`: warm-up generation is recorded synchronously before dispatch.
- `SyncDeviceManagerTest`: a warm-up whose generation was already consumed (cancelled) or superseded sends no request; send/skip matrix updated to the carried-generation signature.
- `PendingExchangeLedgerTest`: concurrent stale-consume vs. replacement-record stress test (1000 rounds); consume drops the record.
- `AppTokenServiceTest`: repeated acquisition by one verifier owns exactly one count; release-after-acquire ordering; hideToken leaves counts owned by others untouched.
- Web (`sync-v2v3.test.ts`): `exchangeV2` auto-cancels its exact generation on a tampered response and on a lost response; 32 concurrent `buildKeyExchangeRequest` calls produce 32 distinct generations.
- Full `app:desktopTest`, web vitest (102 tests), and `tsc --noEmit` pass; core JS library rebuilt and consumed by the web tests.