### PR TITLE
:bug: authenticate sync control requests

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/SyncClientApi.kt
@@ -7,7 +7,11 @@ import com.crosspaste.dto.secure.TrustConfirmRequest
 import com.crosspaste.dto.secure.TrustConfirmResponse
 import com.crosspaste.dto.secure.TrustRequest
 import com.crosspaste.dto.secure.TrustResponse
+import com.crosspaste.dto.sync.AuthenticatedControlRequest
+import com.crosspaste.dto.sync.ControlChallenge
+import com.crosspaste.dto.sync.ControlOperation
 import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.PasteClient
 import com.crosspaste.net.SyncApi
 import com.crosspaste.net.exception.ExceptionHandler
@@ -274,21 +278,71 @@ class SyncClientApi(
             })
         }) { true }
 
-    suspend fun notifyExit(toUrl: URLBuilder.() -> Unit) {
-        request(logger, exceptionHandler, request = {
-            pasteClient.get(urlBuilder = {
-                toUrl()
-                buildUrl("sync", "notifyExit")
-            })
-        }) { true }
+    suspend fun notifyExit(
+        targetAppInstanceId: String,
+        toUrl: URLBuilder.() -> Unit,
+    ) {
+        notifyControl(targetAppInstanceId, ControlOperation.NOTIFY_EXIT, "notifyExit", toUrl)
     }
 
-    suspend fun notifyRemove(toUrl: URLBuilder.() -> Unit) {
-        request(logger, exceptionHandler, request = {
-            pasteClient.get(urlBuilder = {
-                toUrl()
-                buildUrl("sync", "notifyRemove")
-            })
-        }) { true }
+    suspend fun notifyRemove(
+        targetAppInstanceId: String,
+        toUrl: URLBuilder.() -> Unit,
+    ) {
+        notifyControl(targetAppInstanceId, ControlOperation.NOTIFY_REMOVE, "notifyRemove", toUrl)
+    }
+
+    private suspend fun notifyControl(
+        targetAppInstanceId: String,
+        operation: ControlOperation,
+        legacyPath: String,
+        toUrl: URLBuilder.() -> Unit,
+    ) {
+        val challengeResult =
+            request(logger, exceptionHandler, request = {
+                pasteClient.get(
+                    headersBuilder = {
+                        append("targetAppInstanceId", targetAppInstanceId)
+                    },
+                    urlBuilder = {
+                        toUrl()
+                        buildUrl("sync", "control", "challenge")
+                    },
+                )
+            }) { response ->
+                response.body<ControlChallenge>()
+            }
+        if (challengeResult is SuccessResult) {
+            val challenge = challengeResult.getResult<ControlChallenge>()
+            request(logger, exceptionHandler, request = {
+                pasteClient.post(
+                    AuthenticatedControlRequest(
+                        challengeId = challenge.id,
+                        challengeNonce = challenge.nonce,
+                        targetAppInstanceId = targetAppInstanceId,
+                        operation = operation,
+                    ),
+                    typeInfo<AuthenticatedControlRequest>(),
+                    headersBuilder = {
+                        append("targetAppInstanceId", targetAppInstanceId)
+                        append("secure", "1")
+                    },
+                    urlBuilder = {
+                        toUrl()
+                        buildUrl("sync", "control", legacyPath)
+                    },
+                )
+            }) { true }
+        } else if (
+            challengeResult is FailureResult &&
+            challengeResult.exception.match(StandardErrorCode.NOT_FOUND_API)
+        ) {
+            request(logger, exceptionHandler, request = {
+                pasteClient.get(urlBuilder = {
+                    toUrl()
+                    buildUrl("sync", legacyPath)
+                })
+            }) { true }
+        }
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/ControlChallengeStore.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/ControlChallengeStore.kt
@@ -1,0 +1,82 @@
+package com.crosspaste.net.routing
+
+import com.crosspaste.dto.sync.ControlChallenge
+import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
+import dev.whyoleg.cryptography.random.CryptographyRandom
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.time.Duration.Companion.seconds
+
+class ControlChallengeStore(
+    private val ttlMillis: Long = DEFAULT_TTL.inWholeMilliseconds,
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+    private val now: () -> Long = ::nowEpochMilliseconds,
+) {
+    private data class Entry(
+        val peerAppInstanceId: String,
+        val challenge: ControlChallenge,
+        val createdAt: Long,
+    )
+
+    private val mutex = Mutex()
+    private val entries = mutableMapOf<String, Entry>()
+
+    suspend fun issue(peerAppInstanceId: String): ControlChallenge =
+        mutex.withLock {
+            evictExpiredLocked()
+            if (entries.size >= maxEntries) {
+                entries.minByOrNull { it.value.createdAt }?.let { entries.remove(it.key) }
+            }
+            val challenge =
+                ControlChallenge(
+                    id = CryptographyRandom.nextBytes(CHALLENGE_ID_SIZE),
+                    nonce = CryptographyRandom.nextBytes(CHALLENGE_NONCE_SIZE),
+                )
+            entries[challenge.id.toHex()] = Entry(peerAppInstanceId, challenge, now())
+            challenge.detachedCopy()
+        }
+
+    suspend fun consume(
+        peerAppInstanceId: String,
+        challengeId: ByteArray,
+        challengeNonce: ByteArray,
+    ): Boolean =
+        mutex.withLock {
+            evictExpiredLocked()
+            val entry = entries.remove(challengeId.toHex()) ?: return@withLock false
+            entry.peerAppInstanceId == peerAppInstanceId &&
+                constantTimeEquals(entry.challenge.id, challengeId) &&
+                constantTimeEquals(entry.challenge.nonce, challengeNonce)
+        }
+
+    private fun evictExpiredLocked() {
+        val cutoff = now() - ttlMillis
+        entries.entries.removeAll { it.value.createdAt <= cutoff }
+    }
+
+    private fun ControlChallenge.detachedCopy(): ControlChallenge = ControlChallenge(id.copyOf(), nonce.copyOf())
+
+    private fun ByteArray.toHex(): String =
+        joinToString(separator = "") { byte ->
+            (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+        }
+
+    private fun constantTimeEquals(
+        first: ByteArray,
+        second: ByteArray,
+    ): Boolean {
+        if (first.size != second.size) return false
+        var difference = 0
+        first.indices.forEach { index ->
+            difference = difference or (first[index].toInt() xor second[index].toInt())
+        }
+        return difference == 0
+    }
+
+    companion object {
+        private val DEFAULT_TTL = 30.seconds
+        private const val DEFAULT_MAX_ENTRIES = 128
+        private const val CHALLENGE_ID_SIZE = 16
+        private const val CHALLENGE_NONCE_SIZE = 32
+    }
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -10,6 +10,8 @@ import com.crosspaste.dto.secure.TrustConfirmRequest
 import com.crosspaste.dto.secure.TrustConfirmResponse
 import com.crosspaste.dto.secure.TrustRequest
 import com.crosspaste.dto.secure.TrustResponse
+import com.crosspaste.dto.sync.AuthenticatedControlRequest
+import com.crosspaste.dto.sync.ControlOperation
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.NetworkInterfaceService
@@ -56,6 +58,7 @@ fun Routing.syncRouting(
     // active for a peer, that peer must not be able to fall back to v2 trust.
     hasActivePairingV3Session: (String) -> Boolean = { false },
     openPairingV3AcceptanceWindow: () -> Unit = {},
+    controlChallengeStore: ControlChallengeStore = ControlChallengeStore(),
 ) {
     val logger = KotlinLogging.logger {}
 
@@ -97,8 +100,20 @@ fun Routing.syncRouting(
             if (!validateHeartbeat(appInstanceId, call)) {
                 return@let
             }
+            if (call.request.headers["secure"] != "1") {
+                logger.warn { "Ignoring unauthenticated SyncInfo heartbeat from $appInstanceId" }
+                successResponse(call, syncApi.VERSION)
+                return@let
+            }
             runCatching {
-                val syncInfo = call.receive(SyncInfo::class)
+                val receivedSyncInfo = call.receive(SyncInfo::class)
+                if (receivedSyncInfo.appInfo.appInstanceId != appInstanceId) {
+                    logger.warn { "Binding mismatched SyncInfo identity to authenticated peer $appInstanceId" }
+                }
+                val syncInfo =
+                    receivedSyncInfo.copy(
+                        appInfo = receivedSyncInfo.appInfo.copy(appInstanceId = appInstanceId),
+                    )
                 val host = call.request.host()
                 syncRoutingApi.trustSyncInfo(syncInfo, host)
                 logger.info { "$appInstanceId heartbeat to ${appInfo.appInstanceId} success" }
@@ -116,17 +131,67 @@ fun Routing.syncRouting(
     }
 
     get("/sync/notifyExit") {
-        getAppInstanceId(call)?.let { appInstanceId ->
-            syncRoutingApi.markExit(appInstanceId)
+        getAppInstanceId(call)?.let {
+            logger.warn { "Ignoring unauthenticated legacy notifyExit" }
             successResponse(call)
         }
     }
 
     get("/sync/notifyRemove") {
-        getAppInstanceId(call)?.let { appInstanceId ->
-            syncRoutingApi.removeSyncHandler(appInstanceId)
+        getAppInstanceId(call)?.let {
+            logger.warn { "Ignoring unauthenticated legacy notifyRemove" }
             successResponse(call)
         }
+    }
+
+    get("/sync/control/challenge") {
+        getAppInstanceId(call)?.let { appInstanceId ->
+            if (!validateHeartbeat(appInstanceId, call)) {
+                return@let
+            }
+            successResponse(call, controlChallengeStore.issue(appInstanceId))
+        }
+    }
+
+    suspend fun handleAuthenticatedControl(
+        call: ApplicationCall,
+        expectedOperation: ControlOperation,
+        action: (String) -> Unit,
+    ) {
+        val appInstanceId = getAppInstanceId(call) ?: return
+        if (call.request.headers["secure"] != "1") {
+            failResponse(call, StandardErrorCode.DECRYPT_FAIL.toErrorCode())
+            return
+        }
+        if (!validateHeartbeat(appInstanceId, call)) return
+        runCatching {
+            val request = call.receive<AuthenticatedControlRequest>()
+            val valid =
+                request.targetAppInstanceId == appInfo.appInstanceId &&
+                    request.operation == expectedOperation &&
+                    controlChallengeStore.consume(
+                        appInstanceId,
+                        request.challengeId,
+                        request.challengeNonce,
+                    )
+            if (!valid) {
+                failResponse(call, StandardErrorCode.DECRYPT_FAIL.toErrorCode())
+                return
+            }
+            action(appInstanceId)
+            successResponse(call)
+        }.onFailure { e ->
+            logger.warn(e) { "Authenticated control request failed for $appInstanceId" }
+            failResponse(call, StandardErrorCode.DECRYPT_FAIL.toErrorCode())
+        }
+    }
+
+    post("/sync/control/notifyExit") {
+        handleAuthenticatedControl(call, ControlOperation.NOTIFY_EXIT, syncRoutingApi::markExit)
+    }
+
+    post("/sync/control/notifyRemove") {
+        handleAuthenticatedControl(call, ControlOperation.NOTIFY_REMOVE, syncRoutingApi::removeSyncHandler)
     }
 
     get("/sync/showToken") {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
@@ -166,7 +166,7 @@ class SyncDeviceManager(
             }
             syncRuntimeInfo.connectHostAddress?.let { host ->
                 val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
-                syncClientApi.notifyExit {
+                syncClientApi.notifyExit(syncRuntimeInfo.appInstanceId) {
                     buildUrl(hostAndPort)
                 }
             }
@@ -194,20 +194,19 @@ class SyncDeviceManager(
             logger.info { "notifyRemove via WebSocket ${syncRuntimeInfo.appInstanceId}" }
         }
 
-        // Delete local state immediately so UI updates without waiting for remote notification
-        wsSessionManager.closeSession(syncRuntimeInfo.appInstanceId)
-        secureStore.deleteCryptPublicKey(syncRuntimeInfo.appInstanceId)
-        syncRuntimeInfoDao.deleteSyncRuntimeInfo(syncRuntimeInfo.appInstanceId)
-        pastePullCursorManager.removeDevice(syncRuntimeInfo.appInstanceId)
-
-        // HTTP fallback notification (best-effort, after local cleanup)
+        // HTTP authentication needs the shared key, so notify before deleting local trust state.
         if (!notifiedViaWs) {
             syncRuntimeInfo.connectHostAddress?.let { host ->
                 val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
-                syncClientApi.notifyRemove {
+                syncClientApi.notifyRemove(syncRuntimeInfo.appInstanceId) {
                     buildUrl(hostAndPort)
                 }
             }
         }
+
+        wsSessionManager.closeSession(syncRuntimeInfo.appInstanceId)
+        secureStore.deleteCryptPublicKey(syncRuntimeInfo.appInstanceId)
+        syncRuntimeInfoDao.deleteSyncRuntimeInfo(syncRuntimeInfo.appInstanceId)
+        pastePullCursorManager.removeDevice(syncRuntimeInfo.appInstanceId)
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
@@ -1,6 +1,9 @@
 package com.crosspaste.net
 
 import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.dto.sync.AuthenticatedControlRequest
+import com.crosspaste.dto.sync.ControlChallenge
+import com.crosspaste.dto.sync.ControlOperation
 import com.crosspaste.dto.sync.EndpointInfo
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.net.clientapi.FailureResult
@@ -8,6 +11,9 @@ import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.sync.SyncHandler
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
+import io.ktor.client.call.body
+import io.ktor.http.HttpStatusCode
+import io.ktor.util.reflect.typeInfo
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -342,7 +348,7 @@ class SyncIntegrationTest {
             // Add B's handler to A's routing so removal can be verified
             a.syncRoutingApi.innerSyncHandlers[b.appInfo.appInstanceId] = mockk(relaxed = true)
 
-            b.syncClientApi.notifyRemove(urlFor(a))
+            b.syncClientApi.notifyRemove(a.appInfo.appInstanceId, urlFor(a))
 
             // A's handlers should no longer contain B
             assertFalse(a.syncRoutingApi.innerSyncHandlers.containsKey(b.appInfo.appInstanceId))
@@ -367,13 +373,123 @@ class SyncIntegrationTest {
                 }
             a.syncRoutingApi.innerSyncHandlers[b.appInfo.appInstanceId] = mockHandler
 
-            b.syncClientApi.notifyExit(urlFor(a))
+            b.syncClientApi.notifyExit(a.appInfo.appInstanceId, urlFor(a))
 
             // Give the coroutine scope time to execute markExit
             kotlinx.coroutines.delay(200.milliseconds)
 
             // markExit should have been called on B's handler in A
             coVerify { mockHandler.markExit() }
+        }
+
+    @Test
+    fun legacyNotifyRemoveHasNoSideEffect() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            trustBToA(a, b)
+            a.syncRoutingApi.innerSyncHandlers[b.appInfo.appInstanceId] = mockk(relaxed = true)
+
+            val response =
+                b.pasteClient.get(urlBuilder = {
+                    urlFor(a)(this)
+                    buildUrl("sync", "notifyRemove")
+                })
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(a.syncRoutingApi.innerSyncHandlers.containsKey(b.appInfo.appInstanceId))
+        }
+
+    @Test
+    fun plaintextSyncInfoHeartbeatHasNoSideEffect() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            trustBToA(a, b)
+            val syncInfo =
+                SyncInfo(
+                    appInfo = b.appInfo,
+                    endpointInfo =
+                        EndpointInfo(
+                            deviceId = "test-device-id",
+                            deviceName = "test-device",
+                            platform = TestInstance.platform,
+                            hostInfoList = emptyList(),
+                            port = b.getPort(),
+                        ),
+                )
+
+            val response =
+                b.pasteClient.post(
+                    syncInfo,
+                    typeInfo<SyncInfo>(),
+                    headersBuilder = {
+                        append("targetAppInstanceId", a.appInfo.appInstanceId)
+                    },
+                    urlBuilder = {
+                        urlFor(a)(this)
+                        buildUrl("sync", "heartbeat", "syncInfo")
+                    },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(null, a.syncRoutingApi.syncInfo)
+        }
+
+    @Test
+    fun authenticatedControlChallengeCannotBeReplayed() =
+        runBlocking {
+            val a = createInstance("device-a")
+            val b = createInstance("device-b")
+            a.start()
+            b.start()
+
+            trustBToA(a, b)
+            val target = a.appInfo.appInstanceId
+            val challengeResponse =
+                b.pasteClient.get(
+                    headersBuilder = { append("targetAppInstanceId", target) },
+                    urlBuilder = {
+                        urlFor(a)(this)
+                        buildUrl("sync", "control", "challenge")
+                    },
+                )
+            val challenge = challengeResponse.body<ControlChallenge>()
+            val request =
+                AuthenticatedControlRequest(
+                    challengeId = challenge.id,
+                    challengeNonce = challenge.nonce,
+                    targetAppInstanceId = target,
+                    operation = ControlOperation.NOTIFY_REMOVE,
+                )
+
+            suspend fun sendRequest() =
+                b.pasteClient.post(
+                    request,
+                    typeInfo<AuthenticatedControlRequest>(),
+                    headersBuilder = {
+                        append("targetAppInstanceId", target)
+                        append("secure", "1")
+                    },
+                    urlBuilder = {
+                        urlFor(a)(this)
+                        buildUrl("sync", "control", "notifyRemove")
+                    },
+                )
+
+            a.syncRoutingApi.innerSyncHandlers[b.appInfo.appInstanceId] = mockk(relaxed = true)
+            assertEquals(HttpStatusCode.OK, sendRequest().status)
+            assertFalse(a.syncRoutingApi.innerSyncHandlers.containsKey(b.appInfo.appInstanceId))
+
+            a.syncRoutingApi.innerSyncHandlers[b.appInfo.appInstanceId] = mockk(relaxed = true)
+            assertTrue(sendRequest().status.value >= 400)
+            assertTrue(a.syncRoutingApi.innerSyncHandlers.containsKey(b.appInfo.appInstanceId))
         }
 
     // ---- Test 12: Show token ----

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
@@ -380,7 +380,7 @@ class SyncDeviceManagerTest {
 
             manager.notifyExit(syncRuntimeInfo)
 
-            coVerify { deps.syncClientApi.notifyExit(any()) }
+            coVerify { deps.syncClientApi.notifyExit(syncRuntimeInfo.appInstanceId, any()) }
         }
 
     @Test
@@ -392,7 +392,7 @@ class SyncDeviceManagerTest {
 
             manager.notifyExit(syncRuntimeInfo)
 
-            coVerify(exactly = 0) { deps.syncClientApi.notifyExit(any()) }
+            coVerify(exactly = 0) { deps.syncClientApi.notifyExit(any(), any()) }
         }
 
     // ========== markExit ==========
@@ -426,7 +426,7 @@ class SyncDeviceManagerTest {
             coVerify { deps.secureStore.deleteCryptPublicKey(syncRuntimeInfo.appInstanceId) }
             coVerify { deps.syncRuntimeInfoDao.deleteSyncRuntimeInfo(syncRuntimeInfo.appInstanceId) }
             coVerify { deps.pastePullCursorManager.removeDevice(syncRuntimeInfo.appInstanceId) }
-            coVerify { deps.syncClientApi.notifyRemove(any()) }
+            coVerify { deps.syncClientApi.notifyRemove(syncRuntimeInfo.appInstanceId, any()) }
         }
 
     @Test
@@ -444,6 +444,6 @@ class SyncDeviceManagerTest {
 
             coVerify { deps.secureStore.deleteCryptPublicKey(syncRuntimeInfo.appInstanceId) }
             coVerify { deps.syncRuntimeInfoDao.deleteSyncRuntimeInfo(syncRuntimeInfo.appInstanceId) }
-            coVerify(exactly = 0) { deps.syncClientApi.notifyRemove(any()) }
+            coVerify(exactly = 0) { deps.syncClientApi.notifyRemove(any(), any()) }
         }
 }

--- a/core/src/commonMain/kotlin/com/crosspaste/dto/sync/ControlRequest.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/dto/sync/ControlRequest.kt
@@ -1,0 +1,32 @@
+package com.crosspaste.dto.sync
+
+import com.crosspaste.serializer.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ControlChallenge(
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val id: ByteArray,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val nonce: ByteArray,
+)
+
+@Serializable
+enum class ControlOperation {
+    @SerialName("notify_exit")
+    NOTIFY_EXIT,
+
+    @SerialName("notify_remove")
+    NOTIFY_REMOVE,
+}
+
+@Serializable
+data class AuthenticatedControlRequest(
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val challengeId: ByteArray,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val challengeNonce: ByteArray,
+    val targetAppInstanceId: String,
+    val operation: ControlOperation,
+)


### PR DESCRIPTION
## Summary
- require encrypted SyncInfo heartbeat bodies and bind nested identity to the authenticated request identity
- replace destructive legacy GET notifications with one-time challenge plus encrypted POST control requests
- consume challenges once to reject replay and validate peer, target, and operation before side effects
- keep legacy GET routes as successful no-ops; new clients fall back to old GET routes only when an old server has no challenge endpoint
- notify before local key deletion so remove authentication can complete

## Compatibility
New client to old server remains compatible through the 404 fallback. Old client to new server keeps liveness but cannot trigger unauthenticated exit/remove side effects. Existing v2 trust and heartbeat routes remain available.

This touches core/commonMain at commit 62598c1b. Mobile should sync the final merged desktop commit.

## Verification
- ./gradlew :core:build :app:desktopTest
- plaintext SyncInfo no-side-effect regression test
- legacy control no-side-effect regression test
- authenticated challenge replay regression test

Closes review finding R2-03-002.