### PR TITLE
:bug: never rotate device identity on metadata read failure

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
@@ -15,7 +15,11 @@ fun migrateAppInstanceIdIfNeeded(
     metadataPersist: OneFilePersist,
     legacyConfigPersist: OneFilePersist,
 ) {
-    if (runCatching { metadataPersist.read(AppMetadata::class) }.getOrNull() != null) return
+    // Presence check, not a read: if a metadata file exists at all — even unreadable —
+    // never overwrite it here. AppMetadataRepository owns the corrupt/IO-error handling
+    // (quarantine or fail startup, R2-02-006); silently replacing the file on a read
+    // error would rotate the device identity.
+    if (metadataPersist.exists()) return
     val legacyId =
         runCatching {
             legacyConfigPersist

--- a/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/config/DesktopAppMetadataMigration.kt
@@ -3,6 +3,7 @@ package com.crosspaste.config
 import com.crosspaste.presist.OneFilePersist
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 
 private val logger = KotlinLogging.logger {}
 
@@ -15,24 +16,40 @@ fun migrateAppInstanceIdIfNeeded(
     metadataPersist: OneFilePersist,
     legacyConfigPersist: OneFilePersist,
 ) {
-    // Presence check, not a read: if a metadata file exists at all — even unreadable —
-    // never overwrite it here. AppMetadataRepository owns the corrupt/IO-error handling
-    // (quarantine or fail startup, R2-02-006); silently replacing the file on a read
-    // error would rotate the device identity.
-    if (metadataPersist.exists()) return
-    val legacyId =
-        runCatching {
-            legacyConfigPersist
-                .read(LegacyAppInstanceIdHolder::class)
-                ?.appInstanceId
-                ?.takeIf { it.isNotBlank() }
-        }.onFailure {
-            logger.error(it) {
-                "Failed to read legacy appInstanceId; " +
-                    "a new appInstanceId will be generated and this device " +
-                    "will appear as a new peer to previously paired devices"
+    if (metadataPersist.exists()) {
+        // A metadata file is present: if it parses, identity is settled. If it is
+        // corrupt, the legacy config may still hold the original identity — restoring
+        // it here beats letting AppMetadataRepository quarantine the file and mint a
+        // brand-new id, which would orphan existing pairings (R2-02-006). I/O errors
+        // propagate untouched and fail startup: overwriting on a transient read error
+        // could revert a newer identity to the legacy one.
+        try {
+            metadataPersist.read(AppMetadata::class)
+        } catch (e: SerializationException) {
+            val legacyId = readLegacyAppInstanceId(legacyConfigPersist) ?: return
+            val backup = metadataPersist.quarantine()
+            logger.error(e) {
+                "App metadata is corrupt; backed it up to $backup " +
+                    "and restored the legacy appInstanceId"
             }
-        }.getOrNull() ?: return
-
+            metadataPersist.save(AppMetadata(legacyId))
+        }
+        return
+    }
+    val legacyId = readLegacyAppInstanceId(legacyConfigPersist) ?: return
     metadataPersist.save(AppMetadata(legacyId))
 }
+
+private fun readLegacyAppInstanceId(legacyConfigPersist: OneFilePersist): String? =
+    runCatching {
+        legacyConfigPersist
+            .read(LegacyAppInstanceIdHolder::class)
+            ?.appInstanceId
+            ?.takeIf { it.isNotBlank() }
+    }.onFailure {
+        logger.error(it) {
+            "Failed to read legacy appInstanceId; " +
+                "a new appInstanceId will be generated and this device " +
+                "will appear as a new peer to previously paired devices"
+        }
+    }.getOrNull()

--- a/app/src/desktopTest/kotlin/com/crosspaste/config/AppMetadataRepositoryTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/config/AppMetadataRepositoryTest.kt
@@ -1,0 +1,82 @@
+package com.crosspaste.config
+
+import com.crosspaste.presist.OneFilePersist
+import com.crosspaste.utils.DeviceUtils
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import okio.IOException
+import okio.Path.Companion.toOkioPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppMetadataRepositoryTest {
+
+    private val deviceUtils =
+        mockk<DeviceUtils> {
+            every { createAppInstanceId() } returns "generated-id"
+        }
+
+    private fun tempDir() = Files.createTempDirectory("appMetadataTest").toOkioPath()
+
+    @Test
+    fun `missing file creates and persists a new identity`() {
+        val persist = OneFilePersist(tempDir().resolve(".metadata"))
+        val repository = AppMetadataRepository(persist, deviceUtils)
+
+        assertEquals("generated-id", repository.appInstanceId)
+        assertEquals(AppMetadata("generated-id"), persist.read(AppMetadata::class))
+    }
+
+    @Test
+    fun `existing valid file is reused without rotation`() {
+        val persist = OneFilePersist(tempDir().resolve(".metadata"))
+        persist.save(AppMetadata("stored-id"))
+
+        val repository = AppMetadataRepository(persist, deviceUtils)
+
+        assertEquals("stored-id", repository.appInstanceId)
+        verify(exactly = 0) { deviceUtils.createAppInstanceId() }
+
+        // A second repository over the same file must see the same identity.
+        assertEquals("stored-id", AppMetadataRepository(persist, deviceUtils).appInstanceId)
+    }
+
+    @Test
+    fun `corrupt file is quarantined before a new identity is generated`() {
+        val dir = tempDir()
+        val persist = OneFilePersist(dir.resolve(".metadata"))
+        persist.saveBytes("{ not valid json".encodeToByteArray())
+
+        val repository = AppMetadataRepository(persist, deviceUtils)
+
+        assertEquals("generated-id", repository.appInstanceId)
+        // The corrupt payload is preserved for inspection...
+        val backup = dir.resolve(".metadata.corrupt")
+        assertTrue(Files.exists(backup.toNioPath()))
+        assertEquals("{ not valid json", Files.readString(backup.toNioPath()))
+        // ...and the new identity is persisted in its place.
+        assertEquals(AppMetadata("generated-id"), persist.read(AppMetadata::class))
+    }
+
+    @Test
+    fun `read IO error fails instead of rotating the identity`() {
+        val dir = tempDir()
+        // A directory at the metadata path makes the read fail with an I/O error
+        // while fileSystem.exists() still returns true — modelling an unreadable file.
+        val metadataPath = dir.resolve(".metadata")
+        Files.createDirectory(metadataPath.toNioPath())
+        val repository = AppMetadataRepository(OneFilePersist(metadataPath), deviceUtils)
+
+        assertFailsWith<IOException> { repository.appInstanceId }
+
+        // No identity was generated, nothing was quarantined or overwritten.
+        verify(exactly = 0) { deviceUtils.createAppInstanceId() }
+        assertFalse(Files.exists(dir.resolve(".metadata.corrupt").toNioPath()))
+        assertTrue(Files.isDirectory(metadataPath.toNioPath()))
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/config/AppMetadataRepositoryTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/config/AppMetadataRepositoryTest.kt
@@ -64,6 +64,24 @@ class AppMetadataRepositoryTest {
     }
 
     @Test
+    fun `quarantine failure propagates instead of rotating the identity`() {
+        val dir = tempDir()
+        val persist = OneFilePersist(dir.resolve(".metadata"))
+        persist.saveBytes("{ not valid json".encodeToByteArray())
+        // A non-empty directory at the backup path makes quarantine's atomic move fail.
+        val backupPath = dir.resolve(".metadata.corrupt")
+        Files.createDirectory(backupPath.toNioPath())
+        Files.writeString(backupPath.resolve("occupant").toNioPath(), "keep")
+        val repository = AppMetadataRepository(persist, deviceUtils)
+
+        assertFailsWith<IOException> { repository.appInstanceId }
+
+        // No identity was generated and the corrupt file is still in place.
+        verify(exactly = 0) { deviceUtils.createAppInstanceId() }
+        assertEquals("{ not valid json", Files.readString(dir.resolve(".metadata").toNioPath()))
+    }
+
+    @Test
     fun `read IO error fails instead of rotating the identity`() {
         val dir = tempDir()
         // A directory at the metadata path makes the read fail with an I/O error

--- a/app/src/desktopTest/kotlin/com/crosspaste/config/DesktopAppMetadataMigrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/config/DesktopAppMetadataMigrationTest.kt
@@ -1,0 +1,54 @@
+package com.crosspaste.config
+
+import com.crosspaste.presist.OneFilePersist
+import okio.Path.Companion.toOkioPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DesktopAppMetadataMigrationTest {
+
+    private fun tempDir() = Files.createTempDirectory("appMetadataMigrationTest").toOkioPath()
+
+    @Test
+    fun `migrates legacy appInstanceId when metadata file is absent`() {
+        val dir = tempDir()
+        val metadataPersist = OneFilePersist(dir.resolve(".metadata"))
+        val legacyPersist = OneFilePersist(dir.resolve("appConfig.json"))
+        legacyPersist.saveBytes("""{"appInstanceId":"legacy-id","language":"en"}""".encodeToByteArray())
+
+        migrateAppInstanceIdIfNeeded(metadataPersist, legacyPersist)
+
+        assertEquals(AppMetadata("legacy-id"), metadataPersist.read(AppMetadata::class))
+    }
+
+    @Test
+    fun `does nothing when neither metadata nor legacy config exists`() {
+        val dir = tempDir()
+        val metadataPersist = OneFilePersist(dir.resolve(".metadata"))
+        val legacyPersist = OneFilePersist(dir.resolve("appConfig.json"))
+
+        migrateAppInstanceIdIfNeeded(metadataPersist, legacyPersist)
+
+        assertFalse(metadataPersist.exists())
+    }
+
+    @Test
+    fun `never overwrites an existing metadata file even if unreadable`() {
+        val dir = tempDir()
+        val metadataPersist = OneFilePersist(dir.resolve(".metadata"))
+        val legacyPersist = OneFilePersist(dir.resolve("appConfig.json"))
+        // Corrupt metadata: migration must leave it for AppMetadataRepository to
+        // quarantine, not silently replace it with the legacy identity (R2-02-006).
+        metadataPersist.saveBytes("{ not valid json".encodeToByteArray())
+        legacyPersist.saveBytes("""{"appInstanceId":"legacy-id"}""".encodeToByteArray())
+
+        migrateAppInstanceIdIfNeeded(metadataPersist, legacyPersist)
+
+        assertEquals(
+            "{ not valid json",
+            Files.readString(dir.resolve(".metadata").toNioPath()),
+        )
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/config/DesktopAppMetadataMigrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/config/DesktopAppMetadataMigrationTest.kt
@@ -35,14 +35,45 @@ class DesktopAppMetadataMigrationTest {
     }
 
     @Test
-    fun `never overwrites an existing metadata file even if unreadable`() {
+    fun `does not touch an existing valid metadata file`() {
         val dir = tempDir()
         val metadataPersist = OneFilePersist(dir.resolve(".metadata"))
         val legacyPersist = OneFilePersist(dir.resolve("appConfig.json"))
-        // Corrupt metadata: migration must leave it for AppMetadataRepository to
-        // quarantine, not silently replace it with the legacy identity (R2-02-006).
+        metadataPersist.save(AppMetadata("current-id"))
+        legacyPersist.saveBytes("""{"appInstanceId":"legacy-id"}""".encodeToByteArray())
+
+        migrateAppInstanceIdIfNeeded(metadataPersist, legacyPersist)
+
+        assertEquals(AppMetadata("current-id"), metadataPersist.read(AppMetadata::class))
+    }
+
+    @Test
+    fun `restores legacy identity when metadata is corrupt and legacy id exists`() {
+        val dir = tempDir()
+        val metadataPersist = OneFilePersist(dir.resolve(".metadata"))
+        val legacyPersist = OneFilePersist(dir.resolve("appConfig.json"))
         metadataPersist.saveBytes("{ not valid json".encodeToByteArray())
         legacyPersist.saveBytes("""{"appInstanceId":"legacy-id"}""".encodeToByteArray())
+
+        migrateAppInstanceIdIfNeeded(metadataPersist, legacyPersist)
+
+        // The original identity survives instead of being rotated (R2-02-006)...
+        assertEquals(AppMetadata("legacy-id"), metadataPersist.read(AppMetadata::class))
+        // ...and the corrupt payload was quarantined, not destroyed.
+        assertEquals(
+            "{ not valid json",
+            Files.readString(dir.resolve(".metadata.corrupt").toNioPath()),
+        )
+    }
+
+    @Test
+    fun `leaves corrupt metadata untouched when there is no legacy id`() {
+        val dir = tempDir()
+        val metadataPersist = OneFilePersist(dir.resolve(".metadata"))
+        val legacyPersist = OneFilePersist(dir.resolve("appConfig.json"))
+        // No legacy identity to restore: migration must leave the corrupt file for
+        // AppMetadataRepository to quarantine and regenerate.
+        metadataPersist.saveBytes("{ not valid json".encodeToByteArray())
 
         migrateAppInstanceIdIfNeeded(metadataPersist, legacyPersist)
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/presist/OneFilePersistTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/presist/OneFilePersistTest.kt
@@ -1,10 +1,12 @@
 package com.crosspaste.presist
 
 import kotlinx.serialization.Serializable
+import okio.IOException
 import okio.Path.Companion.toOkioPath
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -78,5 +80,37 @@ class OneFilePersistTest {
         val persist = OneFilePersist(tempDir().resolve("payload.json"))
 
         assertNull(persist.quarantine())
+    }
+
+    @Test
+    fun `quarantine replaces an existing corrupt backup`() {
+        val dir = tempDir()
+        val persist = OneFilePersist(dir.resolve("payload.json"))
+        Files.writeString(dir.resolve("payload.json.corrupt").toNioPath(), "old backup")
+        persist.saveBytes("new corrupt".encodeToByteArray())
+
+        val backup = persist.quarantine()
+
+        assertEquals("new corrupt", Files.readString(backup!!.toNioPath()))
+    }
+
+    @Test
+    fun `failed write cleans up its temp file and propagates the error`() {
+        val dir = tempDir()
+        // A non-empty directory at the target path: the temp write succeeds but the
+        // atomic move fails, which must clean the temp file and rethrow.
+        val target = dir.resolve("payload.json")
+        Files.createDirectory(target.toNioPath())
+        Files.writeString(target.resolve("occupant").toNioPath(), "keep")
+        val persist = OneFilePersist(target)
+
+        assertFailsWith<IOException> { persist.save(Payload("hello")) }
+
+        val leftovers =
+            Files.list(dir.toNioPath()).use { stream ->
+                stream.map { it.fileName.toString() }.toList()
+            }
+        assertEquals(listOf("payload.json"), leftovers)
+        assertEquals("keep", Files.readString(target.resolve("occupant").toNioPath()))
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/presist/OneFilePersistTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/presist/OneFilePersistTest.kt
@@ -1,0 +1,82 @@
+package com.crosspaste.presist
+
+import kotlinx.serialization.Serializable
+import okio.Path.Companion.toOkioPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class OneFilePersistTest {
+
+    @Serializable
+    private data class Payload(
+        val value: String,
+    )
+
+    private fun tempDir() = Files.createTempDirectory("oneFilePersistTest").toOkioPath()
+
+    @Test
+    fun `save writes content readable by read`() {
+        val persist = OneFilePersist(tempDir().resolve("payload.json"))
+
+        persist.save(Payload("hello"))
+
+        assertEquals(Payload("hello"), persist.read(Payload::class))
+    }
+
+    @Test
+    fun `save leaves no temp file behind`() {
+        val dir = tempDir()
+        val persist = OneFilePersist(dir.resolve("payload.json"))
+
+        persist.save(Payload("hello"))
+        persist.save(Payload("overwritten"))
+
+        val entries = Files.list(dir.toNioPath()).use { it.map { p -> p.fileName.toString() }.toList() }
+        assertEquals(listOf("payload.json"), entries)
+        assertEquals(Payload("overwritten"), persist.read(Payload::class))
+    }
+
+    @Test
+    fun `save creates missing parent directories`() {
+        val persist = OneFilePersist(tempDir().resolve("nested/deeper/payload.json"))
+
+        persist.save(Payload("hello"))
+
+        assertEquals(Payload("hello"), persist.read(Payload::class))
+    }
+
+    @Test
+    fun `exists reflects file presence`() {
+        val persist = OneFilePersist(tempDir().resolve("payload.json"))
+
+        assertFalse(persist.exists())
+        persist.save(Payload("hello"))
+        assertTrue(persist.exists())
+        persist.delete()
+        assertFalse(persist.exists())
+    }
+
+    @Test
+    fun `quarantine moves the file aside preserving its bytes`() {
+        val dir = tempDir()
+        val persist = OneFilePersist(dir.resolve("payload.json"))
+        persist.saveBytes("not json".encodeToByteArray())
+
+        val backup = persist.quarantine()
+
+        assertEquals(dir.resolve("payload.json.corrupt"), backup)
+        assertFalse(persist.exists())
+        assertEquals("not json", Files.readString(backup!!.toNioPath()))
+    }
+
+    @Test
+    fun `quarantine returns null when there is no file`() {
+        val persist = OneFilePersist(tempDir().resolve("payload.json"))
+
+        assertNull(persist.quarantine())
+    }
+}

--- a/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadataRepository.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadataRepository.kt
@@ -2,14 +2,45 @@ package com.crosspaste.config
 
 import com.crosspaste.presist.OneFilePersist
 import com.crosspaste.utils.DeviceUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.SerializationException
 
 class AppMetadataRepository(
     private val persist: OneFilePersist,
     private val deviceUtils: DeviceUtils,
 ) {
+    private val logger = KotlinLogging.logger {}
+
     val appInstanceId: String by lazy { loadOrCreate().appInstanceId }
 
-    private fun loadOrCreate(): AppMetadata =
-        runCatching { persist.read(AppMetadata::class) }.getOrNull()
-            ?: AppMetadata(deviceUtils.createAppInstanceId()).also { persist.save(it) }
+    /**
+     * The metadata file is this device's persistent identity: silently replacing it
+     * makes every previously paired device see a brand-new peer, orphaning existing
+     * trust and sync state (R2-02-006). Only a genuinely absent file may create a
+     * fresh identity:
+     * - Corrupt content is quarantined next to the original (observable in logs,
+     *   recoverable by hand) before a new identity is generated.
+     * - I/O errors (permissions, transient disk failures) propagate and fail startup
+     *   rather than rotating the identity.
+     */
+    private fun loadOrCreate(): AppMetadata {
+        val existing =
+            try {
+                persist.read(AppMetadata::class)
+            } catch (e: SerializationException) {
+                quarantineCorrupt(e)
+            } catch (e: IllegalArgumentException) {
+                quarantineCorrupt(e)
+            }
+        return existing ?: AppMetadata(deviceUtils.createAppInstanceId()).also { persist.save(it) }
+    }
+
+    private fun quarantineCorrupt(cause: Throwable): AppMetadata? {
+        val backupPath = persist.quarantine()
+        logger.error(cause) {
+            "App metadata is corrupt; backed it up to $backupPath and generating a new appInstanceId. " +
+                "Previously paired devices will see this device as a new peer."
+        }
+        return null
+    }
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadataRepository.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/config/AppMetadataRepository.kt
@@ -28,19 +28,16 @@ class AppMetadataRepository(
             try {
                 persist.read(AppMetadata::class)
             } catch (e: SerializationException) {
-                quarantineCorrupt(e)
-            } catch (e: IllegalArgumentException) {
-                quarantineCorrupt(e)
+                // Corrupt content, not an I/O failure. SerializationException covers all
+                // kotlinx parse failures; anything broader would misclassify unrelated
+                // errors as corruption and rotate the identity.
+                val backupPath = persist.quarantine()
+                logger.error(e) {
+                    "App metadata is corrupt; backed it up to $backupPath and generating a new " +
+                        "appInstanceId. Previously paired devices will see this device as a new peer."
+                }
+                null
             }
         return existing ?: AppMetadata(deviceUtils.createAppInstanceId()).also { persist.save(it) }
-    }
-
-    private fun quarantineCorrupt(cause: Throwable): AppMetadata? {
-        val backupPath = persist.quarantine()
-        logger.error(cause) {
-            "App metadata is corrupt; backed it up to $backupPath and generating a new appInstanceId. " +
-                "Previously paired devices will see this device as a new peer."
-        }
-        return null
     }
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/OneFilePersist.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/OneFilePersist.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 import okio.BufferedSink
 import okio.Path
+import okio.Path.Companion.toPath
 import kotlin.reflect.KClass
 
 @Suppress("UNCHECKED_CAST")
@@ -16,6 +17,8 @@ class OneFilePersist(
 
     private val jsonUtils = getJsonUtils()
     private val fileSystem = getFileUtils().fileSystem
+
+    fun exists(): Boolean = fileSystem.exists(path)
 
     @OptIn(InternalSerializationApi::class)
     fun <T : Any> read(clazz: KClass<T>): T? =
@@ -56,11 +59,38 @@ class OneFilePersist(
             false
         }
 
+    /**
+     * Move the current file aside to `<name>.corrupt` in the same directory, so an
+     * unreadable payload stays available for inspection and manual recovery instead
+     * of being overwritten by regenerated content. Returns the backup path, or null
+     * if there was nothing to move.
+     *
+     * @throws okio.IOException if the move fails.
+     */
+    fun quarantine(): Path? {
+        if (!fileSystem.exists(path)) {
+            return null
+        }
+        val target = "$path.corrupt".toPath()
+        fileSystem.atomicMove(path, target)
+        return target
+    }
+
     private fun writeWithParentDirs(writeOperation: BufferedSink.() -> Unit) {
         val parent = path.parent
         if (parent != null && !fileSystem.exists(parent)) {
             fileSystem.createDirectories(parent)
         }
-        fileSystem.write(path, mustCreate = false, writeOperation)
+        // Write to a same-directory temp file, then atomically move it into place: a
+        // crash or full disk mid-write must never leave a truncated file at [path]
+        // (R2-02-006).
+        val tempPath = "$path.tmp".toPath()
+        try {
+            fileSystem.write(tempPath, mustCreate = false, writeOperation)
+            fileSystem.atomicMove(tempPath, path)
+        } catch (e: Throwable) {
+            runCatching { fileSystem.delete(tempPath, mustExist = false) }
+            throw e
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/com/crosspaste/presist/OneFilePersist.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/presist/OneFilePersist.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.serializer
 import okio.BufferedSink
 import okio.Path
 import okio.Path.Companion.toPath
+import kotlin.random.Random
 import kotlin.reflect.KClass
 
 @Suppress("UNCHECKED_CAST")
@@ -83,8 +84,10 @@ class OneFilePersist(
         }
         // Write to a same-directory temp file, then atomically move it into place: a
         // crash or full disk mid-write must never leave a truncated file at [path]
-        // (R2-02-006).
-        val tempPath = "$path.tmp".toPath()
+        // (R2-02-006). The temp name carries a random suffix so concurrent writers of
+        // the same path never share a temp file — racing writes degrade to a harmless
+        // last-move-wins instead of moving each other's half-written content.
+        val tempPath = "$path.${Random.nextLong().toULong().toString(16)}.tmp".toPath()
         try {
             fileSystem.write(tempPath, mustCreate = false, writeOperation)
             fileSystem.atomicMove(tempPath, path)


### PR DESCRIPTION
Closes #4723

## What

- `AppMetadataRepository` now distinguishes three cases: absent file creates a new identity; corrupt content (`SerializationException` only — it covers all kotlinx parse failures) is quarantined to `.metadata.corrupt` with an error log before regenerating; I/O errors propagate and fail startup. `by lazy` retries the initializer on the next access after an exception, so transient errors self-heal without ever generating an id on the error path.
- `OneFilePersist` writes are now atomic: same-directory temp file with a random unique suffix, then `atomicMove` into place (temp cleaned up on failure). Adds `exists()` and `quarantine()`. Exception contract is unchanged (`okio.IOException`), so existing callers' catch blocks still apply.
- Desktop `migrateAppInstanceIdIfNeeded` no longer silently replaces an existing metadata file: valid file settles identity; corrupt file with a legacy id available is quarantined and the legacy identity restored (recovery instead of rotation); I/O errors propagate.

## Review

Independent strict review found no P0/P1. Both P2 findings were accepted and fixed in a follow-up commit on this branch:

- Fixed temp-file name could make concurrent same-path writers move each other's half-written content — now a random per-write suffix; races degrade to last-move-wins.
- The initial migration guard ("file exists, skip") reintroduced a rotation path for corrupt-metadata-with-legacy-id — now closed by restoring the legacy identity after quarantining.

Also applied from review: narrowed the corrupt-catch to `SerializationException` (it already subsumes kotlinx's `IllegalArgumentException` cases), and added the three missing tests (failed write cleans its temp file and rethrows; quarantine replaces an existing backup; quarantine failure propagates without rotation). Accepted as residual, low-risk: Windows anti-virus holding the target during `ATOMIC_MOVE` is a new failure surface already covered by callers catching `IOException`; a crash can leave an orphaned `.tmp` file (small, ignored by all consumers of those directories).

## Verification

- New `AppMetadataRepositoryTest` (5), `DesktopAppMetadataMigrationTest` (5), `OneFilePersistTest` (8) — PASS
- `./gradlew :shared:build` all targets and the full `:app:desktopTest` suite — PASS