### PR TITLE
:bug: include network prefix in host info equality

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDaoTest.kt
@@ -178,9 +178,9 @@ class SyncRuntimeInfoDaoTest {
     @Test
     fun `insertOrUpdateSyncInfo re-advertising same address set does not write`() =
         runTest {
-            // "restamp doesn't churn": re-advertising the same address set (even with a
-            // different incoming lastSeen) must not produce a DB write, because
-            // hostInfoListEqual compares by address only. Verified via modifyTime stability.
+            // "restamp doesn't churn": re-advertising the same (address, prefix) set (even
+            // with a different incoming lastSeen) must not produce a DB write, because
+            // hostInfoListEqual ignores lastSeen. Verified via modifyTime stability.
             syncRuntimeInfoDao.insertOrUpdateSyncInfo(testSyncInfo) // hostInfoList = [.100]
             val before = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
             assertNotNull(before)
@@ -198,6 +198,29 @@ class SyncRuntimeInfoDaoTest {
             val after = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
             assertNotNull(after)
             assertEquals(before.modifyTime, after.modifyTime)
+        }
+
+    @Test
+    fun `insertOrUpdateSyncInfo same address with changed prefix must write`() =
+        runTest {
+            // The prefix feeds address selection and same-subnet checks; after a network
+            // change the same IP can come back under a different prefix, and that new
+            // prefix must reach the database (R2-02-007).
+            syncRuntimeInfoDao.insertOrUpdateSyncInfo(testSyncInfo) // (32, 192.168.1.100)
+
+            val rePrefixed =
+                testSyncInfo.copy(
+                    endpointInfo =
+                        testSyncInfo.endpointInfo.copy(
+                            hostInfoList = listOf(HostInfo(24, "192.168.1.100")),
+                        ),
+                )
+            syncRuntimeInfoDao.insertOrUpdateSyncInfo(rePrefixed)
+
+            val after = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
+            assertNotNull(after)
+            val stored = after.hostInfoList.single { it.hostAddress == "192.168.1.100" }
+            assertEquals(24.toShort(), stored.networkPrefixLength)
         }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SyncRuntimeInfo.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SyncRuntimeInfo.kt
@@ -88,6 +88,16 @@ data class SyncRuntimeInfo(
                 port = syncInfo.endpointInfo.port,
             )
 
+        /**
+         * Structural equality of host lists, ignoring order and [HostInfo.lastSeen].
+         *
+         * The prefix participates because it feeds address selection and same-subnet
+         * checks — a same-address prefix change must count as a change and reach the
+         * database. [HostInfo.lastSeen] is deliberately excluded: it is a local
+         * recency stamp refreshed on every merge, so including it would turn every
+         * re-advertisement into a spurious "change"; it only persists as a side
+         * effect of writes triggered by real changes.
+         */
         fun hostInfoListEqual(
             hostInfoList: List<HostInfo>,
             otherHostInfoList: List<HostInfo>,
@@ -95,16 +105,13 @@ data class SyncRuntimeInfo(
             if (hostInfoList.size != otherHostInfoList.size) {
                 return false
             }
-            val sortHostInfoList = hostInfoList.sortedWith { o1, o2 -> o1.hostAddress.compareTo(o2.hostAddress) }
-            val otherSortHostInfoList =
-                otherHostInfoList.sortedWith {
-                    o1,
-                    o2,
-                    ->
-                    o1.hostAddress.compareTo(o2.hostAddress)
-                }
-            for (i in 0 until hostInfoList.size) {
-                if (sortHostInfoList[i].hostAddress != otherSortHostInfoList[i].hostAddress) {
+            val comparator = compareBy<HostInfo>({ it.hostAddress }, { it.networkPrefixLength })
+            val sortHostInfoList = hostInfoList.sortedWith(comparator)
+            val otherSortHostInfoList = otherHostInfoList.sortedWith(comparator)
+            for (i in sortHostInfoList.indices) {
+                if (sortHostInfoList[i].hostAddress != otherSortHostInfoList[i].hostAddress ||
+                    sortHostInfoList[i].networkPrefixLength != otherSortHostInfoList[i].networkPrefixLength
+                ) {
                     return false
                 }
             }


### PR DESCRIPTION
Closes #4719

## What

- `hostInfoListEqual()` now compares `(hostAddress, networkPrefixLength)` pairs (sorted with a comparator over both fields), so a same-address prefix change counts as a change and reaches the database.
- `lastSeen` stays excluded by design — it is restamped on every merge, and including it would turn every re-advertisement into a spurious write. Documented in the KDoc.
- Tests: new `same address with changed prefix must write` case; updated the existing `re-advertising same address set does not write` comment to the new (address, prefix) semantics — that behavior is unchanged.

## Review

Independent strict review returned no findings. All three callers were checked: the DAO change-detection now persists prefix updates (the fix target), `diffSyncInfo` correctly reports prefix changes, and `GeneralSyncHandler` triggering a connection re-resolve on a prefix change is a genuine network reconfiguration signal — safe and low-frequency, not churn.

## Verification

- `SyncRuntimeInfoDaoTest`, `com.crosspaste.sync.*`, `SyncIntegrationTest` — PASS