### PR TITLE
:bug: dedupe search results by id in the shared search ViewModel

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
@@ -53,7 +53,11 @@ class GeneralPasteSearchViewModel(
                         // became invalid after the query returned (e.g., concurrent deletion
                         // or corrupted content), which is rare.
                         checkLoadAll(pasteDataList.size)
-                        pasteDataList.filter { it.isValid() }
+                        // distinctBy: corrupted cursor reads (Android CursorWindow) can emit
+                        // duplicate rows, which would crash lazy layouts keyed by id downstream
+                        pasteDataList
+                            .filter { it.isValid() }
+                            .distinctBy { it.id }
                     }
             }.stateIn(
                 scope = viewModelScope,

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModel.kt
@@ -53,8 +53,14 @@ class GeneralPasteSearchViewModel(
                         // became invalid after the query returned (e.g., concurrent deletion
                         // or corrupted content), which is rare.
                         checkLoadAll(pasteDataList.size)
-                        // distinctBy: corrupted cursor reads (Android CursorWindow) can emit
-                        // duplicate rows, which would crash lazy layouts keyed by id downstream
+                        // distinctBy: id is the table's primary key, so healthy SQL can't
+                        // duplicate it — but the Android cursor-reading layer below SQL has
+                        // demonstrably emitted corrupted rows (mobile 2.1.5), and a duplicate
+                        // id crashes lazy layouts keyed by id downstream.
+                        // checkLoadAll must stay on the pre-dedup size: it answers "did the
+                        // query hit its LIMIT"; the deduped size would read as "exhausted"
+                        // whenever a duplicate shrinks a full page, permanently stopping
+                        // pagination and hiding the tail of the history.
                         pasteDataList
                             .filter { it.isValid() }
                             .distinctBy { it.id }

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModelTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/model/GeneralPasteSearchViewModelTest.kt
@@ -1,0 +1,124 @@
+package com.crosspaste.ui.model
+
+import com.crosspaste.db.paste.QueryPasteTag
+import com.crosspaste.db.paste.SearchPasteData
+import com.crosspaste.paste.PasteCollection
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteTag
+import com.crosspaste.paste.PasteType
+import com.crosspaste.paste.SearchContentService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GeneralPasteSearchViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private class FakeSearchPasteData(
+        private val results: List<PasteData>,
+    ) : SearchPasteData {
+        override suspend fun searchPasteData(
+            searchTerms: List<String>,
+            local: Boolean?,
+            pasteTypeList: List<Int>,
+            sort: Boolean,
+            tag: Long?,
+            limit: Int,
+        ): List<PasteData> = results
+
+        override fun searchPasteDataFlow(
+            searchTerms: List<String>,
+            local: Boolean?,
+            pasteTypeList: List<Int>,
+            sort: Boolean,
+            tag: Long?,
+            limit: Int,
+        ): Flow<List<PasteData>> = flowOf(results)
+
+        override suspend fun searchBySource(source: String): List<PasteData> = listOf()
+    }
+
+    private object FakeQueryPasteTag : QueryPasteTag {
+        override fun getAllTagsFlow(): Flow<List<PasteTag>> = flowOf(listOf())
+    }
+
+    private object FakeSearchContentService : SearchContentService {
+        override fun createSearchContent(
+            source: String?,
+            searchContentList: List<String>,
+        ): String = searchContentList.joinToString(" ")
+
+        override fun createSearchTerms(queryString: String): List<String> =
+            queryString
+                .trim()
+                .split("\\s+".toRegex())
+                .filterNot { it.isEmpty() }
+    }
+
+    private fun pasteData(id: Long) =
+        PasteData(
+            id = id,
+            appInstanceId = "test-instance",
+            pasteCollection = PasteCollection(emptyList()),
+            pasteType = PasteType.TEXT_TYPE.type,
+            size = 1,
+            hash = "hash-$id",
+        )
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `searchResults drops rows with duplicate ids`() =
+        runTest {
+            val vm =
+                GeneralPasteSearchViewModel(
+                    FakeSearchPasteData(listOf(pasteData(1), pasteData(1), pasteData(2))),
+                    FakeQueryPasteTag,
+                    FakeSearchContentService,
+                )
+
+            val job = launch { vm.searchResults.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(listOf(1L, 2L), vm.searchResults.value.map { it.id })
+            job.cancel()
+        }
+
+    @Test
+    fun `searchResults passes through unique ids unchanged`() =
+        runTest {
+            val vm =
+                GeneralPasteSearchViewModel(
+                    FakeSearchPasteData(listOf(pasteData(3), pasteData(1), pasteData(2))),
+                    FakeQueryPasteTag,
+                    FakeSearchContentService,
+                )
+
+            val job = launch { vm.searchResults.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(listOf(3L, 1L, 2L), vm.searchResults.value.map { it.id })
+            job.cancel()
+        }
+}


### PR DESCRIPTION
Closes #4734

## What

Add `.distinctBy { it.id }` to the `searchResults` pipeline in `GeneralPasteSearchViewModel`, next to the existing `isValid()` filter, plus unit tests covering the dedup and the pass-through case.

## Why

On Android (CrossPaste mobile 2.1.5), corrupted CursorWindow reads emitted duplicate rows from search queries. Lazy layouts key items by `PasteData.id`, so a duplicate id is a hard crash:

```
java.lang.IllegalArgumentException: Key "360" was already used.
If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```

(9 production events; crosspaste-mobile issue CrossPaste/crosspaste-mobile#1897.)

The underlying cursor bug is fixed on the mobile side, but the search service should guarantee unique ids regardless of platform quirks — every consumer (desktop side list, mobile grids) keys UI items by id. This ViewModel is the single choke point shared by desktop and mobile, so the dedup lives here rather than being repeated in UI code.

A measure-time key crash can also poison Compose layout state and resurface as the secondary `layout state is not idle before measure starts` crash (google issuetracker 359623674), which is what originally surfaced this in production.

## Verification

- `./gradlew :app:compileKotlinDesktop` ✅
- `./gradlew :app:desktopTest --tests GeneralPasteSearchViewModelTest --tests PasteSearchViewModelTest` ✅ (new: dedup + pass-through cases)

https://claude.ai/code/session_01A19opP847YpjHNNzTYMxuf
