### PR TITLE
:bug: validate file transfer path metadata correspondence

### DIFF
--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/FileTransferResourceLimits.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/FileTransferResourceLimits.kt
@@ -2,6 +2,7 @@ package com.crosspaste.presist
 
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.item.PasteFiles
+import okio.Path.Companion.toPath
 
 object FileTransferResourceLimits {
     // Deliberately conservative: the receive side prepares file slots eagerly
@@ -107,8 +108,19 @@ internal fun validateFileTransferMetadata(
     }
 
     pasteFilesItems.forEach { pasteFiles ->
-        require(pasteFiles.relativePathList.size == pasteFiles.fileInfoTreeMap.size) {
-            "relativePathList size does not match fileInfoTreeMap"
+        // Consumers resolve each relative path's file name against
+        // fileInfoTreeMap and silently skip misses
+        // (UserDataPathProvider.resolve), so a size check alone lets a
+        // mismatched pair through: the receive side would then build an empty
+        // or partial FilesIndex and leave a LOADING paste that never
+        // completes. Require exact name ↔ key correspondence instead, using
+        // the same name derivation the consumers use.
+        val fileNames = pasteFiles.relativePathList.map { it.toPath().name }
+        require(fileNames.size == fileNames.toSet().size) {
+            "relativePathList contains duplicate file names"
+        }
+        require(fileNames.toSet() == pasteFiles.fileInfoTreeMap.keys) {
+            "relativePathList does not match fileInfoTreeMap keys"
         }
         require(pasteFiles.size >= 0) { "PasteFiles size must be non-negative" }
         require(pasteFiles.count >= 0) { "PasteFiles count must be non-negative" }

--- a/shared/src/commonTest/kotlin/com/crosspaste/presist/FileTransferResourceLimitsTest.kt
+++ b/shared/src/commonTest/kotlin/com/crosspaste/presist/FileTransferResourceLimitsTest.kt
@@ -111,6 +111,54 @@ class FileTransferResourceLimitsTest {
         }
     }
 
+    @Test
+    fun `metadata rejects relativePathList that does not correspond to fileInfoTreeMap`() {
+        val single = filesItem(mapOf("a.bin" to SingleFileInfoTree(10, "a")))
+
+        // Same size, disjoint names.
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(
+                listOf(single.copy(relativePathList = listOf("b.bin"))),
+                FileTransferValidationLimits(),
+            )
+        }
+
+        // Partial overlap: one resolvable name, one miss.
+        val pair =
+            filesItem(
+                mapOf(
+                    "a.bin" to SingleFileInfoTree(10, "a"),
+                    "b.bin" to SingleFileInfoTree(20, "b"),
+                ),
+            )
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(
+                listOf(pair.copy(relativePathList = listOf("a.bin", "c.bin"))),
+                FileTransferValidationLimits(),
+            )
+        }
+
+        // Duplicate names resolve to the same map entry and on-disk slot.
+        assertFailsWith<IllegalArgumentException> {
+            validateFileTransferMetadata(
+                listOf(pair.copy(relativePathList = listOf("a.bin", "a.bin"))),
+                FileTransferValidationLimits(),
+            )
+        }
+    }
+
+    @Test
+    fun `metadata accepts multi-segment relative paths keyed by file name`() {
+        val item =
+            filesItem(mapOf("a.bin" to SingleFileInfoTree(10, "a")))
+                .copy(relativePathList = listOf("2026/08/01/42/a.bin"))
+
+        val stats = validateFileTransferMetadata(listOf(item), FileTransferValidationLimits())
+
+        assertEquals(1, stats.fileCount)
+        assertEquals(10, stats.totalSize)
+    }
+
     private fun filesItem(fileInfoTreeMap: Map<String, FileInfoTree>): TestPasteFiles =
         TestPasteFiles(
             count = fileInfoTreeMap.values.sumOf { it.getCount() },


### PR DESCRIPTION
Closes #4715

## Problem

`validateFileTransferMetadata` only compared the **sizes** of `relativePathList` and `fileInfoTreeMap`, never their contents. Consumers (`UserDataPathProvider.resolve`) look each relative path's file name up in the map and silently skip misses, so metadata like `relativePathList = ["b.txt"]` / `fileInfoTreeMap = {"a.txt": ...}` passed validation and then failed downstream:

- **Pull receive**: an empty `FilesIndex` is resolved, `FilePullResult.Empty` counts as task success, and `tryWriteRemotePasteboardWithFile` never runs — the LOADING row is stuck forever with no cleanup path.
- **Push receive**: a fully-mismatched map is caught by the empty-index guard, but a partially matching one slips through and completes into a LOADED paste whose metadata references files that were never written.
- Duplicate file names in `relativePathList` produced duplicate chunk slots over the same on-disk path.

## Fix

Validation now requires exact correspondence, using the same name derivation the consumers use (`relativePath.toPath().name`): the file-name set must equal `fileInfoTreeMap.keys`, and names must be unique. This subsumes the old size check. A violation throws `IllegalArgumentException`, which both receive paths already translate into the discard-with-notification semantics.

## Tests

- Rejects disjoint names, partial overlap, and duplicate names (all with matching sizes).
- Accepts multi-segment relative paths keyed by their file name.
- `FileTransferResourceLimitsTest` (7) plus caller-side `PasteReleaseServicePushTest` (4), `FilePushServiceTest` (12), `PushClientApiTest` (8) all pass.

## Note

This code is shared `commonMain`; the mobile repo needs the same follow-up.