### PR TITLE
:bug: bound remote file transfer resources

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
@@ -5,6 +5,7 @@ import com.crosspaste.dto.push.PushCompleteResponse
 import com.crosspaste.dto.push.PushHeaders
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.presist.FileTransferResourceLimits
 import com.crosspaste.sync.PushSession
 import com.crosspaste.sync.PushSessionManager
 import com.crosspaste.utils.FileUtils
@@ -228,7 +229,11 @@ private suspend fun handleIconPush(
 
     val writeFailed =
         runCatching {
-            fileUtils.writeFile(iconPath, call.receiveChannel())
+            fileUtils.writeFile(
+                path = iconPath,
+                byteReadChannel = call.receiveChannel(),
+                maxBytes = FileTransferResourceLimits.MAX_ICON_SIZE,
+            )
         }.isFailure
     if (writeFailed) {
         logger.error { "push icon: write failed source=$source from=$fromAppInstanceId" }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
@@ -21,6 +21,7 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
 import io.ktor.utils.io.*
+import okio.Path
 import okio.Path.Companion.toPath
 
 private val logger: KLogger = KotlinLogging.logger("PushRouting")
@@ -228,21 +229,8 @@ private suspend fun handleIconPush(
             return
         }
 
-    // Write to a sibling temp file and atomically move so an oversized or
-    // aborted upload can never leave a truncated icon at iconPath (a truncated
-    // icon would suppress the pull-icon repair path because the file exists).
-    val tempIconPath = "$iconPath.part".toPath()
-    val writeFailed =
-        runCatching {
-            fileUtils.writeFile(
-                path = tempIconPath,
-                byteReadChannel = call.receiveChannel(),
-                maxBytes = FileTransferResourceLimits.MAX_ICON_SIZE,
-            )
-            fileUtils.moveFile(tempIconPath, iconPath).getOrThrow()
-        }.isFailure
+    val writeFailed = !writeIconAtomically(iconPath, call.receiveChannel())
     if (writeFailed) {
-        fileUtils.deleteFile(tempIconPath)
         logger.error { "push icon: write failed source=$source from=$fromAppInstanceId" }
         failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
         return
@@ -250,4 +238,31 @@ private suspend fun handleIconPush(
 
     logger.info { "push icon: stored source=$source from=$fromAppInstanceId" }
     successResponse(call)
+}
+
+/**
+ * Writes an icon body to a uniquely named sibling temp file and atomically
+ * moves it into place. The unique name keeps concurrent uploads for the same
+ * source from sharing a temp file, and the move ensures an oversized or
+ * aborted upload never leaves a truncated icon at [iconPath] (a truncated
+ * icon would suppress the pull-icon repair path because the file exists).
+ */
+internal suspend fun writeIconAtomically(
+    iconPath: Path,
+    byteReadChannel: ByteReadChannel,
+): Boolean {
+    val tempIconPath = "$iconPath.${fileUtils.createRandomFileName("part")}".toPath()
+    val moved =
+        runCatching {
+            fileUtils.writeFile(
+                path = tempIconPath,
+                byteReadChannel = byteReadChannel,
+                maxBytes = FileTransferResourceLimits.MAX_ICON_SIZE,
+            )
+            fileUtils.moveFile(tempIconPath, iconPath).getOrThrow()
+        }.isSuccess
+    if (!moved) {
+        fileUtils.deleteFile(tempIconPath)
+    }
+    return moved
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
@@ -21,6 +21,7 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
 import io.ktor.utils.io.*
+import okio.Path.Companion.toPath
 
 private val logger: KLogger = KotlinLogging.logger("PushRouting")
 private val fileUtils: FileUtils = getFileUtils()
@@ -227,15 +228,21 @@ private suspend fun handleIconPush(
             return
         }
 
+    // Write to a sibling temp file and atomically move so an oversized or
+    // aborted upload can never leave a truncated icon at iconPath (a truncated
+    // icon would suppress the pull-icon repair path because the file exists).
+    val tempIconPath = "$iconPath.part".toPath()
     val writeFailed =
         runCatching {
             fileUtils.writeFile(
-                path = iconPath,
+                path = tempIconPath,
                 byteReadChannel = call.receiveChannel(),
                 maxBytes = FileTransferResourceLimits.MAX_ICON_SIZE,
             )
+            fileUtils.moveFile(tempIconPath, iconPath).getOrThrow()
         }.isFailure
     if (writeFailed) {
+        fileUtils.deleteFile(tempIconPath)
         logger.error { "push icon: write failed source=$source from=$fromAppInstanceId" }
         failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
         return

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -292,9 +292,10 @@ class PasteReleaseService(
             val remotePasteDataId = pasteData.id
             val isFileType = pasteData.isFileType()
             if (isFileType) {
-                val invalidCause = runCatching { validateFileTransferMetadata(pasteData) }.exceptionOrNull()
-                if (invalidCause != null) {
-                    discardInvalidRemoteFilePaste(pasteData, invalidCause)
+                try {
+                    validateFileTransferMetadata(pasteData)
+                } catch (e: IllegalArgumentException) {
+                    discardInvalidRemoteFilePaste(pasteData, e)
                     return@runCatching
                 }
             }

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -16,6 +16,7 @@ import com.crosspaste.paste.plugin.process.PasteProcessPlugin
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FilesIndex
 import com.crosspaste.presist.buildFilesIndexForReceive
+import com.crosspaste.presist.validateFileTransferMetadata
 import com.crosspaste.sync.FilePullService
 import com.crosspaste.sync.PastePullCursorManager
 import com.crosspaste.task.TaskBuilder
@@ -260,6 +261,9 @@ class PasteReleaseService(
             }
             val remotePasteDataId = pasteData.id
             val isFileType = pasteData.isFileType()
+            if (isFileType) {
+                validateFileTransferMetadata(pasteData)
+            }
             val existIconFile: Boolean? =
                 pasteData.source?.let {
                     fileUtils.existFile(userDataPathProvider.resolveIconPath(pasteData.appInstanceId, it))
@@ -350,6 +354,7 @@ class PasteReleaseService(
                 return@withContext null
             }
             runCatching {
+                validateFileTransferMetadata(pasteData)
                 val existIconFile: Boolean? =
                     pasteData.source?.let {
                         fileUtils.existFile(userDataPathProvider.resolveIconPath(pasteData.appInstanceId, it))

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -251,6 +251,36 @@ class PasteReleaseService(
         return true
     }
 
+    /**
+     * Discard (not fail) a remote file paste whose metadata violates the
+     * transfer resource limits. The pull cursor has already advanced past the
+     * batch this paste arrived in, so propagating a failure would abort
+     * [releaseRemotePasteDataList] and silently drop unrelated pastes pulled in
+     * the same round — including pastes from other devices.
+     */
+    private suspend fun discardInvalidRemoteFilePaste(
+        pasteData: PasteData,
+        cause: Throwable,
+    ) {
+        logger.warn(cause) {
+            "Discard invalid remote file paste from ${pasteData.appInstanceId}: " +
+                "createTime=${pasteData.createTime}"
+        }
+        pastePullCursorManager.persistDiscardedMaxCreateTime(
+            appInstanceId = pasteData.appInstanceId,
+            createTime = pasteData.createTime,
+        )
+        val deviceName =
+            syncRuntimeInfoDao
+                .getSyncRuntimeInfo(pasteData.appInstanceId)
+                ?.getDeviceDisplayName()
+                ?: pasteData.appInstanceId
+        notificationManager.sendNotification(
+            title = { it.getText("remote_file_paste_discarded_invalid", deviceName) },
+            messageType = MessageType.Warning,
+        )
+    }
+
     suspend fun releaseRemotePasteData(
         pasteData: PasteData,
         tryWritePasteboard: (PasteData) -> Unit,
@@ -262,7 +292,11 @@ class PasteReleaseService(
             val remotePasteDataId = pasteData.id
             val isFileType = pasteData.isFileType()
             if (isFileType) {
-                validateFileTransferMetadata(pasteData)
+                val invalidCause = runCatching { validateFileTransferMetadata(pasteData) }.exceptionOrNull()
+                if (invalidCause != null) {
+                    discardInvalidRemoteFilePaste(pasteData, invalidCause)
+                    return@runCatching
+                }
             }
             val existIconFile: Boolean? =
                 pasteData.source?.let {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/FilePushService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/FilePushService.kt
@@ -11,6 +11,7 @@ import com.crosspaste.net.clientapi.createFailureResult
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteSyncProcessManager
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.presist.FileTransferResourceLimits
 import com.crosspaste.presist.FilesIndex
 import com.crosspaste.presist.buildFilesIndex
 import com.crosspaste.utils.FileUtils
@@ -96,9 +97,24 @@ class FilePushService(
                 return prepareResult
             }
             val prepare = prepareResult.getResult<PushPrepareResponse>()
+            validatePrepareResponse(prepare)?.let { message ->
+                logger.warn { "push prepare returned invalid parameters for target=$targetAppInstanceId: $message" }
+                return createFailureResult(StandardErrorCode.PUSH_PREPARE_FAIL, message)
+            }
 
             // 2. build local index with the server-provided chunkSize
-            val filesIndex = filesIndexFactory(pasteData, userDataPathProvider, prepare.chunkSize)
+            val filesIndex =
+                try {
+                    filesIndexFactory(pasteData, userDataPathProvider, prepare.chunkSize)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.warn(e) { "push filesIndex rejected for target=$targetAppInstanceId" }
+                    return createFailureResult(
+                        StandardErrorCode.PUSH_PREPARE_FAIL,
+                        "Unable to build a bounded file index: ${e.message}",
+                    )
+                }
             val localChunkCount = filesIndex.getChunkCount()
             if (localChunkCount != prepare.chunkCount) {
                 logger.error {
@@ -148,6 +164,13 @@ class FilePushService(
                     return completeResult
                 }
                 val complete = completeResult.getResult<PushCompleteResponse>()
+                validateMissingChunks(complete.missingChunks, prepare.chunkCount)?.let { message ->
+                    logger.warn {
+                        "push complete returned invalid missing chunks for target=$targetAppInstanceId " +
+                            "pasteId=${prepare.pasteId}: $message"
+                    }
+                    return createFailureResult(StandardErrorCode.PUSH_COMPLETE_FAIL, message)
+                }
                 if (complete.isComplete) {
                     maybePushIcon(prepare, pasteData, targetAppInstanceId, toUrl)
                     return SuccessResult()
@@ -239,6 +262,29 @@ class FilePushService(
             }
     }
 
+    private fun validatePrepareResponse(prepare: PushPrepareResponse): String? =
+        when {
+            prepare.chunkCount !in 1..FileTransferResourceLimits.MAX_CHUNK_COUNT ->
+                "chunkCount must be between 1 and ${FileTransferResourceLimits.MAX_CHUNK_COUNT}"
+            prepare.chunkSize !in 1..FileTransferResourceLimits.MAX_CHUNK_SIZE ->
+                "chunkSize must be between 1 and ${FileTransferResourceLimits.MAX_CHUNK_SIZE}"
+            prepare.sessionToken.isEmpty() -> "sessionToken must not be empty"
+            prepare.sessionToken.length > FileTransferResourceLimits.MAX_SESSION_TOKEN_LENGTH ->
+                "sessionToken exceeds ${FileTransferResourceLimits.MAX_SESSION_TOKEN_LENGTH} characters"
+            else -> null
+        }
+
+    private fun validateMissingChunks(
+        missingChunks: List<Int>,
+        chunkCount: Int,
+    ): String? =
+        when {
+            missingChunks.size > chunkCount -> "missingChunks contains more entries than chunkCount"
+            missingChunks.any { it !in 0 until chunkCount } -> "missingChunks contains an out-of-range index"
+            missingChunks.toSet().size != missingChunks.size -> "missingChunks contains duplicate indices"
+            else -> null
+        }
+
     /**
      * Fire-and-forget icon push when the peer signalled `needIcon=true`. The
      * receiver's pull-icon task is the durable fallback (per M1+M2 design), so
@@ -257,6 +303,10 @@ class FilePushService(
             val iconPath = userDataPathProvider.resolveIconPath(pasteData.appInstanceId, source)
             if (!fileUtils.existFile(iconPath)) {
                 logger.debug { "push icon skipped: no local icon for source=$source" }
+                return
+            }
+            if (fileUtils.getFileSize(iconPath) > FileTransferResourceLimits.MAX_ICON_SIZE) {
+                logger.info { "push icon skipped: source=$source exceeds the icon size limit" }
                 return
             }
             val bytes =

--- a/app/src/desktopMain/resources/i18n/de.properties
+++ b/app/src/desktopMain/resources/i18n/de.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=vor %s Sekunden
 relative_weeks_ago=vor %s Wochen
 relative_years_ago=vor %s Jahren
 remote=Remote
+remote_file_paste_discarded_invalid=Datei- oder Bildinhalt von %s ist ungültig oder überschreitet die Übertragungsgrenzen und wurde nicht synchronisiert
 remote_non_file_paste_discarded_too_large=Text-, HTML-, Rich-Text- oder Link-Inhalt von %s ist zu groß und wurde nicht synchronisiert
 remote_version_low_desc=Softwareversion des verbundenen Geräts zu niedrig, Upgrade empfohlen.
 remove=Entfernen

--- a/app/src/desktopMain/resources/i18n/en.properties
+++ b/app/src/desktopMain/resources/i18n/en.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=%s seconds ago
 relative_weeks_ago=%s weeks ago
 relative_years_ago=%s years ago
 remote=Remote
+remote_file_paste_discarded_invalid=File or image content from %s is invalid or exceeds transfer limits and was not synced
 remote_non_file_paste_discarded_too_large=Text, HTML, rich text, or link content from %s is too large and was not synced
 remote_version_low_desc=Connected device software version is too low, upgrading is recommended.
 remove=Remove

--- a/app/src/desktopMain/resources/i18n/es.properties
+++ b/app/src/desktopMain/resources/i18n/es.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=hace %s segundos
 relative_weeks_ago=hace %s semanas
 relative_years_ago=hace %s años
 remote=Remoto
+remote_file_paste_discarded_invalid=El contenido de archivo o imagen de %s no es válido o supera los límites de transferencia y no se sincronizó
 remote_non_file_paste_discarded_too_large=El contenido de texto, HTML, texto enriquecido o enlace de %s es demasiado grande y no se sincronizó
 remote_version_low_desc=La versión de software del dispositivo conectado es demasiado baja, se recomienda actualizar.
 remove=Eliminar

--- a/app/src/desktopMain/resources/i18n/fa.properties
+++ b/app/src/desktopMain/resources/i18n/fa.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=%s ثانیه پیش
 relative_weeks_ago=%s هفته پیش
 relative_years_ago=%s سال پیش
 remote=ریموت
+remote_file_paste_discarded_invalid=محتوای فایل / تصویر از %s نامعتبر است یا از محدودیت‌های انتقال فراتر رفته و همگام‌سازی نشد
 remote_non_file_paste_discarded_too_large=محتوای متن / HTML / متن غنی / پیوند از %s بسیار بزرگ است و همگام‌سازی نشد
 remote_version_low_desc=نسخه نرم‌افزار دستگاه متصل بیش از حد قدیمی است، ارتقا توصیه می‌شود.
 remove=حذف

--- a/app/src/desktopMain/resources/i18n/fr.properties
+++ b/app/src/desktopMain/resources/i18n/fr.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=il y a %s secondes
 relative_weeks_ago=il y a %s semaines
 relative_years_ago=il y a %s ans
 remote=Distant
+remote_file_paste_discarded_invalid=Le contenu fichier ou image provenant de %s est invalide ou dépasse les limites de transfert et n'a pas été synchronisé
 remote_non_file_paste_discarded_too_large=Le contenu texte, HTML, texte enrichi ou lien provenant de %s est trop volumineux et n'a pas été synchronisé
 remote_version_low_desc=Version du logiciel de l'appareil connecté trop ancienne, mise à jour recommandée.
 remove=Supprimer

--- a/app/src/desktopMain/resources/i18n/ja.properties
+++ b/app/src/desktopMain/resources/i18n/ja.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=%s 秒前
 relative_weeks_ago=%s 週間前
 relative_years_ago=%s 年前
 remote=リモート
+remote_file_paste_discarded_invalid=%s からのファイル / 画像の内容が無効か転送制限を超えているため同期されませんでした
 remote_non_file_paste_discarded_too_large=%s からのテキスト / HTML / リッチテキスト / リンクの内容が大きすぎるため同期されませんでした
 remote_version_low_desc=接続されたデバイスのソフトウェアバージョンが古すぎます。アップグレードをお勧めします。
 remove=削除

--- a/app/src/desktopMain/resources/i18n/ko.properties
+++ b/app/src/desktopMain/resources/i18n/ko.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=%s초 전
 relative_weeks_ago=%s주 전
 relative_years_ago=%s년 전
 remote=원격
+remote_file_paste_discarded_invalid=%s에서 온 파일 / 이미지 내용이 유효하지 않거나 전송 제한을 초과하여 동기화되지 않았습니다
 remote_non_file_paste_discarded_too_large=%s에서 온 텍스트 / HTML / 서식 있는 텍스트 / 링크 내용이 너무 커서 동기화되지 않았습니다
 remote_version_low_desc=연결된 장치의 소프트웨어 버전이 너무 낮습니다. 업그레이드를 권장합니다.
 remove=제거

--- a/app/src/desktopMain/resources/i18n/pt.properties
+++ b/app/src/desktopMain/resources/i18n/pt.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=há %s segundos
 relative_weeks_ago=há %s semanas
 relative_years_ago=há %s anos
 remote=Remoto
+remote_file_paste_discarded_invalid=O conteúdo de arquivo ou imagem de %s é inválido ou excede os limites de transferência e não foi sincronizado
 remote_non_file_paste_discarded_too_large=Conteúdo de texto, HTML, texto rico ou link de %s é grande demais e não foi sincronizado
 remote_version_low_desc=A versão do software do dispositivo conectado é muito antiga, recomenda-se atualizar.
 remove=Remover

--- a/app/src/desktopMain/resources/i18n/zh.properties
+++ b/app/src/desktopMain/resources/i18n/zh.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=%s 秒前
 relative_weeks_ago=%s 周前
 relative_years_ago=%s 年前
 remote=远程
+remote_file_paste_discarded_invalid=来自 %s 的文件 / 图片内容无效或超出传输限制，未同步
 remote_non_file_paste_discarded_too_large=来自 %s 的文本 / HTML / 富文本 / 链接类内容过大,未同步
 remote_version_low_desc=连接设备软件版本过低，建议升级版本。
 remove=移除

--- a/app/src/desktopMain/resources/i18n/zh_hant.properties
+++ b/app/src/desktopMain/resources/i18n/zh_hant.properties
@@ -268,6 +268,7 @@ relative_seconds_ago=%s 秒前
 relative_weeks_ago=%s 週前
 relative_years_ago=%s 年前
 remote=遠端
+remote_file_paste_discarded_invalid=來自 %s 的檔案 / 圖片內容無效或超出傳輸限制，未同步
 remote_non_file_paste_discarded_too_large=來自 %s 的文字 / HTML / 富文字 / 連結類內容過大,未同步
 remote_version_low_desc=連接設備軟體版本過低，建議升級版本。
 remove=移除

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PushIconWriteTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PushIconWriteTest.kt
@@ -1,0 +1,60 @@
+package com.crosspaste.net.routing
+
+import com.crosspaste.presist.FileTransferResourceLimits
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import okio.Path.Companion.toOkioPath
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PushIconWriteTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private fun partFiles(): List<File> = tempDir.listFiles().orEmpty().filter { it.name.endsWith(".part") }
+
+    @Test
+    fun concurrentUploadsForSameSourceDoNotCorruptTheIcon() =
+        runBlocking {
+            val iconPath = (tempDir.toOkioPath()) / "TestApp.png"
+            val payloadA = ByteArray(100_000) { 0xAA.toByte() }
+            val payloadB = ByteArray(100_000) { 0xBB.toByte() }
+
+            val results =
+                listOf(payloadA, payloadB)
+                    .map { payload ->
+                        async { writeIconAtomically(iconPath, ByteReadChannel(payload)) }
+                    }.awaitAll()
+
+            assertTrue(results.any { it }, "at least one upload must win")
+            val stored = iconPath.toFile().readBytes()
+            assertTrue(
+                stored.contentEquals(payloadA) || stored.contentEquals(payloadB),
+                "stored icon must be exactly one complete payload",
+            )
+            assertEquals(emptyList(), partFiles(), "no temp files may remain")
+        }
+
+    @Test
+    fun oversizedUploadKeepsExistingIconIntact() =
+        runBlocking {
+            val iconPath = (tempDir.toOkioPath()) / "TestApp.png"
+            val existingIcon = ByteArray(1_000) { 0x11 }
+            iconPath.toFile().writeBytes(existingIcon)
+
+            val oversized = ByteArray((FileTransferResourceLimits.MAX_ICON_SIZE + 1).toInt())
+            val result = writeIconAtomically(iconPath, ByteReadChannel(oversized))
+
+            assertFalse(result, "oversized upload must fail")
+            assertContentEquals(existingIcon, iconPath.toFile().readBytes())
+            assertEquals(emptyList(), partFiles(), "no temp files may remain")
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
@@ -35,6 +35,7 @@ class PasteReleaseServicePushTest {
     private fun newService(
         pasteDao: PasteDao = mockk(relaxed = true),
         commonConfigManager: CommonConfigManager = defaultConfigManager(),
+        taskSubmitter: TaskSubmitter = mockk(relaxed = true),
         userDataPathProvider: UserDataPathProvider = mockk(relaxed = true),
     ): PasteReleaseService =
         PasteReleaseService(
@@ -48,7 +49,7 @@ class PasteReleaseServicePushTest {
             pastePullCursorManager = mockk<PastePullCursorManager>(relaxed = true),
             searchContentService = mockk(relaxed = true),
             syncRuntimeInfoDao = mockk(relaxed = true),
-            taskSubmitter = mockk<TaskSubmitter>(relaxed = true),
+            taskSubmitter = taskSubmitter,
             userDataPathProvider = userDataPathProvider,
         )
 
@@ -82,15 +83,9 @@ class PasteReleaseServicePushTest {
     }
 
     @Test
-    fun releaseRemotePasteDataForPush_markDeletesWhenFilesIndexEmpty() =
+    fun releaseRemotePasteDataForPush_rejectsEmptyMetadataBeforeCreatingRow() =
         runBlocking {
             val pasteDao = mockk<PasteDao>(relaxed = true)
-            coEvery { pasteDao.createPasteData(any(), any()) } returns 99L
-            coEvery { pasteDao.markDeletePasteData(any()) } returns Result.success(Unit)
-
-            // userDataPathProvider.resolve is called by buildFilesIndexForReceive with the FilesPasteItem
-            // but relaxed=true makes it a no-op — builder stays empty → FilesIndex has 0 chunks
-            // → triggers the empty-filesIndex cleanup branch in releaseRemotePasteDataForPush.
             val service = newService(pasteDao = pasteDao)
 
             val emptyFilesItem =
@@ -111,8 +106,38 @@ class PasteReleaseServicePushTest {
 
             val result = service.releaseRemotePasteDataForPush(pasteData)
 
-            assertNull(result, "empty filesIndex should yield null result")
-            coVerify(exactly = 1) { pasteDao.markDeletePasteData(99L) }
+            assertNull(result, "invalid file metadata should yield null result")
+            coVerify(exactly = 0) { pasteDao.createPasteData(any(), any()) }
+            coVerify(exactly = 0) { pasteDao.markDeletePasteData(any()) }
+        }
+
+    @Test
+    fun releaseRemotePasteData_rejectsInvalidMetadataBeforeSubmittingTask() =
+        runBlocking {
+            val pasteDao = mockk<PasteDao>(relaxed = true)
+            val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
+            val service = newService(pasteDao = pasteDao, taskSubmitter = taskSubmitter)
+            val emptyFilesItem =
+                createFilesPasteItem(
+                    relativePathList = emptyList(),
+                    fileInfoTreeMap = emptyMap(),
+                )
+            val pasteData =
+                PasteData(
+                    appInstanceId = "test-mobile",
+                    pasteAppearItem = emptyFilesItem,
+                    pasteCollection = PasteCollection(emptyList()),
+                    pasteType = PasteType.FILE_TYPE.type,
+                    source = null,
+                    size = 0L,
+                    hash = "",
+                )
+
+            val result = service.releaseRemotePasteData(pasteData) {}
+
+            assertTrue(result.isFailure)
+            coVerify(exactly = 0) { pasteDao.createPasteData(any(), any()) }
+            coVerify(exactly = 0) { taskSubmitter.submit(any()) }
         }
 
     /**

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
@@ -112,7 +112,7 @@ class PasteReleaseServicePushTest {
         }
 
     @Test
-    fun releaseRemotePasteData_rejectsInvalidMetadataBeforeSubmittingTask() =
+    fun releaseRemotePasteData_discardsInvalidMetadataWithoutFailingBatch() =
         runBlocking {
             val pasteDao = mockk<PasteDao>(relaxed = true)
             val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
@@ -135,7 +135,7 @@ class PasteReleaseServicePushTest {
 
             val result = service.releaseRemotePasteData(pasteData) {}
 
-            assertTrue(result.isFailure)
+            assertTrue(result.isSuccess, "invalid paste is discarded, not failed")
             coVerify(exactly = 0) { pasteDao.createPasteData(any(), any()) }
             coVerify(exactly = 0) { taskSubmitter.submit(any()) }
         }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceRemoteDiscardTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceRemoteDiscardTest.kt
@@ -6,6 +6,7 @@ import com.crosspaste.config.TestAppConfig
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.notification.NotificationManager
+import com.crosspaste.paste.item.CreatePasteItemHelper.createFilesPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.paste.item.PasteItemReader
 import com.crosspaste.paste.item.TextPasteItem
@@ -151,6 +152,52 @@ class PasteReleaseServiceRemoteDiscardTest {
             assertTrue(result.isSuccess)
             coVerify(exactly = 1) { taskSubmitter.submit(any()) }
             verify(exactly = 0) { notificationManager.sendNotification(any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `invalid remote file paste is discarded and the batch continues`() =
+        runBlocking {
+            val notificationManager = mockk<NotificationManager>(relaxed = true)
+            val pastePullCursorManager = mockk<PastePullCursorManager>(relaxed = true)
+            val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
+            val service =
+                newService(
+                    notificationManager = notificationManager,
+                    pastePullCursorManager = pastePullCursorManager,
+                    taskSubmitter = taskSubmitter,
+                )
+            val invalidFilePaste =
+                PasteData(
+                    appInstanceId = "remote-device",
+                    pasteAppearItem =
+                        createFilesPasteItem(
+                            relativePathList = emptyList(),
+                            fileInfoTreeMap = emptyMap(),
+                        ),
+                    pasteCollection = PasteCollection(emptyList()),
+                    pasteType = PasteType.FILE_TYPE.type,
+                    source = null,
+                    size = 0L,
+                    hash = "",
+                    remote = true,
+                ).copy(createTime = 100L)
+            val laterTextPaste =
+                remotePasteData(createTextPasteItem(text = "after")).copy(createTime = 200L)
+
+            val result =
+                service.releaseRemotePasteDataList(listOf(invalidFilePaste, laterTextPaste)) {
+                    service.releaseRemotePasteData(it) { _ -> }
+                }
+
+            assertTrue(result.isSuccess)
+            coVerify(exactly = 1) {
+                pastePullCursorManager.persistDiscardedMaxCreateTime(
+                    appInstanceId = "remote-device",
+                    createTime = 100L,
+                )
+            }
+            verify(exactly = 1) { notificationManager.sendNotification(any(), any(), any(), any()) }
+            coVerify(exactly = 1) { taskSubmitter.submit(any()) }
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/FilePushServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/FilePushServiceTest.kt
@@ -14,6 +14,7 @@ import com.crosspaste.paste.PasteSyncProcessManager
 import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.item.CreatePasteItemHelper.createFilesPasteItem
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.presist.FileTransferResourceLimits
 import com.crosspaste.presist.FilesChunk
 import com.crosspaste.presist.FilesIndex
 import com.crosspaste.utils.HostAndPort
@@ -98,13 +99,14 @@ class FilePushServiceTest {
 
     private fun preparePushResult(
         chunkCount: Int,
+        chunkSize: Long = 1024L,
         needIcon: Boolean = false,
     ): SuccessResult =
         SuccessResult(
             PushPrepareResponse(
                 pasteId = 42L,
                 chunkCount = chunkCount,
-                chunkSize = 1024L,
+                chunkSize = chunkSize,
                 sessionToken = "session-tok",
                 needIcon = needIcon,
             ),
@@ -167,6 +169,61 @@ class FilePushServiceTest {
         }
 
     @Test
+    fun pushFiles_invalidPrepareParameters_returnsFailureWithoutAllocatingTasks() =
+        runBlocking {
+            val api = mockk<PushClientApi>()
+            coEvery { api.preparePush(any(), any(), any()) } returns
+                preparePushResult(chunkCount = FileTransferResourceLimits.MAX_CHUNK_COUNT + 1)
+
+            val svc = service(api)
+            val result = svc.pushFiles(samplePasteData(), "remote-1", toUrl())
+
+            assertTrue(result is FailureResult, "got $result")
+            assertEquals(StandardErrorCode.PUSH_PREPARE_FAIL.toErrorCode(), result.exception.getErrorCode())
+            coVerify(exactly = 0) { api.pushChunk(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { api.completePush(any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun pushFiles_zeroChunkSize_returnsFailureBeforeBuildingIndex() =
+        runBlocking {
+            val api = mockk<PushClientApi>()
+            coEvery { api.preparePush(any(), any(), any()) } returns
+                preparePushResult(chunkCount = 1, chunkSize = 0)
+
+            val svc = service(api, index = fakeIndex(1))
+            val result = svc.pushFiles(samplePasteData(), "remote-1", toUrl())
+
+            assertTrue(result is FailureResult, "got $result")
+            assertEquals(StandardErrorCode.PUSH_PREPARE_FAIL.toErrorCode(), result.exception.getErrorCode())
+            coVerify(exactly = 0) { api.pushChunk(any(), any(), any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun pushFiles_indexResourceLimit_returnsFailureInsteadOfThrowing() =
+        runBlocking {
+            val api = mockk<PushClientApi>()
+            coEvery { api.preparePush(any(), any(), any()) } returns
+                preparePushResult(chunkCount = 1, chunkSize = 1)
+            val svc =
+                FilePushService(
+                    pasteSyncProcessManager = inlineProcessManager(),
+                    pushClientApi = api,
+                    userDataPathProvider = mockk(relaxed = true),
+                    filesIndexFactory = { _, _, _ ->
+                        throw IllegalArgumentException("too many chunks")
+                    },
+                    chunkReader = { byteArrayOf() },
+                )
+
+            val result = svc.pushFiles(samplePasteData(), "remote-1", toUrl())
+
+            assertTrue(result is FailureResult, "got $result")
+            assertEquals(StandardErrorCode.PUSH_PREPARE_FAIL.toErrorCode(), result.exception.getErrorCode())
+            coVerify(exactly = 0) { api.pushChunk(any(), any(), any(), any(), any(), any()) }
+        }
+
+    @Test
     fun pushFiles_missingThenComplete_succeedsWithRetry() =
         runBlocking {
             val api = mockk<PushClientApi>()
@@ -212,6 +269,24 @@ class FilePushServiceTest {
             coVerify(exactly = FilePushService.MAX_COMPLETE_ROUNDS) {
                 api.completePush(any(), any(), any(), any())
             }
+        }
+
+    @Test
+    fun pushFiles_duplicateMissingChunk_returnsFailureWithoutRetry() =
+        runBlocking {
+            val api = mockk<PushClientApi>()
+            coEvery { api.preparePush(any(), any(), any()) } returns preparePushResult(chunkCount = 3)
+            coEvery { api.pushChunk(any(), any(), any(), any(), any(), any()) } returns SuccessResult()
+            coEvery { api.completePush(any(), any(), any(), any()) } returns
+                SuccessResult(PushCompleteResponse(listOf(1, 1)))
+
+            val svc = service(api)
+            val result = svc.pushFiles(samplePasteData(), "remote-1", toUrl())
+
+            assertTrue(result is FailureResult, "got $result")
+            assertEquals(StandardErrorCode.PUSH_COMPLETE_FAIL.toErrorCode(), result.exception.getErrorCode())
+            coVerify(exactly = 3) { api.pushChunk(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 1) { api.completePush(any(), any(), any(), any()) }
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/utils/FileUtilsTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/utils/FileUtilsTest.kt
@@ -1,5 +1,7 @@
 package com.crosspaste.utils
 
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.runBlocking
 import okio.Path
 import okio.Path.Companion.toOkioPath
 import org.junit.jupiter.api.AfterAll
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -111,6 +114,21 @@ class FileUtilsTest {
         assertTrue(fileUtils.existFile(destFile))
         assertEquals("Move me", destFile.toFile().readText())
     }
+
+    @Test
+    fun writeFileRejectsBodyAboveLimit() =
+        runBlocking {
+            val file = tempDir / "limited-write.bin"
+
+            assertFailsWith<IllegalArgumentException> {
+                fileUtils.writeFile(file, ByteReadChannel(byteArrayOf(1, 2, 3, 4)), maxBytes = 3)
+            }
+            assertTrue(file.toFile().length() <= 3L)
+
+            val exactFile = tempDir / "limited-write-exact.bin"
+            fileUtils.writeFile(exactFile, ByteReadChannel(byteArrayOf(1, 2, 3)), maxBytes = 3)
+            assertEquals(byteArrayOf(1, 2, 3).toList(), exactFile.toFile().readBytes().toList())
+        }
 
     @Test
     fun testFormatBytes() {

--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/FileTransferResourceLimits.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/FileTransferResourceLimits.kt
@@ -4,15 +4,16 @@ import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.item.PasteFiles
 
 object FileTransferResourceLimits {
-    // Current peers use 1 MiB chunks and default to a 512 MiB sender limit.
-    // These protocol ceilings leave substantial headroom without permitting
-    // unbounded task lists or receive-side file preallocation.
+    // Anti-abuse ceilings, not user-facing quotas: the operative limit is the
+    // configurable maxSyncFileSize, which users may raise or disable entirely,
+    // so these must stay far above realistic legitimate transfers. Current
+    // peers use 1 MiB chunks, so 64 GiB total = 65,536 chunks.
     const val MAX_CHUNK_SIZE: Long = 16L * 1024 * 1024
-    const val MAX_CHUNK_COUNT: Int = 16_384
+    const val MAX_CHUNK_COUNT: Int = 65_536
     const val MAX_TREE_DEPTH: Int = 64
-    const val MAX_TREE_NODES: Int = 10_000
-    const val MAX_SINGLE_FILE_SIZE: Long = 8L * 1024 * 1024 * 1024
-    const val MAX_TOTAL_SIZE: Long = 8L * 1024 * 1024 * 1024
+    const val MAX_TREE_NODES: Int = 100_000
+    const val MAX_SINGLE_FILE_SIZE: Long = 64L * 1024 * 1024 * 1024
+    const val MAX_TOTAL_SIZE: Long = 64L * 1024 * 1024 * 1024
     const val MAX_ICON_SIZE: Long = 4L * 1024 * 1024
     const val MAX_SESSION_TOKEN_LENGTH: Int = 512
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/FileTransferResourceLimits.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/FileTransferResourceLimits.kt
@@ -4,16 +4,19 @@ import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.item.PasteFiles
 
 object FileTransferResourceLimits {
-    // Anti-abuse ceilings, not user-facing quotas: the operative limit is the
-    // configurable maxSyncFileSize, which users may raise or disable entirely,
-    // so these must stay far above realistic legitimate transfers. Current
-    // peers use 1 MiB chunks, so 64 GiB total = 65,536 chunks.
+    // Deliberately conservative: the receive side prepares file slots eagerly
+    // (native createEmptyPasteFile physically writes zero bytes) and the push
+    // side materializes one task per chunk, so these ceilings bound the write
+    // amplification a single authenticated request can cause. Raising them
+    // requires sparse preallocation, free-disk-space checks, and lazy chunk
+    // scheduling first. Rejections surface to the user via the discard
+    // notification, and the user-facing quota remains maxSyncFileSize.
     const val MAX_CHUNK_SIZE: Long = 16L * 1024 * 1024
-    const val MAX_CHUNK_COUNT: Int = 65_536
+    const val MAX_CHUNK_COUNT: Int = 16_384
     const val MAX_TREE_DEPTH: Int = 64
-    const val MAX_TREE_NODES: Int = 100_000
-    const val MAX_SINGLE_FILE_SIZE: Long = 64L * 1024 * 1024 * 1024
-    const val MAX_TOTAL_SIZE: Long = 64L * 1024 * 1024 * 1024
+    const val MAX_TREE_NODES: Int = 10_000
+    const val MAX_SINGLE_FILE_SIZE: Long = 8L * 1024 * 1024 * 1024
+    const val MAX_TOTAL_SIZE: Long = 8L * 1024 * 1024 * 1024
     const val MAX_ICON_SIZE: Long = 4L * 1024 * 1024
     const val MAX_SESSION_TOKEN_LENGTH: Int = 512
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/FileTransferResourceLimits.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/FileTransferResourceLimits.kt
@@ -1,0 +1,144 @@
+package com.crosspaste.presist
+
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.item.PasteFiles
+
+object FileTransferResourceLimits {
+    // Current peers use 1 MiB chunks and default to a 512 MiB sender limit.
+    // These protocol ceilings leave substantial headroom without permitting
+    // unbounded task lists or receive-side file preallocation.
+    const val MAX_CHUNK_SIZE: Long = 16L * 1024 * 1024
+    const val MAX_CHUNK_COUNT: Int = 16_384
+    const val MAX_TREE_DEPTH: Int = 64
+    const val MAX_TREE_NODES: Int = 10_000
+    const val MAX_SINGLE_FILE_SIZE: Long = 8L * 1024 * 1024 * 1024
+    const val MAX_TOTAL_SIZE: Long = 8L * 1024 * 1024 * 1024
+    const val MAX_ICON_SIZE: Long = 4L * 1024 * 1024
+    const val MAX_SESSION_TOKEN_LENGTH: Int = 512
+}
+
+internal data class FileTransferValidationLimits(
+    val maxTreeDepth: Int = FileTransferResourceLimits.MAX_TREE_DEPTH,
+    val maxTreeNodes: Int = FileTransferResourceLimits.MAX_TREE_NODES,
+    val maxSingleFileSize: Long = FileTransferResourceLimits.MAX_SINGLE_FILE_SIZE,
+    val maxTotalSize: Long = FileTransferResourceLimits.MAX_TOTAL_SIZE,
+)
+
+internal data class FileTransferMetadataStats(
+    val fileCount: Long,
+    val totalSize: Long,
+)
+
+fun validateFileTransferMetadata(pasteData: PasteData) {
+    val pasteFilesItems = pasteData.getPasteAppearItems().filterIsInstance<PasteFiles>()
+    require(pasteFilesItems.isNotEmpty()) { "file paste must contain PasteFiles metadata" }
+    validateFileTransferMetadata(pasteFilesItems, FileTransferValidationLimits())
+}
+
+internal fun validateFileTransferMetadata(
+    pasteFilesItems: List<PasteFiles>,
+    limits: FileTransferValidationLimits,
+): FileTransferMetadataStats {
+    require(limits.maxTreeDepth > 0) { "maxTreeDepth must be positive" }
+    require(limits.maxTreeNodes > 0) { "maxTreeNodes must be positive" }
+    require(limits.maxSingleFileSize >= 0) { "maxSingleFileSize must be non-negative" }
+    require(limits.maxTotalSize >= 0) { "maxTotalSize must be non-negative" }
+    require(pasteFilesItems.isNotEmpty()) { "file paste must contain PasteFiles metadata" }
+
+    var nodeCount = 0
+    var totalFileCount = 0L
+    var totalSize = 0L
+
+    fun addSize(
+        current: Long,
+        addition: Long,
+        limit: Long,
+        description: String,
+    ): Long {
+        require(addition <= limit - current) { "$description exceeds $limit bytes" }
+        return current + addition
+    }
+
+    fun validateTree(
+        fileInfoTree: FileInfoTree,
+        depth: Int,
+    ): FileTransferMetadataStats {
+        require(depth <= limits.maxTreeDepth) {
+            "file tree depth exceeds ${limits.maxTreeDepth}"
+        }
+        nodeCount += 1
+        require(nodeCount <= limits.maxTreeNodes) {
+            "file tree node count exceeds ${limits.maxTreeNodes}"
+        }
+        require(fileInfoTree.size >= 0) { "file tree size must be non-negative" }
+
+        return when (fileInfoTree) {
+            is SingleFileInfoTree -> {
+                require(fileInfoTree.size <= limits.maxSingleFileSize) {
+                    "single file size exceeds ${limits.maxSingleFileSize} bytes"
+                }
+                FileTransferMetadataStats(fileCount = 1, totalSize = fileInfoTree.size)
+            }
+
+            is DirFileInfoTree -> {
+                var directoryFileCount = 0L
+                var directorySize = 0L
+                fileInfoTree.iterator().forEach { (_, child) ->
+                    val childStats = validateTree(child, depth + 1)
+                    directoryFileCount += childStats.fileCount
+                    directorySize =
+                        addSize(
+                            current = directorySize,
+                            addition = childStats.totalSize,
+                            limit = limits.maxTotalSize,
+                            description = "directory size",
+                        )
+                }
+                require(fileInfoTree.size == directorySize) {
+                    "directory size does not match its children"
+                }
+                FileTransferMetadataStats(directoryFileCount, directorySize)
+            }
+        }
+    }
+
+    pasteFilesItems.forEach { pasteFiles ->
+        require(pasteFiles.relativePathList.size == pasteFiles.fileInfoTreeMap.size) {
+            "relativePathList size does not match fileInfoTreeMap"
+        }
+        require(pasteFiles.size >= 0) { "PasteFiles size must be non-negative" }
+        require(pasteFiles.count >= 0) { "PasteFiles count must be non-negative" }
+
+        var itemFileCount = 0L
+        var itemSize = 0L
+        pasteFiles.fileInfoTreeMap.values.forEach { fileInfoTree ->
+            val stats = validateTree(fileInfoTree, depth = 1)
+            itemFileCount += stats.fileCount
+            itemSize =
+                addSize(
+                    current = itemSize,
+                    addition = stats.totalSize,
+                    limit = limits.maxTotalSize,
+                    description = "PasteFiles size",
+                )
+        }
+        require(pasteFiles.count == itemFileCount) {
+            "PasteFiles count does not match file tree"
+        }
+        require(pasteFiles.size == itemSize) {
+            "PasteFiles size does not match file tree"
+        }
+
+        totalFileCount += itemFileCount
+        totalSize =
+            addSize(
+                current = totalSize,
+                addition = itemSize,
+                limit = limits.maxTotalSize,
+                description = "file transfer size",
+            )
+    }
+
+    require(totalFileCount > 0) { "file paste must contain at least one file" }
+    return FileTransferMetadataStats(totalFileCount, totalSize)
+}

--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/FilesIndex.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/FilesIndex.kt
@@ -6,14 +6,43 @@ class FilesIndexBuilder(
     private val chunkSize: Long,
 ) {
 
+    init {
+        require(chunkSize in 1..FileTransferResourceLimits.MAX_CHUNK_SIZE) {
+            "chunkSize must be between 1 and ${FileTransferResourceLimits.MAX_CHUNK_SIZE}: $chunkSize"
+        }
+    }
+
     private val filesChunks = mutableListOf<FilesChunk>()
 
     private var filesChunkBuilder = FilesChunkBuilder(chunkSize)
+
+    private var totalSize = 0L
 
     fun addFile(
         filePath: Path,
         size: Long,
     ) {
+        require(size >= 0) { "file size must be non-negative: $size" }
+        require(size <= FileTransferResourceLimits.MAX_TOTAL_SIZE - totalSize) {
+            "total file size exceeds ${FileTransferResourceLimits.MAX_TOTAL_SIZE} bytes"
+        }
+        val newTotalSize = totalSize + size
+        val requiredChunkCount =
+            if (newTotalSize == 0L) {
+                1L
+            } else {
+                ((newTotalSize - 1) / chunkSize) + 1
+            }
+        require(requiredChunkCount <= FileTransferResourceLimits.MAX_CHUNK_COUNT) {
+            "file index requires more than ${FileTransferResourceLimits.MAX_CHUNK_COUNT} chunks"
+        }
+        totalSize = newTotalSize
+
+        if (size > 0 && filesChunkBuilder.isFull()) {
+            filesChunks.add(filesChunkBuilder.build())
+            filesChunkBuilder = FilesChunkBuilder(chunkSize)
+        }
+
         var remainingSize = size
         do {
             remainingSize = filesChunkBuilder.addFile(filePath, remainingSize, size)
@@ -42,8 +71,14 @@ class FilesIndex(
 }
 
 class FilesChunkBuilder(
-    chunkSize: Long,
+    private val chunkSize: Long,
 ) {
+
+    init {
+        require(chunkSize in 1..FileTransferResourceLimits.MAX_CHUNK_SIZE) {
+            "chunkSize must be between 1 and ${FileTransferResourceLimits.MAX_CHUNK_SIZE}: $chunkSize"
+        }
+    }
 
     private val fileChunks = mutableListOf<FileChunk>()
 
@@ -54,6 +89,13 @@ class FilesChunkBuilder(
         remainingSize: Long,
         size: Long,
     ): Long {
+        require(size >= 0) { "file size must be non-negative: $size" }
+        require(remainingSize in 0..size) {
+            "remainingSize must be between 0 and file size: remaining=$remainingSize size=$size"
+        }
+        check(remainingChunkSize in 0..chunkSize) {
+            "remaining chunk size is invalid: $remainingChunkSize"
+        }
         val addNewChunkSize = if (remainingSize > remainingChunkSize) remainingChunkSize else remainingSize
         fileChunks.add(FileChunk(size - remainingSize, addNewChunkSize, filePath))
         remainingChunkSize -= addNewChunkSize
@@ -62,12 +104,24 @@ class FilesChunkBuilder(
 
     fun isNotEmpty(): Boolean = fileChunks.isNotEmpty()
 
+    fun isFull(): Boolean = remainingChunkSize == 0L
+
     fun build(): FilesChunk = FilesChunk(fileChunks.toList())
 }
 
 data class FilesChunk(
     val fileChunks: List<FileChunk>,
 ) {
+    init {
+        var totalSize = 0L
+        fileChunks.forEach { fileChunk ->
+            require(fileChunk.size <= FileTransferResourceLimits.MAX_CHUNK_SIZE - totalSize) {
+                "files chunk exceeds ${FileTransferResourceLimits.MAX_CHUNK_SIZE} bytes"
+            }
+            totalSize += fileChunk.size
+        }
+    }
+
     override fun toString(): String {
         val fileChunksToString = fileChunks.joinToString(", ") { it.toString() }
         return "FilesChunk(chunks: [$fileChunksToString])"
@@ -79,5 +133,13 @@ data class FileChunk(
     val size: Long,
     val path: Path,
 ) {
+    init {
+        require(offset >= 0) { "file chunk offset must be non-negative: $offset" }
+        require(size in 0..FileTransferResourceLimits.MAX_CHUNK_SIZE) {
+            "file chunk size must be between 0 and ${FileTransferResourceLimits.MAX_CHUNK_SIZE}: $size"
+        }
+        require(offset <= Long.MAX_VALUE - size) { "file chunk range exceeds Long.MAX_VALUE" }
+    }
+
     override fun toString(): String = "FileChunk(path: ${path.name}, offset: $offset, size: $size)"
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/utils/FileUtils.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/utils/FileUtils.kt
@@ -310,6 +310,32 @@ interface FileUtils {
         byteReadChannel: ByteReadChannel,
     )
 
+    suspend fun writeFile(
+        path: Path,
+        byteReadChannel: ByteReadChannel,
+        maxBytes: Long,
+    ) {
+        require(maxBytes in 0 until Long.MAX_VALUE) { "maxBytes must be non-negative and finite" }
+        writeFile(path) { sink ->
+            val buffer = ByteArray(fileBufferSize)
+            var written = 0L
+            while (true) {
+                val remaining = maxBytes - written
+                val readSize =
+                    if (remaining < buffer.size) {
+                        (remaining + 1).toInt()
+                    } else {
+                        buffer.size
+                    }
+                val read = byteReadChannel.readAvailable(buffer, 0, readSize)
+                if (read == -1) break
+                written += read
+                require(written <= maxBytes) { "input exceeds $maxBytes bytes" }
+                sink.write(buffer, 0, read)
+            }
+        }
+    }
+
     suspend fun writeFilesChunk(
         filesChunk: FilesChunk,
         byteReadChannel: ByteReadChannel,

--- a/shared/src/commonTest/kotlin/com/crosspaste/presist/FileTransferResourceLimitsTest.kt
+++ b/shared/src/commonTest/kotlin/com/crosspaste/presist/FileTransferResourceLimitsTest.kt
@@ -1,0 +1,131 @@
+package com.crosspaste.presist
+
+import com.crosspaste.paste.item.PasteFiles
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class FileTransferResourceLimitsTest {
+
+    @Test
+    fun `valid metadata returns computed totals`() {
+        val item =
+            filesItem(
+                mapOf(
+                    "a.bin" to SingleFileInfoTree(10, "a"),
+                    "b.bin" to SingleFileInfoTree(20, "b"),
+                ),
+            )
+
+        val stats = validateFileTransferMetadata(listOf(item), FileTransferValidationLimits())
+
+        assertEquals(2, stats.fileCount)
+        assertEquals(30, stats.totalSize)
+    }
+
+    @Test
+    fun `metadata rejects depth and node count limits`() {
+        var deepTree: FileInfoTree = SingleFileInfoTree(1, "file")
+        repeat(3) { depth ->
+            deepTree = DirFileInfoTree(mapOf("d$depth" to deepTree), 1, "dir-$depth")
+        }
+        val deepItem = filesItem(mapOf("root" to deepTree))
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(
+                listOf(deepItem),
+                FileTransferValidationLimits(maxTreeDepth = 2),
+            )
+        }
+
+        val wideItem =
+            filesItem(
+                mapOf(
+                    "a" to SingleFileInfoTree(1, "a"),
+                    "b" to SingleFileInfoTree(1, "b"),
+                    "c" to SingleFileInfoTree(1, "c"),
+                ),
+            )
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(
+                listOf(wideItem),
+                FileTransferValidationLimits(maxTreeNodes = 2),
+            )
+        }
+    }
+
+    @Test
+    fun `metadata rejects single and total size limits without allocating files`() {
+        val oversized = filesItem(mapOf("large.bin" to SingleFileInfoTree(11, "large")))
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(
+                listOf(oversized),
+                FileTransferValidationLimits(maxSingleFileSize = 10, maxTotalSize = 20),
+            )
+        }
+
+        val first = filesItem(mapOf("first.bin" to SingleFileInfoTree(6, "first")))
+        val second = filesItem(mapOf("second.bin" to SingleFileInfoTree(5, "second")))
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(
+                listOf(first, second),
+                FileTransferValidationLimits(maxSingleFileSize = 10, maxTotalSize = 10),
+            )
+        }
+    }
+
+    @Test
+    fun `metadata rejects long overflow`() {
+        val first = filesItem(mapOf("first.bin" to SingleFileInfoTree(Long.MAX_VALUE, "first")))
+        val second = filesItem(mapOf("second.bin" to SingleFileInfoTree(1, "second")))
+
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(
+                listOf(first, second),
+                FileTransferValidationLimits(
+                    maxSingleFileSize = Long.MAX_VALUE,
+                    maxTotalSize = Long.MAX_VALUE,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `metadata rejects inconsistent directory and PasteFiles declarations`() {
+        val inconsistentDirectory =
+            DirFileInfoTree(
+                tree = mapOf("child.bin" to SingleFileInfoTree(5, "child")),
+                size = 6,
+                hash = "dir",
+            )
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(
+                listOf(filesItem(mapOf("dir" to inconsistentDirectory))),
+                FileTransferValidationLimits(),
+            )
+        }
+
+        val valid = filesItem(mapOf("file.bin" to SingleFileInfoTree(5, "file")))
+        val inconsistent = valid.copy(count = 2, size = 6)
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(listOf(inconsistent), FileTransferValidationLimits())
+        }
+    }
+
+    private fun filesItem(fileInfoTreeMap: Map<String, FileInfoTree>): TestPasteFiles =
+        TestPasteFiles(
+            count = fileInfoTreeMap.values.sumOf { it.getCount() },
+            size = fileInfoTreeMap.values.sumOf { it.size },
+            relativePathList = fileInfoTreeMap.keys.toList(),
+            fileInfoTreeMap = fileInfoTreeMap,
+        )
+
+    private data class TestPasteFiles(
+        override val count: Long,
+        override val size: Long,
+        override val relativePathList: List<String>,
+        override val fileInfoTreeMap: Map<String, FileInfoTree>,
+        override val basePath: String? = null,
+    ) : PasteFiles {
+        override fun applyRenameMap(renameMap: Map<String, String>): PasteFiles = this
+    }
+}

--- a/shared/src/commonTest/kotlin/com/crosspaste/presist/FilesIndexValidationTest.kt
+++ b/shared/src/commonTest/kotlin/com/crosspaste/presist/FilesIndexValidationTest.kt
@@ -1,0 +1,88 @@
+package com.crosspaste.presist
+
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class FilesIndexValidationTest {
+
+    @Test
+    fun `builder rejects invalid chunk sizes`() {
+        assertFailsWith<IllegalArgumentException> { FilesIndexBuilder(0) }
+        assertFailsWith<IllegalArgumentException> { FilesIndexBuilder(-1) }
+        assertFailsWith<IllegalArgumentException> {
+            FilesIndexBuilder(FileTransferResourceLimits.MAX_CHUNK_SIZE + 1)
+        }
+    }
+
+    @Test
+    fun `builder rejects negative file size`() {
+        val builder = FilesIndexBuilder(1024)
+
+        assertFailsWith<IllegalArgumentException> {
+            builder.addFile("negative.bin".toPath(), -1)
+        }
+    }
+
+    @Test
+    fun `builder rejects cumulative size above transfer limit`() {
+        val builder = FilesIndexBuilder(FileTransferResourceLimits.MAX_CHUNK_SIZE)
+        builder.addFile("max.bin".toPath(), FileTransferResourceLimits.MAX_TOTAL_SIZE)
+
+        assertFailsWith<IllegalArgumentException> {
+            builder.addFile("overflow.bin".toPath(), 1)
+        }
+    }
+
+    @Test
+    fun `builder rejects excessive chunk count before constructing chunks`() {
+        val builder = FilesIndexBuilder(1)
+
+        assertFailsWith<IllegalArgumentException> {
+            builder.addFile(
+                "too-many-chunks.bin".toPath(),
+                FileTransferResourceLimits.MAX_CHUNK_COUNT.toLong() + 1,
+            )
+        }
+    }
+
+    @Test
+    fun `file after exact chunk boundary has no zero-size fragment`() {
+        val builder = FilesIndexBuilder(10)
+        builder.addFile("first.bin".toPath(), 10)
+        builder.addFile("second.bin".toPath(), 5)
+
+        val index = builder.build()
+
+        assertEquals(2, index.getChunkCount())
+        assertEquals(listOf(10L), index.getChunk(0)!!.fileChunks.map { it.size })
+        assertEquals(listOf(5L), index.getChunk(1)!!.fileChunks.map { it.size })
+    }
+
+    @Test
+    fun `chunk builder rejects inconsistent remaining size`() {
+        val builder = FilesChunkBuilder(10)
+
+        assertFailsWith<IllegalArgumentException> {
+            builder.addFile("file.bin".toPath(), remainingSize = 11, size = 10)
+        }
+    }
+
+    @Test
+    fun `file chunk rejects invalid ranges and aggregate size`() {
+        val path = "file.bin".toPath()
+        assertFailsWith<IllegalArgumentException> { FileChunk(offset = -1, size = 1, path = path) }
+        assertFailsWith<IllegalArgumentException> {
+            FileChunk(offset = Long.MAX_VALUE, size = 1, path = path)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            FilesChunk(
+                listOf(
+                    FileChunk(offset = 0, size = FileTransferResourceLimits.MAX_CHUNK_SIZE, path = path),
+                    FileChunk(offset = 0, size = 1, path = path),
+                ),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- fail fast on invalid chunk sizes, ranges, cumulative bytes, and excessive chunk counts
- validate remote file-tree depth, node count, file count, declared sizes, and total bytes before DB or filesystem side effects
- discard (rather than fail) remote file pastes whose metadata fails validation with `IllegalArgumentException`, persisting the pull cursor and notifying the user, so one bad paste cannot drop other pastes pulled in the same round; unexpected errors still propagate as release failures
- reject malformed push prepare/complete parameters and cap icon uploads with a bounded streaming write to a uniquely named temp file plus atomic move, so concurrent or aborted uploads never corrupt or truncate an existing icon

## Limits

Deliberately conservative ceilings: the receive side prepares file slots eagerly (native `createEmptyPasteFile` physically writes zero bytes) and the push side materializes one task per chunk, so these bound the write amplification a single authenticated request can cause. Raising them requires sparse preallocation, free-disk-space checks, and lazy chunk scheduling first. Rejections surface to the user via a discard notification; the user-facing quota remains the configurable `maxSyncFileSize`.

- 16 MiB maximum chunk size and 16,384 chunks
- 64 levels and 10,000 file-tree nodes
- 8 GiB per file and per transfer
- 4 MiB icon body and 512-character session token

The current protocol uses 1 MiB chunks and the desktop sender defaults to 512 MiB, so normal v2/v3 traffic remains well inside these ceilings. No DTO or wire-format fields change.

## Verification

- `./gradlew :shared:build`
- `./gradlew :app:desktopTest` (full desktop test suite)
- new regression tests: invalid remote file paste is discarded with cursor persistence and notification while the rest of the batch continues; concurrent icon uploads for the same source never corrupt the stored icon or leave temp files; oversized icon upload keeps the existing icon intact
