### PR TITLE
:bug: reject unsafe remote file paths

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -177,6 +177,8 @@ class PasteReleaseService(
     private suspend fun bindFilePasteForReceive(pasteData: PasteData): PasteData? {
         val pasteFiles = pasteData.getPasteItem(PasteFiles::class) ?: return null
 
+        userDataPathProvider.validateReceivePaths(pasteData.appInstanceId, pasteFiles)
+
         val id = pasteDao.createPasteData(pasteData, PasteState.LOADING)
 
         val fileSize = pasteFiles.size

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
@@ -8,6 +8,7 @@ import com.crosspaste.paste.item.CreatePasteItemHelper.createFilesPasteItem
 import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.path.PlatformUserDataPathProvider
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.presist.DirFileInfoTree
 import com.crosspaste.presist.SingleFileInfoTree
 import com.crosspaste.task.TaskSubmitter
 import com.crosspaste.utils.getJsonUtils
@@ -184,5 +185,42 @@ class PasteReleaseServicePushTest {
         assertTrue(expectedFile.parentFile.isDirectory, "parent directory must exist")
         assertTrue(expectedFile.isFile, "file slot must be pre-allocated")
         assertEquals(fileSize, expectedFile.length(), "pre-allocated slot must have the expected length")
+    }
+
+    @Test
+    fun releaseRemotePasteDataForPush_rejectsUnsafeTreeBeforeCreatingPaste(
+        @TempDir tempDir: File,
+    ) = runBlocking {
+        val pasteDao = mockk<PasteDao>(relaxed = true)
+        val service =
+            newService(
+                pasteDao = pasteDao,
+                userDataPathProvider = realPathProvider(File(tempDir, "storage")),
+            )
+        val filesItem =
+            createFilesPasteItem(
+                relativePathList = listOf("folder"),
+                fileInfoTreeMap =
+                    mapOf(
+                        "folder" to
+                            DirFileInfoTree(
+                                tree = mapOf("../../escape.txt" to SingleFileInfoTree(1, "hash")),
+                                size = 1,
+                                hash = "dir-hash",
+                            ),
+                    ),
+            )
+        val pasteData =
+            PasteData(
+                appInstanceId = "test-mobile",
+                pasteAppearItem = filesItem,
+                pasteCollection = PasteCollection(emptyList()),
+                pasteType = PasteType.FILE_TYPE.type,
+                size = 1,
+                hash = "hash",
+            )
+
+        assertNull(service.releaseRemotePasteDataForPush(pasteData))
+        coVerify(exactly = 0) { pasteDao.createPasteData(any(), any()) }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/path/UserDataPathProviderResolveTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/path/UserDataPathProviderResolveTest.kt
@@ -4,6 +4,7 @@ import com.crosspaste.config.AppConfig
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.paste.item.CreatePasteItemHelper.createFilesPasteItem
 import com.crosspaste.paste.item.FilesPasteItem
+import com.crosspaste.presist.DirFileInfoTree
 import com.crosspaste.presist.FilesIndexBuilder
 import com.crosspaste.presist.SingleFileInfoTree
 import com.crosspaste.utils.getJsonUtils
@@ -16,6 +17,8 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -166,5 +169,47 @@ class UserDataPathProviderResolveTest {
             )
 
         assertTrue(renameMap.isEmpty())
+    }
+
+    @Test
+    fun `receive paths reject unsafe app instance ids`() {
+        val item = createFilesItem("safe.txt")
+
+        listOf("../peer", "/absolute", "C:\\escape", "peer/child", "peer\u0000id").forEach { appInstanceId ->
+            assertFailsWith<IllegalArgumentException> {
+                userDataPathProvider.validateReceivePaths(appInstanceId, item)
+            }
+        }
+    }
+
+    @Test
+    fun `nested traversal is rejected without creating an escaped file`() {
+        val escapedFile = File(nioTempFolder, "escaped.txt")
+        val item =
+            createFilesPasteItem(
+                relativePathList = listOf("folder"),
+                fileInfoTreeMap =
+                    mapOf(
+                        "folder" to
+                            DirFileInfoTree(
+                                tree = mapOf("../../../../../escaped.txt" to SingleFileInfoTree(64, "hash")),
+                                size = 64,
+                                hash = "dir-hash",
+                            ),
+                    ),
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            userDataPathProvider.resolve(
+                "app1",
+                "2025-01-01",
+                6L,
+                item,
+                true,
+                FilesIndexBuilder(1024),
+            )
+        }
+
+        assertFalse(escapedFile.exists())
     }
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/path/UserDataPathProvider.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/path/UserDataPathProvider.kt
@@ -86,7 +86,7 @@ class UserDataPathProvider(
         val basePath =
             pasteFiles.basePath?.toPath() ?: run {
                 resolve(appFileType = pasteFiles.getAppFileType())
-                    .resolve(appInstanceId)
+                    .resolveStorageComponent(appInstanceId)
                     .resolve(dateString)
                     .resolve(pasteId.toString())
             }
@@ -117,6 +117,28 @@ class UserDataPathProvider(
         return renameMap
     }
 
+    fun validateReceivePaths(
+        appInstanceId: String,
+        pasteFiles: PasteFiles,
+    ) {
+        validateStorageComponent(appInstanceId)
+
+        val pending = ArrayDeque<FileInfoTree>()
+        pasteFiles.fileInfoTreeMap.forEach { (name, fileInfoTree) ->
+            validateStorageComponent(name)
+            pending.addLast(fileInfoTree)
+        }
+        while (pending.isNotEmpty()) {
+            val fileInfoTree = pending.removeFirst()
+            if (fileInfoTree is DirFileInfoTree) {
+                fileInfoTree.iterator().forEach { (name, child) ->
+                    validateStorageComponent(name)
+                    pending.addLast(child)
+                }
+            }
+        }
+    }
+
     private fun resolveFileInfoTree(
         basePath: Path,
         name: String,
@@ -125,7 +147,7 @@ class UserDataPathProvider(
         filesIndexBuilder: FilesIndexBuilder?,
     ) {
         if (fileInfoTree.isFile()) {
-            val filePath = basePath.resolve(name)
+            val filePath = basePath.resolveStorageComponent(name)
             if (isPull) {
                 if (fileUtils.createEmptyPasteFile(filePath, fileInfoTree.size).isFailure) {
                     throw PasteException(
@@ -136,7 +158,7 @@ class UserDataPathProvider(
             }
             filesIndexBuilder?.addFile(filePath, fileInfoTree.size)
         } else {
-            val dirPath = basePath.resolve(name)
+            val dirPath = basePath.resolveStorageComponent(name)
             if (isPull) {
                 autoCreateDir(dirPath)
             }
@@ -178,6 +200,30 @@ class UserDataPathProvider(
             !value.contains('/') &&
             !value.contains('\\') &&
             !value.contains("..")
+
+    private fun Path.resolveStorageComponent(component: String): Path {
+        validateStorageComponent(component)
+        val normalizedBase = normalized()
+        val resolved = normalizedBase.resolve(component, normalize = true)
+        require(resolved.parent == normalizedBase) { "Storage path escaped its parent" }
+        return resolved
+    }
+
+    private fun validateStorageComponent(component: String) {
+        require(
+            component.isNotEmpty() &&
+                component != "." &&
+                component != ".." &&
+                component.none { char ->
+                    char == '/' ||
+                        char == '\\' ||
+                        char == ':' ||
+                        char.code == 0 ||
+                        char.code in 1..31 ||
+                        char.code == 127
+                },
+        ) { "Unsafe storage path component" }
+    }
 
     fun getUserDataPath(): Path =
         if (configManager.getCurrentConfig().useDefaultStoragePath) {


### PR DESCRIPTION
## Summary
- validate remote app identity and every file-tree path component before persistence
- enforce normalized parent containment again while resolving file slots
- reject traversal before creating the LOADING database row or files outside storage

## Compatibility
- no wire-format changes
- valid v2/v3 file names keep their existing paths

## Verification
- ./gradlew :shared:build
- targeted UserDataPathProviderResolveTest and PasteReleaseServicePushTest