### PR TITLE
:bug: give SyncRuntimeInfo flow broadcast semantics

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDaoTest.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.db.sync
 
 import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.crosspaste.app.AppInfo
 import com.crosspaste.db.TestDriverFactory
 import com.crosspaste.db.createDatabase
@@ -156,6 +157,53 @@ class SyncRuntimeInfoDaoTest {
                 expectNoEvents()
 
                 // Cancel the test
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `two concurrent collectors both receive every change`() =
+        runTest {
+            // Broadcast semantics (R2-02-005): notifications must not be split between
+            // collectors — each collector observes every insert, update, and delete.
+            turbineScope {
+                val first = syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow().testIn(backgroundScope)
+                val second = syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow().testIn(backgroundScope)
+
+                assertTrue(first.awaitItem().isEmpty())
+                assertTrue(second.awaitItem().isEmpty())
+
+                syncRuntimeInfoDao.insertOrUpdateSyncInfo(testSyncInfo)
+                assertEquals(1, first.awaitItem().size)
+                assertEquals(1, second.awaitItem().size)
+
+                syncRuntimeInfoDao.updateConnectInfo(updatedSyncRuntimeInfo)
+                assertEquals(updatedSyncRuntimeInfo.connectState, first.awaitItem()[0].connectState)
+                assertEquals(updatedSyncRuntimeInfo.connectState, second.awaitItem()[0].connectState)
+
+                syncRuntimeInfoDao.deleteSyncRuntimeInfo(testSyncRuntimeInfo.appInstanceId)
+                assertTrue(first.awaitItem().isEmpty())
+                assertTrue(second.awaitItem().isEmpty())
+            }
+        }
+
+    @Test
+    fun `late subscriber receives full current snapshot`() =
+        runTest {
+            syncRuntimeInfoDao.insertOrUpdateSyncInfo(testSyncInfo)
+
+            syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow().test {
+                assertEquals(1, awaitItem().size)
+
+                // A collector subscribing after all changes were consumed by an earlier
+                // collector must still get the full current snapshot, not an empty view.
+                syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow().test {
+                    val snapshot = awaitItem()
+                    assertEquals(1, snapshot.size)
+                    assertEquals(testSyncRuntimeInfo.appInstanceId, snapshot[0].appInstanceId)
+                    cancelAndIgnoreRemainingEvents()
+                }
+
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SqlSyncRuntimeInfoDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SqlSyncRuntimeInfoDao.kt
@@ -1,15 +1,14 @@
 package com.crosspaste.db.sync
 
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
 import com.crosspaste.Database
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -24,37 +23,19 @@ class SqlSyncRuntimeInfoDao(
 
     private val writeMutex = Mutex()
 
-    private val updateNotifier = Channel<String>(Channel.UNLIMITED)
-
-    private fun cleanUpdateNotifier() {
-        while (updateNotifier.tryReceive().isSuccess) {
-            // do nothing
-        }
-    }
-
+    /**
+     * Broadcast semantics: every collector independently observes the query via
+     * SQLDelight's listener mechanism, so each one receives the current snapshot
+     * on subscription and every subsequent change — concurrent collectors never
+     * compete for notifications (R2-02-005). [distinctUntilChanged] suppresses
+     * re-emissions from table notifications that did not change the result set.
+     */
     override fun getAllSyncRuntimeInfosFlow(): Flow<List<SyncRuntimeInfo>> =
-        flow {
-            cleanUpdateNotifier()
-            val currentMap = getAllSyncRuntimeInfos().associateBy { it.appInstanceId }.toMutableMap()
-            emit(currentMap.values.toList())
-
-            updateNotifier.receiveAsFlow().collect { appInstanceId ->
-                val updated =
-                    syncRuntimeInfoDatabaseQueries
-                        .getSyncRuntimeInfo(
-                            appInstanceId,
-                            SyncRuntimeInfo::mapper,
-                        ).executeAsOneOrNull()
-
-                if (updated != null) {
-                    currentMap[appInstanceId] = updated
-                } else {
-                    currentMap.remove(appInstanceId)
-                }
-
-                emit(currentMap.values.toList())
-            }
-        }.flowOn(ioDispatcher)
+        syncRuntimeInfoDatabaseQueries
+            .getAllSyncRuntimeInfos(SyncRuntimeInfo::mapper)
+            .asFlow()
+            .mapToList(ioDispatcher)
+            .distinctUntilChanged()
 
     override suspend fun getAllSyncRuntimeInfos(): List<SyncRuntimeInfo> =
         withContext(ioDispatcher) {
@@ -82,7 +63,6 @@ class SqlSyncRuntimeInfoDao(
                     }
                 }
             if (change) {
-                updateNotifier.trySend(syncRuntimeInfo.appInstanceId)
                 syncRuntimeInfo.appInstanceId
             } else {
                 null
@@ -134,15 +114,10 @@ class SqlSyncRuntimeInfoDao(
 
     override suspend fun deleteSyncRuntimeInfo(appInstanceId: String) {
         withContext(ioDispatcher) {
-            val deleted =
-                writeMutex.withLock {
-                    database.transactionWithResult {
-                        syncRuntimeInfoDatabaseQueries.deleteSyncRuntimeInfo(appInstanceId)
-                        syncRuntimeInfoDatabaseQueries.change().executeAsOne() > 0
-                    }
+            writeMutex.withLock {
+                database.transaction {
+                    syncRuntimeInfoDatabaseQueries.deleteSyncRuntimeInfo(appInstanceId)
                 }
-            if (deleted) {
-                updateNotifier.trySend(appInstanceId)
             }
         }
     }
@@ -154,129 +129,124 @@ class SqlSyncRuntimeInfoDao(
         connectInfo: ConnectInfo?,
     ) {
         withContext(ioDispatcher) {
-            val changed =
-                writeMutex.withLock {
-                    database.transactionWithResult {
-                        val now = nowEpochMilliseconds()
-                        val existing =
-                            syncRuntimeInfoDatabaseQueries
-                                .getSyncRuntimeInfo(
-                                    syncInfo.appInfo.appInstanceId,
-                                    SyncRuntimeInfo::mapper,
-                                ).executeAsOneOrNull()
+            writeMutex.withLock {
+                database.transactionWithResult {
+                    val now = nowEpochMilliseconds()
+                    val existing =
+                        syncRuntimeInfoDatabaseQueries
+                            .getSyncRuntimeInfo(
+                                syncInfo.appInfo.appInstanceId,
+                                SyncRuntimeInfo::mapper,
+                            ).executeAsOneOrNull()
 
-                        if (existing != null) {
-                            // Recency-ordered, capacity-capped merge (LRU) instead of an
-                            // unbounded union — bounds ghost-address accumulation (#4499).
-                            val hostInfoList =
-                                HostInfo.mergeRecent(
-                                    existing = existing.hostInfoList,
-                                    incoming = syncInfo.endpointInfo.hostInfoList,
-                                    now = now,
+                    if (existing != null) {
+                        // Recency-ordered, capacity-capped merge (LRU) instead of an
+                        // unbounded union — bounds ghost-address accumulation (#4499).
+                        val hostInfoList =
+                            HostInfo.mergeRecent(
+                                existing = existing.hostInfoList,
+                                incoming = syncInfo.endpointInfo.hostInfoList,
+                                now = now,
+                            )
+
+                        // When this update carries no connectInfo (e.g. an mDNS
+                        // re-advertisement), preserve the existing connect address /
+                        // prefix instead of nulling them. The connectState column is
+                        // already preserved via a CASE on the -1 sentinel; the address
+                        // must be preserved too, otherwise a peer's IP-change broadcast
+                        // wipes connectHostAddress and forces a visible disconnect
+                        // (#4499 weakness ①).
+                        val connectNetworkPrefixLength: Long? =
+                            connectInfo?.networkPrefixLength?.toLong()
+                                ?: existing.connectNetworkPrefixLength?.toLong()
+                        val connectHostAddress: String? =
+                            connectInfo?.hostAddress ?: existing.connectHostAddress
+                        val connectState: Long = if (connectInfo != null) SyncState.CONNECTED.toLong() else -1L
+
+                        val hostInfoChanged =
+                            !SyncRuntimeInfo.hostInfoListEqual(
+                                existing.hostInfoList,
+                                hostInfoList,
+                            )
+                        val syncInfoChanged = existing.diffSyncInfo(syncInfo)
+                        val connectChanged =
+                            connectInfo != null &&
+                                (
+                                    existing.connectHostAddress != connectHostAddress ||
+                                        existing.connectNetworkPrefixLength?.toLong() !=
+                                        connectNetworkPrefixLength ||
+                                        existing.connectState.toLong() != connectState
                                 )
 
-                            // When this update carries no connectInfo (e.g. an mDNS
-                            // re-advertisement), preserve the existing connect address /
-                            // prefix instead of nulling them. The connectState column is
-                            // already preserved via a CASE on the -1 sentinel; the address
-                            // must be preserved too, otherwise a peer's IP-change broadcast
-                            // wipes connectHostAddress and forces a visible disconnect
-                            // (#4499 weakness ①).
-                            val connectNetworkPrefixLength: Long? =
-                                connectInfo?.networkPrefixLength?.toLong()
-                                    ?: existing.connectNetworkPrefixLength?.toLong()
-                            val connectHostAddress: String? =
-                                connectInfo?.hostAddress ?: existing.connectHostAddress
-                            val connectState: Long = if (connectInfo != null) SyncState.CONNECTED.toLong() else -1L
+                        if (!hostInfoChanged && !syncInfoChanged && !connectChanged) {
+                            return@transactionWithResult false
+                        }
 
-                            val hostInfoChanged =
-                                !SyncRuntimeInfo.hostInfoListEqual(
-                                    existing.hostInfoList,
-                                    hostInfoList,
-                                )
-                            val syncInfoChanged = existing.diffSyncInfo(syncInfo)
-                            val connectChanged =
-                                connectInfo != null &&
-                                    (
-                                        existing.connectHostAddress != connectHostAddress ||
-                                            existing.connectNetworkPrefixLength?.toLong() !=
-                                            connectNetworkPrefixLength ||
-                                            existing.connectState.toLong() != connectState
-                                    )
-
-                            if (!hostInfoChanged && !syncInfoChanged && !connectChanged) {
-                                return@transactionWithResult false
+                        val hostInfoArrayJson = jsonUtils.JSON.encodeToString(hostInfoList)
+                        syncRuntimeInfoDatabaseQueries.updateSyncInfo(
+                            syncInfo.appInfo.appVersion,
+                            syncInfo.appInfo.userName,
+                            syncInfo.endpointInfo.deviceId,
+                            syncInfo.endpointInfo.deviceName,
+                            syncInfo.endpointInfo.platform.name,
+                            syncInfo.endpointInfo.platform.arch,
+                            syncInfo.endpointInfo.platform.bitMode
+                                .toLong(),
+                            syncInfo.endpointInfo.platform.version,
+                            hostInfoArrayJson,
+                            syncInfo.endpointInfo.port.toLong(),
+                            syncInfo.endpointInfo.port.toLong(),
+                            connectNetworkPrefixLength,
+                            connectHostAddress,
+                            connectState,
+                            connectState,
+                            now,
+                            syncInfo.appInfo.appInstanceId,
+                        )
+                        true
+                    } else {
+                        val connectNetworkPrefixLength: Long? = connectInfo?.networkPrefixLength?.toLong()
+                        val connectHostAddress: String? = connectInfo?.hostAddress
+                        val connectState: Long =
+                            if (connectInfo !=
+                                null
+                            ) {
+                                SyncState.CONNECTED.toLong()
+                            } else {
+                                SyncState.DISCONNECTED.toLong()
                             }
 
-                            val hostInfoArrayJson = jsonUtils.JSON.encodeToString(hostInfoList)
-                            syncRuntimeInfoDatabaseQueries.updateSyncInfo(
-                                syncInfo.appInfo.appVersion,
-                                syncInfo.appInfo.userName,
-                                syncInfo.endpointInfo.deviceId,
-                                syncInfo.endpointInfo.deviceName,
-                                syncInfo.endpointInfo.platform.name,
-                                syncInfo.endpointInfo.platform.arch,
-                                syncInfo.endpointInfo.platform.bitMode
-                                    .toLong(),
-                                syncInfo.endpointInfo.platform.version,
-                                hostInfoArrayJson,
-                                syncInfo.endpointInfo.port.toLong(),
-                                syncInfo.endpointInfo.port.toLong(),
-                                connectNetworkPrefixLength,
-                                connectHostAddress,
-                                connectState,
-                                connectState,
-                                now,
-                                syncInfo.appInfo.appInstanceId,
+                        // Stamp recency and apply the capacity cap on first insert too,
+                        // so a peer can't seed an unbounded address list.
+                        val hostInfoList =
+                            HostInfo.mergeRecent(
+                                existing = emptyList(),
+                                incoming = syncInfo.endpointInfo.hostInfoList,
+                                now = now,
                             )
-                            true
-                        } else {
-                            val connectNetworkPrefixLength: Long? = connectInfo?.networkPrefixLength?.toLong()
-                            val connectHostAddress: String? = connectInfo?.hostAddress
-                            val connectState: Long =
-                                if (connectInfo !=
-                                    null
-                                ) {
-                                    SyncState.CONNECTED.toLong()
-                                } else {
-                                    SyncState.DISCONNECTED.toLong()
-                                }
-
-                            // Stamp recency and apply the capacity cap on first insert too,
-                            // so a peer can't seed an unbounded address list.
-                            val hostInfoList =
-                                HostInfo.mergeRecent(
-                                    existing = emptyList(),
-                                    incoming = syncInfo.endpointInfo.hostInfoList,
-                                    now = now,
-                                )
-                            val hostInfoArrayJson = jsonUtils.JSON.encodeToString(hostInfoList)
-                            syncRuntimeInfoDatabaseQueries.createSyncRuntimeInfo(
-                                syncInfo.appInfo.appInstanceId,
-                                syncInfo.appInfo.appVersion,
-                                syncInfo.appInfo.userName,
-                                syncInfo.endpointInfo.deviceId,
-                                syncInfo.endpointInfo.deviceName,
-                                syncInfo.endpointInfo.platform.name,
-                                syncInfo.endpointInfo.platform.arch,
-                                syncInfo.endpointInfo.platform.bitMode
-                                    .toLong(),
-                                syncInfo.endpointInfo.platform.version,
-                                hostInfoArrayJson,
-                                syncInfo.endpointInfo.port.toLong(),
-                                connectNetworkPrefixLength,
-                                connectHostAddress,
-                                connectState,
-                                now,
-                                now,
-                            )
-                            true
-                        }
+                        val hostInfoArrayJson = jsonUtils.JSON.encodeToString(hostInfoList)
+                        syncRuntimeInfoDatabaseQueries.createSyncRuntimeInfo(
+                            syncInfo.appInfo.appInstanceId,
+                            syncInfo.appInfo.appVersion,
+                            syncInfo.appInfo.userName,
+                            syncInfo.endpointInfo.deviceId,
+                            syncInfo.endpointInfo.deviceName,
+                            syncInfo.endpointInfo.platform.name,
+                            syncInfo.endpointInfo.platform.arch,
+                            syncInfo.endpointInfo.platform.bitMode
+                                .toLong(),
+                            syncInfo.endpointInfo.platform.version,
+                            hostInfoArrayJson,
+                            syncInfo.endpointInfo.port.toLong(),
+                            connectNetworkPrefixLength,
+                            connectHostAddress,
+                            connectState,
+                            now,
+                            now,
+                        )
+                        true
                     }
                 }
-
-            if (changed) {
-                updateNotifier.trySend(syncInfo.appInfo.appInstanceId)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SqlSyncRuntimeInfoDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SqlSyncRuntimeInfoDao.kt
@@ -29,6 +29,10 @@ class SqlSyncRuntimeInfoDao(
      * on subscription and every subsequent change — concurrent collectors never
      * compete for notifications (R2-02-005). [distinctUntilChanged] suppresses
      * re-emissions from table notifications that did not change the result set.
+     *
+     * This is a latest-wins *state* flow, not an event stream: rapid successive
+     * writes may be conflated into a single emission of the newest snapshot, so
+     * consumers must not rely on observing every intermediate state.
      */
     override fun getAllSyncRuntimeInfosFlow(): Flow<List<SyncRuntimeInfo>> =
         syncRuntimeInfoDatabaseQueries


### PR DESCRIPTION
Closes #4721

## What

- `getAllSyncRuntimeInfosFlow()` now uses SQLDelight `asFlow().mapToList(ioDispatcher).distinctUntilChanged()`. Each collector independently observes the query via the driver's listener mechanism: current snapshot on subscription, every subsequent change after that — no competing consumption, no destructive drain, no unbounded buffering while nobody collects.
- Removed the global notifier channel and all `trySend` sites. `updateTemplate` keeps its return contract (instance id only when a row actually changed); `deleteSyncRuntimeInfo` drops the now-unused `change()` read.
- KDoc documents that this is a latest-wins state flow (rapid successive writes may conflate into one emission of the newest snapshot), for future mobile consumers.
- Tests: two concurrent collectors both receive every insert/update/delete; a late subscriber gets the full current snapshot.

## Review

Independent strict review confirmed via the generated SQLDelight code that all seven mutation paths notify the `SyncRuntimeInfoEntity` table the query listens on, and that the sole current consumer (`GeneralSyncManager`) is an idempotent set-reconciliation loop compatible with conflation. Three P3 notes were adjudicated:

- Latest-wins conflation vs. the old per-event channel: correct and preferable for snapshot consumers; documented in KDoc (addressed).
- Full-table requery plus JSON decode per notification: accepted — table size equals the number of paired devices (single digits).
- Result order changed from insertion order to `ORDER BY createTime DESC`: accepted — no consumer depends on the old order.

## Verification

- `SyncRuntimeInfoDaoTest` (10 tests incl. the two new ones), `com.crosspaste.sync.*`, `SyncIntegrationTest` forced re-run, `./gradlew :shared:build` all targets — PASS