### PR TITLE
:bug: fail truncated file chunks

### DIFF
--- a/shared/src/commonTest/kotlin/com/crosspaste/utils/FileChunkIoTest.kt
+++ b/shared/src/commonTest/kotlin/com/crosspaste/utils/FileChunkIoTest.kt
@@ -1,0 +1,59 @@
+package com.crosspaste.utils
+
+import com.crosspaste.presist.FileChunk
+import com.crosspaste.presist.FilesChunk
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.runBlocking
+import okio.EOFException
+import okio.FileSystem
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class FileChunkIoTest {
+
+    private val fileUtils = getFileUtils()
+
+    @Test
+    fun `writeFilesChunk rejects a truncated input channel`() {
+        val path = createTempPath()
+        try {
+            fileUtils.createEmptyPasteFile(path, CHUNK_SIZE).getOrThrow()
+            val filesChunk = FilesChunk(listOf(FileChunk(0, CHUNK_SIZE, path)))
+
+            assertFailsWith<EOFException> {
+                runBlocking {
+                    fileUtils.writeFilesChunk(filesChunk, ByteReadChannel(ByteArray(4)))
+                }
+            }
+        } finally {
+            fileUtils.fileSystem.delete(path, mustExist = false)
+        }
+    }
+
+    @Test
+    fun `readFilesChunk rejects a file shorter than the chunk`() {
+        val path = createTempPath()
+        val output = ByteChannel(true)
+        try {
+            fileUtils.fileSystem.write(path) { write(ByteArray(4)) }
+            val filesChunk = FilesChunk(listOf(FileChunk(0, CHUNK_SIZE, path)))
+
+            assertFailsWith<EOFException> {
+                runBlocking {
+                    fileUtils.readFilesChunk(filesChunk, output)
+                }
+            }
+        } finally {
+            output.cancel(null)
+            fileUtils.fileSystem.delete(path, mustExist = false)
+        }
+    }
+
+    private fun createTempPath() = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "crosspaste-chunk-${Random.nextInt()}"
+
+    private companion object {
+        const val CHUNK_SIZE = 10L
+    }
+}

--- a/shared/src/desktopMain/kotlin/com/crosspaste/utils/FileUtils.desktop.kt
+++ b/shared/src/desktopMain/kotlin/com/crosspaste/utils/FileUtils.desktop.kt
@@ -4,6 +4,7 @@ import com.crosspaste.presist.FilesChunk
 import io.ktor.utils.io.*
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import okio.EOFException
 import okio.FileSystem
 import okio.Path
 import java.io.RandomAccessFile
@@ -62,7 +63,10 @@ object DesktopFileUtils : FileUtils {
                         val toRead = minOf(buffer.size, remaining.toInt())
                         val readSize = byteReadChannel.readAvailable(buffer, 0, toRead)
                         if (readSize == -1) {
-                            break
+                            throw EOFException(
+                                "Unexpected EOF while writing ${fileChunk.path.name}: " +
+                                    "${size - remaining} of $size bytes",
+                            )
                         }
                         randomAccessFile.write(buffer, 0, readSize)
                         remaining -= readSize
@@ -91,7 +95,10 @@ object DesktopFileUtils : FileUtils {
                     val toRead = minOf(buffer.size, remaining.toInt())
                     val readSize = randomAccessFile.read(buffer, 0, toRead)
                     if (readSize == -1) {
-                        break
+                        throw EOFException(
+                            "Unexpected EOF while reading ${fileChunk.path.name}: " +
+                                "${size - remaining} of $size bytes",
+                        )
                     }
                     byteWriteChannel.writeFully(buffer, 0, readSize)
                     remaining -= readSize

--- a/shared/src/nativeMain/kotlin/com/crosspaste/utils/FileUtils.native.kt
+++ b/shared/src/nativeMain/kotlin/com/crosspaste/utils/FileUtils.native.kt
@@ -5,6 +5,7 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
 import io.ktor.utils.io.readAvailable
 import io.ktor.utils.io.writeFully
+import okio.EOFException
 import okio.FileSystem
 import okio.Path
 import okio.buffer
@@ -67,7 +68,10 @@ object NativeFileUtils : FileUtils {
                         val toRead = minOf(buffer.size, remaining.toInt())
                         val readSize = byteReadChannel.readAvailable(buffer, 0, toRead)
                         if (readSize == -1) {
-                            break
+                            throw EOFException(
+                                "Unexpected EOF while writing ${fileChunk.path.name}: " +
+                                    "${size - remaining} of $size bytes",
+                            )
                         }
                         fileHandle.write(offset, buffer, 0, readSize)
                         offset += readSize
@@ -113,7 +117,10 @@ object NativeFileUtils : FileUtils {
                     val toRead = minOf(buffer.size, remaining.toInt())
                     val readSize = fileHandle.read(offset, buffer, 0, toRead)
                     if (readSize == -1) {
-                        break
+                        throw EOFException(
+                            "Unexpected EOF while reading ${fileChunk.path.name}: " +
+                                "${size - remaining} of $size bytes",
+                        )
                     }
                     byteWriteChannel.writeFully(buffer, 0, readSize)
                     offset += readSize


### PR DESCRIPTION
## Summary
- throw EOFException when a network chunk ends before its declared byte count
- throw the same failure when a local source file is shorter than its FileChunk
- keep desktop and Native actual behavior identical

## Behavior
- push routes no longer mark truncated chunks as received
- pull/send callers receive a failure and retain their existing retry behavior

## Verification
- ./gradlew :shared:build
- FileChunkIoTest runs on desktop and host Native