### PR TITLE
:bug: tolerate corrupted hostInfo JSON per row in device-list mapping

### DIFF
--- a/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/sync/SyncRuntimeInfoDaoTest.kt
@@ -333,6 +333,71 @@ class SyncRuntimeInfoDaoTest {
             assertTrue(after.hostInfoList.any { it.hostAddress == "192.168.1.200" })
         }
 
+    /**
+     * Writes a device row whose hostInfo column is not valid JSON, bypassing the
+     * DAO (which always writes valid JSON) — simulates on-disk corruption or a
+     * downgrade to a schema the current decoder cannot parse.
+     */
+    private fun insertCorruptedHostInfoRow(appInstanceId: String) {
+        database.syncRuntimeInfoDatabaseQueries.createSyncRuntimeInfo(
+            appInstanceId,
+            "1.0.0",
+            "testUser",
+            "device-corrupt",
+            "CorruptDevice",
+            testPlatform.name,
+            testPlatform.arch,
+            testPlatform.bitMode.toLong(),
+            testPlatform.version,
+            "[{ corrupted json",
+            8080L,
+            null,
+            null,
+            SyncState.DISCONNECTED.toLong(),
+            1L,
+            1L,
+        )
+    }
+
+    @Test
+    fun `corrupted hostInfo row degrades to empty host list instead of killing the flow`() =
+        runTest {
+            // R2-02-009: one undecodable row must not abort the whole device-list
+            // query — every other device must still be delivered to collectors.
+            syncRuntimeInfoDao.insertOrUpdateSyncInfo(testSyncInfo)
+            insertCorruptedHostInfoRow("corrupt-instance")
+
+            syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow().test {
+                val list = awaitItem()
+                assertEquals(2, list.size)
+
+                val healthy = list.single { it.appInstanceId == "test-instance-1" }
+                assertEquals(listOf("192.168.1.100"), healthy.hostInfoList.map { it.hostAddress })
+
+                val corrupted = list.single { it.appInstanceId == "corrupt-instance" }
+                assertTrue(corrupted.hostInfoList.isEmpty())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `corrupted hostInfo row recovers when a valid sync info is written`() =
+        runTest {
+            insertCorruptedHostInfoRow("test-instance-1")
+
+            // Single-row reads degrade the same way as the list query…
+            val degraded = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
+            assertNotNull(degraded)
+            assertTrue(degraded.hostInfoList.isEmpty())
+
+            // …and the next discovery/sync write restores valid addresses.
+            syncRuntimeInfoDao.insertOrUpdateSyncInfo(testSyncInfo)
+            val recovered = syncRuntimeInfoDao.getSyncRuntimeInfo("test-instance-1")
+            assertNotNull(recovered)
+            assertEquals(listOf("192.168.1.100"), recovered.hostInfoList.map { it.hostAddress })
+        }
+
     @Test
     fun `insertOrUpdateSyncInfo evicts old ghost addresses as new ones arrive`() =
         runTest {

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SyncRuntimeInfo.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SyncRuntimeInfo.kt
@@ -4,6 +4,7 @@ import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.platform.Platform
 import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.getJsonUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -28,7 +29,32 @@ data class SyncRuntimeInfo(
 
     companion object {
 
+        private val logger = KotlinLogging.logger {}
+
         private val jsonUtils = getJsonUtils()
+
+        /**
+         * Row-level tolerance for corrupted hostInfo JSON: one undecodable row
+         * must not abort the whole device-list query (and with it every
+         * collector of `getAllSyncRuntimeInfosFlow`). The row degrades to an
+         * empty host list — the device record and its trust survive, and the
+         * next discovery/sync write restores valid addresses. The log is
+         * deliberately limited to the exception type and a truncated
+         * appInstanceId; the raw JSON (device addresses) is never logged.
+         */
+        private fun decodeHostInfoList(
+            appInstanceId: String,
+            hostInfo: String,
+        ): List<HostInfo> =
+            try {
+                jsonUtils.JSON.decodeFromString(hostInfo)
+            } catch (e: IllegalArgumentException) {
+                logger.warn {
+                    "Corrupted hostInfo JSON (${e::class.simpleName}) for " +
+                        "appInstanceId=${appInstanceId.take(8)}…, degrading to empty host list"
+                }
+                emptyList()
+            }
 
         fun mapper(
             appInstanceId: String,
@@ -64,7 +90,7 @@ data class SyncRuntimeInfo(
                         bitMode = platformBitMode.toInt(),
                         version = platformVersion,
                     ),
-                hostInfoList = jsonUtils.JSON.decodeFromString(hostInfo),
+                hostInfoList = decodeHostInfoList(appInstanceId, hostInfo),
                 port = port.toInt(),
                 noteName = noteName,
                 connectNetworkPrefixLength = connectNetworkPrefixLength?.toShort(),

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SyncRuntimeInfo.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/sync/SyncRuntimeInfo.kt
@@ -6,6 +6,7 @@ import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.getJsonUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
+import kotlin.concurrent.Volatile
 
 @Serializable
 data class SyncRuntimeInfo(
@@ -33,6 +34,14 @@ data class SyncRuntimeInfo(
 
         private val jsonUtils = getJsonUtils()
 
+        // The mapper re-runs for every collector on every table change, so a
+        // persistently corrupted row would repeat the same warning forever;
+        // warn once per appInstanceId per process instead. Copy-on-write
+        // behind @Volatile keeps shared/commonMain dependency-free — the
+        // dedup is best-effort and a racing read may at worst warn twice.
+        @Volatile
+        private var warnedCorruptedHostInfo: Set<String> = emptySet()
+
         /**
          * Row-level tolerance for corrupted hostInfo JSON: one undecodable row
          * must not abort the whole device-list query (and with it every
@@ -49,9 +58,12 @@ data class SyncRuntimeInfo(
             try {
                 jsonUtils.JSON.decodeFromString(hostInfo)
             } catch (e: IllegalArgumentException) {
-                logger.warn {
-                    "Corrupted hostInfo JSON (${e::class.simpleName}) for " +
-                        "appInstanceId=${appInstanceId.take(8)}…, degrading to empty host list"
+                if (appInstanceId !in warnedCorruptedHostInfo) {
+                    warnedCorruptedHostInfo = warnedCorruptedHostInfo + appInstanceId
+                    logger.warn {
+                        "Corrupted hostInfo JSON (${e::class.simpleName}) for " +
+                            "appInstanceId=${appInstanceId.take(8)}..., degrading to empty host list"
+                    }
                 }
                 emptyList()
             }


### PR DESCRIPTION
Closes #4727

## What

A single corrupted `hostInfo` JSON row no longer aborts the entire device-list query and every collector of `getAllSyncRuntimeInfosFlow()`.

- `SyncRuntimeInfo.mapper` now decodes `hostInfo` through `decodeHostInfoList`, which catches `IllegalArgumentException` (the supertype of all kotlinx.serialization decode failures) and degrades that row to `hostInfoList = emptyList()`. The device record and its trust survive; the next discovery/sync write restores valid addresses via the existing `HostInfo.mergeRecent` path, so the database self-heals.
- The warning is sanitized (exception type + truncated `appInstanceId` only — never the raw JSON, which contains device addresses, and never `e.message`, which may embed a JSON snippet) and deduplicated to once per instance per process, because the mapper re-runs for every collector on every table change.
- Tests: a corrupted row written directly to the table (bypassing the DAO) degrades to an empty host list while healthy rows and the flow keep working; a subsequent valid `insertOrUpdateSyncInfo` restores the address list.

## Review summary

Independent strict review found no P0/P1.

- **Fixed (P2):** unbounded repetition of the warning for a persistently corrupted, offline row — now warned once per instance per process. Implemented with a copy-on-write set behind `@Volatile` instead of `io.ktor.util.collections.ConcurrentSet`, because `shared` only depends on `ktor-io` and a log-dedup did not justify a new dependency; the dedup is best-effort (a race may at worst warn twice).
- **Fixed (nit):** non-ASCII ellipsis in the log message replaced with `...`.
- **Accepted as-is (nit):** pathological deeply-nested JSON could still throw `StackOverflowError` (an `Error`, deliberately not caught — all real writes come from the DAO's own encoder, so this input is unreachable in practice).
- **Accepted as-is (nit):** the test helper calls the generated `createSyncRuntimeInfo` with positional arguments; it is strongly typed and intentionally bypasses the DAO to simulate corruption.

## Mobile follow-up

`shared/commonMain` change only (`kotlin.concurrent.Volatile`, no new dependencies) — mobile repos should pick up the updated `SyncRuntimeInfo.kt` as usual.