### PR TITLE
:bug: disambiguate WebSocket whole-file pulls

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessageHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessageHandler.kt
@@ -216,24 +216,22 @@ class WsMessageHandler(
                 return
             }
 
-        // Find the file across all PasteFiles items in this paste
-        val allFileItems = pasteData.getPasteAppearItems().filterIsInstance<PasteFiles>()
-        var targetPath: okio.Path? = null
-
-        for (pasteFiles in allFileItems) {
-            val filePaths = pasteFiles.getFilePaths(userDataPathProvider)
-            for (filePath in filePaths) {
-                if (filePath.name == request.fileName) {
-                    targetPath = filePath
-                    break
+        val candidates =
+            pasteData
+                .getPasteAppearItems()
+                .filterIsInstance<PasteFiles>()
+                .flatMap { pasteFiles ->
+                    pasteFiles.relativePathList
+                        .zip(pasteFiles.getFilePaths(userDataPathProvider))
+                        .map { (relativePath, filePath) -> WholeFileCandidate(relativePath, filePath) }
                 }
-            }
-            if (targetPath != null) break
-        }
+        val targetPath = selectWholeFilePath(candidates, request)
 
         if (targetPath == null) {
-            logger.error { "FILE_PULL_REQUEST whole-file: file '${request.fileName}' not found in paste ${request.id}" }
-            sendErrorResponse(appInstanceId, requestId, "File not found: ${request.fileName}")
+            logger.error {
+                "FILE_PULL_REQUEST whole-file: file '${request.fileName}' not found or ambiguous in paste ${request.id}"
+            }
+            sendErrorResponse(appInstanceId, requestId, "File not found or ambiguous: ${request.fileName}")
             return
         }
 
@@ -310,4 +308,20 @@ class WsMessageHandler(
             )
         wsSessionManager.send(appInstanceId, errorEnvelope)
     }
+}
+
+internal data class WholeFileCandidate(
+    val relativePath: String,
+    val filePath: okio.Path,
+)
+
+internal fun selectWholeFilePath(
+    candidates: List<WholeFileCandidate>,
+    request: WsPullFileRequest.WholeFileRequest,
+): okio.Path? {
+    val matches =
+        request.relativePath?.let { requestedPath ->
+            candidates.filter { it.relativePath == requestedPath }
+        } ?: candidates.filter { it.filePath.name == request.fileName }
+    return matches.singleOrNull()?.filePath
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
@@ -210,8 +210,8 @@ class FilePullService(
 
             runCatching {
                 val expectedFileInfo =
-                    pasteFiles.fileInfoTreeMap[relativePath]
-                        ?: error("Missing file metadata for $relativePath")
+                    pasteFiles.fileInfoTreeMap[requestFileName]
+                        ?: error("Missing file metadata for $requestFileName")
                 val request: WsPullFileRequest =
                     WsPullFileRequest.WholeFileRequest(
                         hash = hash,

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/FilePullService.kt
@@ -17,11 +17,13 @@ import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.paste.item.PasteItem
 import com.crosspaste.paste.item.getFilePaths
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.presist.FileInfoTree
 import com.crosspaste.presist.FilesIndexBuilder
 import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.FileUtils
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
+import com.crosspaste.utils.getCodecsUtils
 import com.crosspaste.utils.getDateUtils
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.getJsonUtils
@@ -207,6 +209,9 @@ class FilePullService(
             val targetPath = targetPaths[index]
 
             runCatching {
+                val expectedFileInfo =
+                    pasteFiles.fileInfoTreeMap[relativePath]
+                        ?: error("Missing file metadata for $relativePath")
                 val request: WsPullFileRequest =
                     WsPullFileRequest.WholeFileRequest(
                         hash = hash,
@@ -229,6 +234,9 @@ class FilePullService(
                 if (response.type == WsMessageType.ERROR) {
                     val errorMsg = response.payload.decodeToString()
                     throw IllegalStateException("File pull error: $errorMsg")
+                }
+                check(isValidWholeFilePayload(expectedFileInfo, response.payload)) {
+                    "Whole-file response failed size/hash validation"
                 }
 
                 // Write the received bytes directly to the target file path
@@ -357,3 +365,11 @@ class FilePullService(
         }
     }
 }
+
+internal fun isValidWholeFilePayload(
+    expected: FileInfoTree,
+    payload: ByteArray,
+): Boolean =
+    expected.isFile() &&
+        expected.size == payload.size.toLong() &&
+        expected.hash == getCodecsUtils().hash(payload)

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WholeFileSelectionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WholeFileSelectionTest.kt
@@ -1,6 +1,9 @@
 package com.crosspaste.net.ws
 
 import com.crosspaste.dto.pull.WsPullFileRequest
+import com.crosspaste.presist.SingleFileInfoTree
+import com.crosspaste.sync.isValidWholeFilePayload
+import com.crosspaste.utils.getCodecsUtils
 import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -38,5 +41,15 @@ class WholeFileSelectionTest {
         val request = WsPullFileRequest.WholeFileRequest(fileName = "unique.txt")
 
         assertEquals("/paste/unique.txt".toPath(), selectWholeFilePath(candidates, request))
+    }
+
+    @Test
+    fun `whole-file payload requires matching size and hash`() {
+        val payload = "expected".encodeToByteArray()
+        val expected = SingleFileInfoTree(payload.size.toLong(), getCodecsUtils().hash(payload))
+
+        assertEquals(true, isValidWholeFilePayload(expected, payload))
+        assertEquals(false, isValidWholeFilePayload(expected, "tampered".encodeToByteArray()))
+        assertEquals(false, isValidWholeFilePayload(expected, payload + 0))
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WholeFileSelectionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WholeFileSelectionTest.kt
@@ -7,7 +7,9 @@ import com.crosspaste.utils.getCodecsUtils
 import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class WholeFileSelectionTest {
 
@@ -48,8 +50,8 @@ class WholeFileSelectionTest {
         val payload = "expected".encodeToByteArray()
         val expected = SingleFileInfoTree(payload.size.toLong(), getCodecsUtils().hash(payload))
 
-        assertEquals(true, isValidWholeFilePayload(expected, payload))
-        assertEquals(false, isValidWholeFilePayload(expected, "tampered".encodeToByteArray()))
-        assertEquals(false, isValidWholeFilePayload(expected, payload + 0))
+        assertTrue(isValidWholeFilePayload(expected, payload))
+        assertFalse(isValidWholeFilePayload(expected, "tampered".encodeToByteArray()))
+        assertFalse(isValidWholeFilePayload(expected, payload + 0))
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WholeFileSelectionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WholeFileSelectionTest.kt
@@ -1,0 +1,42 @@
+package com.crosspaste.net.ws
+
+import com.crosspaste.dto.pull.WsPullFileRequest
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class WholeFileSelectionTest {
+
+    private val candidates =
+        listOf(
+            WholeFileCandidate("dir-a/file.txt", "/paste/dir-a/file.txt".toPath()),
+            WholeFileCandidate("dir-b/file.txt", "/paste/dir-b/file.txt".toPath()),
+            WholeFileCandidate("unique.txt", "/paste/unique.txt".toPath()),
+        )
+
+    @Test
+    fun `relative path selects exact file when basenames collide`() {
+        val request =
+            WsPullFileRequest.WholeFileRequest(
+                fileName = "file.txt",
+                relativePath = "dir-b/file.txt",
+            )
+
+        assertEquals("/paste/dir-b/file.txt".toPath(), selectWholeFilePath(candidates, request))
+    }
+
+    @Test
+    fun `legacy basename request rejects ambiguous match`() {
+        val request = WsPullFileRequest.WholeFileRequest(fileName = "file.txt")
+
+        assertNull(selectWholeFilePath(candidates, request))
+    }
+
+    @Test
+    fun `legacy basename request keeps unique fallback`() {
+        val request = WsPullFileRequest.WholeFileRequest(fileName = "unique.txt")
+
+        assertEquals("/paste/unique.txt".toPath(), selectWholeFilePath(candidates, request))
+    }
+}

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/pull/WsPullFileRequest.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/pull/WsPullFileRequest.kt
@@ -30,5 +30,6 @@ sealed class WsPullFileRequest {
         val id: Long = 0,
         val hash: String = "",
         val fileName: String,
+        val relativePath: String? = null,
     ) : WsPullFileRequest()
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
@@ -9,11 +9,20 @@ interface PasteFiles {
     val basePath: String?
 
     /**
-     * Keyed by the top-level entry name (file name for a `SingleFileInfoTree`,
-     * directory name for a `DirFileInfoTree`), NOT by [relativePathList]
-     * entries: those may be multi-segment bound paths like
-     * "appInstanceId/date/id/name.png" while the map key stays "name.png".
-     * Derive keys via `relativePath.toPath().name`.
+     * Describes the file payload copied in one clipboard operation.
+     *
+     * A paste can contain multiple top-level entries, and each entry can be either
+     * a file or a directory. For internally stored pastes, `appInstanceId/date/id/`
+     * is the paste root; its direct children are the entries copied together.
+     * [relativePathList] stores paths to those children, for example
+     * `appInstanceId/date/id/report.pdf` and `appInstanceId/date/id/photos`.
+     *
+     * This map has one entry for each direct child of that paste root and is keyed
+     * only by the child's name: `"report.pdf"` maps to a `SingleFileInfoTree`, while
+     * `"photos"` maps to a `DirFileInfoTree` containing its descendants. Therefore,
+     * derive the key from the final component of the corresponding relative path
+     * (`relativePath.toPath().name`), not from the full relative path or from names
+     * nested inside a directory tree.
      */
     val fileInfoTreeMap: Map<String, FileInfoTree>
 

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
@@ -9,9 +9,11 @@ interface PasteFiles {
     val basePath: String?
 
     /**
-     * Keyed by file basename, NOT by [relativePathList] entries: those may be
-     * multi-segment bound paths like "appInstanceId/date/id/name.png" while the
-     * map key stays "name.png". Derive keys via `relativePath.toPath().name`.
+     * Keyed by the top-level entry name (file name for a `SingleFileInfoTree`,
+     * directory name for a `DirFileInfoTree`), NOT by [relativePathList]
+     * entries: those may be multi-segment bound paths like
+     * "appInstanceId/date/id/name.png" while the map key stays "name.png".
+     * Derive keys via `relativePath.toPath().name`.
      */
     val fileInfoTreeMap: Map<String, FileInfoTree>
 

--- a/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/paste/item/PasteFiles.kt
@@ -8,6 +8,11 @@ interface PasteFiles {
 
     val basePath: String?
 
+    /**
+     * Keyed by file basename, NOT by [relativePathList] entries: those may be
+     * multi-segment bound paths like "appInstanceId/date/id/name.png" while the
+     * map key stays "name.png". Derive keys via `relativePath.toPath().name`.
+     */
     val fileInfoTreeMap: Map<String, FileInfoTree>
 
     val relativePathList: List<String>

--- a/core/src/commonTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
+++ b/core/src/commonTest/kotlin/com/crosspaste/dto/DtoSerializationTest.kt
@@ -89,17 +89,33 @@ class DtoSerializationTest {
     @Test
     fun `WsPullFileRequest roundtrip preserves subtype`() {
         val whole: WsPullFileRequest =
-            WsPullFileRequest.WholeFileRequest(hash = "h", fileName = "f.png")
+            WsPullFileRequest.WholeFileRequest(
+                hash = "h",
+                fileName = "f.png",
+                relativePath = "dir/f.png",
+            )
         val decodedWhole = json.decodeFromString<WsPullFileRequest>(json.encodeToString(whole))
         assertTrue(decodedWhole is WsPullFileRequest.WholeFileRequest)
         assertEquals("h", decodedWhole.hash)
         assertEquals("f.png", decodedWhole.fileName)
+        assertEquals("dir/f.png", decodedWhole.relativePath)
 
         val chunk: WsPullFileRequest = WsPullFileRequest.ChunkRequest(id = 5L, chunkIndex = 2)
         val decodedChunk = json.decodeFromString<WsPullFileRequest>(json.encodeToString(chunk))
         assertTrue(decodedChunk is WsPullFileRequest.ChunkRequest)
         assertEquals(5L, decodedChunk.id)
         assertEquals(2, decodedChunk.chunkIndex)
+    }
+
+    @Test
+    fun `WsPullFileRequest legacy whole-file payload defaults relativePath to null`() {
+        val legacyWire =
+            """{"mode":"whole","id":1,"hash":"h","fileName":"f.png"}"""
+
+        val decoded = json.decodeFromString<WsPullFileRequest>(legacyWire)
+
+        assertTrue(decoded is WsPullFileRequest.WholeFileRequest)
+        assertEquals(null, decoded.relativePath)
     }
 
     // --- EndpointInfo ---

--- a/web/src/shared/ws/__tests__/whole-file-wire.test.ts
+++ b/web/src/shared/ws/__tests__/whole-file-wire.test.ts
@@ -1,0 +1,33 @@
+import { CrossPasteHash } from "@/shared/core";
+import { describe, expect, it } from "vitest";
+import { createWholeFileRequest, isValidWholeFilePayload } from "../ws-message-handler";
+
+describe("whole-file WebSocket wire", () => {
+  it("includes the exact relative path while preserving the legacy basename", () => {
+    expect(createWholeFileRequest(7, "paste-hash", "dir/file.txt")).toEqual({
+      mode: "whole",
+      id: 7,
+      hash: "paste-hash",
+      fileName: "file.txt",
+      relativePath: "dir/file.txt",
+    });
+  });
+
+  it("accepts only payloads matching the advertised file size and hash", () => {
+    const payload = new TextEncoder().encode("expected");
+    const bytes = new Int8Array(payload.buffer, payload.byteOffset, payload.byteLength);
+    const metadata = {
+      "dir/file.txt": {
+        type: "file",
+        size: payload.byteLength,
+        hash: CrossPasteHash.hashBytes(bytes),
+      },
+    };
+
+    expect(isValidWholeFilePayload(metadata, "dir/file.txt", payload)).toBe(true);
+    expect(
+      isValidWholeFilePayload(metadata, "dir/file.txt", new TextEncoder().encode("tampered")),
+    ).toBe(false);
+    expect(isValidWholeFilePayload(metadata, "other/file.txt", payload)).toBe(false);
+  });
+});

--- a/web/src/shared/ws/__tests__/whole-file-wire.test.ts
+++ b/web/src/shared/ws/__tests__/whole-file-wire.test.ts
@@ -16,18 +16,23 @@ describe("whole-file WebSocket wire", () => {
   it("accepts only payloads matching the advertised file size and hash", () => {
     const payload = new TextEncoder().encode("expected");
     const bytes = new Int8Array(payload.buffer, payload.byteOffset, payload.byteLength);
+    // fileInfoTreeMap is keyed by basename even when relativePathList entries
+    // are multi-segment bound paths (matches desktop paste creation).
     const metadata = {
-      "dir/file.txt": {
+      "file.txt": {
         type: "file",
         size: payload.byteLength,
         hash: CrossPasteHash.hashBytes(bytes),
       },
     };
 
-    expect(isValidWholeFilePayload(metadata, "dir/file.txt", payload)).toBe(true);
+    expect(isValidWholeFilePayload(metadata, "app-instance/2026-08-01/7/file.txt", payload)).toBe(
+      true,
+    );
+    expect(isValidWholeFilePayload(metadata, "file.txt", payload)).toBe(true);
     expect(
-      isValidWholeFilePayload(metadata, "dir/file.txt", new TextEncoder().encode("tampered")),
+      isValidWholeFilePayload(metadata, "file.txt", new TextEncoder().encode("tampered")),
     ).toBe(false);
-    expect(isValidWholeFilePayload(metadata, "other/file.txt", payload)).toBe(false);
+    expect(isValidWholeFilePayload(metadata, "dir/other.txt", payload)).toBe(false);
   });
 });

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -32,17 +32,22 @@ interface SingleFileMetadata {
   hash: string;
 }
 
+/** Basename of a relative path; desktop paths may be multi-segment like "appInstanceId/date/id/name.png". */
+function baseFileName(relativePath: string): string {
+  const parts = relativePath.split(/[\\/]/);
+  return parts[parts.length - 1] || relativePath;
+}
+
 export function createWholeFileRequest(
   id: number,
   hash: string,
   relativePath: string,
 ): WsWholeFileRequest {
-  const parts = relativePath.split(/[\\/]/);
   return {
     mode: "whole",
     id,
     hash,
-    fileName: parts[parts.length - 1] || relativePath,
+    fileName: baseFileName(relativePath),
     relativePath,
   };
 }
@@ -52,7 +57,10 @@ export function isValidWholeFilePayload(
   relativePath: string,
   payload: Uint8Array,
 ): boolean {
-  const metadata = fileInfoTreeMap[relativePath] as Partial<SingleFileMetadata> | undefined;
+  // fileInfoTreeMap is keyed by basename (see Kotlin PasteFiles.fileInfoTreeMap).
+  const metadata = fileInfoTreeMap[baseFileName(relativePath)] as
+    | Partial<SingleFileMetadata>
+    | undefined;
   if (
     metadata?.type !== "file" ||
     metadata.size !== payload.byteLength ||

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -6,6 +6,7 @@ import { BlobStore } from "@/shared/storage/blob-store";
 import { PasteStore } from "@/shared/storage/paste-store";
 import { ingestPaste } from "@/shared/paste/paste-ingestion";
 import { writeRemotePasteToClipboard } from "@/shared/clipboard/clipboard-sync-writer";
+import { CrossPasteHash } from "@/shared/core";
 import { shouldWriteRemotePaste } from "./paste-push-policy";
 
 /** Payload of a FILE_PULL_REQUEST message (matches Kotlin WsPullFileRequest sealed class). */
@@ -15,7 +16,7 @@ interface WsChunkRequest {
   chunkIndex: number;
 }
 
-interface WsWholeFileRequest {
+export interface WsWholeFileRequest {
   mode: "whole";
   id?: number;
   hash?: string;
@@ -24,6 +25,44 @@ interface WsWholeFileRequest {
 }
 
 type WsPullFileRequest = WsChunkRequest | WsWholeFileRequest;
+
+interface SingleFileMetadata {
+  type: "file";
+  size: number;
+  hash: string;
+}
+
+export function createWholeFileRequest(
+  id: number,
+  hash: string,
+  relativePath: string,
+): WsWholeFileRequest {
+  const parts = relativePath.split(/[\\/]/);
+  return {
+    mode: "whole",
+    id,
+    hash,
+    fileName: parts[parts.length - 1] || relativePath,
+    relativePath,
+  };
+}
+
+export function isValidWholeFilePayload(
+  fileInfoTreeMap: Record<string, unknown>,
+  relativePath: string,
+  payload: Uint8Array,
+): boolean {
+  const metadata = fileInfoTreeMap[relativePath] as Partial<SingleFileMetadata> | undefined;
+  if (
+    metadata?.type !== "file" ||
+    metadata.size !== payload.byteLength ||
+    typeof metadata.hash !== "string"
+  ) {
+    return false;
+  }
+  const bytes = new Int8Array(payload.buffer, payload.byteOffset, payload.byteLength);
+  return CrossPasteHash.hashBytes(bytes) === metadata.hash;
+}
 
 /** Payload of a PASTE_REJECTED_OVERSIZE message (matches Kotlin OversizePasteNotice). */
 export interface OversizePasteNotice {
@@ -241,14 +280,7 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
         }
 
         try {
-          const bareFileName = fileName.includes("/") ? fileName.split("/").pop() || fileName : fileName;
-          const request: WsWholeFileRequest = {
-            mode: "whole",
-            id: pasteData.id,
-            hash,
-            fileName: bareFileName,
-            relativePath: fileName,
-          };
+          const request = createWholeFileRequest(pasteData.id, hash, fileName);
 
           const requestEnvelope: WsEnvelope = {
             type: WsMessageType.FILE_PULL_REQUEST,
@@ -264,13 +296,16 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
             continue;
           }
 
-          if (response.payload.length > 0) {
-            await BlobStore.put(hash, fileName, response.payload.slice().buffer as ArrayBuffer);
-            pulledAny = true;
-            console.log(
-              `[WsHandler] Pulled file ${fileName} (${response.payload.length} bytes) from ${appInstanceId}`,
-            );
+          if (!isValidWholeFilePayload(item.fileInfoTreeMap, fileName, response.payload)) {
+            console.warn(`[WsHandler] Rejected invalid file payload for ${fileName}`);
+            continue;
           }
+
+          await BlobStore.put(hash, fileName, response.payload.slice().buffer as ArrayBuffer);
+          pulledAny = true;
+          console.log(
+            `[WsHandler] Pulled file ${fileName} (${response.payload.length} bytes) from ${appInstanceId}`,
+          );
         } catch (e) {
           console.error(`[WsHandler] Failed to pull file ${fileName} from ${appInstanceId}:`, e);
         }

--- a/web/src/shared/ws/ws-message-handler.ts
+++ b/web/src/shared/ws/ws-message-handler.ts
@@ -20,6 +20,7 @@ interface WsWholeFileRequest {
   id?: number;
   hash?: string;
   fileName: string;
+  relativePath?: string;
 }
 
 type WsPullFileRequest = WsChunkRequest | WsWholeFileRequest;
@@ -246,6 +247,7 @@ export function createWsMessageHandler(deps: WsMessageHandlerDeps) {
             id: pasteData.id,
             hash,
             fileName: bareFileName,
+            relativePath: fileName,
           };
 
           const requestEnvelope: WsEnvelope = {


### PR DESCRIPTION
## Summary
- add optional relativePath to whole-file requests while preserving legacy fileName
- select new requests by exact path and allow basename fallback only for a unique legacy match
- reject ambiguous legacy requests instead of returning the first same-name file
- validate returned whole-file size and Murmur hash before writing on desktop and browser extension receivers
- add Kotlin compatibility/selection/integrity tests and TypeScript wire/integrity tests

## Compatibility
The new DTO field defaults to null and shared JSON ignores unknown fields. New request to old server still carries the legacy basename; old request to new server succeeds only when the basename is unambiguous.

This touches core/commonMain at commit cbdadeb5. Mobile should sync the final merged desktop commit.

## Verification
- ./gradlew :core:build
- focused app desktop whole-file tests and ktlint
- web npm test: 10 files, 104 tests
- web production build

Closes review finding R2-03-004.

## Review follow-up (commit 5bbdbe80)
- Fixed a key-convention mismatch in the new validation on both sides: `fileInfoTreeMap` is keyed by file basename while `relativePathList` entries may be multi-segment bound paths (`appInstanceId/date/id/name.png`), so the metadata lookup by full relative path never matched and every valid pull was rejected. Both `FilePullService` and the extension `ws-message-handler` now look up by basename; the convention is documented on `PasteFiles.fileInfoTreeMap` and tests use the production key shape.
- Legacy-hash note: the optional `hashBytes` fallback in the extension paste collector (`hashText`-based hashes) predates nothing — `hashBytes` shipped in the same commit as WebSocket file pulling (301213ff), so no released extension ever produced pullable file metadata without a raw-byte hash. Strict hash validation therefore cannot reject legacy-format metadata.
