### PR TITLE
:bug: auto-show main window on first launch for all desktop platforms

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/CrossPasteWindows.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/CrossPasteWindows.kt
@@ -20,6 +20,18 @@ import com.crosspaste.ui.tray.NonMacTrayView
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 
+internal fun handleFirstLaunch(
+    firstLaunch: Boolean,
+    firstLaunchCompleted: Boolean,
+    showMainWindow: () -> Unit,
+    markFirstLaunchCompleted: () -> Unit,
+) {
+    if (firstLaunch && !firstLaunchCompleted) {
+        showMainWindow()
+        markFirstLaunchCompleted()
+    }
+}
+
 @Composable
 fun ApplicationScope.CrossPasteWindows(exiting: Boolean) {
     val platform = koinInject<Platform>()
@@ -49,10 +61,16 @@ fun ApplicationScope.CrossPasteWindows(exiting: Boolean) {
     val appWindowManager = koinInject<DesktopAppWindowManager>()
 
     LaunchedEffect(Unit) {
-        if (appLaunchState.firstLaunch && !appLaunch.firstLaunchCompleted.value) {
-            appWindowManager.showMainWindow(WindowTrigger.SYSTEM)
-            appLaunch.setFirstLaunchCompleted(true)
-        }
+        handleFirstLaunch(
+            firstLaunch = appLaunchState.firstLaunch,
+            firstLaunchCompleted = appLaunch.firstLaunchCompleted.value,
+            showMainWindow = {
+                appWindowManager.showMainWindow(WindowTrigger.SYSTEM)
+            },
+            markFirstLaunchCompleted = {
+                appLaunch.setFirstLaunchCompleted(true)
+            },
+        )
     }
 
     MainWindow(windowIcon)

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/CrossPasteWindows.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/CrossPasteWindows.kt
@@ -1,12 +1,16 @@
 package com.crosspaste.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.window.ApplicationScope
+import com.crosspaste.app.AppLaunchState
+import com.crosspaste.app.DesktopAppLaunch
 import com.crosspaste.app.DesktopAppWindowManager
+import com.crosspaste.app.WindowTrigger
 import com.crosspaste.app.generated.resources.Res
 import com.crosspaste.app.generated.resources.crosspaste
 import com.crosspaste.app.generated.resources.crosspaste_mac
@@ -40,11 +44,21 @@ fun ApplicationScope.CrossPasteWindows(exiting: Boolean) {
         }
     }
 
+    val appLaunch = koinInject<DesktopAppLaunch>()
+    val appLaunchState = koinInject<AppLaunchState>()
+    val appWindowManager = koinInject<DesktopAppWindowManager>()
+
+    LaunchedEffect(Unit) {
+        if (appLaunchState.firstLaunch && !appLaunch.firstLaunchCompleted.value) {
+            appWindowManager.showMainWindow(WindowTrigger.SYSTEM)
+            appLaunch.setFirstLaunchCompleted(true)
+        }
+    }
+
     MainWindow(windowIcon)
 
     SearchWindow(windowIcon)
 
-    val appWindowManager = koinInject<DesktopAppWindowManager>()
     val bubbleWindowInfo by appWindowManager.bubbleWindowInfo.collectAsState()
     if (bubbleWindowInfo.show) {
         BubbleWindow(windowIcon)

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/tray/MacTrayView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/tray/MacTrayView.kt
@@ -3,14 +3,11 @@ package com.crosspaste.ui.tray
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import com.crosspaste.app.AppLaunchState
 import com.crosspaste.app.AppName
-import com.crosspaste.app.DesktopAppLaunch
 import com.crosspaste.app.DesktopAppWindowManager
 import com.crosspaste.app.ExitMode
 import com.crosspaste.app.WindowTrigger
@@ -37,13 +34,9 @@ object MacTrayView {
     @Composable
     fun Tray() {
         val applicationExit = LocalExitApplication.current
-        val appLaunch = koinInject<DesktopAppLaunch>()
-        val appLaunchState = koinInject<AppLaunchState>()
         val appWindowManager = koinInject<DesktopAppWindowManager>()
         val configManager = koinInject<CommonConfigManager>()
         val menuHelper = koinInject<MenuHelper>()
-
-        val firstLaunchCompleted by appLaunch.firstLaunchCompleted.collectAsState()
 
         var trayManager by remember { mutableStateOf<NativeTrayManager?>(null) }
 
@@ -55,11 +48,6 @@ object MacTrayView {
                     menuHelper,
                     applicationExit,
                 )
-
-            if (appLaunchState.firstLaunch && !firstLaunchCompleted) {
-                appWindowManager.showMainWindow(WindowTrigger.SYSTEM)
-                appLaunch.setFirstLaunchCompleted(true)
-            }
         }
 
         DisposableEffect(Unit) {

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/CrossPasteWindowsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/CrossPasteWindowsTest.kt
@@ -1,0 +1,49 @@
+package com.crosspaste.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CrossPasteWindowsTest {
+
+    @Test
+    fun firstLaunch_showsMainWindowBeforeMarkingLaunchCompleted() {
+        val actions = mutableListOf<String>()
+
+        handleFirstLaunch(
+            firstLaunch = true,
+            firstLaunchCompleted = false,
+            showMainWindow = { actions += "show" },
+            markFirstLaunchCompleted = { actions += "complete" },
+        )
+
+        assertEquals(listOf("show", "complete"), actions)
+    }
+
+    @Test
+    fun nonFirstLaunch_keepsMainWindowHidden() {
+        val actions = mutableListOf<String>()
+
+        handleFirstLaunch(
+            firstLaunch = false,
+            firstLaunchCompleted = false,
+            showMainWindow = { actions += "show" },
+            markFirstLaunchCompleted = { actions += "complete" },
+        )
+
+        assertEquals(emptyList(), actions)
+    }
+
+    @Test
+    fun completedFirstLaunch_doesNotShowMainWindowAgain() {
+        val actions = mutableListOf<String>()
+
+        handleFirstLaunch(
+            firstLaunch = true,
+            firstLaunchCompleted = true,
+            showMainWindow = { actions += "show" },
+            markFirstLaunchCompleted = { actions += "complete" },
+        )
+
+        assertEquals(emptyList(), actions)
+    }
+}


### PR DESCRIPTION
Closes #4696

## Summary

On Windows and Linux the first launch showed no window at all: the main window starts hidden and the only first-launch auto-show call lived in the macOS tray view (`MacTrayView.Tray()`). New users saw nothing but a (possibly overflow-collapsed) tray icon and perceived the app as "not opening".

This PR lifts the first-launch logic into the platform-agnostic `CrossPasteWindows` composable:

- `firstLaunch && !firstLaunchCompleted` → `showMainWindow(WindowTrigger.SYSTEM)` + `setFirstLaunchCompleted(true)` now runs on macOS, Windows, and Linux
- The duplicate block and now-unused injections are removed from `MacTrayView`

## Side effect fixed

`setFirstLaunchCompleted(true)` was previously macOS-only, so `firstLaunchCompleted` stayed `false` forever on Windows/Linux and the blinking `TutorialButton` (gated on `firstLaunchCompleted && config.showTutorial`) never appeared there. It now works on all platforms.

## Behavior notes

- The effect is placed after the tray section in `CrossPasteWindows`, preserving the previous macOS ordering (tray init before window show)
- On macOS the window now shows even if native tray init throws, which previously would have skipped it — a strict improvement
- Non-first launches are unchanged: the app still starts hidden in the tray

## Testing

- `./gradlew ktlintFormat` clean
- `./gradlew app:compileKotlinDesktop` passes
- `./gradlew app:desktopTest` passes