### PR TITLE
Persist paste pull cursor for discarded oversized remote pastes

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -230,6 +230,10 @@ class PasteReleaseService(
             "Discard oversized remote non-file paste from ${pasteData.appInstanceId}: " +
                 "size=${pasteData.size}, limit=$maxSize"
         }
+        pasteDao.upsertPastePullCursorMaxCreateTime(
+            appInstanceId = pasteData.appInstanceId,
+            maxCreateTime = pasteData.createTime,
+        )
         val deviceName =
             syncRuntimeInfoDao
                 .getSyncRuntimeInfo(pasteData.appInstanceId)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PastePullService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PastePullService.kt
@@ -26,7 +26,15 @@ class PastePullService(
     private val mutex = Mutex()
 
     suspend fun init() {
-        val maxCreateTimeMap = pasteDao.getMaxCreateTimeByRemoteAppInstanceId()
+        val storedPasteMaxCreateTimes = pasteDao.getMaxCreateTimeByRemoteAppInstanceId()
+        val persistedPullCursorMaxCreateTimes = pasteDao.getPastePullCursorMaxCreateTimes()
+        val maxCreateTimeMap =
+            (storedPasteMaxCreateTimes.keys + persistedPullCursorMaxCreateTimes.keys).associateWith { appInstanceId ->
+                listOfNotNull(
+                    storedPasteMaxCreateTimes[appInstanceId],
+                    persistedPullCursorMaxCreateTimes[appInstanceId],
+                ).max()
+            }
         deviceMaxCreateTime.putAll(maxCreateTimeMap)
         maxCreateTimeMap.forEach { (appInstanceId, maxCreateTime) ->
             logger.debug { "Initialized sync state for $appInstanceId: maxCreateTime=$maxCreateTime" }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.sync
 
+import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
@@ -15,6 +16,7 @@ import com.crosspaste.utils.buildUrl
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 class SyncDeviceManager(
+    private val pasteDao: PasteDao,
     private val pendingExchangeLedger: PendingExchangeLedger,
     private val secureStore: SecureStore,
     private val syncClientApi: SyncClientApi,
@@ -197,6 +199,7 @@ class SyncDeviceManager(
         wsSessionManager.closeSession(syncRuntimeInfo.appInstanceId)
         secureStore.deleteCryptPublicKey(syncRuntimeInfo.appInstanceId)
         syncRuntimeInfoDao.deleteSyncRuntimeInfo(syncRuntimeInfo.appInstanceId)
+        pasteDao.deletePastePullCursor(syncRuntimeInfo.appInstanceId)
 
         // HTTP fallback notification (best-effort, after local cleanup)
         if (!notifiedViaWs) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -252,6 +252,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
         single<SharePushOrchestrator> { SharePushOrchestrator(get(), get(), get()) }
         single<SyncDeviceManager> {
             SyncDeviceManager(
+                pasteDao = get(),
                 pendingExchangeLedger = get(),
                 secureStore = get(),
                 syncClientApi = get(),

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/paste/PasteDaoTest.kt
@@ -202,6 +202,36 @@ class PasteDaoTest {
             assertTrue(after >= before)
         }
 
+    @Test
+    fun `paste pull cursor upsert never moves backwards`() =
+        runTest {
+            pasteDao.upsertPastePullCursorMaxCreateTime("remote-device", 200L)
+            pasteDao.upsertPastePullCursorMaxCreateTime("remote-device", 100L)
+            pasteDao.upsertPastePullCursorMaxCreateTime("other-device", 300L)
+
+            assertEquals(
+                mapOf(
+                    "remote-device" to 200L,
+                    "other-device" to 300L,
+                ),
+                pasteDao.getPastePullCursorMaxCreateTimes(),
+            )
+        }
+
+    @Test
+    fun `paste pull cursor delete only removes the given device`() =
+        runTest {
+            pasteDao.upsertPastePullCursorMaxCreateTime("remote-device", 200L)
+            pasteDao.upsertPastePullCursorMaxCreateTime("other-device", 300L)
+
+            pasteDao.deletePastePullCursor("remote-device")
+
+            assertEquals(
+                mapOf("other-device" to 300L),
+                pasteDao.getPastePullCursorMaxCreateTimes(),
+            )
+        }
+
     // --- Delete ---
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceRemoteDiscardTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceRemoteDiscardTest.kt
@@ -38,6 +38,7 @@ class PasteReleaseServiceRemoteDiscardTest {
     private fun newService(
         commonConfigManager: CommonConfigManager = configManager(),
         notificationManager: NotificationManager = mockk(relaxed = true),
+        pasteDao: PasteDao = mockk(relaxed = true),
         syncRuntimeInfoDao: SyncRuntimeInfoDao = mockk(relaxed = true),
         taskSubmitter: TaskSubmitter = mockk(relaxed = true),
     ): PasteReleaseService =
@@ -46,7 +47,7 @@ class PasteReleaseServiceRemoteDiscardTest {
             currentPaste = mockk(relaxed = true),
             database = mockk<Database>(relaxed = true),
             notificationManager = notificationManager,
-            pasteDao = mockk<PasteDao>(relaxed = true),
+            pasteDao = pasteDao,
             pasteItemReader = mockk<PasteItemReader>(relaxed = true),
             pasteProcessPlugins = emptyList(),
             searchContentService = mockk(relaxed = true),
@@ -79,12 +80,14 @@ class PasteReleaseServiceRemoteDiscardTest {
     fun `oversized remote non-file paste is skipped entirely with notification`() =
         runBlocking {
             val notificationManager = mockk<NotificationManager>(relaxed = true)
+            val pasteDao = mockk<PasteDao>(relaxed = true)
             val syncRuntimeInfoDao = mockk<SyncRuntimeInfoDao>(relaxed = true)
             coEvery { syncRuntimeInfoDao.getSyncRuntimeInfo("remote-device") } returns null
             val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
             val service =
                 newService(
                     notificationManager = notificationManager,
+                    pasteDao = pasteDao,
                     syncRuntimeInfoDao = syncRuntimeInfoDao,
                     taskSubmitter = taskSubmitter,
                 )
@@ -98,6 +101,12 @@ class PasteReleaseServiceRemoteDiscardTest {
             assertTrue(result.isSuccess)
             assertTrue(!wrotePasteboard)
             coVerify(exactly = 0) { taskSubmitter.submit(any()) }
+            coVerify(exactly = 1) {
+                pasteDao.upsertPastePullCursorMaxCreateTime(
+                    appInstanceId = "remote-device",
+                    maxCreateTime = any(),
+                )
+            }
             verify(exactly = 1) { notificationManager.sendNotification(any(), any(), any(), any()) }
         }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/PastePullServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/PastePullServiceTest.kt
@@ -1,0 +1,61 @@
+package com.crosspaste.sync
+
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.net.clientapi.PullClientApi
+import com.crosspaste.paste.PasteboardService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PastePullServiceTest {
+
+    private fun newService(pasteDao: PasteDao): PastePullService =
+        PastePullService(
+            pasteDao = pasteDao,
+            pasteboardService = mockk<PasteboardService>(relaxed = true),
+            pullClientApi = mockk<PullClientApi>(relaxed = true),
+            syncManager = mockk<SyncManager>(relaxed = true),
+        )
+
+    @Test
+    fun `init restores newest cursor from stored pastes and durable pull cursor`() =
+        runTest {
+            val pasteDao = mockk<PasteDao>()
+            coEvery { pasteDao.getMaxCreateTimeByRemoteAppInstanceId() } returns
+                mapOf(
+                    "stored-only" to 100L,
+                    "both" to 200L,
+                )
+            coEvery { pasteDao.getPastePullCursorMaxCreateTimes() } returns
+                mapOf(
+                    "cursor-only" to 300L,
+                    "both" to 250L,
+                )
+
+            val service = newService(pasteDao)
+            service.init()
+
+            assertEquals(100L, service.getMaxCreateTime("stored-only"))
+            assertEquals(300L, service.getMaxCreateTime("cursor-only"))
+            assertEquals(250L, service.getMaxCreateTime("both"))
+        }
+
+    @Test
+    fun `in-memory cursor update does not mark an unpersisted paste as durable`() =
+        runTest {
+            val pasteDao = mockk<PasteDao>()
+            coEvery { pasteDao.getMaxCreateTimeByRemoteAppInstanceId() } returns emptyMap()
+            coEvery { pasteDao.getPastePullCursorMaxCreateTimes() } returns
+                mapOf("remote-device" to 200L)
+
+            val service = newService(pasteDao)
+            service.init()
+            service.updateMaxCreateTime("remote-device", 300L)
+
+            assertEquals(300L, service.getMaxCreateTime("remote-device"))
+            coVerify(exactly = 0) { pasteDao.upsertPastePullCursorMaxCreateTime(any(), any()) }
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.sync
 
+import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
@@ -24,6 +25,7 @@ import kotlin.test.assertTrue
 class SyncDeviceManagerTest {
 
     private class TestDeps {
+        val pasteDao: PasteDao = mockk(relaxed = true)
         val pendingExchangeLedger: PendingExchangeLedger = PendingExchangeLedger()
         val secureStore: SecureStore = mockk(relaxed = true)
         val syncClientApi: SyncClientApi = mockk(relaxed = true)
@@ -33,6 +35,7 @@ class SyncDeviceManagerTest {
 
         fun createManager(): SyncDeviceManager =
             SyncDeviceManager(
+                pasteDao = pasteDao,
                 pendingExchangeLedger = pendingExchangeLedger,
                 secureStore = secureStore,
                 syncClientApi = syncClientApi,
@@ -423,6 +426,7 @@ class SyncDeviceManagerTest {
 
             coVerify { deps.secureStore.deleteCryptPublicKey(syncRuntimeInfo.appInstanceId) }
             coVerify { deps.syncRuntimeInfoDao.deleteSyncRuntimeInfo(syncRuntimeInfo.appInstanceId) }
+            coVerify { deps.pasteDao.deletePastePullCursor(syncRuntimeInfo.appInstanceId) }
             coVerify { deps.syncClientApi.notifyRemove(any()) }
         }
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -104,4 +104,13 @@ interface PasteDao : SearchPasteData {
     ): List<PasteData>
 
     suspend fun getMaxCreateTimeByRemoteAppInstanceId(): Map<String, Long>
+
+    suspend fun getPastePullCursorMaxCreateTimes(): Map<String, Long>
+
+    suspend fun upsertPastePullCursorMaxCreateTime(
+        appInstanceId: String,
+        maxCreateTime: Long,
+    )
+
+    suspend fun deletePastePullCursor(appInstanceId: String)
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
@@ -566,4 +566,30 @@ class SqlPasteDao(
                 .mapNotNull { row -> row.maxCreateTime?.let { row.appInstanceId to it } }
                 .toMap()
         }
+
+    override suspend fun getPastePullCursorMaxCreateTimes(): Map<String, Long> =
+        withContext(ioDispatcher) {
+            pasteDatabaseQueries
+                .getPastePullCursorMaxCreateTimes()
+                .executeAsList()
+                .associate { row -> row.appInstanceId to row.maxCreateTime }
+        }
+
+    override suspend fun upsertPastePullCursorMaxCreateTime(
+        appInstanceId: String,
+        maxCreateTime: Long,
+    ) {
+        withContext(ioDispatcher) {
+            pasteDatabaseQueries.upsertPastePullCursorMaxCreateTime(
+                appInstanceId = appInstanceId,
+                maxCreateTime = maxCreateTime,
+            )
+        }
+    }
+
+    override suspend fun deletePastePullCursor(appInstanceId: String) {
+        withContext(ioDispatcher) {
+            pasteDatabaseQueries.deletePastePullCursor(appInstanceId)
+        }
+    }
 }

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
@@ -22,6 +22,11 @@ CREATE TABLE IF NOT EXISTS PasteDataEntity (
     remote INTEGER AS Boolean NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS PastePullCursorEntity (
+    appInstanceId TEXT PRIMARY KEY NOT NULL,
+    maxCreateTime INTEGER NOT NULL
+);
+
 CREATE TRIGGER IF NOT EXISTS PasteDataEntityAI AFTER INSERT ON PasteDataEntity BEGIN
     INSERT INTO PasteDataEntityFts(rowid, pasteSearchContent)
     VALUES (new.id, new.pasteSearchContent);
@@ -291,6 +296,18 @@ SELECT appInstanceId, MAX(createTime) AS maxCreateTime
 FROM PasteDataEntity
 WHERE remote = 1 AND pasteState != -1
 GROUP BY appInstanceId;
+
+getPastePullCursorMaxCreateTimes:
+SELECT appInstanceId, maxCreateTime FROM PastePullCursorEntity;
+
+upsertPastePullCursorMaxCreateTime:
+INSERT INTO PastePullCursorEntity(appInstanceId, maxCreateTime)
+VALUES (:appInstanceId, :maxCreateTime)
+ON CONFLICT(appInstanceId) DO UPDATE SET
+    maxCreateTime = MAX(PastePullCursorEntity.maxCreateTime, excluded.maxCreateTime);
+
+deletePastePullCursor:
+DELETE FROM PastePullCursorEntity WHERE appInstanceId = :appInstanceId;
 
 change:
 SELECT changes() AS changes;

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/migrations/3.sqm
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/migrations/3.sqm
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS PastePullCursorEntity (
+    appInstanceId TEXT PRIMARY KEY NOT NULL,
+    maxCreateTime INTEGER NOT NULL
+);


### PR DESCRIPTION
Closes #4702

## Problem

#4699 discards oversized remote non-file pastes without storing them, but the pull cursor only advances in memory. After a restart, `PastePullService.init()` rebuilds each device's cursor from the max `createTime` of stored pastes — which never includes a discarded paste. If the newest paste from a peer was discarded, every restart re-pulls it, re-discards it, and re-notifies, repeatedly transferring tens of MB until the peer produces a newer stored paste.

## Changes

- **New `PastePullCursorEntity` table** (`appInstanceId` PK, `maxCreateTime`) with SQLDelight migration `3.sqm`. The migration uses `CREATE TABLE IF NOT EXISTS` so it stays idempotent under `DesktopDriverFactory`'s migration replay after a fresh create.
- **Discard path** (`PasteReleaseService.discardOversizedRemoteNonFilePaste`) upserts the cursor with the discarded paste's `createTime`; the SQL upsert takes `MAX(existing, excluded)` so the cursor never moves backwards.
- **`PastePullService.init()`** restores each device's cursor as the max of the stored-paste max `createTime` and the durable cursor.
- **Device removal cleanup**: `SyncDeviceManager.removeDevice` (reached by both local unpair and remote `NOTIFY_REMOVE`) now deletes the device's cursor row alongside the other local state. `PasteDao` is injected directly rather than going through `PastePullService` to avoid a constructor dependency cycle via `SyncManager`.

## Safety notes

- The durable cursor is written synchronously in the discard path; in the pull batch flow items are processed in ascending `createTime` order and persisted inline, so the cursor can never cover an older item that has not yet been stored.
- The pull query uses strict `createTime > :createTime`, so a cursor equal to the discarded paste's `createTime` is sufficient to suppress re-pulls.

## Tests

- `PasteDaoTest`: cursor upsert is monotonic; delete only removes the given device's row.
- `PasteReleaseServiceRemoteDiscardTest`: discarding upserts the durable cursor exactly once.
- `PastePullServiceTest` (new): `init()` merges stored max and durable cursor per device; in-memory updates never write the durable cursor.
- `SyncDeviceManagerTest`: `removeDevice` deletes the cursor row.

Note for mobile: `shared/commonMain` changes include the new table + `3.sqm`; the mobile repos must pick up the migration file when syncing shared code.