### PR TITLE
:bug: authenticate WebSocket sessions

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
@@ -29,7 +29,6 @@ fun Routing.wsRouting(
     wsMessageHandler: WsMessageHandler,
 ) {
     val logger = KotlinLogging.logger {}
-    val json = getJsonUtils().JSON
 
     webSocket("/ws/sync") {
         val appInstanceId = call.request.queryParameters["appInstanceId"]
@@ -51,64 +50,11 @@ fun Routing.wsRouting(
             return@webSocket
         }
 
-        val rawSession = WsSession(this, appInstanceId)
+        val authenticationRequested =
+            call.request.queryParameters["authVersion"] == WsAuthenticationCodec.VERSION.toString()
         val authenticationContext =
-            if (call.request.queryParameters["authVersion"] == WsAuthenticationCodec.VERSION.toString()) {
-                val processor = secureStore.getMessageProcessor(appInstanceId)
-                val challenge =
-                    WsAuthChallenge(
-                        sessionId = getCodecsUtils().base64Encode(CryptographyRandom.nextBytes(16)),
-                        nonce = CryptographyRandom.nextBytes(32),
-                    )
-                rawSession.sendEnvelope(
-                    WsEnvelope(
-                        type = WsMessageType.AUTH_CHALLENGE,
-                        payload = json.encodeToString(challenge).encodeToByteArray(),
-                    ),
-                )
-                val receivedProof = withTimeoutOrNull(AUTHENTICATION_TIMEOUT_MS) { receiveWsEnvelope(incoming) }
-                val proof =
-                    receivedProof
-                        ?.takeIf { it.envelope.type == WsMessageType.AUTH_PROOF }
-                        ?.let { json.decodeFromString<WsAuthProof>(it.envelope.payload.decodeToString()) }
-                val validProof =
-                    proof != null &&
-                        processor.verifyAuthentication(
-                            WsAuthenticationCodec.handshakePayload(
-                                role = WsAuthenticationCodec.CLIENT_PROOF,
-                                sourceAppInstanceId = appInstanceId,
-                                targetAppInstanceId = appInfo.appInstanceId,
-                                challenge = challenge,
-                            ),
-                            proof.authenticationCode,
-                        )
-                if (!validProof) {
-                    close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "WebSocket authentication failed"))
-                    return@webSocket
-                }
-                val ack =
-                    WsAuthProof(
-                        processor.authenticationCode(
-                            WsAuthenticationCodec.handshakePayload(
-                                role = WsAuthenticationCodec.SERVER_PROOF,
-                                sourceAppInstanceId = appInfo.appInstanceId,
-                                targetAppInstanceId = appInstanceId,
-                                challenge = challenge,
-                            ),
-                        ),
-                    )
-                rawSession.sendEnvelope(
-                    WsEnvelope(
-                        type = WsMessageType.AUTH_ACK,
-                        payload = json.encodeToString(ack).encodeToByteArray(),
-                    ),
-                )
-                WsAuthenticationContext(
-                    sessionId = challenge.sessionId,
-                    localAppInstanceId = appInfo.appInstanceId,
-                    remoteAppInstanceId = appInstanceId,
-                    processor = processor,
-                )
+            if (authenticationRequested) {
+                authenticateWebSocketPeer(appInfo, appInstanceId, secureStore) ?: return@webSocket
             } else {
                 val remoteHost = runCatching { call.request.origin.remoteHost }.getOrNull()
                 if (!isLoopbackHost(remoteHost)) {
@@ -124,21 +70,89 @@ fun Routing.wsRouting(
         wsSessionManager.registerSession(appInstanceId, wsSession)
 
         try {
-            while (true) {
-                val received = receiveWsEnvelope(incoming) ?: break
-                if (authenticationContext != null &&
-                    !authenticationContext.verify(received.header, received.envelope.payload)
-                ) {
-                    logger.warn { "Rejected unauthenticated WS message from $appInstanceId" }
-                    close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Invalid message authentication"))
-                    break
-                }
-                wsMessageHandler.handleMessage(appInstanceId, received.envelope)
-            }
+            receiveWebSocketMessages(appInstanceId, authenticationContext, wsMessageHandler)
         } finally {
             logger.info { "WebSocket disconnected: $appInstanceId" }
             wsSessionManager.notifySessionClosed(appInstanceId, wsSession)
         }
+    }
+}
+
+private suspend fun DefaultWebSocketServerSession.authenticateWebSocketPeer(
+    appInfo: AppInfo,
+    appInstanceId: String,
+    secureStore: SecureStore,
+): WsAuthenticationContext? {
+    val json = getJsonUtils().JSON
+    val processor = secureStore.getMessageProcessor(appInstanceId)
+    val rawSession = WsSession(this, appInstanceId)
+    val challenge =
+        WsAuthChallenge(
+            sessionId = getCodecsUtils().base64Encode(CryptographyRandom.nextBytes(16)),
+            nonce = CryptographyRandom.nextBytes(32),
+        )
+    rawSession.sendEnvelope(
+        WsEnvelope(
+            type = WsMessageType.AUTH_CHALLENGE,
+            payload = json.encodeToString(challenge).encodeToByteArray(),
+        ),
+    )
+    val proof =
+        runCatching {
+            withTimeoutOrNull(AUTHENTICATION_TIMEOUT_MS) { receiveWsEnvelope(incoming) }
+                ?.takeIf { it.envelope.type == WsMessageType.AUTH_PROOF }
+                ?.let { json.decodeFromString<WsAuthProof>(it.envelope.payload.decodeToString()) }
+        }.getOrNull()
+    val proofPayload =
+        WsAuthenticationCodec.handshakePayload(
+            role = WsAuthenticationCodec.CLIENT_PROOF,
+            sourceAppInstanceId = appInstanceId,
+            targetAppInstanceId = appInfo.appInstanceId,
+            challenge = challenge,
+        )
+    if (proof == null || !processor.verifyAuthentication(proofPayload, proof.authenticationCode)) {
+        close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "WebSocket authentication failed"))
+        return null
+    }
+
+    val ackPayload =
+        WsAuthenticationCodec.handshakePayload(
+            role = WsAuthenticationCodec.SERVER_PROOF,
+            sourceAppInstanceId = appInfo.appInstanceId,
+            targetAppInstanceId = appInstanceId,
+            challenge = challenge,
+        )
+    val ack = WsAuthProof(processor.authenticationCode(ackPayload))
+    rawSession.sendEnvelope(
+        WsEnvelope(
+            type = WsMessageType.AUTH_ACK,
+            payload = json.encodeToString(ack).encodeToByteArray(),
+        ),
+    )
+    return WsAuthenticationContext(
+        sessionId = challenge.sessionId,
+        localAppInstanceId = appInfo.appInstanceId,
+        remoteAppInstanceId = appInstanceId,
+        processor = processor,
+    )
+}
+
+private suspend fun DefaultWebSocketServerSession.receiveWebSocketMessages(
+    appInstanceId: String,
+    authenticationContext: WsAuthenticationContext?,
+    wsMessageHandler: WsMessageHandler,
+) {
+    val logger = KotlinLogging.logger {}
+    while (true) {
+        val received = receiveWsEnvelope(incoming) ?: break
+        if (authenticationContext != null &&
+            !authenticationContext.verify(received.header, received.envelope.payload)
+        ) {
+            logger.warn { "Rejected unauthenticated WS message from $appInstanceId" }
+            close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Invalid message authentication"))
+            break
+        }
+        wsMessageHandler.handleMessage(appInstanceId, received.envelope)
     }
 }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
@@ -1,17 +1,26 @@
 package com.crosspaste.net.routing
 
 import com.crosspaste.app.AppInfo
+import com.crosspaste.net.ws.WsAuthChallenge
+import com.crosspaste.net.ws.WsAuthProof
+import com.crosspaste.net.ws.WsAuthenticationCodec
+import com.crosspaste.net.ws.WsAuthenticationContext
 import com.crosspaste.net.ws.WsEnvelope
-import com.crosspaste.net.ws.WsEnvelopeHeader
 import com.crosspaste.net.ws.WsMessageHandler
+import com.crosspaste.net.ws.WsMessageType
 import com.crosspaste.net.ws.WsSession
 import com.crosspaste.net.ws.WsSessionManager
+import com.crosspaste.net.ws.receiveWsEnvelope
 import com.crosspaste.secure.SecureStore
+import com.crosspaste.utils.getCodecsUtils
 import com.crosspaste.utils.getJsonUtils
+import dev.whyoleg.cryptography.random.CryptographyRandom
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.plugins.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.websocket.*
+import kotlinx.coroutines.withTimeoutOrNull
 
 fun Routing.wsRouting(
     appInfo: AppInfo,
@@ -42,43 +51,89 @@ fun Routing.wsRouting(
             return@webSocket
         }
 
+        val rawSession = WsSession(this, appInstanceId)
+        val authenticationContext =
+            if (call.request.queryParameters["authVersion"] == WsAuthenticationCodec.VERSION.toString()) {
+                val processor = secureStore.getMessageProcessor(appInstanceId)
+                val challenge =
+                    WsAuthChallenge(
+                        sessionId = getCodecsUtils().base64Encode(CryptographyRandom.nextBytes(16)),
+                        nonce = CryptographyRandom.nextBytes(32),
+                    )
+                rawSession.sendEnvelope(
+                    WsEnvelope(
+                        type = WsMessageType.AUTH_CHALLENGE,
+                        payload = json.encodeToString(challenge).encodeToByteArray(),
+                    ),
+                )
+                val receivedProof = withTimeoutOrNull(AUTHENTICATION_TIMEOUT_MS) { receiveWsEnvelope(incoming) }
+                val proof =
+                    receivedProof
+                        ?.takeIf { it.envelope.type == WsMessageType.AUTH_PROOF }
+                        ?.let { json.decodeFromString<WsAuthProof>(it.envelope.payload.decodeToString()) }
+                val validProof =
+                    proof != null &&
+                        processor.verifyAuthentication(
+                            WsAuthenticationCodec.handshakePayload(
+                                role = WsAuthenticationCodec.CLIENT_PROOF,
+                                sourceAppInstanceId = appInstanceId,
+                                targetAppInstanceId = appInfo.appInstanceId,
+                                challenge = challenge,
+                            ),
+                            proof.authenticationCode,
+                        )
+                if (!validProof) {
+                    close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "WebSocket authentication failed"))
+                    return@webSocket
+                }
+                val ack =
+                    WsAuthProof(
+                        processor.authenticationCode(
+                            WsAuthenticationCodec.handshakePayload(
+                                role = WsAuthenticationCodec.SERVER_PROOF,
+                                sourceAppInstanceId = appInfo.appInstanceId,
+                                targetAppInstanceId = appInstanceId,
+                                challenge = challenge,
+                            ),
+                        ),
+                    )
+                rawSession.sendEnvelope(
+                    WsEnvelope(
+                        type = WsMessageType.AUTH_ACK,
+                        payload = json.encodeToString(ack).encodeToByteArray(),
+                    ),
+                )
+                WsAuthenticationContext(
+                    sessionId = challenge.sessionId,
+                    localAppInstanceId = appInfo.appInstanceId,
+                    remoteAppInstanceId = appInstanceId,
+                    processor = processor,
+                )
+            } else {
+                val remoteHost = runCatching { call.request.origin.remoteHost }.getOrNull()
+                if (!isLoopbackHost(remoteHost)) {
+                    close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Authenticated WebSocket required"))
+                    return@webSocket
+                }
+                logger.warn { "Allowing legacy unauthenticated WebSocket from loopback for $appInstanceId" }
+                null
+            }
+
         logger.info { "WebSocket connected: $appInstanceId → ${appInfo.appInstanceId}" }
-        val wsSession = WsSession(this, appInstanceId)
+        val wsSession = WsSession(this, appInstanceId, authenticationContext)
         wsSessionManager.registerSession(appInstanceId, wsSession)
 
         try {
-            for (frame in incoming) {
-                when (frame) {
-                    is Frame.Text -> {
-                        runCatching {
-                            val header = json.decodeFromString<WsEnvelopeHeader>(frame.readText())
-                            val payload =
-                                if (header.hasPayload) {
-                                    (incoming.receive() as Frame.Binary).readBytes()
-                                } else {
-                                    byteArrayOf()
-                                }
-                            val envelope =
-                                WsEnvelope(
-                                    type = header.type,
-                                    payload = payload,
-                                    encrypted = header.encrypted,
-                                    requestId = header.requestId,
-                                )
-                            wsMessageHandler.handleMessage(appInstanceId, envelope)
-                        }.onFailure { e ->
-                            logger.error(e) { "Failed to handle WS message from $appInstanceId" }
-                        }
-                    }
-
-                    is Frame.Close -> {
-                        logger.info { "WebSocket close frame from $appInstanceId" }
-                    }
-
-                    else -> {
-                        logger.debug { "Ignoring non-text WS frame from $appInstanceId" }
-                    }
+            while (true) {
+                val received = receiveWsEnvelope(incoming) ?: break
+                if (authenticationContext != null &&
+                    !authenticationContext.verify(received.header, received.envelope.payload)
+                ) {
+                    logger.warn { "Rejected unauthenticated WS message from $appInstanceId" }
+                    close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Invalid message authentication"))
+                    break
                 }
+                wsMessageHandler.handleMessage(appInstanceId, received.envelope)
             }
         } finally {
             logger.info { "WebSocket disconnected: $appInstanceId" }
@@ -86,3 +141,7 @@ fun Routing.wsRouting(
         }
     }
 }
+
+internal fun isLoopbackHost(host: String?): Boolean = host == "127.0.0.1" || host == "::1" || host == "0:0:0:0:0:0:0:1"
+
+private const val AUTHENTICATION_TIMEOUT_MS = 5_000L

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.net.routing
 
 import com.crosspaste.app.AppInfo
+import com.crosspaste.net.ws.WS_AUTHENTICATION_TIMEOUT
 import com.crosspaste.net.ws.WsAuthChallenge
 import com.crosspaste.net.ws.WsAuthProof
 import com.crosspaste.net.ws.WsAuthenticationCodec
@@ -20,6 +21,7 @@ import io.ktor.server.plugins.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.websocket.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withTimeoutOrNull
 
 fun Routing.wsRouting(
@@ -56,8 +58,8 @@ fun Routing.wsRouting(
             if (authenticationRequested) {
                 authenticateWebSocketPeer(appInfo, appInstanceId, secureStore) ?: return@webSocket
             } else {
-                val remoteHost = runCatching { call.request.origin.remoteHost }.getOrNull()
-                if (!isLoopbackHost(remoteHost)) {
+                val remoteAddress = runCatching { call.request.origin.remoteAddress }.getOrNull()
+                if (!isLoopbackAddress(remoteAddress)) {
                     close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Authenticated WebSocket required"))
                     return@webSocket
                 }
@@ -84,7 +86,11 @@ private suspend fun DefaultWebSocketServerSession.authenticateWebSocketPeer(
     secureStore: SecureStore,
 ): WsAuthenticationContext? {
     val json = getJsonUtils().JSON
-    val processor = secureStore.getMessageProcessor(appInstanceId)
+    val processor = runCatching { secureStore.getMessageProcessor(appInstanceId) }.getOrNull()
+    if (processor == null) {
+        close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "WebSocket authentication unavailable"))
+        return null
+    }
     val rawSession = WsSession(this, appInstanceId)
     val challenge =
         WsAuthChallenge(
@@ -99,7 +105,7 @@ private suspend fun DefaultWebSocketServerSession.authenticateWebSocketPeer(
     )
     val proof =
         runCatching {
-            withTimeoutOrNull(AUTHENTICATION_TIMEOUT_MS) { receiveWsEnvelope(incoming) }
+            withTimeoutOrNull(WS_AUTHENTICATION_TIMEOUT) { receiveWsEnvelope(incoming) }
                 ?.takeIf { it.envelope.type == WsMessageType.AUTH_PROOF }
                 ?.let { json.decodeFromString<WsAuthProof>(it.envelope.payload.decodeToString()) }
         }.getOrNull()
@@ -144,7 +150,19 @@ private suspend fun DefaultWebSocketServerSession.receiveWebSocketMessages(
 ) {
     val logger = KotlinLogging.logger {}
     while (true) {
-        val received = receiveWsEnvelope(incoming) ?: break
+        val receivedResult = runCatching { receiveWsEnvelope(incoming) }
+        val receiveFailure = receivedResult.exceptionOrNull()
+        if (receiveFailure != null) {
+            if (receiveFailure is CancellationException) throw receiveFailure
+            if (authenticationContext != null) {
+                logger.warn { "Rejected malformed authenticated WS message from $appInstanceId" }
+                close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Malformed authenticated message"))
+                break
+            }
+            logger.error(receiveFailure) { "Failed to handle legacy WS message from $appInstanceId" }
+            continue
+        }
+        val received = receivedResult.getOrNull() ?: break
         if (authenticationContext != null &&
             !authenticationContext.verify(received.header, received.envelope.payload)
         ) {
@@ -156,6 +174,5 @@ private suspend fun DefaultWebSocketServerSession.receiveWebSocketMessages(
     }
 }
 
-internal fun isLoopbackHost(host: String?): Boolean = host == "127.0.0.1" || host == "::1" || host == "0:0:0:0:0:0:0:1"
-
-private const val AUTHENTICATION_TIMEOUT_MS = 5_000L
+internal fun isLoopbackAddress(address: String?): Boolean =
+    address == "127.0.0.1" || address == "::1" || address == "0:0:0:0:0:0:0:1"

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/ReceivedWsEnvelope.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/ReceivedWsEnvelope.kt
@@ -1,0 +1,44 @@
+package com.crosspaste.net.ws
+
+import com.crosspaste.utils.getJsonUtils
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readBytes
+import io.ktor.websocket.readText
+import kotlinx.coroutines.channels.ReceiveChannel
+
+data class ReceivedWsEnvelope(
+    val header: WsEnvelopeHeader,
+    val envelope: WsEnvelope,
+)
+
+suspend fun receiveWsEnvelope(incoming: ReceiveChannel<Frame>): ReceivedWsEnvelope? {
+    val json = getJsonUtils().JSON
+    while (true) {
+        when (val frame = incoming.receiveCatching().getOrNull() ?: return null) {
+            is Frame.Text -> {
+                val header = json.decodeFromString<WsEnvelopeHeader>(frame.readText())
+                val payload =
+                    if (header.hasPayload) {
+                        val payloadFrame = incoming.receiveCatching().getOrNull()
+                        require(payloadFrame is Frame.Binary) { "Expected binary WebSocket payload" }
+                        payloadFrame.readBytes()
+                    } else {
+                        byteArrayOf()
+                    }
+                return ReceivedWsEnvelope(
+                    header = header,
+                    envelope =
+                        WsEnvelope(
+                            type = header.type,
+                            payload = payload,
+                            encrypted = header.encrypted,
+                            requestId = header.requestId,
+                        ),
+                )
+            }
+
+            is Frame.Close -> return null
+            else -> Unit
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsAuthentication.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsAuthentication.kt
@@ -4,6 +4,9 @@ import com.crosspaste.pairing.v3.CanonicalWriter
 import com.crosspaste.secure.SecureMessageProcessor
 import com.crosspaste.serializer.Base64ByteArraySerializer
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration.Companion.seconds
+
+internal val WS_AUTHENTICATION_TIMEOUT = 5.seconds
 
 @Serializable
 data class WsAuthChallenge(

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsAuthentication.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsAuthentication.kt
@@ -1,0 +1,116 @@
+package com.crosspaste.net.ws
+
+import com.crosspaste.pairing.v3.CanonicalWriter
+import com.crosspaste.secure.SecureMessageProcessor
+import com.crosspaste.serializer.Base64ByteArraySerializer
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WsAuthChallenge(
+    val sessionId: String,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val nonce: ByteArray,
+)
+
+@Serializable
+data class WsAuthProof(
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val authenticationCode: ByteArray,
+)
+
+class WsAuthenticationContext(
+    private val sessionId: String,
+    private val localAppInstanceId: String,
+    private val remoteAppInstanceId: String,
+    private val processor: SecureMessageProcessor,
+) {
+    private var nextSendSequence = 0L
+    private var nextReceiveSequence = 0L
+
+    suspend fun createHeader(envelope: WsEnvelope): WsEnvelopeHeader {
+        check(nextSendSequence != Long.MAX_VALUE) { "WebSocket authentication sequence exhausted" }
+        val sequence = nextSendSequence++
+        val authenticationCode =
+            processor.authenticationCode(
+                WsAuthenticationCodec.envelopePayload(
+                    sessionId = sessionId,
+                    sequence = sequence,
+                    sourceAppInstanceId = localAppInstanceId,
+                    targetAppInstanceId = remoteAppInstanceId,
+                    envelope = envelope,
+                ),
+            )
+        return envelope.toHeader().copy(
+            authSessionId = sessionId,
+            authSequence = sequence,
+            authenticationCode = authenticationCode,
+        )
+    }
+
+    suspend fun verify(
+        header: WsEnvelopeHeader,
+        payload: ByteArray,
+    ): Boolean {
+        val sequence = header.authSequence ?: return false
+        val authenticationCode = header.authenticationCode ?: return false
+        if (header.authSessionId != sessionId || sequence != nextReceiveSequence) return false
+        val envelope =
+            WsEnvelope(
+                type = header.type,
+                payload = payload,
+                encrypted = header.encrypted,
+                requestId = header.requestId,
+            )
+        val valid =
+            processor.verifyAuthentication(
+                WsAuthenticationCodec.envelopePayload(
+                    sessionId = sessionId,
+                    sequence = sequence,
+                    sourceAppInstanceId = remoteAppInstanceId,
+                    targetAppInstanceId = localAppInstanceId,
+                    envelope = envelope,
+                ),
+                authenticationCode,
+            )
+        if (valid) nextReceiveSequence++
+        return valid
+    }
+}
+
+object WsAuthenticationCodec {
+    const val VERSION = 1
+    const val CLIENT_PROOF = "client-proof"
+    const val SERVER_PROOF = "server-proof"
+
+    fun handshakePayload(
+        role: String,
+        sourceAppInstanceId: String,
+        targetAppInstanceId: String,
+        challenge: WsAuthChallenge,
+    ): ByteArray =
+        CanonicalWriter("crosspaste-ws-handshake-v1")
+            .field(1, role)
+            .field(2, sourceAppInstanceId)
+            .field(3, targetAppInstanceId)
+            .field(4, challenge.sessionId)
+            .field(5, challenge.nonce)
+            .build()
+
+    fun envelopePayload(
+        sessionId: String,
+        sequence: Long,
+        sourceAppInstanceId: String,
+        targetAppInstanceId: String,
+        envelope: WsEnvelope,
+    ): ByteArray =
+        CanonicalWriter("crosspaste-ws-envelope-v1")
+            .field(1, sessionId)
+            .field(2, sequence)
+            .field(3, sourceAppInstanceId)
+            .field(4, targetAppInstanceId)
+            .field(5, envelope.type)
+            .field(6, if (envelope.encrypted) 1 else 0)
+            .field(7, envelope.requestId ?: "")
+            .field(8, envelope.payload)
+            .build()
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.net.ws
 
 import com.crosspaste.app.AppInfo
+import com.crosspaste.secure.SecureStore
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
@@ -9,10 +10,12 @@ import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 class WsClientConnector(
     private val appInfo: AppInfo,
     private val client: HttpClient,
+    private val secureStore: SecureStore,
     private val wsSessionManager: WsSessionManager,
     private val wsMessageHandler: WsMessageHandler,
 ) {
@@ -31,46 +34,78 @@ class WsClientConnector(
         targetAppInstanceId: String,
     ): Boolean =
         runCatching {
-            val path = "/ws/sync?appInstanceId=${appInfo.appInstanceId}&targetAppInstanceId=$targetAppInstanceId"
+            val path =
+                "/ws/sync?appInstanceId=${appInfo.appInstanceId}" +
+                    "&targetAppInstanceId=$targetAppInstanceId" +
+                    "&authVersion=${WsAuthenticationCodec.VERSION}"
 
             client.webSocket(host = host, port = port, path = path) {
-                logger.info { "WebSocket client connected to $targetAppInstanceId at $host:$port" }
-                val wsSession = WsSession(this, targetAppInstanceId)
+                val rawSession = WsSession(this, targetAppInstanceId)
+                val receivedChallenge =
+                    withTimeoutOrNull(AUTHENTICATION_TIMEOUT_MS) { receiveWsEnvelope(incoming) }
+                        ?: error("WebSocket authentication challenge timed out")
+                require(receivedChallenge.envelope.type == WsMessageType.AUTH_CHALLENGE) {
+                    "Expected WebSocket authentication challenge"
+                }
+                val challenge =
+                    json.decodeFromString<WsAuthChallenge>(receivedChallenge.envelope.payload.decodeToString())
+                val processor = secureStore.getMessageProcessor(targetAppInstanceId)
+                val proof =
+                    WsAuthProof(
+                        processor.authenticationCode(
+                            WsAuthenticationCodec.handshakePayload(
+                                role = WsAuthenticationCodec.CLIENT_PROOF,
+                                sourceAppInstanceId = appInfo.appInstanceId,
+                                targetAppInstanceId = targetAppInstanceId,
+                                challenge = challenge,
+                            ),
+                        ),
+                    )
+                rawSession.sendEnvelope(
+                    WsEnvelope(
+                        type = WsMessageType.AUTH_PROOF,
+                        payload = json.encodeToString(proof).encodeToByteArray(),
+                    ),
+                )
+                val receivedAck =
+                    withTimeoutOrNull(AUTHENTICATION_TIMEOUT_MS) { receiveWsEnvelope(incoming) }
+                        ?: error("WebSocket authentication acknowledgement timed out")
+                require(receivedAck.envelope.type == WsMessageType.AUTH_ACK) {
+                    "Expected WebSocket authentication acknowledgement"
+                }
+                val ack = json.decodeFromString<WsAuthProof>(receivedAck.envelope.payload.decodeToString())
+                require(
+                    processor.verifyAuthentication(
+                        WsAuthenticationCodec.handshakePayload(
+                            role = WsAuthenticationCodec.SERVER_PROOF,
+                            sourceAppInstanceId = targetAppInstanceId,
+                            targetAppInstanceId = appInfo.appInstanceId,
+                            challenge = challenge,
+                        ),
+                        ack.authenticationCode,
+                    ),
+                ) { "WebSocket server authentication failed" }
+
+                val authenticationContext =
+                    WsAuthenticationContext(
+                        sessionId = challenge.sessionId,
+                        localAppInstanceId = appInfo.appInstanceId,
+                        remoteAppInstanceId = targetAppInstanceId,
+                        processor = processor,
+                    )
+                logger.info { "Authenticated WebSocket connected to $targetAppInstanceId at $host:$port" }
+                val wsSession = WsSession(this, targetAppInstanceId, authenticationContext)
                 wsSessionManager.registerSession(targetAppInstanceId, wsSession)
 
                 try {
-                    for (frame in incoming) {
-                        when (frame) {
-                            is Frame.Text -> {
-                                runCatching {
-                                    val header = json.decodeFromString<WsEnvelopeHeader>(frame.readText())
-                                    val payload =
-                                        if (header.hasPayload) {
-                                            (incoming.receive() as Frame.Binary).readBytes()
-                                        } else {
-                                            byteArrayOf()
-                                        }
-                                    val envelope =
-                                        WsEnvelope(
-                                            type = header.type,
-                                            payload = payload,
-                                            encrypted = header.encrypted,
-                                            requestId = header.requestId,
-                                        )
-                                    wsMessageHandler.handleMessage(targetAppInstanceId, envelope)
-                                }.onFailure { e ->
-                                    logger.error(e) { "Failed to handle WS message from $targetAppInstanceId" }
-                                }
-                            }
-
-                            is Frame.Close -> {
-                                logger.info { "WebSocket close frame from $targetAppInstanceId" }
-                            }
-
-                            else -> {
-                                logger.debug { "Ignoring non-text WS frame from $targetAppInstanceId" }
-                            }
+                    while (true) {
+                        val received = receiveWsEnvelope(incoming) ?: break
+                        if (!authenticationContext.verify(received.header, received.envelope.payload)) {
+                            logger.warn { "Rejected unauthenticated WS message from $targetAppInstanceId" }
+                            close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Invalid message authentication"))
+                            break
                         }
+                        wsMessageHandler.handleMessage(targetAppInstanceId, received.envelope)
                     }
                 } finally {
                     logger.info { "WebSocket client disconnected from $targetAppInstanceId" }
@@ -94,5 +129,9 @@ class WsClientConnector(
         connectScope.launch {
             connect(host, port, targetAppInstanceId)
         }
+    }
+
+    companion object {
+        private const val AUTHENTICATION_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
@@ -42,7 +42,7 @@ class WsClientConnector(
             client.webSocket(host = host, port = port, path = path) {
                 val rawSession = WsSession(this, targetAppInstanceId)
                 val receivedChallenge =
-                    withTimeoutOrNull(AUTHENTICATION_TIMEOUT_MS) { receiveWsEnvelope(incoming) }
+                    withTimeoutOrNull(WS_AUTHENTICATION_TIMEOUT) { receiveWsEnvelope(incoming) }
                         ?: error("WebSocket authentication challenge timed out")
                 require(receivedChallenge.envelope.type == WsMessageType.AUTH_CHALLENGE) {
                     "Expected WebSocket authentication challenge"
@@ -68,7 +68,7 @@ class WsClientConnector(
                     ),
                 )
                 val receivedAck =
-                    withTimeoutOrNull(AUTHENTICATION_TIMEOUT_MS) { receiveWsEnvelope(incoming) }
+                    withTimeoutOrNull(WS_AUTHENTICATION_TIMEOUT) { receiveWsEnvelope(incoming) }
                         ?: error("WebSocket authentication acknowledgement timed out")
                 require(receivedAck.envelope.type == WsMessageType.AUTH_ACK) {
                     "Expected WebSocket authentication acknowledgement"
@@ -129,9 +129,5 @@ class WsClientConnector(
         connectScope.launch {
             connect(host, port, targetAppInstanceId)
         }
-    }
-
-    companion object {
-        private const val AUTHENTICATION_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.net.ws
 
+import com.crosspaste.serializer.Base64ByteArraySerializer
 import kotlinx.serialization.Serializable
 
 /**
@@ -12,6 +13,10 @@ data class WsEnvelopeHeader(
     val encrypted: Boolean = false,
     val hasPayload: Boolean = false,
     val requestId: String? = null,
+    val authSessionId: String? = null,
+    val authSequence: Long? = null,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val authenticationCode: ByteArray? = null,
 )
 
 /**
@@ -61,4 +66,7 @@ object WsMessageType {
     const val FILE_PULL_RESPONSE = "file_pull_response"
     const val PASTE_REJECTED_OVERSIZE = "paste_rejected_oversize"
     const val ERROR = "error"
+    const val AUTH_CHALLENGE = "auth_challenge"
+    const val AUTH_PROOF = "auth_proof"
+    const val AUTH_ACK = "auth_ack"
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
@@ -22,6 +22,7 @@ import kotlin.coroutines.cancellation.CancellationException
 class WsSession(
     private val session: WebSocketSession,
     val remoteAppInstanceId: String,
+    private val authenticationContext: WsAuthenticationContext? = null,
 ) {
     private val json = getJsonUtils().JSON
     private val sendMutex = Mutex()
@@ -31,7 +32,8 @@ class WsSession(
 
     suspend fun sendEnvelope(envelope: WsEnvelope) {
         sendMutex.withLock {
-            session.send(Frame.Text(json.encodeToString(envelope.toHeader())))
+            val header = authenticationContext?.createHeader(envelope) ?: envelope.toHeader()
+            session.send(Frame.Text(json.encodeToString(header)))
             if (envelope.payload.isNotEmpty()) {
                 session.send(Frame.Binary(true, envelope.payload))
             }

--- a/app/src/commonMain/kotlin/com/crosspaste/secure/SecureMessageProcessor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/secure/SecureMessageProcessor.kt
@@ -18,6 +18,7 @@ class SecureMessageProcessor(
     private val provider = CryptographyProvider.Default
 
     private val cipher: IvCipher
+    private val peerAuthenticator: PeerAuthenticator
 
     init {
         val aes = provider.get(AES.CBC)
@@ -30,6 +31,7 @@ class SecureMessageProcessor(
                 .keyDecoder()
                 .decodeFromByteArrayBlocking(AES.Key.Format.RAW, bytes)
         cipher = key.cipher()
+        peerAuthenticator = PeerAuthenticator(privateKey, publicKey)
     }
 
     fun encrypt(data: ByteArray): ByteArray {
@@ -49,4 +51,11 @@ class SecureMessageProcessor(
             throw PasteException(StandardErrorCode.DECRYPT_FAIL.toErrorCode(), e)
         }
     }
+
+    suspend fun authenticationCode(data: ByteArray): ByteArray = peerAuthenticator.authenticationCode(data)
+
+    suspend fun verifyAuthentication(
+        data: ByteArray,
+        expectedCode: ByteArray,
+    ): Boolean = peerAuthenticator.verify(data, expectedCode)
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -201,6 +201,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
             WsClientConnector(
                 appInfo = get(),
                 client = wsHttpClient,
+                secureStore = get(),
                 wsSessionManager = get(),
                 wsMessageHandler = get(),
             )

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationIntegrationTest.kt
@@ -1,0 +1,123 @@
+package com.crosspaste.net.ws
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.config.TestReadWritePort
+import com.crosspaste.db.secure.MemorySecureIO
+import com.crosspaste.net.DesktopPasteServer
+import com.crosspaste.net.DesktopServerFactory
+import com.crosspaste.net.ServerModule
+import com.crosspaste.net.exception.DesktopExceptionHandler
+import com.crosspaste.net.routing.wsRouting
+import com.crosspaste.secure.GeneralSecureStore
+import com.crosspaste.secure.SecureKeyPairSerializer
+import com.crosspaste.utils.CryptographyUtils
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.routing.routing
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class WsAuthenticationIntegrationTest {
+
+    @Test
+    fun `client and server authenticate before exchanging messages`() =
+        runBlocking {
+            val serializer = SecureKeyPairSerializer()
+            val serverKeys = CryptographyUtils.generateSecureKeyPair()
+            val clientKeys = CryptographyUtils.generateSecureKeyPair()
+            val serverStore = GeneralSecureStore(serverKeys, serializer, MemorySecureIO())
+            val clientStore = GeneralSecureStore(clientKeys, serializer, MemorySecureIO())
+            val serverInfo = appInfo("server")
+            val clientInfo = appInfo("client")
+            serverStore.saveCryptPublicKey(
+                clientInfo.appInstanceId,
+                serializer.encodeCryptPublicKey(clientKeys.cryptKeyPair.publicKey),
+            )
+            clientStore.saveCryptPublicKey(
+                serverInfo.appInstanceId,
+                serializer.encodeCryptPublicKey(serverKeys.cryptKeyPair.publicKey),
+            )
+
+            val serverSessions = WsSessionManager()
+            val clientSessions = WsSessionManager()
+            val serverHandler = mockk<WsMessageHandler>(relaxed = true)
+            val clientHandler = mockk<WsMessageHandler>(relaxed = true)
+            val server =
+                DesktopPasteServer(
+                    TestReadWritePort(),
+                    DesktopExceptionHandler(),
+                    DesktopServerFactory(),
+                    AuthenticatedWsServerModule(serverInfo, serverStore, serverSessions, serverHandler),
+                )
+            val httpClient = HttpClient(CIO) { install(WebSockets) }
+            val connector =
+                WsClientConnector(
+                    appInfo = clientInfo,
+                    client = httpClient,
+                    secureStore = clientStore,
+                    wsSessionManager = clientSessions,
+                    wsMessageHandler = clientHandler,
+                )
+
+            try {
+                server.start()
+                connector.connectAsync("127.0.0.1", server.port(), serverInfo.appInstanceId)
+                withTimeout(5_000) {
+                    while (!clientSessions.isConnected(serverInfo.appInstanceId) ||
+                        !serverSessions.isConnected(clientInfo.appInstanceId)
+                    ) {
+                        delay(10)
+                    }
+                }
+
+                assertTrue(
+                    clientSessions.send(
+                        serverInfo.appInstanceId,
+                        WsEnvelope(type = "authenticated-test", payload = "payload".encodeToByteArray()),
+                    ),
+                )
+                coVerify(timeout = 5_000) {
+                    serverHandler.handleMessage(
+                        clientInfo.appInstanceId,
+                        match { it.type == "authenticated-test" && it.payload.decodeToString() == "payload" },
+                    )
+                }
+            } finally {
+                clientSessions.closeAll()
+                serverSessions.closeAll()
+                httpClient.close()
+                server.stop()
+            }
+        }
+
+    private fun appInfo(id: String): AppInfo =
+        AppInfo(
+            appInstanceId = id,
+            appVersion = "test",
+            appRevision = "test",
+            userName = id,
+        )
+}
+
+private class AuthenticatedWsServerModule(
+    private val appInfo: AppInfo,
+    private val secureStore: GeneralSecureStore,
+    private val sessionManager: WsSessionManager,
+    private val messageHandler: WsMessageHandler,
+) : ServerModule {
+    override fun installModules(): Application.() -> Unit =
+        {
+            install(io.ktor.server.websocket.WebSockets)
+            routing {
+                wsRouting(appInfo, secureStore, sessionManager, messageHandler)
+            }
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationIntegrationTest.kt
@@ -10,20 +10,29 @@ import com.crosspaste.net.exception.DesktopExceptionHandler
 import com.crosspaste.net.routing.wsRouting
 import com.crosspaste.secure.GeneralSecureStore
 import com.crosspaste.secure.SecureKeyPairSerializer
+import com.crosspaste.secure.SecureStore
 import com.crosspaste.utils.CryptographyUtils
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.routing.routing
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.Frame
+import io.ktor.websocket.send
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class WsAuthenticationIntegrationTest {
 
@@ -70,11 +79,11 @@ class WsAuthenticationIntegrationTest {
             try {
                 server.start()
                 connector.connectAsync("127.0.0.1", server.port(), serverInfo.appInstanceId)
-                withTimeout(5_000) {
+                withTimeout(5.seconds) {
                     while (!clientSessions.isConnected(serverInfo.appInstanceId) ||
                         !serverSessions.isConnected(clientInfo.appInstanceId)
                     ) {
-                        delay(10)
+                        delay(10.milliseconds)
                     }
                 }
 
@@ -98,6 +107,93 @@ class WsAuthenticationIntegrationTest {
             }
         }
 
+    @Test
+    fun `loopback legacy client tolerates a malformed message`() =
+        runBlocking {
+            val serializer = SecureKeyPairSerializer()
+            val serverKeys = CryptographyUtils.generateSecureKeyPair()
+            val clientKeys = CryptographyUtils.generateSecureKeyPair()
+            val serverStore = GeneralSecureStore(serverKeys, serializer, MemorySecureIO())
+            val serverInfo = appInfo("legacy-server")
+            val clientInfo = appInfo("legacy-client")
+            serverStore.saveCryptPublicKey(
+                clientInfo.appInstanceId,
+                serializer.encodeCryptPublicKey(clientKeys.cryptKeyPair.publicKey),
+            )
+            val serverSessions = WsSessionManager()
+            val serverHandler = mockk<WsMessageHandler>(relaxed = true)
+            val server =
+                DesktopPasteServer(
+                    TestReadWritePort(),
+                    DesktopExceptionHandler(),
+                    DesktopServerFactory(),
+                    AuthenticatedWsServerModule(serverInfo, serverStore, serverSessions, serverHandler),
+                )
+            val httpClient = HttpClient(CIO) { install(WebSockets) }
+
+            try {
+                server.start()
+                val path =
+                    "/ws/sync?appInstanceId=${clientInfo.appInstanceId}" +
+                        "&targetAppInstanceId=${serverInfo.appInstanceId}"
+                httpClient.webSocket(host = "127.0.0.1", port = server.port(), path = path) {
+                    send(Frame.Text("not-json"))
+                    WsSession(this, serverInfo.appInstanceId).sendEnvelope(
+                        WsEnvelope(type = "legacy-test", payload = "payload".encodeToByteArray()),
+                    )
+                    coVerify(timeout = 5_000) {
+                        serverHandler.handleMessage(
+                            clientInfo.appInstanceId,
+                            match { it.type == "legacy-test" && it.payload.decodeToString() == "payload" },
+                        )
+                    }
+                    assertTrue(serverSessions.isConnected(clientInfo.appInstanceId))
+                }
+            } finally {
+                serverSessions.closeAll()
+                httpClient.close()
+                server.stop()
+            }
+        }
+
+    @Test
+    fun `authentication closes cleanly when the paired key disappears`() =
+        runBlocking {
+            val serverInfo = appInfo("missing-key-server")
+            val clientInfo = appInfo("missing-key-client")
+            val serverStore = mockk<SecureStore>()
+            coEvery { serverStore.existCryptPublicKey(clientInfo.appInstanceId) } returns true
+            coEvery { serverStore.getMessageProcessor(clientInfo.appInstanceId) } throws IllegalStateException("gone")
+            val server =
+                DesktopPasteServer(
+                    TestReadWritePort(),
+                    DesktopExceptionHandler(),
+                    DesktopServerFactory(),
+                    AuthenticatedWsServerModule(
+                        serverInfo,
+                        serverStore,
+                        WsSessionManager(),
+                        mockk(relaxed = true),
+                    ),
+                )
+            val httpClient = HttpClient(CIO) { install(WebSockets) }
+
+            try {
+                server.start()
+                val path =
+                    "/ws/sync?appInstanceId=${clientInfo.appInstanceId}" +
+                        "&targetAppInstanceId=${serverInfo.appInstanceId}" +
+                        "&authVersion=${WsAuthenticationCodec.VERSION}"
+                httpClient.webSocket(host = "127.0.0.1", port = server.port(), path = path) {
+                    val reason = withTimeout(5.seconds) { closeReason.await() }
+                    assertEquals(CloseReason.Codes.VIOLATED_POLICY.code, reason?.code)
+                }
+            } finally {
+                httpClient.close()
+                server.stop()
+            }
+        }
+
     private fun appInfo(id: String): AppInfo =
         AppInfo(
             appInstanceId = id,
@@ -109,7 +205,7 @@ class WsAuthenticationIntegrationTest {
 
 private class AuthenticatedWsServerModule(
     private val appInfo: AppInfo,
-    private val secureStore: GeneralSecureStore,
+    private val secureStore: SecureStore,
     private val sessionManager: WsSessionManager,
     private val messageHandler: WsMessageHandler,
 ) : ServerModule {

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationTest.kt
@@ -1,0 +1,43 @@
+package com.crosspaste.net.ws
+
+import com.crosspaste.net.routing.isLoopbackHost
+import com.crosspaste.secure.SecureMessageProcessor
+import com.crosspaste.utils.CryptographyUtils
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WsAuthenticationTest {
+
+    @Test
+    fun `authenticated envelope rejects tampering and replay`() =
+        runTest {
+            val firstKeys = CryptographyUtils.generateSecureKeyPair()
+            val secondKeys = CryptographyUtils.generateSecureKeyPair()
+            val firstProcessor =
+                SecureMessageProcessor(firstKeys.cryptKeyPair.privateKey, secondKeys.cryptKeyPair.publicKey)
+            val secondProcessor =
+                SecureMessageProcessor(secondKeys.cryptKeyPair.privateKey, firstKeys.cryptKeyPair.publicKey)
+            val sender = WsAuthenticationContext("session", "first", "second", firstProcessor)
+            val receiver = WsAuthenticationContext("session", "second", "first", secondProcessor)
+
+            val firstEnvelope = WsEnvelope(WsMessageType.HEARTBEAT)
+            val firstHeader = sender.createHeader(firstEnvelope)
+            assertTrue(receiver.verify(firstHeader, firstEnvelope.payload))
+            assertFalse(receiver.verify(firstHeader, firstEnvelope.payload))
+
+            val secondEnvelope = WsEnvelope(WsMessageType.PASTE_PUSH, "payload".encodeToByteArray())
+            val secondHeader = sender.createHeader(secondEnvelope)
+            assertFalse(receiver.verify(secondHeader, "tampered".encodeToByteArray()))
+            assertTrue(receiver.verify(secondHeader, secondEnvelope.payload))
+        }
+
+    @Test
+    fun `legacy websocket is limited to loopback`() {
+        assertTrue(isLoopbackHost("127.0.0.1"))
+        assertTrue(isLoopbackHost("::1"))
+        assertFalse(isLoopbackHost("192.168.1.10"))
+        assertFalse(isLoopbackHost(null))
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationTest.kt
@@ -1,6 +1,6 @@
 package com.crosspaste.net.ws
 
-import com.crosspaste.net.routing.isLoopbackHost
+import com.crosspaste.net.routing.isLoopbackAddress
 import com.crosspaste.secure.SecureMessageProcessor
 import com.crosspaste.utils.CryptographyUtils
 import kotlinx.coroutines.test.runTest
@@ -35,9 +35,10 @@ class WsAuthenticationTest {
 
     @Test
     fun `legacy websocket is limited to loopback`() {
-        assertTrue(isLoopbackHost("127.0.0.1"))
-        assertTrue(isLoopbackHost("::1"))
-        assertFalse(isLoopbackHost("192.168.1.10"))
-        assertFalse(isLoopbackHost(null))
+        assertTrue(isLoopbackAddress("127.0.0.1"))
+        assertTrue(isLoopbackAddress("::1"))
+        assertFalse(isLoopbackAddress("localhost"))
+        assertFalse(isLoopbackAddress("192.168.1.10"))
+        assertFalse(isLoopbackAddress(null))
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsModuleDependencyTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsModuleDependencyTest.kt
@@ -116,6 +116,7 @@ class WsModuleDependencyTest : KoinTest {
                     WsClientConnector(
                         appInfo = get(),
                         client = wsHttpClient,
+                        secureStore = get(),
                         wsSessionManager = get(),
                         wsMessageHandler = get(),
                     )

--- a/core/src/commonMain/kotlin/com/crosspaste/secure/PeerAuthenticator.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/secure/PeerAuthenticator.kt
@@ -1,0 +1,76 @@
+package com.crosspaste.secure
+
+import dev.whyoleg.cryptography.CryptographyProvider
+import dev.whyoleg.cryptography.algorithms.ECDH
+import dev.whyoleg.cryptography.algorithms.HMAC
+import dev.whyoleg.cryptography.algorithms.SHA256
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** HMAC authentication derived independently from the long-term ECDH secret. */
+class PeerAuthenticator(
+    private val privateKey: ECDH.PrivateKey,
+    private val publicKey: ECDH.PublicKey,
+) {
+    private val hmac = CryptographyProvider.Default.get(HMAC)
+    private val keyMutex = Mutex()
+    private var authenticationKey: ByteArray? = null
+
+    suspend fun authenticationCode(data: ByteArray): ByteArray =
+        hmacSha256(getAuthenticationKey(), AUTHENTICATION_DOMAIN + data)
+
+    suspend fun verify(
+        data: ByteArray,
+        expectedCode: ByteArray,
+    ): Boolean = constantTimeEquals(authenticationCode(data), expectedCode)
+
+    private suspend fun getAuthenticationKey(): ByteArray {
+        authenticationKey?.let { return it }
+        return keyMutex.withLock {
+            authenticationKey?.let { return it }
+            val sharedSecret =
+                privateKey
+                    .sharedSecretGenerator()
+                    .generateSharedSecretToByteArray(publicKey)
+            try {
+                val extracted = hmacSha256(HKDF_SALT, sharedSecret)
+                try {
+                    hmacSha256(extracted, HKDF_INFO + byteArrayOf(1))
+                        .also { authenticationKey = it }
+                } finally {
+                    extracted.fill(0)
+                }
+            } finally {
+                sharedSecret.fill(0)
+            }
+        }
+    }
+
+    private suspend fun hmacSha256(
+        key: ByteArray,
+        data: ByteArray,
+    ): ByteArray =
+        hmac
+            .keyDecoder(SHA256)
+            .decodeFromByteArray(HMAC.Key.Format.RAW, key)
+            .signatureGenerator()
+            .generateSignature(data)
+
+    private fun constantTimeEquals(
+        first: ByteArray,
+        second: ByteArray,
+    ): Boolean {
+        if (first.size != second.size) return false
+        var difference = 0
+        first.indices.forEach { index ->
+            difference = difference or (first[index].toInt() xor second[index].toInt())
+        }
+        return difference == 0
+    }
+
+    companion object {
+        private val HKDF_SALT = "crosspaste-peer-auth-hkdf-v1".encodeToByteArray()
+        private val HKDF_INFO = "crosspaste-peer-auth-key-v1".encodeToByteArray()
+        private val AUTHENTICATION_DOMAIN = "crosspaste-peer-auth-message-v1".encodeToByteArray()
+    }
+}

--- a/core/src/commonMain/kotlin/com/crosspaste/secure/PeerAuthenticator.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/secure/PeerAuthenticator.kt
@@ -6,6 +6,7 @@ import dev.whyoleg.cryptography.algorithms.HMAC
 import dev.whyoleg.cryptography.algorithms.SHA256
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 
 /** HMAC authentication derived independently from the long-term ECDH secret. */
 class PeerAuthenticator(
@@ -14,6 +15,8 @@ class PeerAuthenticator(
 ) {
     private val hmac = CryptographyProvider.Default.get(HMAC)
     private val keyMutex = Mutex()
+
+    @Volatile
     private var authenticationKey: ByteArray? = null
 
     suspend fun authenticationCode(data: ByteArray): ByteArray =

--- a/core/src/commonTest/kotlin/com/crosspaste/secure/PeerAuthenticatorTest.kt
+++ b/core/src/commonTest/kotlin/com/crosspaste/secure/PeerAuthenticatorTest.kt
@@ -1,0 +1,27 @@
+package com.crosspaste.secure
+
+import com.crosspaste.utils.CryptographyUtils
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PeerAuthenticatorTest {
+
+    @Test
+    fun `both peers derive the same authentication key`() =
+        runTest {
+            val first = CryptographyUtils.generateSecureKeyPair()
+            val second = CryptographyUtils.generateSecureKeyPair()
+            val firstAuthenticator =
+                PeerAuthenticator(first.cryptKeyPair.privateKey, second.cryptKeyPair.publicKey)
+            val secondAuthenticator =
+                PeerAuthenticator(second.cryptKeyPair.privateKey, first.cryptKeyPair.publicKey)
+            val payload = "authenticated payload".encodeToByteArray()
+
+            val code = firstAuthenticator.authenticationCode(payload)
+
+            assertTrue(secondAuthenticator.verify(payload, code))
+            assertFalse(secondAuthenticator.verify("tampered payload".encodeToByteArray(), code))
+        }
+}


### PR DESCRIPTION
## Summary
- add an optional authVersion=1 proof-of-key handshake using the existing paired ECDH keys
- mutually authenticate client/server before session registration
- MAC every envelope with session identity and strict sequence numbers to reject tampering, replay, and cross-session forwarding
- retain unauthenticated WebSocket only for loopback browser extensions; older remote desktop/mobile peers fall back to v2 HTTP

## Compatibility
No existing DTO meaning is changed and no global protocol version is bumped. New clients request authenticated WebSocket explicitly. Released same-machine extensions remain usable through the loopback-only legacy path.

This touches core/commonMain at commit 502b2d3c. Mobile should sync the final merged desktop commit, not the branch SHA.

## Verification
- ./gradlew :core:build
- ./gradlew :app:desktopTest
- real Netty/CIO authenticated WebSocket integration test
- JS WebCrypto, native, and desktop PeerAuthenticator tests

Closes review finding R2-03-001.