### PR TITLE
:bug: roll back push prepare on session capacity rejection

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -148,6 +148,15 @@ private suspend fun handlePushPrepare(
         return
     }
 
+    // Cheap precheck before the release step below creates a LOADING row and
+    // preallocates file slots on disk. Advisory only — create() re-checks
+    // atomically and the rejection branch rolls the preparation back.
+    if (!pushSessionManager.hasCapacity()) {
+        logger.warn { "push sync: rejected from $appInstanceId (capacity)" }
+        failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
+        return
+    }
+
     val prepared = pasteReleaseService.releaseRemotePasteDataForPush(pasteData)
     if (prepared == null) {
         failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
@@ -162,6 +171,7 @@ private suspend fun handlePushPrepare(
         )
     if (session == null) {
         logger.warn { "push sync: rejected pasteId=${prepared.pasteId} (capacity)" }
+        pasteReleaseService.discardPushPrepared(prepared.pasteId)
         failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
         return
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -148,50 +148,57 @@ private suspend fun handlePushPrepare(
         return
     }
 
-    // Cheap precheck before the release step below creates a LOADING row and
-    // preallocates file slots on disk. Advisory only — create() re-checks
-    // atomically and the rejection branch rolls the preparation back.
-    if (!pushSessionManager.hasCapacity()) {
+    // Reserve before the release step creates a LOADING row and preallocates
+    // file slots. This bounds both in-flight preparation and active sessions.
+    val reservation = pushSessionManager.tryReserve()
+    if (reservation == null) {
         logger.warn { "push sync: rejected from $appInstanceId (capacity)" }
         failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
         return
     }
 
-    val prepared = pasteReleaseService.releaseRemotePasteDataForPush(pasteData)
-    if (prepared == null) {
-        failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
-        return
-    }
+    try {
+        val prepared = pasteReleaseService.releaseRemotePasteDataForPush(pasteData)
+        if (prepared == null) {
+            failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
+            return
+        }
 
-    val session =
-        pushSessionManager.create(
-            pasteId = prepared.pasteId,
-            fromAppInstanceId = appInstanceId,
-            filesIndex = prepared.filesIndex,
+        val session =
+            pushSessionManager.create(
+                reservation = reservation,
+                pasteId = prepared.pasteId,
+                fromAppInstanceId = appInstanceId,
+                filesIndex = prepared.filesIndex,
+            )
+        if (session == null) {
+            logger.warn { "push sync: rejected pasteId=${prepared.pasteId} (session creation)" }
+            pasteReleaseService.discardPushPrepared(prepared.pasteId).onFailure { error ->
+                logger.error(error) { "push sync: rollback failed for pasteId=${prepared.pasteId}" }
+            }
+            failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
+            return
+        }
+
+        pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
+        appControl.completeReceiveOperation()
+        logger.debug {
+            "sync handler ($appInstanceId) push prepare ok: pasteId=${prepared.pasteId} " +
+                "chunkCount=${prepared.chunkCount}"
+        }
+        successResponse(
+            call,
+            PushPrepareResponse(
+                pasteId = prepared.pasteId,
+                chunkCount = prepared.chunkCount,
+                chunkSize = prepared.chunkSize,
+                sessionToken = session.token,
+                needIcon = prepared.needIcon,
+            ),
         )
-    if (session == null) {
-        logger.warn { "push sync: rejected pasteId=${prepared.pasteId} (capacity)" }
-        pasteReleaseService.discardPushPrepared(prepared.pasteId)
-        failResponse(call, StandardErrorCode.PUSH_SESSION_REJECTED.toErrorCode())
-        return
+    } finally {
+        reservation.release()
     }
-
-    pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
-    appControl.completeReceiveOperation()
-    logger.debug {
-        "sync handler ($appInstanceId) push prepare ok: pasteId=${prepared.pasteId} " +
-            "chunkCount=${prepared.chunkCount}"
-    }
-    successResponse(
-        call,
-        PushPrepareResponse(
-            pasteId = prepared.pasteId,
-            chunkCount = prepared.chunkCount,
-            chunkSize = prepared.chunkSize,
-            sessionToken = session.token,
-            needIcon = prepared.needIcon,
-        ),
-    )
 }
 
 private suspend fun handlePullSync(

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -424,4 +424,16 @@ class PasteReleaseService(
                 logger.error(e) { "releaseRemotePasteDataForPush failed" }
             }.getOrNull()
         }
+
+    /**
+     * Rolls back a successful [releaseRemotePasteDataForPush] whose prepared
+     * paste never got attached to a push session (capacity rejection lost the
+     * race). Mirrors the session-expiry path in
+     * [com.crosspaste.sync.PushSessionManager.sweepExpired]: marking the
+     * LOADING row deleted lets the regular delete pipeline reclaim the
+     * preallocated file slots.
+     */
+    suspend fun discardPushPrepared(pasteId: Long) {
+        pasteDao.markDeletePasteData(pasteId)
+    }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -24,9 +24,12 @@ import com.crosspaste.task.TaskSubmitter
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonPrimitive
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
 
 data class PushPrepareResult(
@@ -55,6 +58,8 @@ class PasteReleaseService(
 
     companion object {
         private val fileUtils = getFileUtils()
+        private const val DISCARD_PUSH_PREPARED_ATTEMPTS = 3
+        private val DISCARD_PUSH_PREPARED_RETRY_DELAY = 50.milliseconds
     }
 
     private val logger = KotlinLogging.logger {}
@@ -427,13 +432,22 @@ class PasteReleaseService(
 
     /**
      * Rolls back a successful [releaseRemotePasteDataForPush] whose prepared
-     * paste never got attached to a push session (capacity rejection lost the
-     * race). Mirrors the session-expiry path in
+     * paste could not be attached to a push session. Mirrors the session-expiry path in
      * [com.crosspaste.sync.PushSessionManager.sweepExpired]: marking the
      * LOADING row deleted lets the regular delete pipeline reclaim the
      * preallocated file slots.
      */
-    suspend fun discardPushPrepared(pasteId: Long) {
-        pasteDao.markDeletePasteData(pasteId)
-    }
+    suspend fun discardPushPrepared(pasteId: Long): Result<Unit> =
+        withContext(NonCancellable) {
+            var lastFailure: Throwable? = null
+            repeat(DISCARD_PUSH_PREPARED_ATTEMPTS) { attempt ->
+                val result = pasteDao.markDeletePasteData(pasteId)
+                if (result.isSuccess) return@withContext result
+                lastFailure = result.exceptionOrNull()
+                if (attempt < DISCARD_PUSH_PREPARED_ATTEMPTS - 1) {
+                    delay(DISCARD_PUSH_PREPARED_RETRY_DELAY)
+                }
+            }
+            Result.failure(lastFailure ?: IllegalStateException("Failed to discard prepared paste $pasteId"))
+        }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
@@ -22,6 +22,22 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
+internal class PushSessionReservation(
+    private val owner: PushSessionManager,
+    private val releaseSlot: () -> Unit,
+) {
+    private val held = atomic(true)
+
+    internal fun transferTo(manager: PushSessionManager): Boolean =
+        owner === manager && held.compareAndSet(expect = true, update = false)
+
+    fun release() {
+        if (held.compareAndSet(expect = true, update = false)) {
+            releaseSlot()
+        }
+    }
+}
+
 /**
  * Concurrency model: writes (markReceived) go through [lock] so the
  * "check-then-set" on `received[i]` and the count increment stay paired.
@@ -120,14 +136,6 @@ class PushSessionManager(
 
     fun activeCount(): Int = sessions.size
 
-    /**
-     * Advisory precheck for callers that must do expensive preparation
-     * (LOADING row + file slot preallocation) before [create]. A `true`
-     * result can still lose the race to a concurrent prepare — callers must
-     * handle a null from [create] by rolling their preparation back.
-     */
-    fun hasCapacity(): Boolean = activeSlots.value < maxActive
-
     private fun tryReserveSlot(): Boolean {
         while (true) {
             val current = activeSlots.value
@@ -140,31 +148,70 @@ class PushSessionManager(
         activeSlots.decrementAndGet()
     }
 
+    /**
+     * Reserves capacity before callers create a LOADING row or preallocate files.
+     * The caller must release the reservation in `finally`; a successful [create]
+     * transfers ownership to the session, making the release a no-op.
+     */
+    internal fun tryReserve(): PushSessionReservation? =
+        if (tryReserveSlot()) {
+            PushSessionReservation(this, ::releaseSlot)
+        } else {
+            null
+        }
+
     @OptIn(ExperimentalUuidApi::class)
     fun create(
         pasteId: Long,
         fromAppInstanceId: String,
         filesIndex: FilesIndex,
     ): PushSession? {
-        if (filesIndex.getChunkCount() <= 0) {
-            logger.warn { "PushSession create rejected: empty filesIndex for pasteId=$pasteId" }
-            return null
-        }
-        if (!tryReserveSlot()) {
+        val reservation = tryReserve()
+        if (reservation == null) {
             logger.warn { "PushSession create rejected: maxActive=$maxActive reached" }
             return null
         }
-        val session =
-            PushSession(
-                pasteId = pasteId,
-                fromAppInstanceId = fromAppInstanceId,
-                token = Uuid.random().toString(),
-                filesIndex = filesIndex,
-                createdAt = nowEpochMilliseconds(),
-            )
-        sessions[pasteId] = session
-        return session
+        return create(reservation, pasteId, fromAppInstanceId, filesIndex)
     }
+
+    @OptIn(ExperimentalUuidApi::class)
+    internal fun create(
+        reservation: PushSessionReservation,
+        pasteId: Long,
+        fromAppInstanceId: String,
+        filesIndex: FilesIndex,
+    ): PushSession? =
+        try {
+            if (filesIndex.getChunkCount() <= 0) {
+                logger.warn { "PushSession create rejected: empty filesIndex for pasteId=$pasteId" }
+                return null
+            }
+            val session =
+                PushSession(
+                    pasteId = pasteId,
+                    fromAppInstanceId = fromAppInstanceId,
+                    token = Uuid.random().toString(),
+                    filesIndex = filesIndex,
+                    createdAt = nowEpochMilliseconds(),
+                )
+            var inserted = false
+            sessions.computeIfAbsent(pasteId) {
+                inserted = true
+                session
+            }
+            if (!inserted) {
+                logger.warn { "PushSession create rejected: duplicate pasteId=$pasteId" }
+                return null
+            }
+            if (!reservation.transferTo(this)) {
+                sessions.remove(pasteId, session)
+                logger.warn { "PushSession create rejected: invalid reservation for pasteId=$pasteId" }
+                return null
+            }
+            session
+        } finally {
+            reservation.release()
+        }
 
     fun get(
         pasteId: Long,

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
@@ -8,6 +8,7 @@ import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.ConcurrentMap
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -102,6 +103,12 @@ class PushSessionManager(
 
     private val sessions = ConcurrentMap<Long, PushSession>()
 
+    // Capacity is governed by this counter, not `sessions.size`: a CAS
+    // reservation makes the check-then-insert in [create] atomic, so
+    // concurrent prepares cannot overshoot [maxActive]. Every path that
+    // removes a session from the map must release its slot.
+    private val activeSlots = atomic(0)
+
     init {
         scope.launch {
             while (isActive) {
@@ -113,6 +120,26 @@ class PushSessionManager(
 
     fun activeCount(): Int = sessions.size
 
+    /**
+     * Advisory precheck for callers that must do expensive preparation
+     * (LOADING row + file slot preallocation) before [create]. A `true`
+     * result can still lose the race to a concurrent prepare — callers must
+     * handle a null from [create] by rolling their preparation back.
+     */
+    fun hasCapacity(): Boolean = activeSlots.value < maxActive
+
+    private fun tryReserveSlot(): Boolean {
+        while (true) {
+            val current = activeSlots.value
+            if (current >= maxActive) return false
+            if (activeSlots.compareAndSet(current, current + 1)) return true
+        }
+    }
+
+    private fun releaseSlot() {
+        activeSlots.decrementAndGet()
+    }
+
     @OptIn(ExperimentalUuidApi::class)
     fun create(
         pasteId: Long,
@@ -123,7 +150,7 @@ class PushSessionManager(
             logger.warn { "PushSession create rejected: empty filesIndex for pasteId=$pasteId" }
             return null
         }
-        if (sessions.size >= maxActive) {
+        if (!tryReserveSlot()) {
             logger.warn { "PushSession create rejected: maxActive=$maxActive reached" }
             return null
         }
@@ -158,6 +185,7 @@ class PushSessionManager(
      */
     fun tryFinalize(pasteId: Long): Boolean {
         if (sessions.remove(pasteId) == null) return false
+        releaseSlot()
         scope.launch {
             runCatching {
                 pasteboardService.tryWriteRemotePasteboardWithFile(pasteId)
@@ -201,6 +229,7 @@ class PushSessionManager(
                 }
             } else {
                 val removed = sessions.remove(id) ?: continue
+                releaseSlot()
                 runCatching {
                     pasteDao.markDeletePasteData(id)
                 }.onFailure { e ->
@@ -217,5 +246,6 @@ class PushSessionManager(
     fun close() {
         scope.cancel()
         sessions.clear()
+        activeSlots.value = 0
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
@@ -215,6 +215,17 @@ class PasteReleaseServicePushTest {
     }
 
     @Test
+    fun discardPushPrepared_marksPreparedPasteDeleted() =
+        runBlocking {
+            val pasteDao = mockk<PasteDao>(relaxed = true)
+            val service = newService(pasteDao = pasteDao)
+
+            service.discardPushPrepared(42L)
+
+            coVerify(exactly = 1) { pasteDao.markDeletePasteData(42L) }
+        }
+
+    @Test
     fun releaseRemotePasteDataForPush_rejectsUnsafeTreeBeforeCreatingPaste(
         @TempDir tempDir: File,
     ) = runBlocking {

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServicePushTest.kt
@@ -218,11 +218,42 @@ class PasteReleaseServicePushTest {
     fun discardPushPrepared_marksPreparedPasteDeleted() =
         runBlocking {
             val pasteDao = mockk<PasteDao>(relaxed = true)
+            coEvery { pasteDao.markDeletePasteData(42L) } returns Result.success(Unit)
             val service = newService(pasteDao = pasteDao)
 
-            service.discardPushPrepared(42L)
+            val result = service.discardPushPrepared(42L)
 
+            assertTrue(result.isSuccess)
             coVerify(exactly = 1) { pasteDao.markDeletePasteData(42L) }
+        }
+
+    @Test
+    fun discardPushPrepared_retriesFailureAndReturnsSuccess() =
+        runBlocking {
+            val failure = Result.failure<Unit>(IllegalStateException("busy"))
+            val pasteDao = mockk<PasteDao>()
+            coEvery { pasteDao.markDeletePasteData(42L) } returnsMany
+                listOf(failure, failure, Result.success(Unit))
+            val service = newService(pasteDao = pasteDao)
+
+            val result = service.discardPushPrepared(42L)
+
+            assertTrue(result.isSuccess)
+            coVerify(exactly = 3) { pasteDao.markDeletePasteData(42L) }
+        }
+
+    @Test
+    fun discardPushPrepared_reportsFailureAfterRetries() =
+        runBlocking {
+            val failure = Result.failure<Unit>(IllegalStateException("unavailable"))
+            val pasteDao = mockk<PasteDao>()
+            coEvery { pasteDao.markDeletePasteData(42L) } returns failure
+            val service = newService(pasteDao = pasteDao)
+
+            val result = service.discardPushPrepared(42L)
+
+            assertTrue(result.isFailure)
+            coVerify(exactly = 3) { pasteDao.markDeletePasteData(42L) }
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
@@ -90,49 +90,76 @@ class PushSessionManagerTest {
     }
 
     @Test
-    fun hasCapacity_tracksSlotReservationAndRelease() =
+    fun reservation_tracksSlotReservationAndRelease() =
         runBlocking {
             val pasteDao = mockk<PasteDao>(relaxed = true)
             coEvery { pasteDao.markDeletePasteData(any()) } returns Result.success(Unit)
             val (mgr) = newManager(maxActive = 1, sessionTtl = 10.milliseconds, pasteDao = pasteDao)
-            assertTrue(mgr.hasCapacity())
+
+            val preparation = assertNotNull(mgr.tryReserve())
+            assertNull(mgr.tryReserve())
+            preparation.release()
+            assertNotNull(mgr.tryReserve()).release()
 
             mgr.create(1L, "mobile", fakeFilesIndex(1))!!
-            assertFalse(mgr.hasCapacity())
+            assertNull(mgr.tryReserve())
             assertNull(mgr.create(2L, "mobile", fakeFilesIndex(1)))
 
             // Finalize frees the slot.
             assertTrue(mgr.tryFinalize(1L))
-            assertTrue(mgr.hasCapacity())
+            assertNotNull(mgr.tryReserve()).release()
 
             // Sweep-expiry of an incomplete session frees the slot too.
             mgr.create(3L, "mobile", fakeFilesIndex(2))!!
-            assertFalse(mgr.hasCapacity())
+            assertNull(mgr.tryReserve())
             delay(50.milliseconds)
             mgr.sweepExpired()
-            assertTrue(mgr.hasCapacity())
             assertNotNull(mgr.create(4L, "mobile", fakeFilesIndex(1)))
             mgr.close()
         }
 
     @Test
-    fun create_neverExceedsMaxActiveUnderConcurrency() =
+    fun reservation_neverExceedsMaxActiveBeforePreparation() =
         runBlocking {
             val maxActive = 4
             val (mgr) = newManager(maxActive = maxActive)
-            val created =
-                (1L..64L)
-                    .map { id ->
+            val reservations =
+                (0 until 64)
+                    .map {
                         async(Dispatchers.Default) {
-                            mgr.create(id, "mobile", fakeFilesIndex(1))
+                            mgr.tryReserve()
                         }
                     }.awaitAll()
                     .filterNotNull()
-            assertEquals(maxActive, created.size)
+            assertEquals(maxActive, reservations.size)
+            assertEquals(0, mgr.activeCount(), "capacity must be held before preparation creates sessions")
+            assertNull(mgr.tryReserve())
+
+            reservations.forEachIndexed { index, reservation ->
+                assertNotNull(
+                    mgr.create(
+                        reservation = reservation,
+                        pasteId = index.toLong(),
+                        fromAppInstanceId = "mobile",
+                        filesIndex = fakeFilesIndex(1),
+                    ),
+                )
+            }
             assertEquals(maxActive, mgr.activeCount())
-            assertFalse(mgr.hasCapacity())
             mgr.close()
         }
+
+    @Test
+    fun create_rejectsDuplicatePasteIdWithoutLeakingCapacity() {
+        val (mgr) = newManager(maxActive = 2)
+        val original = assertNotNull(mgr.create(1L, "mobile", fakeFilesIndex(1)))
+
+        assertNull(mgr.create(1L, "mobile", fakeFilesIndex(1)))
+        assertSame(original, mgr.peek(1L))
+        assertNotNull(mgr.create(2L, "mobile", fakeFilesIndex(1)))
+        assertEquals(2, mgr.activeCount())
+        mgr.close()
+    }
 
     @Test
     fun get_requiresMatchingTokenAndAppInstance() {

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
@@ -9,7 +9,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -85,6 +88,51 @@ class PushSessionManagerTest {
         assertEquals(2, mgr.activeCount())
         mgr.close()
     }
+
+    @Test
+    fun hasCapacity_tracksSlotReservationAndRelease() =
+        runBlocking {
+            val pasteDao = mockk<PasteDao>(relaxed = true)
+            coEvery { pasteDao.markDeletePasteData(any()) } returns Result.success(Unit)
+            val (mgr) = newManager(maxActive = 1, sessionTtl = 10.milliseconds, pasteDao = pasteDao)
+            assertTrue(mgr.hasCapacity())
+
+            mgr.create(1L, "mobile", fakeFilesIndex(1))!!
+            assertFalse(mgr.hasCapacity())
+            assertNull(mgr.create(2L, "mobile", fakeFilesIndex(1)))
+
+            // Finalize frees the slot.
+            assertTrue(mgr.tryFinalize(1L))
+            assertTrue(mgr.hasCapacity())
+
+            // Sweep-expiry of an incomplete session frees the slot too.
+            mgr.create(3L, "mobile", fakeFilesIndex(2))!!
+            assertFalse(mgr.hasCapacity())
+            delay(50.milliseconds)
+            mgr.sweepExpired()
+            assertTrue(mgr.hasCapacity())
+            assertNotNull(mgr.create(4L, "mobile", fakeFilesIndex(1)))
+            mgr.close()
+        }
+
+    @Test
+    fun create_neverExceedsMaxActiveUnderConcurrency() =
+        runBlocking {
+            val maxActive = 4
+            val (mgr) = newManager(maxActive = maxActive)
+            val created =
+                (1L..64L)
+                    .map { id ->
+                        async(Dispatchers.Default) {
+                            mgr.create(id, "mobile", fakeFilesIndex(1))
+                        }
+                    }.awaitAll()
+                    .filterNotNull()
+            assertEquals(maxActive, created.size)
+            assertEquals(maxActive, mgr.activeCount())
+            assertFalse(mgr.hasCapacity())
+            mgr.close()
+        }
 
     @Test
     fun get_requiresMatchingTokenAndAppInstance() {


### PR DESCRIPTION
Closes #4713

## Problem

`handlePushPrepare` runs `releaseRemotePasteDataForPush` (creates a LOADING row, physically preallocates up to 8 GiB of file slots, submits relay/icon tasks) **before** `PushSessionManager.create` checks capacity. A capacity rejection returned `PUSH_SESSION_REJECTED` without any rollback, orphaning the LOADING row and the preallocated files — no sweep or cleanup ever reclaims them, since the sweep only covers sessions that made it into the map. This let an authenticated peer bypass the write-amplification bound that `FileTransferResourceLimits` and `maxActive` are supposed to enforce, simply by repeating prepare requests against a full session table.

The `sessions.size >= maxActive` check itself was also non-atomic (check-then-insert), so concurrent prepares could overshoot `maxActive`.

## Fix

- `PushSessionManager`: capacity is now governed by an atomicfu CAS slot counter. `create` reserves a slot atomically; every removal path (`tryFinalize`, sweep expiry, `close`) releases it. Added an advisory `hasCapacity()` for callers.
- `handlePushPrepare`: cheap `hasCapacity()` precheck before the expensive release step, so a full session table rejects without creating any side effects.
- When `create` still loses the race after a successful release, the new `PasteReleaseService.discardPushPrepared` marks the LOADING row deleted — the same primitive the sweep-expiry path uses, so the delete pipeline reclaims the preallocated slots.

## Tests

- `hasCapacity_tracksSlotReservationAndRelease`: slot freed by finalize and by sweep expiry.
- `create_neverExceedsMaxActiveUnderConcurrency`: 64 concurrent creates against `maxActive = 4` yield exactly 4 sessions.
- `discardPushPrepared_marksPreparedPasteDeleted`: rollback contract.
- `PushSessionManagerTest` (14) and `PasteReleaseServicePushTest` (5) all pass.

## Note

This code is shared `commonMain`; the mobile repo needs the same follow-up.