### PR TITLE
:heavy_minus_sign: drop unused Compose plugin and runtime from shared

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -18,8 +18,6 @@ group = "com.crosspaste"
 version = versionProperties.getProperty("version")
 
 plugins {
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.ktlint)
@@ -33,10 +31,6 @@ sqldelight {
             dialect("app.cash.sqldelight:sqlite-3-25-dialect:${libs.versions.sqldelight.get()}")
         }
     }
-}
-
-composeCompiler {
-    stabilityConfigurationFiles.add(rootProject.layout.projectDirectory.file("compose-stability.conf"))
 }
 
 ktlint {
@@ -101,7 +95,6 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":core"))
-            implementation(libs.compose.runtime)
             implementation(libs.cryptography.core)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)


### PR DESCRIPTION
Closes #4725

## What

Remove from `shared/build.gradle.kts`:

- `alias(libs.plugins.compose.compiler)` and `alias(libs.plugins.jetbrainsCompose)`
- the `composeCompiler { stabilityConfigurationFiles ... }` block
- `implementation(libs.compose.runtime)`

No source changes: `shared/src` has no `androidx.compose` reference.

## Review

Independent strict review returned no findings, and verified the removal is real and safe: the dependency was `implementation` (not `api`), so nothing was exposed transitively and every Compose-using module (app, shared-ui) declares its own plugin and runtime; `compose-stability.conf` remains referenced by app and shared-ui; shared has no `composeResources`/`Res.` usage, so the plugin provided no hidden resource generation; the root build applies Compose plugins with `apply false`, so removal here genuinely shrinks the K/N and mobile dependency surface.

## Verification

- `./gradlew :shared:build` (desktop + native targets, tests, ktlint) — PASS
- `./gradlew :app:compileKotlinDesktop` — PASS