### PR TITLE
Harden paste process plugin pipeline and cap max non-file paste size input

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -88,11 +88,20 @@ class PasteReleaseService(
             var pasteAppearItems = pasteItems
             for (pastePlugin in pasteProcessPlugins) {
                 pasteAppearItems =
-                    pastePlugin.process(
-                        pasteData.getPasteCoordinate(),
-                        pasteAppearItems,
-                        pasteData.source,
-                    )
+                    runCatching {
+                        pastePlugin.process(
+                            pasteData.getPasteCoordinate(),
+                            pasteAppearItems,
+                            pasteData.source,
+                        )
+                    }.getOrElse { e ->
+                        // A failing plugin must not leave the row stuck in loading state;
+                        // skip its transformation and continue with the current items.
+                        logger.warn(e) {
+                            "Paste process plugin ${pastePlugin::class.simpleName} failed, id=$id"
+                        }
+                        pasteAppearItems
+                    }
             }
 
             if (pasteAppearItems.isEmpty()) {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/settings/PasteboardSettingsContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/settings/PasteboardSettingsContentView.kt
@@ -98,7 +98,7 @@ fun PasteboardSettingsContentView(extContent: @Composable () -> Unit = {}) {
                     icon = IconData(MaterialSymbols.Rounded.Title, themeExt.cyanIconColor),
                     trailingContent = {
                         Counter(defaultValue = config.maxNonFilePasteSize, unit = "MB", rule = {
-                            it > 0
+                            it in 1..64
                         }) { currentMaxNonFilePasteSize ->
                             configManager.updateConfig("maxNonFilePasteSize", currentMaxNonFilePasteSize)
                         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopPasteComponentModule.kt
@@ -169,6 +169,19 @@ fun desktopPasteComponentModule(headless: Boolean): Module =
                 notificationManager = get(),
                 pasteDao = get(),
                 pasteItemReader = get(),
+                // Plugin order is load-bearing (mobile assembles the same commonMain
+                // plugins and must keep these invariants):
+                // 1. RemoveInvalid must run first.
+                // 2. DiscardOversizedNonFile must precede Distinct: FirstPlugin keeps only
+                //    the first item per type and clears the rest from disk, so an oversized
+                //    first item would otherwise destroy a smaller surviving variant before
+                //    being discarded itself.
+                // 3. Generate plugins run after Distinct and chain html/rtf -> text -> url/color.
+                //    Any plugin placed after DiscardOversizedNonFile must never emit an item
+                //    larger than its already-size-checked source, or it bypasses the limit.
+                // 4. FilesToImages/FileToUrl rely on Distinct having merged multi-file items;
+                //    Remove*Image must run after every plugin that can add image items.
+                // 5. Sort must be last: the first item determines the row's type/hash/search content.
                 pasteProcessPlugins =
                     listOf(
                         RemoveInvalidPlugin,


### PR DESCRIPTION
Closes #4700

## Summary

Follow-up hardening after #4698 / #4699, in three parts:

1. **Isolate plugin failures in `PasteReleaseService.releaseLocalPasteData`.** Each `PasteProcessPlugin.process` call is now wrapped in `runCatching`: on failure the plugin's transformation is skipped with a warning log and the pipeline continues with the current items. Previously a throwing plugin (e.g. `FilesToImagesPlugin` on a failed file move) aborted the whole loop and left the paste row stuck in LOADING state forever. This is graceful degradation, not rollback — a plugin that failed mid-mutation may still leave its own item imperfect, but the row always reaches a terminal state.

2. **Document the plugin order invariants** at the `pasteProcessPlugins` assembly site in `DesktopPasteComponentModule`. The order is load-bearing and the constraints were previously only implicit — notably `DiscardOversizedNonFilePlugin` must precede `DistinctPlugin` (otherwise `FirstPlugin` may keep an oversized first item and clear a smaller surviving variant from disk before the oversized one is discarded), plugins placed after the size check must never emit items larger than their already-checked sources, and `SortPlugin` must stay last because the first item determines the row's type/hash/search content. Mobile assembles the same commonMain plugins and must keep these invariants.

3. **Cap the `maxNonFilePasteSize` settings input to 1..64 MB.** Without an upper bound the setting could effectively disable the oversized-item guard. The `Counter` rule rejects out-of-range values from both the +/- buttons and typed input; the bound is UI-level validation only, consistent with sibling settings.

## Test plan

- `./gradlew app:compileKotlinDesktop app:compileTestKotlinDesktop` clean
- `./gradlew app:desktopTest --tests "*DiscardOversized*" --tests "*PasteReleaseService*"` — 11 tests pass
- ktlintFormat applied