### PR TITLE
:bug: make ErrorCode hashCode consistent with equals

### DIFF
--- a/shared/src/commonMain/kotlin/com/crosspaste/exception/ErrorCode.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/exception/ErrorCode.kt
@@ -26,7 +26,12 @@ class ErrorCode(
         return code == other.code && name == other.name && type === other.type
     }
 
-    override fun hashCode(): Int = arrayOf<Any>(code, name, type).hashCode()
+    override fun hashCode(): Int {
+        var result = code
+        result = 31 * result + name.hashCode()
+        result = 31 * result + type.hashCode()
+        return result
+    }
 }
 
 enum class ErrorType {

--- a/shared/src/commonTest/kotlin/com/crosspaste/exception/ErrorCodeContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/crosspaste/exception/ErrorCodeContractTest.kt
@@ -1,0 +1,47 @@
+package com.crosspaste.exception
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class ErrorCodeContractTest {
+
+    @Test
+    fun `equal instances have equal hashCode`() {
+        val first = ErrorCode(2007, "ENCRYPT_FAIL", ErrorType.EXTERNAL_ERROR)
+        val second = ErrorCode(2007, "ENCRYPT_FAIL", ErrorType.EXTERNAL_ERROR)
+
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+    }
+
+    @Test
+    fun `independently constructed equal instances are interchangeable in hash sets`() {
+        val first = ErrorCode(2007, "ENCRYPT_FAIL", ErrorType.EXTERNAL_ERROR)
+        val second = ErrorCode(2007, "ENCRYPT_FAIL", ErrorType.EXTERNAL_ERROR)
+
+        val set = hashSetOf(first)
+        assertTrue(second in set)
+        assertTrue(set.remove(second))
+        assertTrue(set.isEmpty())
+    }
+
+    @Test
+    fun `independently constructed equal instances are interchangeable as hash map keys`() {
+        val first = ErrorCode(2007, "ENCRYPT_FAIL", ErrorType.EXTERNAL_ERROR)
+        val second = ErrorCode(2007, "ENCRYPT_FAIL", ErrorType.EXTERNAL_ERROR)
+
+        val map = hashMapOf(first to "value")
+        assertEquals("value", map[second])
+    }
+
+    @Test
+    fun `distinct instances differ in equals`() {
+        val base = ErrorCode(2007, "ENCRYPT_FAIL", ErrorType.EXTERNAL_ERROR)
+
+        assertNotEquals(base, ErrorCode(2008, "ENCRYPT_FAIL", ErrorType.EXTERNAL_ERROR))
+        assertNotEquals(base, ErrorCode(2007, "DECRYPT_FAIL", ErrorType.EXTERNAL_ERROR))
+        assertNotEquals(base, ErrorCode(2007, "ENCRYPT_FAIL", ErrorType.INTERNAL_ERROR))
+    }
+}


### PR DESCRIPTION
Closes #4717

## What

- Replace `arrayOf<Any>(code, name, type).hashCode()` (array identity hash — different on every call) with a standard 31-based combination of the exact fields `equals()` compares, restoring the equals/hashCode contract.
- Add `ErrorCodeContractTest` in `shared/commonTest` (runs on desktop and native targets): equal instances hash equally, are interchangeable in `HashSet`/`HashMap`, and field-wise distinct instances stay unequal.

## Review

Independent strict review returned no findings: the hash combines exactly the fields `equals()` compares (Int / String / enum singleton — value-stable on JVM, K/N and JS), `hashCode` does not participate in protocol serialization (`FailResponse` uses the `code` field), and the new tests do not duplicate the existing `ErrorCodeTest` coverage.

## Verification

- `./gradlew :shared:build` (desktop + native targets, tests, ktlint) — PASS