### PR TITLE
:bug: bind remote paste to authenticated identity

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -102,7 +102,12 @@ private suspend fun receiveRemotePasteData(
     appInstanceId: String,
 ): PasteData? =
     runCatching {
-        call.receive<PasteData>().copy(remote = true)
+        call.receive<PasteData>().let { pasteData ->
+            if (pasteData.appInstanceId != appInstanceId) {
+                logger.warn { "Ignoring mismatched PasteData identity from authenticated peer $appInstanceId" }
+            }
+            pasteData.bindAuthenticatedRemoteIdentity(appInstanceId)
+        }
     }.onFailure { e ->
         logger.error(e) { "sync handler ($appInstanceId) receive pasteData error" }
         val code =
@@ -113,6 +118,12 @@ private suspend fun receiveRemotePasteData(
             }
         failResponse(call, code.toErrorCode())
     }.getOrNull()
+
+internal fun PasteData.bindAuthenticatedRemoteIdentity(appInstanceId: String): PasteData =
+    copy(
+        appInstanceId = appInstanceId,
+        remote = true,
+    )
 
 /**
  * Permission gating policy: the caller ([handleSyncPaste]) already ran

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PasteRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PasteRoutingTest.kt
@@ -1,0 +1,41 @@
+package com.crosspaste.net.routing
+
+import com.crosspaste.paste.PasteCollection
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PasteRoutingTest {
+
+    @Test
+    fun `authenticated identity replaces body identity`() {
+        val pasteData = createPasteData(appInstanceId = "spoofed-peer")
+
+        val bound = pasteData.bindAuthenticatedRemoteIdentity("authenticated-peer")
+
+        assertEquals("authenticated-peer", bound.appInstanceId)
+        assertTrue(bound.remote)
+        assertEquals(pasteData.hash, bound.hash)
+    }
+
+    @Test
+    fun `matching identity is still marked remote`() {
+        val pasteData = createPasteData(appInstanceId = "authenticated-peer")
+
+        val bound = pasteData.bindAuthenticatedRemoteIdentity("authenticated-peer")
+
+        assertEquals("authenticated-peer", bound.appInstanceId)
+        assertTrue(bound.remote)
+    }
+
+    private fun createPasteData(appInstanceId: String): PasteData =
+        PasteData(
+            appInstanceId = appInstanceId,
+            pasteCollection = PasteCollection(emptyList()),
+            pasteType = PasteType.TEXT_TYPE.type,
+            size = 4,
+            hash = "hash",
+        )
+}


### PR DESCRIPTION
## Summary
- canonicalize remote PasteData identity from the authenticated request header
- ignore spoofed body identity for both pull and push paths
- keep old clients compatible by overriding mismatches instead of adding a wire field or rejecting the request

## Verification
- ./gradlew :app:desktopTest --tests com.crosspaste.net.routing.PasteRoutingTest