### PR TITLE
:sparkles: add chunked WebSocket payload transfer negotiated via the pairing v3 handshake

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -17,6 +17,7 @@ import com.crosspaste.net.routing.pullRouting
 import com.crosspaste.net.routing.pushRouting
 import com.crosspaste.net.routing.syncRouting
 import com.crosspaste.net.routing.wsRouting
+import com.crosspaste.net.ws.WS_MAX_FRAME_SIZE
 import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.pairing.v3.PairingProtocolV3Service
@@ -91,7 +92,7 @@ open class DefaultServerModule(
             install(io.ktor.server.websocket.WebSockets) {
                 pingPeriodMillis = 30_000
                 timeoutMillis = 15_000
-                maxFrameSize = 1024 * 1024
+                maxFrameSize = WS_MAX_FRAME_SIZE
             }
             install(serverEncryptPluginFactory.createPlugin())
             install(serverDecryptionPluginFactory.createPlugin())

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.net.routing
 
 import com.crosspaste.app.AppInfo
+import com.crosspaste.net.SyncApi
 import com.crosspaste.net.ws.WS_AUTHENTICATION_TIMEOUT
 import com.crosspaste.net.ws.WsAuthChallenge
 import com.crosspaste.net.ws.WsAuthProof
@@ -9,6 +10,7 @@ import com.crosspaste.net.ws.WsAuthenticationContext
 import com.crosspaste.net.ws.WsEnvelope
 import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsMessageType
+import com.crosspaste.net.ws.WsServerAuthentication
 import com.crosspaste.net.ws.WsSession
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.net.ws.receiveWsEnvelope
@@ -54,7 +56,7 @@ fun Routing.wsRouting(
 
         val authenticationRequested =
             call.request.queryParameters["authVersion"] == WsAuthenticationCodec.VERSION.toString()
-        val authenticationContext =
+        val serverAuthentication =
             if (authenticationRequested) {
                 authenticateWebSocketPeer(appInfo, appInstanceId, secureStore) ?: return@webSocket
             } else {
@@ -66,9 +68,17 @@ fun Routing.wsRouting(
                 logger.warn { "Allowing legacy unauthenticated WebSocket from loopback for $appInstanceId" }
                 null
             }
+        val authenticationContext = serverAuthentication?.context
 
         logger.info { "WebSocket connected: $appInstanceId → ${appInfo.appInstanceId}" }
-        val wsSession = WsSession(this, appInstanceId, authenticationContext)
+        val wsSession =
+            WsSession(
+                this,
+                appInstanceId,
+                authenticationContext,
+                peerSupportsChunkedPayload =
+                    SyncApi.supportsPairingV3(serverAuthentication?.remotePairingVersion),
+            )
         wsSessionManager.registerSession(appInstanceId, wsSession)
 
         try {
@@ -84,7 +94,7 @@ private suspend fun DefaultWebSocketServerSession.authenticateWebSocketPeer(
     appInfo: AppInfo,
     appInstanceId: String,
     secureStore: SecureStore,
-): WsAuthenticationContext? {
+): WsServerAuthentication? {
     val json = getJsonUtils().JSON
     val processor = runCatching { secureStore.getMessageProcessor(appInstanceId) }.getOrNull()
     if (processor == null) {
@@ -96,6 +106,7 @@ private suspend fun DefaultWebSocketServerSession.authenticateWebSocketPeer(
         WsAuthChallenge(
             sessionId = getCodecsUtils().base64Encode(CryptographyRandom.nextBytes(16)),
             nonce = CryptographyRandom.nextBytes(32),
+            pairingVersion = appInfo.pairingVersion,
         )
     rawSession.sendEnvelope(
         WsEnvelope(
@@ -135,11 +146,15 @@ private suspend fun DefaultWebSocketServerSession.authenticateWebSocketPeer(
             payload = json.encodeToString(ack).encodeToByteArray(),
         ),
     )
-    return WsAuthenticationContext(
-        sessionId = challenge.sessionId,
-        localAppInstanceId = appInfo.appInstanceId,
-        remoteAppInstanceId = appInstanceId,
-        processor = processor,
+    return WsServerAuthentication(
+        context =
+            WsAuthenticationContext(
+                sessionId = challenge.sessionId,
+                localAppInstanceId = appInfo.appInstanceId,
+                remoteAppInstanceId = appInstanceId,
+                processor = processor,
+            ),
+        remotePairingVersion = proof.pairingVersion,
     )
 }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/ReceivedWsEnvelope.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/ReceivedWsEnvelope.kt
@@ -19,9 +19,7 @@ suspend fun receiveWsEnvelope(incoming: ReceiveChannel<Frame>): ReceivedWsEnvelo
                 val header = json.decodeFromString<WsEnvelopeHeader>(frame.readText())
                 val payload =
                     if (header.hasPayload) {
-                        val payloadFrame = incoming.receiveCatching().getOrNull()
-                        require(payloadFrame is Frame.Binary) { "Expected binary WebSocket payload" }
-                        payloadFrame.readBytes()
+                        receiveChunkedPayload(incoming, header.payloadChunkCount)
                     } else {
                         byteArrayOf()
                     }
@@ -41,4 +39,33 @@ suspend fun receiveWsEnvelope(incoming: ReceiveChannel<Frame>): ReceivedWsEnvelo
             else -> Unit
         }
     }
+}
+
+private suspend fun receiveChunkedPayload(
+    incoming: ReceiveChannel<Frame>,
+    chunkCount: Int,
+): ByteArray {
+    require(chunkCount in 1..WS_MAX_PAYLOAD_CHUNK_COUNT) {
+        "Invalid WebSocket payload chunk count: $chunkCount"
+    }
+    val chunks = ArrayList<ByteArray>(chunkCount)
+    var totalSize = 0L
+    repeat(chunkCount) {
+        val payloadFrame = incoming.receiveCatching().getOrNull()
+        require(payloadFrame is Frame.Binary) { "Expected binary WebSocket payload" }
+        val bytes = payloadFrame.readBytes()
+        totalSize += bytes.size
+        require(totalSize <= WS_MAX_PAYLOAD_SIZE) {
+            "WebSocket payload exceeds $WS_MAX_PAYLOAD_SIZE bytes"
+        }
+        chunks.add(bytes)
+    }
+    if (chunks.size == 1) return chunks[0]
+    val payload = ByteArray(totalSize.toInt())
+    var offset = 0
+    for (chunk in chunks) {
+        chunk.copyInto(payload, offset)
+        offset += chunk.size
+    }
+    return payload
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsAuthentication.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsAuthentication.kt
@@ -8,17 +8,34 @@ import kotlin.time.Duration.Companion.seconds
 
 internal val WS_AUTHENTICATION_TIMEOUT = 5.seconds
 
+/**
+ * [pairingVersion] on the challenge (server → client) and proof (client →
+ * server) is each side's advertised pairing version (AppInfo.pairingVersion);
+ * a peer advertising >= 3 accepts chunked envelope payloads. The field is
+ * deliberately NOT part of the handshake MAC ([WsAuthenticationCodec] canonical
+ * fields are frozen for legacy compatibility): a tampered or stripped value can
+ * only downgrade to single-frame or break the connection, never alter accepted
+ * data — every envelope payload carries its own authentication code.
+ */
 @Serializable
 data class WsAuthChallenge(
     val sessionId: String,
     @Serializable(with = Base64ByteArraySerializer::class)
     val nonce: ByteArray,
+    val pairingVersion: Int? = null,
 )
 
 @Serializable
 data class WsAuthProof(
     @Serializable(with = Base64ByteArraySerializer::class)
     val authenticationCode: ByteArray,
+    val pairingVersion: Int? = null,
+)
+
+/** Result of the server-side WebSocket handshake: the MAC context plus what the peer advertised. */
+data class WsServerAuthentication(
+    val context: WsAuthenticationContext,
+    val remotePairingVersion: Int?,
 )
 
 class WsAuthenticationContext(

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsClientConnector.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.net.ws
 
 import com.crosspaste.app.AppInfo
+import com.crosspaste.net.SyncApi
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
@@ -60,6 +61,7 @@ class WsClientConnector(
                                 challenge = challenge,
                             ),
                         ),
+                        pairingVersion = appInfo.pairingVersion,
                     )
                 rawSession.sendEnvelope(
                     WsEnvelope(
@@ -94,7 +96,13 @@ class WsClientConnector(
                         processor = processor,
                     )
                 logger.info { "Authenticated WebSocket connected to $targetAppInstanceId at $host:$port" }
-                val wsSession = WsSession(this, targetAppInstanceId, authenticationContext)
+                val wsSession =
+                    WsSession(
+                        this,
+                        targetAppInstanceId,
+                        authenticationContext,
+                        peerSupportsChunkedPayload = SyncApi.supportsPairingV3(challenge.pairingVersion),
+                    )
                 wsSessionManager.registerSession(targetAppInstanceId, wsSession)
 
                 try {

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
@@ -7,11 +7,12 @@ import kotlinx.serialization.Serializable
  * Upper bound for a single WebSocket frame. Native pairing v2 intentionally
  * keeps its 1 MiB WebSocket payload contract even when a particular client
  * implementation can receive a larger frame; native file bytes use the HTTPS
- * pull/push path and are not constrained by this WebSocket limit. Pairing v3
- * raises the logical-message limit through negotiated chunking rather than a
- * larger frame. A frame over the receiver's limit does not just drop that
- * message — Ktor tears down the whole connection (1009 TOO_BIG) while the
- * sender's local write still succeeds.
+ * pull/push path, and the WebSocket file-pull fallback stays within this
+ * limit by serving 1 MiB chunks. Pairing v3 raises the logical-message limit
+ * through negotiated chunking rather than a larger frame. A frame over the
+ * receiver's limit does not just drop that message — Ktor tears down the
+ * whole connection (1009 TOO_BIG) while the sender's local write still
+ * succeeds.
  */
 const val WS_MAX_FRAME_SIZE: Long = 1024L * 1024
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
@@ -4,8 +4,47 @@ import com.crosspaste.serializer.Base64ByteArraySerializer
 import kotlinx.serialization.Serializable
 
 /**
+ * Upper bound for a single WebSocket frame. Unchanged from the legacy protocol
+ * so that peers that predate chunked payload transfer keep interoperating:
+ * a frame over the receiver's limit does not just drop that message — Ktor
+ * tears down the whole connection (1009 TOO_BIG) while the sender's local
+ * write still succeeds.
+ */
+const val WS_MAX_FRAME_SIZE: Long = 1024L * 1024
+
+/**
+ * Size of each Binary frame when a payload is sent chunked. Matches
+ * [WS_MAX_FRAME_SIZE] exactly — Ktor's receive check is strictly
+ * greater-than, the same boundary FilePullService's 1 MiB chunks already
+ * rely on. Keeping frames small also lets ping/pong interleave between
+ * chunks, so heartbeats are not starved during a large transfer on a slow
+ * link.
+ */
+const val WS_PAYLOAD_CHUNK_SIZE: Int = 1024 * 1024
+
+/**
+ * Upper bound for a complete (reassembled) payload. Sized as 2x the largest
+ * configurable non-file paste (maxNonFilePasteSize, capped at 64 MiB in
+ * settings) to cover typical JSON string escaping plus encryption overhead;
+ * pathological escaping (control-character-heavy content inflates up to 6x)
+ * can still exceed it, in which case the sender guard fails the push cleanly.
+ */
+const val WS_MAX_PAYLOAD_SIZE: Long = 128L * 1024 * 1024
+
+/** Maximum accepted [WsEnvelopeHeader.payloadChunkCount], derived from the two limits above. */
+const val WS_MAX_PAYLOAD_CHUNK_COUNT: Int = (WS_MAX_PAYLOAD_SIZE / WS_PAYLOAD_CHUNK_SIZE).toInt()
+
+/**
  * Wire header sent as a Text frame (JSON).
- * When [hasPayload] is true, the next frame MUST be a Binary frame containing the payload bytes.
+ * When [hasPayload] is true, the next [payloadChunkCount] frames MUST be Binary
+ * frames whose concatenation is the payload bytes.
+ *
+ * [payloadChunkCount] > 1 may only be sent to a peer that advertised pairing
+ * version >= 3 during the WebSocket authentication handshake; legacy peers
+ * ignore the field (ignoreUnknownKeys) and always receive a single Binary
+ * frame. The count is not covered by the per-message authentication code, but
+ * tampering with it only desynchronizes reassembly, which the payload MAC then
+ * rejects — it cannot alter accepted data.
  */
 @Serializable
 data class WsEnvelopeHeader(
@@ -17,6 +56,7 @@ data class WsEnvelopeHeader(
     val authSequence: Long? = null,
     @Serializable(with = Base64ByteArraySerializer::class)
     val authenticationCode: ByteArray? = null,
+    val payloadChunkCount: Int = 1,
 )
 
 /**

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsMessage.kt
@@ -4,11 +4,14 @@ import com.crosspaste.serializer.Base64ByteArraySerializer
 import kotlinx.serialization.Serializable
 
 /**
- * Upper bound for a single WebSocket frame. Unchanged from the legacy protocol
- * so that peers that predate chunked payload transfer keep interoperating:
- * a frame over the receiver's limit does not just drop that message — Ktor
- * tears down the whole connection (1009 TOO_BIG) while the sender's local
- * write still succeeds.
+ * Upper bound for a single WebSocket frame. Native pairing v2 intentionally
+ * keeps its 1 MiB WebSocket payload contract even when a particular client
+ * implementation can receive a larger frame; native file bytes use the HTTPS
+ * pull/push path and are not constrained by this WebSocket limit. Pairing v3
+ * raises the logical-message limit through negotiated chunking rather than a
+ * larger frame. A frame over the receiver's limit does not just drop that
+ * message — Ktor tears down the whole connection (1009 TOO_BIG) while the
+ * sender's local write still succeeds.
  */
 const val WS_MAX_FRAME_SIZE: Long = 1024L * 1024
 

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
@@ -13,16 +13,21 @@ import kotlin.coroutines.cancellation.CancellationException
  * Provides a simple send/close/isActive API for WsSessionManager.
  *
  * Wire protocol: each logical message is sent as 1 Text frame (JSON header)
- * followed by 0 or 1 Binary frames (payload). A [Mutex] guarantees atomicity
- * for these data-frame pairs so concurrent senders cannot interleave them.
- * Control frames (ping) are single frames and bypass the mutex — RFC 6455
- * permits control frames to be injected between data frames, and Ktor handles
- * pong replies internally so they are invisible to the application stream.
+ * followed by 0..n Binary frames (payload). Payloads larger than
+ * [WS_PAYLOAD_CHUNK_SIZE] are split into multiple Binary frames only when the
+ * peer advertised support during the authentication handshake
+ * ([peerSupportsChunkedPayload]); otherwise the payload is always a single
+ * frame. A [Mutex] guarantees atomicity for these data-frame sequences so
+ * concurrent senders cannot interleave them. Control frames (ping) are single
+ * frames and bypass the mutex — RFC 6455 permits control frames to be injected
+ * between data frames, and Ktor handles pong replies internally so they are
+ * invisible to the application stream.
  */
 class WsSession(
     private val session: WebSocketSession,
     val remoteAppInstanceId: String,
     private val authenticationContext: WsAuthenticationContext? = null,
+    val peerSupportsChunkedPayload: Boolean = false,
 ) {
     private val json = getJsonUtils().JSON
     private val sendMutex = Mutex()
@@ -32,10 +37,27 @@ class WsSession(
 
     suspend fun sendEnvelope(envelope: WsEnvelope) {
         sendMutex.withLock {
-            val header = authenticationContext?.createHeader(envelope) ?: envelope.toHeader()
+            val payload = envelope.payload
+            val chunkCount =
+                if (peerSupportsChunkedPayload && payload.size > WS_PAYLOAD_CHUNK_SIZE) {
+                    (payload.size + WS_PAYLOAD_CHUNK_SIZE - 1) / WS_PAYLOAD_CHUNK_SIZE
+                } else {
+                    1
+                }
+            val baseHeader = authenticationContext?.createHeader(envelope) ?: envelope.toHeader()
+            val header =
+                if (chunkCount > 1) baseHeader.copy(payloadChunkCount = chunkCount) else baseHeader
             session.send(Frame.Text(json.encodeToString(header)))
-            if (envelope.payload.isNotEmpty()) {
-                session.send(Frame.Binary(true, envelope.payload))
+            if (payload.isEmpty()) return@withLock
+            if (chunkCount == 1) {
+                session.send(Frame.Binary(true, payload))
+            } else {
+                var offset = 0
+                while (offset < payload.size) {
+                    val end = minOf(offset + WS_PAYLOAD_CHUNK_SIZE, payload.size)
+                    session.send(Frame.Binary(true, payload.copyOfRange(offset, end)))
+                    offset = end
+                }
             }
         }
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSession.kt
@@ -8,6 +8,18 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.cancellation.CancellationException
 
+sealed interface WsPayloadSendResult {
+
+    data object Sent : WsPayloadSendResult
+
+    data object Failed : WsPayloadSendResult
+
+    data class PayloadTooLarge(
+        val payloadSize: Int,
+        val payloadLimit: Long,
+    ) : WsPayloadSendResult
+}
+
 /**
  * Unified wrapper around Ktor WebSocket sessions (server or client).
  * Provides a simple send/close/isActive API for WsSessionManager.
@@ -37,27 +49,51 @@ class WsSession(
 
     suspend fun sendEnvelope(envelope: WsEnvelope) {
         sendMutex.withLock {
-            val payload = envelope.payload
-            val chunkCount =
-                if (peerSupportsChunkedPayload && payload.size > WS_PAYLOAD_CHUNK_SIZE) {
-                    (payload.size + WS_PAYLOAD_CHUNK_SIZE - 1) / WS_PAYLOAD_CHUNK_SIZE
+            sendEnvelopeLocked(envelope)
+        }
+    }
+
+    /** Selects the negotiated limit and sends while holding this session's send lock. */
+    suspend fun sendEnvelopeWithPayloadLimits(
+        envelope: WsEnvelope,
+        singleFramePayloadLimit: Long,
+        chunkedPayloadLimit: Long,
+    ): WsPayloadSendResult =
+        sendMutex.withLock {
+            val payloadLimit =
+                if (peerSupportsChunkedPayload) {
+                    chunkedPayloadLimit
                 } else {
-                    1
+                    singleFramePayloadLimit
                 }
-            val baseHeader = authenticationContext?.createHeader(envelope) ?: envelope.toHeader()
-            val header =
-                if (chunkCount > 1) baseHeader.copy(payloadChunkCount = chunkCount) else baseHeader
-            session.send(Frame.Text(json.encodeToString(header)))
-            if (payload.isEmpty()) return@withLock
-            if (chunkCount == 1) {
-                session.send(Frame.Binary(true, payload))
+            if (envelope.payload.size > payloadLimit) {
+                return@withLock WsPayloadSendResult.PayloadTooLarge(envelope.payload.size, payloadLimit)
+            }
+            sendEnvelopeLocked(envelope)
+            WsPayloadSendResult.Sent
+        }
+
+    private suspend fun sendEnvelopeLocked(envelope: WsEnvelope) {
+        val payload = envelope.payload
+        val chunkCount =
+            if (peerSupportsChunkedPayload && payload.size > WS_PAYLOAD_CHUNK_SIZE) {
+                (payload.size + WS_PAYLOAD_CHUNK_SIZE - 1) / WS_PAYLOAD_CHUNK_SIZE
             } else {
-                var offset = 0
-                while (offset < payload.size) {
-                    val end = minOf(offset + WS_PAYLOAD_CHUNK_SIZE, payload.size)
-                    session.send(Frame.Binary(true, payload.copyOfRange(offset, end)))
-                    offset = end
-                }
+                1
+            }
+        val baseHeader = authenticationContext?.createHeader(envelope) ?: envelope.toHeader()
+        val header =
+            if (chunkCount > 1) baseHeader.copy(payloadChunkCount = chunkCount) else baseHeader
+        session.send(Frame.Text(json.encodeToString(header)))
+        if (payload.isEmpty()) return
+        if (chunkCount == 1) {
+            session.send(Frame.Binary(true, payload))
+        } else {
+            var offset = 0
+            while (offset < payload.size) {
+                val end = minOf(offset + WS_PAYLOAD_CHUNK_SIZE, payload.size)
+                session.send(Frame.Binary(true, payload.copyOfRange(offset, end)))
+                offset = end
             }
         }
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
@@ -49,6 +49,9 @@ class WsSessionManager {
 
     fun isConnected(appInstanceId: String): Boolean = sessions[appInstanceId]?.isActive == true
 
+    fun supportsChunkedPayload(appInstanceId: String): Boolean =
+        sessions[appInstanceId]?.peerSupportsChunkedPayload == true
+
     suspend fun probe(appInstanceId: String): Boolean {
         val session = sessions[appInstanceId] ?: return false
         if (!session.isActive) {

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
@@ -94,4 +94,28 @@ class WsSessionManager {
             notifySessionClosed(appInstanceId, session)
         }.getOrDefault(false)
     }
+
+    /**
+     * Validates and sends against the same session snapshot. Keeping these
+     * operations together prevents a reconnect from replacing a chunk-capable
+     * session with a legacy session between capability inspection and send.
+     */
+    suspend fun sendWithPayloadLimits(
+        appInstanceId: String,
+        envelope: WsEnvelope,
+        singleFramePayloadLimit: Long,
+        chunkedPayloadLimit: Long,
+    ): WsPayloadSendResult {
+        val session = sessions[appInstanceId] ?: return WsPayloadSendResult.Failed
+        return runCatching {
+            session.sendEnvelopeWithPayloadLimits(
+                envelope = envelope,
+                singleFramePayloadLimit = singleFramePayloadLimit,
+                chunkedPayloadLimit = chunkedPayloadLimit,
+            )
+        }.onFailure { e ->
+            logger.warn(e) { "WebSocket send failed for $appInstanceId" }
+            notifySessionClosed(appInstanceId, session)
+        }.getOrDefault(WsPayloadSendResult.Failed)
+    }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -17,6 +17,8 @@ import com.crosspaste.net.clientapi.PasteClientApi
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.createFailureResult
 import com.crosspaste.net.filter
+import com.crosspaste.net.ws.WS_MAX_FRAME_SIZE
+import com.crosspaste.net.ws.WS_MAX_PAYLOAD_SIZE
 import com.crosspaste.net.ws.WsEnvelope
 import com.crosspaste.net.ws.WsMessageType
 import com.crosspaste.net.ws.WsSessionManager
@@ -46,6 +48,8 @@ class SyncPasteTaskExecutor(
     private val secureStore: SecureStore,
     private val syncManager: SyncManager,
     private val wsSessionManager: WsSessionManager,
+    private val wsSingleFramePayloadLimit: Long = WS_MAX_FRAME_SIZE,
+    private val wsChunkedPayloadLimit: Long = WS_MAX_PAYLOAD_SIZE,
 ) : SingleTypeTaskExecutor {
 
     private val logger = KotlinLogging.logger {}
@@ -228,7 +232,7 @@ class SyncPasteTaskExecutor(
 
         // 1. Extension targets always use WebSocket
         if (syncRuntimeInfo.platform.isExtension()) {
-            return trySendViaWebSocket(targetAppInstanceId, pasteData)
+            return trySendViaWebSocket(targetAppInstanceId, pasteData, isExtensionTarget = true)
                 ?: createFailureResult(
                     StandardErrorCode.SYNC_PASTE_ERROR,
                     "WebSocket send failed for extension $handlerKey",
@@ -248,7 +252,7 @@ class SyncPasteTaskExecutor(
         }
 
         // 3. No host address — fall back to WebSocket
-        return trySendViaWebSocket(targetAppInstanceId, pasteData)
+        return trySendViaWebSocket(targetAppInstanceId, pasteData, isExtensionTarget = false)
             ?: createFailureResult(
                 StandardErrorCode.CANT_GET_SYNC_ADDRESS,
                 "Failed to get connect host address by $handlerKey and WebSocket unavailable",
@@ -258,6 +262,7 @@ class SyncPasteTaskExecutor(
     private suspend fun trySendViaWebSocket(
         targetAppInstanceId: String,
         pasteData: PasteData,
+        isExtensionTarget: Boolean,
     ): ClientApiResult? =
         runCatching {
             val jsonBytes = getJsonUtils().JSON.encodeToString(pasteData).encodeToByteArray()
@@ -268,6 +273,29 @@ class SyncPasteTaskExecutor(
                 } else {
                     jsonBytes
                 }
+            // A payload the receiver cannot accept is never delivered — an oversized
+            // frame makes the receiver tear down the whole connection (1009 TOO_BIG)
+            // while the local write still succeeds — so fail definitively instead of
+            // reporting success. Peers that advertised chunked-payload support take
+            // the message-level cap; legacy native peers are bound by their 1 MiB
+            // receive frame limit. Extension targets are browser clients on loopback
+            // with no receive frame cap, so only the message-level cap applies.
+            val payloadLimit =
+                if (isExtensionTarget || wsSessionManager.supportsChunkedPayload(targetAppInstanceId)) {
+                    wsChunkedPayloadLimit
+                } else {
+                    wsSingleFramePayloadLimit
+                }
+            if (payload.size > payloadLimit) {
+                logger.warn {
+                    "WS paste push to $targetAppInstanceId rejected: " +
+                        "payload ${payload.size} bytes exceeds limit $payloadLimit"
+                }
+                return createFailureResult(
+                    StandardErrorCode.SYNC_PASTE_ERROR,
+                    "Paste payload ${payload.size} bytes exceeds WebSocket limit for $targetAppInstanceId",
+                )
+            }
             val envelope =
                 WsEnvelope(
                     type = WsMessageType.PASTE_PUSH,

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -21,6 +21,7 @@ import com.crosspaste.net.ws.WS_MAX_FRAME_SIZE
 import com.crosspaste.net.ws.WS_MAX_PAYLOAD_SIZE
 import com.crosspaste.net.ws.WsEnvelope
 import com.crosspaste.net.ws.WsMessageType
+import com.crosspaste.net.ws.WsPayloadSendResult
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteType
@@ -273,39 +274,42 @@ class SyncPasteTaskExecutor(
                 } else {
                     jsonBytes
                 }
-            // A payload the receiver cannot accept is never delivered — an oversized
-            // frame makes the receiver tear down the whole connection (1009 TOO_BIG)
-            // while the local write still succeeds — so fail definitively instead of
-            // reporting success. Peers that advertised chunked-payload support take
-            // the message-level cap; legacy native peers are bound by their 1 MiB
-            // receive frame limit. Extension targets are browser clients on loopback
-            // with no receive frame cap, so only the message-level cap applies.
-            val payloadLimit =
-                if (isExtensionTarget || wsSessionManager.supportsChunkedPayload(targetAppInstanceId)) {
-                    wsChunkedPayloadLimit
-                } else {
-                    wsSingleFramePayloadLimit
-                }
-            if (payload.size > payloadLimit) {
-                logger.warn {
-                    "WS paste push to $targetAppInstanceId rejected: " +
-                        "payload ${payload.size} bytes exceeds limit $payloadLimit"
-                }
-                return createFailureResult(
-                    StandardErrorCode.SYNC_PASTE_ERROR,
-                    "Paste payload ${payload.size} bytes exceeds WebSocket limit for $targetAppInstanceId",
-                )
-            }
             val envelope =
                 WsEnvelope(
                     type = WsMessageType.PASTE_PUSH,
                     payload = payload,
                     encrypted = encrypt,
                 )
-            if (wsSessionManager.send(targetAppInstanceId, envelope)) {
-                SuccessResult()
-            } else {
-                null // WebSocket send failed, fall back to HTTP
+            // Native pairing v2 deliberately keeps the 1 MiB WebSocket payload
+            // contract; file bytes use HTTPS. Pairing v3 opts into the larger
+            // logical-message cap through chunking. Extension clients remain
+            // single-frame but use the browser-compatible message cap. The
+            // manager selects the limit and sends through one session snapshot,
+            // so a reconnect cannot change capability between those operations.
+            val singleFramePayloadLimit =
+                if (isExtensionTarget) wsChunkedPayloadLimit else wsSingleFramePayloadLimit
+            when (
+                val sendResult =
+                    wsSessionManager.sendWithPayloadLimits(
+                        appInstanceId = targetAppInstanceId,
+                        envelope = envelope,
+                        singleFramePayloadLimit = singleFramePayloadLimit,
+                        chunkedPayloadLimit = wsChunkedPayloadLimit,
+                    )
+            ) {
+                WsPayloadSendResult.Sent -> SuccessResult()
+                WsPayloadSendResult.Failed -> null // WebSocket send failed, fall back to HTTP
+                is WsPayloadSendResult.PayloadTooLarge -> {
+                    logger.warn {
+                        "WS paste push to $targetAppInstanceId rejected: " +
+                            "payload ${sendResult.payloadSize} bytes exceeds limit ${sendResult.payloadLimit}"
+                    }
+                    createFailureResult(
+                        StandardErrorCode.SYNC_PASTE_ERROR,
+                        "Paste payload ${sendResult.payloadSize} bytes exceeds " +
+                            "WebSocket limit for $targetAppInstanceId",
+                    )
+                }
             }
         }.onFailure { e ->
             logger.warn(e) { "WebSocket paste send failed for $targetAppInstanceId, falling back to HTTP" }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -39,6 +39,7 @@ import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.exception.DesktopExceptionHandler
 import com.crosspaste.net.exception.ExceptionHandler
 import com.crosspaste.net.routing.SyncRoutingApi
+import com.crosspaste.net.ws.WS_MAX_PAYLOAD_SIZE
 import com.crosspaste.net.ws.WsClientConnector
 import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsPendingRequests
@@ -196,6 +197,11 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 HttpClient(CIO) {
                     install(WebSockets) {
                         pingIntervalMillis = 30_000
+                        // Message-level cap, not the 1 MiB frame limit: legacy peers
+                        // may still push a whole paste as one oversized frame, which
+                        // must keep being deliverable, but the buffer a paired peer
+                        // can force into memory has to stay bounded.
+                        maxFrameSize = WS_MAX_PAYLOAD_SIZE
                     }
                 }
             WsClientConnector(

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -197,10 +197,11 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 HttpClient(CIO) {
                     install(WebSockets) {
                         pingIntervalMillis = 30_000
-                        // Message-level cap, not the 1 MiB frame limit: legacy peers
-                        // may still push a whole paste as one oversized frame, which
-                        // must keep being deliverable, but the buffer a paired peer
-                        // can force into memory has to stay bounded.
+                        // Receive-side compatibility cap, not an expansion of the
+                        // native pairing v2 send contract: legacy peers may still
+                        // push a whole paste as one oversized frame, which must keep
+                        // being deliverable, but the buffer a paired peer can force
+                        // into memory has to stay bounded.
                         maxFrameSize = WS_MAX_PAYLOAD_SIZE
                     }
                 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationIntegrationTest.kt
@@ -194,12 +194,157 @@ class WsAuthenticationIntegrationTest {
             }
         }
 
-    private fun appInfo(id: String): AppInfo =
+    @Test
+    fun `pairing v3 peers negotiate chunked payload and round-trip a large envelope`() =
+        runBlocking {
+            val serializer = SecureKeyPairSerializer()
+            val serverKeys = CryptographyUtils.generateSecureKeyPair()
+            val clientKeys = CryptographyUtils.generateSecureKeyPair()
+            val serverStore = GeneralSecureStore(serverKeys, serializer, MemorySecureIO())
+            val clientStore = GeneralSecureStore(clientKeys, serializer, MemorySecureIO())
+            val serverInfo = appInfo("chunk-server", pairingVersion = 3)
+            val clientInfo = appInfo("chunk-client", pairingVersion = 3)
+            serverStore.saveCryptPublicKey(
+                clientInfo.appInstanceId,
+                serializer.encodeCryptPublicKey(clientKeys.cryptKeyPair.publicKey),
+            )
+            clientStore.saveCryptPublicKey(
+                serverInfo.appInstanceId,
+                serializer.encodeCryptPublicKey(serverKeys.cryptKeyPair.publicKey),
+            )
+
+            val serverSessions = WsSessionManager()
+            val clientSessions = WsSessionManager()
+            val serverHandler = mockk<WsMessageHandler>(relaxed = true)
+            val clientHandler = mockk<WsMessageHandler>(relaxed = true)
+            val server =
+                DesktopPasteServer(
+                    TestReadWritePort(),
+                    DesktopExceptionHandler(),
+                    DesktopServerFactory(),
+                    AuthenticatedWsServerModule(serverInfo, serverStore, serverSessions, serverHandler),
+                )
+            val httpClient = HttpClient(CIO) { install(WebSockets) }
+            val connector =
+                WsClientConnector(
+                    appInfo = clientInfo,
+                    client = httpClient,
+                    secureStore = clientStore,
+                    wsSessionManager = clientSessions,
+                    wsMessageHandler = clientHandler,
+                )
+
+            try {
+                server.start()
+                connector.connectAsync("127.0.0.1", server.port(), serverInfo.appInstanceId)
+                withTimeout(5.seconds) {
+                    while (!clientSessions.isConnected(serverInfo.appInstanceId) ||
+                        !serverSessions.isConnected(clientInfo.appInstanceId)
+                    ) {
+                        delay(10.milliseconds)
+                    }
+                }
+
+                assertTrue(clientSessions.supportsChunkedPayload(serverInfo.appInstanceId))
+                assertTrue(serverSessions.supportsChunkedPayload(clientInfo.appInstanceId))
+
+                // Larger than the server's 1 MiB receive frame limit — only
+                // deliverable when actually split into chunked frames
+                val payload = ByteArray(WS_PAYLOAD_CHUNK_SIZE * 2 + 12345) { (it % 251).toByte() }
+                assertTrue(
+                    clientSessions.send(
+                        serverInfo.appInstanceId,
+                        WsEnvelope(type = "chunk-test", payload = payload),
+                    ),
+                )
+                coVerify(timeout = 10_000) {
+                    serverHandler.handleMessage(
+                        clientInfo.appInstanceId,
+                        match { it.type == "chunk-test" && it.payload.contentEquals(payload) },
+                    )
+                }
+            } finally {
+                clientSessions.closeAll()
+                serverSessions.closeAll()
+                httpClient.close()
+                server.stop()
+            }
+        }
+
+    @Test
+    fun `peers without pairing v3 stay single-frame`() =
+        runBlocking {
+            val serializer = SecureKeyPairSerializer()
+            val serverKeys = CryptographyUtils.generateSecureKeyPair()
+            val clientKeys = CryptographyUtils.generateSecureKeyPair()
+            val serverStore = GeneralSecureStore(serverKeys, serializer, MemorySecureIO())
+            val clientStore = GeneralSecureStore(clientKeys, serializer, MemorySecureIO())
+            val serverInfo = appInfo("legacy-frame-server")
+            val clientInfo = appInfo("legacy-frame-client")
+            serverStore.saveCryptPublicKey(
+                clientInfo.appInstanceId,
+                serializer.encodeCryptPublicKey(clientKeys.cryptKeyPair.publicKey),
+            )
+            clientStore.saveCryptPublicKey(
+                serverInfo.appInstanceId,
+                serializer.encodeCryptPublicKey(serverKeys.cryptKeyPair.publicKey),
+            )
+
+            val serverSessions = WsSessionManager()
+            val clientSessions = WsSessionManager()
+            val server =
+                DesktopPasteServer(
+                    TestReadWritePort(),
+                    DesktopExceptionHandler(),
+                    DesktopServerFactory(),
+                    AuthenticatedWsServerModule(
+                        serverInfo,
+                        serverStore,
+                        serverSessions,
+                        mockk(relaxed = true),
+                    ),
+                )
+            val httpClient = HttpClient(CIO) { install(WebSockets) }
+            val connector =
+                WsClientConnector(
+                    appInfo = clientInfo,
+                    client = httpClient,
+                    secureStore = clientStore,
+                    wsSessionManager = clientSessions,
+                    wsMessageHandler = mockk(relaxed = true),
+                )
+
+            try {
+                server.start()
+                connector.connectAsync("127.0.0.1", server.port(), serverInfo.appInstanceId)
+                withTimeout(5.seconds) {
+                    while (!clientSessions.isConnected(serverInfo.appInstanceId) ||
+                        !serverSessions.isConnected(clientInfo.appInstanceId)
+                    ) {
+                        delay(10.milliseconds)
+                    }
+                }
+
+                assertTrue(!clientSessions.supportsChunkedPayload(serverInfo.appInstanceId))
+                assertTrue(!serverSessions.supportsChunkedPayload(clientInfo.appInstanceId))
+            } finally {
+                clientSessions.closeAll()
+                serverSessions.closeAll()
+                httpClient.close()
+                server.stop()
+            }
+        }
+
+    private fun appInfo(
+        id: String,
+        pairingVersion: Int? = null,
+    ): AppInfo =
         AppInfo(
             appInstanceId = id,
             appVersion = "test",
             appRevision = "test",
             userName = id,
+            pairingVersion = pairingVersion,
         )
 }
 
@@ -211,7 +356,9 @@ private class AuthenticatedWsServerModule(
 ) : ServerModule {
     override fun installModules(): Application.() -> Unit =
         {
-            install(io.ktor.server.websocket.WebSockets)
+            install(io.ktor.server.websocket.WebSockets) {
+                maxFrameSize = WS_MAX_FRAME_SIZE
+            }
             routing {
                 wsRouting(appInfo, secureStore, sessionManager, messageHandler)
             }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsChunkedPayloadTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsChunkedPayloadTest.kt
@@ -1,0 +1,145 @@
+package com.crosspaste.net.ws
+
+import io.ktor.websocket.Frame
+import io.ktor.websocket.WebSocketSession
+import io.ktor.websocket.readBytes
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class WsChunkedPayloadTest {
+
+    private fun sessionOver(channel: Channel<Frame>): WebSocketSession =
+        mockk<WebSocketSession> {
+            coEvery { send(any()) } coAnswers { channel.send(firstArg()) }
+        }
+
+    private suspend fun drainFrames(channel: Channel<Frame>): List<Frame> {
+        val frames = mutableListOf<Frame>()
+        while (true) {
+            frames.add(channel.tryReceive().getOrNull() ?: break)
+        }
+        return frames
+    }
+
+    @Test
+    fun chunkCapablePeer_largePayload_roundTripsAcrossChunks() =
+        runTest {
+            val channel = Channel<Frame>(Channel.UNLIMITED)
+            val wsSession = WsSession(sessionOver(channel), "peer", peerSupportsChunkedPayload = true)
+            val payload = ByteArray(WS_PAYLOAD_CHUNK_SIZE * 2 + 123) { (it % 251).toByte() }
+
+            wsSession.sendEnvelope(WsEnvelope(type = WsMessageType.PASTE_PUSH, payload = payload))
+            channel.close()
+
+            val received = receiveWsEnvelope(channel)
+
+            assertNotNull(received)
+            assertEquals(3, received.header.payloadChunkCount)
+            assertContentEquals(payload, received.envelope.payload)
+        }
+
+    @Test
+    fun chunkCapablePeer_smallPayload_staysSingleFrame() =
+        runTest {
+            val channel = Channel<Frame>(Channel.UNLIMITED)
+            val wsSession = WsSession(sessionOver(channel), "peer", peerSupportsChunkedPayload = true)
+            val payload = ByteArray(1024) { it.toByte() }
+
+            wsSession.sendEnvelope(WsEnvelope(type = WsMessageType.PASTE_PUSH, payload = payload))
+            channel.close()
+
+            val frames = drainFrames(channel)
+
+            assertEquals(2, frames.size)
+            val binary = frames[1]
+            assertContentEquals(payload, (binary as Frame.Binary).readBytes())
+        }
+
+    @Test
+    fun legacyPeer_largePayload_staysSingleFrame() =
+        runTest {
+            val channel = Channel<Frame>(Channel.UNLIMITED)
+            val wsSession = WsSession(sessionOver(channel), "peer", peerSupportsChunkedPayload = false)
+            val payload = ByteArray(WS_PAYLOAD_CHUNK_SIZE + 1)
+
+            wsSession.sendEnvelope(WsEnvelope(type = WsMessageType.PASTE_PUSH, payload = payload))
+            channel.close()
+
+            val frames = drainFrames(channel)
+
+            assertEquals(2, frames.size)
+            assertEquals(payload.size, (frames[1] as Frame.Binary).readBytes().size)
+        }
+
+    @Test
+    fun legacyHeaderWithoutChunkCount_decodesAsSingleChunk() =
+        runTest {
+            val channel = Channel<Frame>(Channel.UNLIMITED)
+            channel.send(Frame.Text("""{"type":"paste_push","hasPayload":true}"""))
+            channel.send(Frame.Binary(true, byteArrayOf(1, 2, 3)))
+            channel.close()
+
+            val received = receiveWsEnvelope(channel)
+
+            assertNotNull(received)
+            assertEquals(1, received.header.payloadChunkCount)
+            assertContentEquals(byteArrayOf(1, 2, 3), received.envelope.payload)
+        }
+
+    @Test
+    fun zeroChunkCount_isRejected() =
+        runTest {
+            val channel = Channel<Frame>(Channel.UNLIMITED)
+            channel.send(Frame.Text("""{"type":"paste_push","hasPayload":true,"payloadChunkCount":0}"""))
+            channel.close()
+
+            assertFailsWith<IllegalArgumentException> { receiveWsEnvelope(channel) }
+        }
+
+    @Test
+    fun excessiveChunkCount_isRejected() =
+        runTest {
+            val channel = Channel<Frame>(Channel.UNLIMITED)
+            val count = WS_MAX_PAYLOAD_CHUNK_COUNT + 1
+            channel.send(Frame.Text("""{"type":"paste_push","hasPayload":true,"payloadChunkCount":$count}"""))
+            channel.close()
+
+            assertFailsWith<IllegalArgumentException> { receiveWsEnvelope(channel) }
+        }
+
+    @Test
+    fun truncatedChunkSequence_isRejected() =
+        runTest {
+            val channel = Channel<Frame>(Channel.UNLIMITED)
+            channel.send(Frame.Text("""{"type":"paste_push","hasPayload":true,"payloadChunkCount":2}"""))
+            channel.send(Frame.Binary(true, byteArrayOf(1, 2, 3)))
+            channel.close()
+
+            assertFailsWith<IllegalArgumentException> { receiveWsEnvelope(channel) }
+        }
+
+    @Test
+    fun legacyAuthDtosWithoutPairingVersion_decodeAsNull() =
+        runTest {
+            val json =
+                com.crosspaste.utils
+                    .getJsonUtils()
+                    .JSON
+
+            val challenge =
+                json.decodeFromString<WsAuthChallenge>(
+                    """{"sessionId":"abc","nonce":"AAECAw=="}""",
+                )
+            val proof = json.decodeFromString<WsAuthProof>("""{"authenticationCode":"AAECAw=="}""")
+
+            assertEquals(null, challenge.pairingVersion)
+            assertEquals(null, proof.pairingVersion)
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
@@ -209,4 +209,31 @@ class WsSessionManagerTest {
             coVerify(exactly = 1) { inner.send(any<Frame.Text>()) }
             coVerify(exactly = 1) { inner.send(any<Frame.Binary>()) }
         }
+
+    @Test
+    fun sendWithPayloadLimits_chunkCapableSessionRejectsAboveChunkedLimit() =
+        runTest {
+            val mgr = WsSessionManager()
+            val activeJob = Job()
+            val inner: WebSocketSession =
+                mockk(relaxed = true) {
+                    every { coroutineContext } returns activeJob
+                }
+            mgr.registerSession(
+                "A",
+                WsSession(inner, "remote", peerSupportsChunkedPayload = true),
+            )
+            val envelope = WsEnvelope(type = "test", payload = ByteArray(129))
+
+            val result =
+                mgr.sendWithPayloadLimits(
+                    appInstanceId = "A",
+                    envelope = envelope,
+                    singleFramePayloadLimit = 64,
+                    chunkedPayloadLimit = 128,
+                )
+
+            assertEquals(WsPayloadSendResult.PayloadTooLarge(129, 128), result)
+            coVerify(exactly = 0) { inner.send(any<Frame>()) }
+        }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
@@ -4,6 +4,7 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.WebSocketSession
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -155,5 +156,57 @@ class WsSessionManagerTest {
             assertTrue(mgr.probe("A"))
             assertEquals(emptyList(), fired)
             assertTrue(mgr.isConnected("A"))
+        }
+
+    @Test
+    fun sendWithPayloadLimits_legacySessionRejectsAboveSingleFrameLimit() =
+        runTest {
+            val mgr = WsSessionManager()
+            val activeJob = Job()
+            val inner: WebSocketSession =
+                mockk(relaxed = true) {
+                    every { coroutineContext } returns activeJob
+                }
+            mgr.registerSession("A", WsSession(inner, "remote"))
+            val envelope = WsEnvelope(type = "test", payload = ByteArray(65))
+
+            val result =
+                mgr.sendWithPayloadLimits(
+                    appInstanceId = "A",
+                    envelope = envelope,
+                    singleFramePayloadLimit = 64,
+                    chunkedPayloadLimit = 128,
+                )
+
+            assertEquals(WsPayloadSendResult.PayloadTooLarge(65, 64), result)
+            coVerify(exactly = 0) { inner.send(any<Frame>()) }
+        }
+
+    @Test
+    fun sendWithPayloadLimits_chunkCapableSessionUsesChunkedLimitAndSends() =
+        runTest {
+            val mgr = WsSessionManager()
+            val activeJob = Job()
+            val inner: WebSocketSession =
+                mockk(relaxed = true) {
+                    every { coroutineContext } returns activeJob
+                }
+            mgr.registerSession(
+                "A",
+                WsSession(inner, "remote", peerSupportsChunkedPayload = true),
+            )
+            val envelope = WsEnvelope(type = "test", payload = ByteArray(65))
+
+            val result =
+                mgr.sendWithPayloadLimits(
+                    appInstanceId = "A",
+                    envelope = envelope,
+                    singleFramePayloadLimit = 64,
+                    chunkedPayloadLimit = 128,
+                )
+
+            assertEquals(WsPayloadSendResult.Sent, result)
+            coVerify(exactly = 1) { inner.send(any<Frame.Text>()) }
+            coVerify(exactly = 1) { inner.send(any<Frame.Binary>()) }
         }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
@@ -16,6 +16,7 @@ import com.crosspaste.net.clientapi.PasteClientApi
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.ws.WS_MAX_FRAME_SIZE
 import com.crosspaste.net.ws.WS_MAX_PAYLOAD_SIZE
+import com.crosspaste.net.ws.WsPayloadSendResult
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
@@ -429,12 +430,21 @@ class SyncPasteTaskExecutorTest {
 
             coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
             coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
-            coEvery { deps.wsSessionManager.send(any(), any()) } returns true
+            coEvery {
+                deps.wsSessionManager.sendWithPayloadLimits(any(), any(), any(), any())
+            } returns WsPayloadSendResult.Sent
 
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is SuccessPasteTaskResult)
-            coVerify(exactly = 1) { deps.wsSessionManager.send("remote-1", any()) }
+            coVerify(exactly = 1) {
+                deps.wsSessionManager.sendWithPayloadLimits(
+                    "remote-1",
+                    any(),
+                    WS_MAX_FRAME_SIZE,
+                    WS_MAX_PAYLOAD_SIZE,
+                )
+            }
         }
 
     @Test
@@ -447,14 +457,18 @@ class SyncPasteTaskExecutorTest {
 
             val handler = createMockSyncHandler("remote-1", connectHostAddress = null)
 
-            every { deps.wsSessionManager.supportsChunkedPayload("remote-1") } returns false
             coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
             coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+            coEvery {
+                deps.wsSessionManager.sendWithPayloadLimits("remote-1", any(), 64, WS_MAX_PAYLOAD_SIZE)
+            } returns WsPayloadSendResult.PayloadTooLarge(1024, 64)
 
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is FailurePasteTaskResult)
-            coVerify(exactly = 0) { deps.wsSessionManager.send(any(), any()) }
+            coVerify(exactly = 1) {
+                deps.wsSessionManager.sendWithPayloadLimits("remote-1", any(), 64, WS_MAX_PAYLOAD_SIZE)
+            }
         }
 
     @Test
@@ -467,15 +481,18 @@ class SyncPasteTaskExecutorTest {
 
             val handler = createMockSyncHandler("remote-1", connectHostAddress = null)
 
-            every { deps.wsSessionManager.supportsChunkedPayload("remote-1") } returns true
             coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
             coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
-            coEvery { deps.wsSessionManager.send(any(), any()) } returns true
+            coEvery {
+                deps.wsSessionManager.sendWithPayloadLimits("remote-1", any(), 64, WS_MAX_PAYLOAD_SIZE)
+            } returns WsPayloadSendResult.Sent
 
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is SuccessPasteTaskResult)
-            coVerify(exactly = 1) { deps.wsSessionManager.send("remote-1", any()) }
+            coVerify(exactly = 1) {
+                deps.wsSessionManager.sendWithPayloadLimits("remote-1", any(), 64, WS_MAX_PAYLOAD_SIZE)
+            }
         }
 
     @Test
@@ -489,14 +506,18 @@ class SyncPasteTaskExecutorTest {
 
             val handler = createMockSyncHandler("remote-1", connectHostAddress = null)
 
-            every { deps.wsSessionManager.supportsChunkedPayload("remote-1") } returns true
             coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
             coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+            coEvery {
+                deps.wsSessionManager.sendWithPayloadLimits("remote-1", any(), 64, 256)
+            } returns WsPayloadSendResult.PayloadTooLarge(1024, 256)
 
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is FailurePasteTaskResult)
-            coVerify(exactly = 0) { deps.wsSessionManager.send(any(), any()) }
+            coVerify(exactly = 1) {
+                deps.wsSessionManager.sendWithPayloadLimits("remote-1", any(), 64, 256)
+            }
         }
 
     @Test
@@ -514,15 +535,28 @@ class SyncPasteTaskExecutorTest {
                 )
             every { handler.currentSyncRuntimeInfo } returns extensionInfo
 
-            every { deps.wsSessionManager.supportsChunkedPayload("remote-1") } returns false
             coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
             coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
-            coEvery { deps.wsSessionManager.send(any(), any()) } returns true
+            coEvery {
+                deps.wsSessionManager.sendWithPayloadLimits(
+                    "remote-1",
+                    any(),
+                    WS_MAX_PAYLOAD_SIZE,
+                    WS_MAX_PAYLOAD_SIZE,
+                )
+            } returns WsPayloadSendResult.Sent
 
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is SuccessPasteTaskResult)
-            coVerify(exactly = 1) { deps.wsSessionManager.send("remote-1", any()) }
+            coVerify(exactly = 1) {
+                deps.wsSessionManager.sendWithPayloadLimits(
+                    "remote-1",
+                    any(),
+                    WS_MAX_PAYLOAD_SIZE,
+                    WS_MAX_PAYLOAD_SIZE,
+                )
+            }
         }
 
     @Test
@@ -542,10 +576,15 @@ class SyncPasteTaskExecutorTest {
             coEvery { deps.secureStore.getMessageProcessor("remote-1") } returns processor
             coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
             coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+            coEvery {
+                deps.wsSessionManager.sendWithPayloadLimits("remote-1", any(), 1024, WS_MAX_PAYLOAD_SIZE)
+            } returns WsPayloadSendResult.PayloadTooLarge(2048, 1024)
 
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is FailurePasteTaskResult)
-            coVerify(exactly = 0) { deps.wsSessionManager.send(any(), any()) }
+            coVerify(exactly = 1) {
+                deps.wsSessionManager.sendWithPayloadLimits("remote-1", any(), 1024, WS_MAX_PAYLOAD_SIZE)
+            }
         }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
@@ -14,12 +14,20 @@ import com.crosspaste.net.VersionRelation
 import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.PasteClientApi
 import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.net.ws.WS_MAX_FRAME_SIZE
+import com.crosspaste.net.ws.WS_MAX_PAYLOAD_SIZE
 import com.crosspaste.net.ws.WsSessionManager
+import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteState
 import com.crosspaste.paste.PasteType
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.platform.Platform
+import com.crosspaste.secure.SecureMessageProcessor
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.SyncHandler
 import com.crosspaste.sync.SyncManager
+import com.crosspaste.sync.SyncTestFixtures
 import com.crosspaste.sync.SyncTestFixtures.createConnectedSyncRuntimeInfo
 import com.crosspaste.utils.getJsonUtils
 import io.mockk.coEvery
@@ -54,8 +62,9 @@ class SyncPasteTaskExecutorTest {
                 every { isConnected(any()) } returns false
             }
 
+        val config = mockk<AppConfig>(relaxed = true)
+
         init {
-            val config = mockk<AppConfig>(relaxed = true)
             every { config.enableSyncText } returns true
             every { config.enableSyncUrl } returns true
             every { config.enableSyncHtml } returns true
@@ -68,7 +77,10 @@ class SyncPasteTaskExecutorTest {
             coEvery { appControl.isSendEnabled() } returns true
         }
 
-        fun createExecutor(): SyncPasteTaskExecutor =
+        fun createExecutor(
+            wsSingleFramePayloadLimit: Long = WS_MAX_FRAME_SIZE,
+            wsChunkedPayloadLimit: Long = WS_MAX_PAYLOAD_SIZE,
+        ): SyncPasteTaskExecutor =
             SyncPasteTaskExecutor(
                 appControl = appControl,
                 appInfo = appInfo,
@@ -78,6 +90,8 @@ class SyncPasteTaskExecutorTest {
                 secureStore = secureStore,
                 syncManager = syncManager,
                 wsSessionManager = wsSessionManager,
+                wsSingleFramePayloadLimit = wsSingleFramePayloadLimit,
+                wsChunkedPayloadLimit = wsChunkedPayloadLimit,
             )
     }
 
@@ -100,6 +114,21 @@ class SyncPasteTaskExecutorTest {
         val pasteData = mockk<PasteData>(relaxed = true)
         every { pasteData.getType() } returns pasteType
         return pasteData
+    }
+
+    private fun createRealTextPasteData(text: String): PasteData {
+        val textItem = createTextPasteItem(identifiers = listOf("text"), text = text)
+        return PasteData(
+            appInstanceId = "local-app-1",
+            pasteAppearItem = textItem,
+            pasteCollection = PasteCollection(listOf()),
+            pasteType = PasteType.TEXT_TYPE.type,
+            source = null,
+            size = textItem.size,
+            hash = textItem.hash,
+            pasteState = PasteState.LOADED,
+            createTime = 0L,
+        )
     }
 
     private fun createMockSyncHandler(
@@ -384,5 +413,139 @@ class SyncPasteTaskExecutorTest {
             val result = executor.doExecuteTask(task)
 
             assertTrue(result is SuccessPasteTaskResult)
+        }
+
+    // ========== E. WebSocket fallback ==========
+
+    @Test
+    fun doExecuteTask_wsPayloadWithinLimit_sendsViaWebSocket() =
+        runTest {
+            val deps = TestDeps()
+            val executor = deps.createExecutor()
+            val task = createPasteTask()
+            val pasteData = createRealTextPasteData("hello ws")
+
+            val handler = createMockSyncHandler("remote-1", connectHostAddress = null)
+
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+            coEvery { deps.wsSessionManager.send(any(), any()) } returns true
+
+            val result = executor.doExecuteTask(task)
+
+            assertTrue(result is SuccessPasteTaskResult)
+            coVerify(exactly = 1) { deps.wsSessionManager.send("remote-1", any()) }
+        }
+
+    @Test
+    fun doExecuteTask_legacyPeerPayloadExceedsSingleFrameLimit_failsWithoutSending() =
+        runTest {
+            val deps = TestDeps()
+            val executor = deps.createExecutor(wsSingleFramePayloadLimit = 64)
+            val task = createPasteTask()
+            val pasteData = createRealTextPasteData("x".repeat(1024))
+
+            val handler = createMockSyncHandler("remote-1", connectHostAddress = null)
+
+            every { deps.wsSessionManager.supportsChunkedPayload("remote-1") } returns false
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+
+            val result = executor.doExecuteTask(task)
+
+            assertTrue(result is FailurePasteTaskResult)
+            coVerify(exactly = 0) { deps.wsSessionManager.send(any(), any()) }
+        }
+
+    @Test
+    fun doExecuteTask_chunkCapablePeer_sendsPayloadAboveSingleFrameLimit() =
+        runTest {
+            val deps = TestDeps()
+            val executor = deps.createExecutor(wsSingleFramePayloadLimit = 64)
+            val task = createPasteTask()
+            val pasteData = createRealTextPasteData("x".repeat(1024))
+
+            val handler = createMockSyncHandler("remote-1", connectHostAddress = null)
+
+            every { deps.wsSessionManager.supportsChunkedPayload("remote-1") } returns true
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+            coEvery { deps.wsSessionManager.send(any(), any()) } returns true
+
+            val result = executor.doExecuteTask(task)
+
+            assertTrue(result is SuccessPasteTaskResult)
+            coVerify(exactly = 1) { deps.wsSessionManager.send("remote-1", any()) }
+        }
+
+    @Test
+    fun doExecuteTask_chunkCapablePeerPayloadExceedsMessageLimit_failsWithoutSending() =
+        runTest {
+            val deps = TestDeps()
+            val executor =
+                deps.createExecutor(wsSingleFramePayloadLimit = 64, wsChunkedPayloadLimit = 256)
+            val task = createPasteTask()
+            val pasteData = createRealTextPasteData("x".repeat(1024))
+
+            val handler = createMockSyncHandler("remote-1", connectHostAddress = null)
+
+            every { deps.wsSessionManager.supportsChunkedPayload("remote-1") } returns true
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+
+            val result = executor.doExecuteTask(task)
+
+            assertTrue(result is FailurePasteTaskResult)
+            coVerify(exactly = 0) { deps.wsSessionManager.send(any(), any()) }
+        }
+
+    @Test
+    fun doExecuteTask_extensionTarget_toleratesPayloadAboveSingleFrameLimit() =
+        runTest {
+            val deps = TestDeps()
+            val executor = deps.createExecutor(wsSingleFramePayloadLimit = 64)
+            val task = createPasteTask()
+            val pasteData = createRealTextPasteData("x".repeat(1024))
+
+            val handler = createMockSyncHandler("remote-1", connectHostAddress = null)
+            val extensionInfo =
+                handler.currentSyncRuntimeInfo.copy(
+                    platform = SyncTestFixtures.TEST_PLATFORM.copy(name = Platform.CHROME_EXTENSION),
+                )
+            every { handler.currentSyncRuntimeInfo } returns extensionInfo
+
+            every { deps.wsSessionManager.supportsChunkedPayload("remote-1") } returns false
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+            coEvery { deps.wsSessionManager.send(any(), any()) } returns true
+
+            val result = executor.doExecuteTask(task)
+
+            assertTrue(result is SuccessPasteTaskResult)
+            coVerify(exactly = 1) { deps.wsSessionManager.send("remote-1", any()) }
+        }
+
+    @Test
+    fun doExecuteTask_encryptedPayloadExceedsSingleFrameLimit_failsWithoutSending() =
+        runTest {
+            val deps = TestDeps()
+            val executor = deps.createExecutor(wsSingleFramePayloadLimit = 1024)
+            val task = createPasteTask()
+            // Plaintext JSON stays under the limit; only the encrypted payload exceeds it
+            val pasteData = createRealTextPasteData("short text")
+
+            val handler = createMockSyncHandler("remote-1", connectHostAddress = null)
+            val processor = mockk<SecureMessageProcessor>()
+            every { processor.encrypt(any()) } returns ByteArray(2048)
+
+            every { deps.config.enableEncryptSync } returns true
+            coEvery { deps.secureStore.getMessageProcessor("remote-1") } returns processor
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("remote-1" to handler)
+
+            val result = executor.doExecuteTask(task)
+
+            assertTrue(result is FailurePasteTaskResult)
+            coVerify(exactly = 0) { deps.wsSessionManager.send(any(), any()) }
         }
 }


### PR DESCRIPTION
Closes #4731

## What

Reworked from the earlier single-frame approach (raising `maxFrameSize` to 128 MiB) after review: a single huge frame blocks the outgoing pipe, so pings/pongs queue behind it and the 15s WebSocket timeout can kill the connection mid-transfer on slow links — while the sender has already reported success. Application-layer chunking removes both the silent loss and the head-of-line blocking.

### Wire protocol (`WsMessage.kt`, `WsSession.kt`, `ReceivedWsEnvelope.kt`)

- `WsEnvelopeHeader` gains `payloadChunkCount` (default 1). With `payloadChunkCount = n`, the Text header frame is followed by `n` standalone Binary frames (each `fin=true`, no RFC continuation frames needed) whose concatenation is the payload.
- Sender splits payloads over 1 MiB into ≤1 MiB chunks; the existing send mutex keeps the whole header+chunks sequence atomic, and pings/pongs can interleave between chunks so heartbeats are not starved during large transfers.
- Receiver reassembles by count, validating `payloadChunkCount ∈ 1..128` and a 128 MiB message-level cap (`WS_MAX_PAYLOAD_SIZE`, 2x the 64 MiB `maxNonFilePasteSize` settings cap). The per-message authentication code covers the complete payload and is verified after reassembly, so a tampered chunk count desynchronizes reassembly and gets rejected by the MAC — it can never alter accepted data.

### Capability negotiation (`WsAuthentication.kt`, `WsRouting.kt`, `WsClientConnector.kt`)

- The WS authentication handshake now advertises each side's `AppInfo.pairingVersion` (`WsAuthChallenge` server → client, `WsAuthProof` client → server). Chunked sending is enabled only toward peers advertising pairing version >= 3.
- Production currently advertises `PAIRING_VERSION = 2`, so chunking ships dormant and activates together with the pairing v3 rollout — upgraded devices get it on their next connection without re-pairing. Chunking and v3 must keep shipping in the same release on every platform (same-vehicle rule).
- The advertised version is deliberately not part of the handshake MAC (the canonical fields are frozen for legacy compatibility); tampering can only downgrade to single-frame or break the connection, never corrupt data. Legacy peers, the legacy loopback path, and the Chrome extension never advertise support and always stay single-frame; old receivers ignore the new JSON fields (`ignoreUnknownKeys`).

### Sender-side limit enforcement (`WsSession.kt`, `WsSessionManager.kt`, `SyncPasteTaskExecutor.kt`)

Before writing, the actual (post-encryption) payload size is checked against what the receiver can accept: 1 MiB for legacy native peers (their server frame limit), 128 MiB for chunk-capable peers, 128 MiB for extension targets (browser clients on loopback have no receive frame cap — preserves today's behavior of large pastes reaching the extension). Oversized payloads now return a definitive retriable failure instead of a fake success followed by the receiver tearing down the connection (1009 TOO_BIG).

The limit check lives in `WsSession.sendEnvelopeWithPayloadLimits` and runs under the session's send mutex against the same session snapshot that performs the write (`WsSessionManager.sendWithPayloadLimits`), so a reconnect can never swap a chunk-capable session for a legacy one between capability inspection and send. The tri-state `WsPayloadSendResult` distinguishes transport failure (`Failed`, falls back to HTTP) from a deterministic oversize (`PayloadTooLarge`, definitive retriable failure); the task executor maps these onto the existing task-result semantics.

### Receive limits

- Sync server `maxFrameSize` stays at 1 MiB (now referencing the shared constant).
- Desktop WS client sets `maxFrameSize = WS_MAX_PAYLOAD_SIZE` (was Ktor's ~2 GiB default): legacy peers pushing a whole paste as one oversized frame stay deliverable up to the message cap, while the buffer a paired peer can force into memory becomes bounded (review finding).

## Tests

Full `app:desktopTest` suite green. 16 new cases:
- `WsChunkedPayloadTest` (8): cross-chunk reassembly byte-for-byte, exact-fit single frame, zero/excessive/truncated chunk counts rejected, legacy header and auth DTOs without the new fields decode correctly.
- `WsAuthenticationIntegrationTest` (+2, real Ktor client+server with a 1 MiB server frame limit): v3↔v3 negotiates chunking and round-trips a 2 MiB+ payload through the authenticated channel; peers without v3 stay single-frame in both directions.
- `SyncPasteTaskExecutorTest` (+6): guard tiers (legacy fail-clean / chunk-capable pass and cap / extension tolerance), encrypted-payload sizing, within-limit WS fallback success.

## Review summary

Independent strict review found no P0/P1. Four P2 findings: unbounded desktop client receive buffer — **fixed** (second commit); capability riding the pairing version could break if a platform ever ships v3 without the reassembly code — **accepted**, guarded by the same-vehicle rule above; reassembly happens before envelope MAC verification (bounded 128 MiB, paired/loopback peers only) — **accepted**; guard falls back to the strict 1 MiB tier when no session exists — **accepted**, no behavioral impact since the send fails anyway and the task retries.

## Follow-ups

- Mobile: copy the commonMain changes as usual and set the WS client's `maxFrameSize = WS_MAX_PAYLOAD_SIZE` like the desktop module; keep chunking in the same release as the pairing v3 rollout.
- Extension project: local pre-send size check with a "use the native app" notice for oversized pastes (extension stays single-frame by design).
