### PR TITLE
:construction_worker: add Microsoft Store publish automation

### DIFF
--- a/.github/workflows/msstore-publish.yml
+++ b/.github/workflows/msstore-publish.yml
@@ -42,19 +42,19 @@ jobs:
         shell: pwsh
         run: |
           msstore reconfigure `
-            --tenantId ${{ secrets.AZURE_AD_TENANT_ID }} `
-            --sellerId ${{ secrets.SELLER_ID }} `
-            --clientId ${{ secrets.AZURE_AD_APPLICATION_CLIENT_ID }} `
-            --clientSecret ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
+            --tenantId ${{ secrets.WINDOWS_TENANT_ID }} `
+            --sellerId ${{ secrets.WINDOWS_SELLER_ID }} `
+            --clientId ${{ secrets.WINDOWS_CLIENT_ID }} `
+            --clientSecret ${{ secrets.WINDOWS_CLIENT_SECRET }}
 
       - name: Get base submission metadata
         if: inputs.mode == 'get-base-metadata'
         shell: pwsh
-        run: msstore submission get ${{ vars.MSSTORE_PRODUCT_ID }}
+        run: msstore submission get ${{ secrets.WINDOWS_STORE_ID }}
 
       - name: Publish package and release notes
         if: inputs.mode == 'publish'
         shell: bash
         env:
-          MSSTORE_PRODUCT_ID: ${{ vars.MSSTORE_PRODUCT_ID }}
+          WINDOWS_STORE_ID: ${{ secrets.WINDOWS_STORE_ID }}
         run: bash scripts/publish-msstore.sh "${{ inputs.version }}"

--- a/.github/workflows/msstore-publish.yml
+++ b/.github/workflows/msstore-publish.yml
@@ -1,0 +1,60 @@
+name: "Publish to Microsoft Store"
+
+# Uploads a released MSIX (from the OSS release bucket) plus the release notes
+# from whats-new/{en,zh}.md to the Microsoft Store, and commits the submission
+# for certification. Manual-only: Store publishing has its own certification
+# pipeline and cadence, so it is deliberately not chained to the GitHub
+# Release. The app must already be live in the Store — the first submission
+# (listing, screenshots, age rating, markets) is manual in Partner Center.
+# One-time credential setup: see doc/en/MicrosoftStore.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Full released version whose MSIX to submit (e.g. 2.1.7.2452)"
+        required: true
+      mode:
+        description: "publish: submit package + release notes; get-base-metadata: print the current submission JSON (baseline for msstore/metadata.json)"
+        type: choice
+        default: publish
+        options:
+          - publish
+          - get-base-metadata
+
+permissions: {}
+
+# Partner Center allows one pending submission at a time; never interleave.
+concurrency:
+  group: msstore-publish
+  cancel-in-progress: false
+
+jobs:
+  msstore:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Microsoft Store Developer CLI
+        uses: microsoft/microsoft-store-apppublisher@v1.1
+
+      - name: Configure Store credentials
+        shell: pwsh
+        run: |
+          msstore reconfigure `
+            --tenantId ${{ secrets.AZURE_AD_TENANT_ID }} `
+            --sellerId ${{ secrets.SELLER_ID }} `
+            --clientId ${{ secrets.AZURE_AD_APPLICATION_CLIENT_ID }} `
+            --clientSecret ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
+
+      - name: Get base submission metadata
+        if: inputs.mode == 'get-base-metadata'
+        shell: pwsh
+        run: msstore submission get ${{ vars.MSSTORE_PRODUCT_ID }}
+
+      - name: Publish package and release notes
+        if: inputs.mode == 'publish'
+        shell: bash
+        env:
+          MSSTORE_PRODUCT_ID: ${{ vars.MSSTORE_PRODUCT_ID }}
+        run: bash scripts/publish-msstore.sh "${{ inputs.version }}"

--- a/.github/workflows/msstore-publish.yml
+++ b/.github/workflows/msstore-publish.yml
@@ -22,7 +22,8 @@ on:
           - publish
           - get-submission
 
-permissions: {}
+permissions:
+  contents: read
 
 # Partner Center allows one pending submission at a time; never interleave.
 concurrency:
@@ -38,6 +39,10 @@ jobs:
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     environment: msstore-publish
     runs-on: windows-latest
+    # `msstore submission poll` returns once commit processing finishes and
+    # certification starts (a few minutes) — it does not wait for the days-long
+    # certification itself, so a tight timeout is safe.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/msstore-publish.yml
+++ b/.github/workflows/msstore-publish.yml
@@ -15,12 +15,12 @@ on:
         description: "Full released version whose MSIX to submit (e.g. 2.1.7.2452)"
         required: true
       mode:
-        description: "publish: submit package + release notes; get-base-metadata: print the current submission JSON (baseline for msstore/metadata.json)"
+        description: "publish: submit package + release notes; get-submission: print the current submission JSON (debugging)"
         type: choice
         default: publish
         options:
           - publish
-          - get-base-metadata
+          - get-submission
 
 permissions: {}
 
@@ -31,6 +31,12 @@ concurrency:
 
 jobs:
   msstore:
+    # Store credentials must only ever run scripts from the default branch.
+    # The msstore-publish environment enforces this server-side (deployment
+    # branches restricted to main); this condition is an extra guard against
+    # accidentally dispatching from a stale ref.
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    environment: msstore-publish
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -47,8 +53,8 @@ jobs:
             --clientId ${{ secrets.WINDOWS_CLIENT_ID }} `
             --clientSecret ${{ secrets.WINDOWS_CLIENT_SECRET }}
 
-      - name: Get base submission metadata
-        if: inputs.mode == 'get-base-metadata'
+      - name: Get current submission
+        if: inputs.mode == 'get-submission'
         shell: pwsh
         run: msstore submission get ${{ secrets.WINDOWS_STORE_ID }}
 
@@ -57,4 +63,8 @@ jobs:
         shell: bash
         env:
           WINDOWS_STORE_ID: ${{ secrets.WINDOWS_STORE_ID }}
-        run: bash scripts/publish-msstore.sh "${{ inputs.version }}"
+          # Untrusted input: only ever passed through the environment (never
+          # interpolated into the script text) and strictly validated as
+          # N.N.N.N by publish-msstore.sh.
+          VERSION: ${{ inputs.version }}
+        run: bash scripts/publish-msstore.sh "$VERSION"

--- a/doc/en/MicrosoftStore.md
+++ b/doc/en/MicrosoftStore.md
@@ -14,15 +14,20 @@ or runnable locally on macOS/Linux) performs, per release:
 1. Download the MSIX for the given version from
    `https://oss.crosspaste.com/<version>/` and verify its SHA256 against
    `checksum.txt`.
-2. Patch the "What's new in this version" release notes into the submission
-   metadata — `whats-new/en.md` → the `en-us` listing, `whats-new/zh.md` → the
-   `zh-cn` listing (each truncated to the Store's 1500-character limit).
-3. Upload the package into the pending submission, commit it, and poll until
-   certification processing starts.
+2. Upload the package into a fresh pending submission (`msstore publish
+   --noCommit`). This runs first because, for a live app, msstore-cli deletes
+   any existing pending submission and creates a new one — metadata written
+   earlier would be lost.
+3. Fetch that pending submission, patch the "What's new in this version"
+   release notes for the given version's section — `whats-new/en.md` → the
+   `en-us` listing, `whats-new/zh.md` → the `zh-cn` listing (each capped at
+   the Store's 1500-character limit) — and push it back with
+   `msstore submission updateMetadata`.
+4. Commit the submission and poll until certification processing starts.
 
 Everything else in the listing (description, screenshots, markets, pricing)
-stays untouched: the script only rewrites `releaseNotes` on listings that
-already exist in the checked-in baseline `msstore/metadata.json`.
+stays untouched: the script fetches the live submission and only rewrites
+`ReleaseNotes` on listings that already exist in it.
 
 ## One-time setup
 
@@ -46,10 +51,14 @@ The Store submission API cannot create the first listing. Do this once:
    one new secret `WINDOWS_SELLER_ID` — the Partner Center Seller ID
    (Partner Center → Account settings → Organization profile → Legal info),
    required by `msstore reconfigure`.
-4. **Metadata baseline.** Run the `Publish to Microsoft Store` workflow once
-   with mode `get-base-metadata`, copy the submission JSON from the log into
-   `msstore/metadata.json`, and commit it. Release-notes patching is skipped
-   with a warning until this file exists.
+4. **Protected environment.** Create a GitHub Environment named
+   `msstore-publish` (Settings → Environments) and restrict its deployment
+   branches to `main` only. The workflow job runs in this environment, so
+   GitHub enforces server-side that a manual dispatch cannot execute a
+   modified script from an arbitrary branch with the Store credentials.
+   Prefer adding `WINDOWS_SELLER_ID` as an environment secret rather than a
+   repo secret (the other `WINDOWS_*` secrets must stay repo-level because
+   `build-release.yml` consumes them).
 
 ## Per-release usage
 
@@ -62,6 +71,11 @@ by `build-release.yml` at tag time):
   `WINDOWS_STORE_ID=9N... scripts/publish-msstore.sh 2.1.7.2452`.
   Use `--dry-run` to preview the extracted release notes without touching the
   pending submission.
+
+The release notes are taken from the `# [x.y.z]` section matching the given
+version (not simply the newest section), so re-publishing an older version
+cannot ship the wrong notes; the script fails if `whats-new/en.md` has no
+section for that version.
 
 Certification typically takes from a few hours up to three business days;
 progress is visible in Partner Center or via

--- a/doc/en/MicrosoftStore.md
+++ b/doc/en/MicrosoftStore.md
@@ -1,0 +1,64 @@
+# Publishing CrossPaste to the Microsoft Store
+
+CrossPaste's release build already produces a Store-identity MSIX
+(`crosspaste-<version>-<revision>.x64.msix`, package family
+`ShenzhenCompileFutureTech.CrossPaste_gphsk9mrjnczc`). This document describes
+how Store publishing is automated and what has to be done by hand exactly once.
+
+## What is automated
+
+`scripts/publish-msstore.sh` (invoked by the manual
+[`msstore-publish.yml`](../../.github/workflows/msstore-publish.yml) workflow,
+or runnable locally on macOS/Linux) performs, per release:
+
+1. Download the MSIX for the given version from
+   `https://oss.crosspaste.com/<version>/` and verify its SHA256 against
+   `checksum.txt`.
+2. Patch the "What's new in this version" release notes into the submission
+   metadata — `whats-new/en.md` → the `en-us` listing, `whats-new/zh.md` → the
+   `zh-cn` listing (each truncated to the Store's 1500-character limit).
+3. Upload the package into the pending submission, commit it, and poll until
+   certification processing starts.
+
+Everything else in the listing (description, screenshots, markets, pricing)
+stays untouched: the script only rewrites `releaseNotes` on listings that
+already exist in the checked-in baseline `msstore/metadata.json`.
+
+## One-time setup
+
+The Store submission API cannot create the first listing. Do this once:
+
+1. **First submission by hand.** In [Partner Center](https://partner.microsoft.com/),
+   complete the app's first submission: listing texts, screenshots, age
+   rating, markets, pricing, and upload the MSIX manually. Wait until the app
+   is published and live.
+2. **Service principal.** Associate a Microsoft Entra tenant with the Partner
+   Center account, register an application in Entra ID, and add it under
+   Partner Center → Account settings → User management → Microsoft Entra
+   applications with the **Manager** role.
+3. **GitHub secrets/variables.** In the repo settings add secrets
+   `AZURE_AD_TENANT_ID`, `SELLER_ID`, `AZURE_AD_APPLICATION_CLIENT_ID`,
+   `AZURE_AD_APPLICATION_SECRET` (names follow the
+   [official docs](https://learn.microsoft.com/windows/apps/publish/msstore-dev-cli/github-actions)),
+   and a repository **variable** `MSSTORE_PRODUCT_ID` with the Store product
+   ID (Partner Center → the app → Product identity, the `9N…` ID).
+4. **Metadata baseline.** Run the `Publish to Microsoft Store` workflow once
+   with mode `get-base-metadata`, copy the submission JSON from the log into
+   `msstore/metadata.json`, and commit it. Release-notes patching is skipped
+   with a warning until this file exists.
+
+## Per-release usage
+
+After the GitHub Release for `<version>` is out (the OSS bucket is populated
+by `build-release.yml` at tag time):
+
+- **CI:** Actions → "Publish to Microsoft Store" → Run workflow with
+  `version = <full version>` (e.g. `2.1.7.2452`), mode `publish`.
+- **Locally:** `msstore reconfigure ...` once on the machine, then
+  `MSSTORE_PRODUCT_ID=9N... scripts/publish-msstore.sh 2.1.7.2452`.
+  Use `--dry-run` to preview the extracted release notes without touching the
+  pending submission.
+
+Certification typically takes from a few hours up to three business days;
+progress is visible in Partner Center or via
+`msstore submission status <productId>`.

--- a/doc/en/MicrosoftStore.md
+++ b/doc/en/MicrosoftStore.md
@@ -32,16 +32,20 @@ The Store submission API cannot create the first listing. Do this once:
    complete the app's first submission: listing texts, screenshots, age
    rating, markets, pricing, and upload the MSIX manually. Wait until the app
    is published and live.
-2. **Service principal.** Associate a Microsoft Entra tenant with the Partner
-   Center account, register an application in Entra ID, and add it under
-   Partner Center → Account settings → User management → Microsoft Entra
-   applications with the **Manager** role.
-3. **GitHub secrets/variables.** In the repo settings add secrets
-   `AZURE_AD_TENANT_ID`, `SELLER_ID`, `AZURE_AD_APPLICATION_CLIENT_ID`,
-   `AZURE_AD_APPLICATION_SECRET` (names follow the
-   [official docs](https://learn.microsoft.com/windows/apps/publish/msstore-dev-cli/github-actions)),
-   and a repository **variable** `MSSTORE_PRODUCT_ID` with the Store product
-   ID (Partner Center → the app → Product identity, the `9N…` ID).
+2. **Service principal.** The workflow reuses the Entra ID application the
+   Conveyor release build already authenticates with (repo secrets
+   `WINDOWS_TENANT_ID`, `WINDOWS_CLIENT_ID`, `WINDOWS_CLIENT_SECRET`, consumed
+   by `build.conveyor.conf`). If setting up from scratch: associate a
+   Microsoft Entra tenant with the Partner Center account, register an
+   application in Entra ID, and add it under Partner Center → Account
+   settings → User management → Microsoft Entra applications with the
+   **Manager** role.
+3. **GitHub secrets.** Besides the existing `WINDOWS_TENANT_ID`,
+   `WINDOWS_CLIENT_ID`, `WINDOWS_CLIENT_SECRET`, and `WINDOWS_STORE_ID` (the
+   `9N…` Store product ID, Partner Center → the app → Product identity), add
+   one new secret `WINDOWS_SELLER_ID` — the Partner Center Seller ID
+   (Partner Center → Account settings → Organization profile → Legal info),
+   required by `msstore reconfigure`.
 4. **Metadata baseline.** Run the `Publish to Microsoft Store` workflow once
    with mode `get-base-metadata`, copy the submission JSON from the log into
    `msstore/metadata.json`, and commit it. Release-notes patching is skipped
@@ -55,7 +59,7 @@ by `build-release.yml` at tag time):
 - **CI:** Actions → "Publish to Microsoft Store" → Run workflow with
   `version = <full version>` (e.g. `2.1.7.2452`), mode `publish`.
 - **Locally:** `msstore reconfigure ...` once on the machine, then
-  `MSSTORE_PRODUCT_ID=9N... scripts/publish-msstore.sh 2.1.7.2452`.
+  `WINDOWS_STORE_ID=9N... scripts/publish-msstore.sh 2.1.7.2452`.
   Use `--dry-run` to preview the extracted release notes without touching the
   pending submission.
 

--- a/scripts/publish-msstore.sh
+++ b/scripts/publish-msstore.sh
@@ -26,7 +26,8 @@
 #   scripts/publish-msstore.sh <full-version> [--msix <path>] [--product-id <id>] [--dry-run]
 #     <full-version>   e.g. 2.1.7.2452 (the git tag / OSS prefix)
 #     --msix <path>    use a local MSIX instead of downloading from OSS
-#     --product-id     Store product ID; defaults to $MSSTORE_PRODUCT_ID
+#     --product-id     Store product ID; defaults to $WINDOWS_STORE_ID (same
+#                      secret the Conveyor release build uses)
 #     --dry-run        stop before any msstore call that mutates the submission
 
 set -euo pipefail
@@ -49,7 +50,7 @@ VERSION="${1:-}"
 shift
 
 MSIX=""
-PRODUCT_ID="${MSSTORE_PRODUCT_ID:-}"
+PRODUCT_ID="${WINDOWS_STORE_ID:-}"
 DRY_RUN=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -60,7 +61,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "$PRODUCT_ID" ]] || { echo "Missing Store product ID: set MSSTORE_PRODUCT_ID or pass --product-id." >&2; exit 2; }
+[[ -n "$PRODUCT_ID" ]] || { echo "Missing Store product ID: set WINDOWS_STORE_ID or pass --product-id." >&2; exit 2; }
 [[ "$DRY_RUN" == 1 ]] || command -v msstore >/dev/null || { echo "msstore-cli not found on PATH." >&2; exit 2; }
 command -v jq >/dev/null || { echo "jq not found on PATH." >&2; exit 2; }
 

--- a/scripts/publish-msstore.sh
+++ b/scripts/publish-msstore.sh
@@ -6,12 +6,16 @@
 #   1. Downloads the Store-identity MSIX for <version> from the OSS release
 #      bucket (or uses --msix <path>) and verifies its SHA256 against
 #      checksum.txt.
-#   2. If msstore/metadata.json exists, patches the per-listing release notes
-#      ("What's new") from whats-new/en.md (en-us) and whats-new/zh.md (zh-cn)
-#      and pushes it with `msstore submission updateMetadata`.
-#   3. Uploads the MSIX into the pending submission (`msstore publish
-#      --noCommit`), then commits it (`msstore submission publish`) and polls
-#      until the Store accepts or rejects it.
+#   2. Uploads the MSIX into a new pending submission (`msstore publish
+#      --noCommit`). This must happen FIRST: for a live app msstore-cli
+#      deletes any existing pending submission and creates a fresh one, so
+#      metadata written earlier would be lost.
+#   3. Fetches that fresh pending submission (`msstore submission get`),
+#      patches the per-listing release notes ("What's new") for <version>'s
+#      section of whats-new/en.md (en-us) and whats-new/zh.md (zh-cn), and
+#      pushes it back with `msstore submission updateMetadata`.
+#   4. Commits the submission (`msstore submission publish`) and polls until
+#      the Store accepts or rejects it.
 #
 # Prerequisites:
 #   - msstore-cli on PATH (brew install microsoft/msstore-cli/msstore-cli) and
@@ -35,7 +39,6 @@ set -euo pipefail
 OSS_BASE="https://oss.crosspaste.com"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WHATS_NEW_DIR="$REPO_ROOT/app/src/desktopMain/resources/whats-new"
-METADATA_BASE="$REPO_ROOT/msstore/metadata.json"
 # Store release notes are capped at 1500 characters per listing. awk length()
 # counts characters on gawk (CI) but bytes on macOS awk, so a local --dry-run
 # truncates CJK notes more aggressively than the real CI run; both stay under
@@ -48,6 +51,13 @@ VERSION="${1:-}"
   exit 2
 }
 shift
+
+# Strict N.N.N.N — also the injection barrier for the version coming in from
+# the workflow_dispatch input via the environment.
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "Invalid version '$VERSION': expected N.N.N.N (e.g. 2.1.7.2452)." >&2
+  exit 2
+}
 
 MSIX=""
 PRODUCT_ID="${WINDOWS_STORE_ID:-}"
@@ -93,20 +103,22 @@ else
   [[ -f "$MSIX" ]] || { echo "MSIX not found: $MSIX" >&2; exit 1; }
 fi
 
-# Extract the latest "# [x.y.z] - date" section from a whats-new file as plain
-# text: section titles ("## 🛡️ Title") become bullet lines, paragraphs follow
-# verbatim. Sections that would exceed the Store's release-notes limit are
-# dropped whole, so the output never cuts mid-sentence or mid-character.
+# Extract the "# [$BASE_VERSION] - date" section (not blindly the newest one,
+# so re-publishing an older version cannot ship the wrong notes) from a
+# whats-new file as plain text: section titles ("## 🛡️ Title") become bullet
+# lines, paragraphs follow verbatim. Sections that would exceed the Store's
+# release-notes limit are dropped whole, so the output never cuts mid-sentence
+# or mid-character.
 release_notes() {
   local file="$1"
-  awk -v max="$RELEASE_NOTES_MAX" '
+  awk -v max="$RELEASE_NOTES_MAX" -v ver="$BASE_VERSION" '
     function flush() {
       if (buf == "" || done) { buf = ""; return }
       candidate = out (out == "" ? "" : "\n\n") buf
       if (length(candidate) <= max) out = candidate; else done = 1
       buf = ""
     }
-    /^# \[/ { if (started) exit; started = 1; next }
+    /^# \[/ { if (started) exit; if (index($0, "# [" ver "]") == 1) started = 1; next }
     !started { next }
     /^## /  { flush(); sub(/^## /, ""); buf = "• " $0; next }
     NF      { buf = buf (buf == "" ? "" : "\n") $0 }
@@ -116,43 +128,60 @@ release_notes() {
 
 NOTES_EN="$(release_notes "$WHATS_NEW_DIR/en.md")"
 NOTES_ZH="$(release_notes "$WHATS_NEW_DIR/zh.md")"
-[[ -n "$NOTES_EN" ]] || { echo "Could not extract release notes from whats-new/en.md." >&2; exit 1; }
+[[ -n "$NOTES_EN" ]] || { echo "No '# [$BASE_VERSION]' section found in whats-new/en.md." >&2; exit 1; }
+[[ -n "$NOTES_ZH" ]] || echo "WARNING: no '# [$BASE_VERSION]' section in whats-new/zh.md — zh-cn release notes will not be updated." >&2
 echo "--- en-us release notes (${#NOTES_EN} chars) ---"
 echo "$NOTES_EN"
 echo "--- zh-cn release notes ---"
 echo "$NOTES_ZH"
 echo "-----------------------------------------------"
 
-if [[ -f "$METADATA_BASE" ]]; then
-  # Only patch releaseNotes on listings that already exist in the baseline;
-  # everything else in the submission metadata stays exactly as checked in.
-  jq --arg en "$NOTES_EN" --arg zh "$NOTES_ZH" '
-    if .listings["en-us"] then .listings["en-us"].baseListing.releaseNotes = $en else . end
-    | if .listings["zh-cn"] and ($zh != "") then .listings["zh-cn"].baseListing.releaseNotes = $zh else . end
-  ' "$METADATA_BASE" > "$WORK_DIR/metadata.json"
-  METADATA_JSON="$(cat "$WORK_DIR/metadata.json")"
-  if [[ -n "$NOTES_ZH" ]] && ! jq -e '.listings["zh-cn"]' "$METADATA_BASE" >/dev/null; then
-    echo "WARNING: no zh-cn listing in $METADATA_BASE — Chinese release notes will NOT be published." >&2
-    echo "         Add Chinese (Simplified) as a listing language in Partner Center, then refresh the baseline." >&2
-  fi
-else
-  echo "WARNING: $METADATA_BASE not found — skipping release-notes metadata update."
-  echo "         (Run the get-base-metadata workflow once the app is live and check the JSON in as msstore/metadata.json.)"
-  METADATA_JSON=""
-fi
-
 if [[ "$DRY_RUN" == 1 ]]; then
-  echo "Dry run: would upload $MSIX to product $PRODUCT_ID, update metadata ($([[ -n "$METADATA_JSON" ]] && echo yes || echo no)), publish, poll."
+  echo "Dry run: would upload $MSIX to product $PRODUCT_ID, then patch the pending submission's release notes, publish, poll."
   exit 0
 fi
 
-if [[ -n "$METADATA_JSON" ]]; then
-  echo "Updating submission metadata (release notes) ..."
-  msstore submission updateMetadata "$PRODUCT_ID" "$METADATA_JSON"
+# Package first: for a live app `msstore publish` deletes any pending
+# submission and creates a new one, so metadata must be written afterwards.
+echo "Uploading package into a fresh pending submission ..."
+msstore publish --inputFile "$MSIX" --appId "$PRODUCT_ID" --noCommit
+
+echo "Fetching the pending submission ..."
+# stdout carries human status lines before the pretty-printed JSON object;
+# keep everything from the first line starting with '{'.
+SUBMISSION_JSON="$(msstore submission get "$PRODUCT_ID" | tr -d '\r' | sed -e 's/\x1b\[[0-9;]*m//g' | awk '/^\{/{found=1} found')"
+jq -e . >/dev/null <<<"$SUBMISSION_JSON" || { echo "Could not parse submission JSON from 'msstore submission get'." >&2; exit 1; }
+
+# `submission get` falls back to the LAST PUBLISHED submission when no pending
+# one exists — updating that would be wrong, so insist on a draft.
+jq -e '.Status and .Status != "Published"' >/dev/null <<<"$SUBMISSION_JSON" || {
+  echo "Fetched submission is not a pending draft (Status=$(jq -r .Status <<<"$SUBMISSION_JSON")); aborting before touching metadata." >&2
+  exit 1
+}
+
+# msstore-cli serializes with an upper-case-first naming policy: the paths are
+# .Listings["en-us"].BaseListing.ReleaseNotes (NOT camelCase).
+jq -e '.Listings["en-us"].BaseListing' >/dev/null <<<"$SUBMISSION_JSON" || {
+  echo "Submission has no en-us listing (or the JSON shape changed); refusing to guess." >&2
+  exit 1
+}
+PATCHED_JSON="$(jq --arg en "$NOTES_EN" --arg zh "$NOTES_ZH" '
+  .Listings["en-us"].BaseListing.ReleaseNotes = $en
+  | if .Listings["zh-cn"] and ($zh != "") then .Listings["zh-cn"].BaseListing.ReleaseNotes = $zh else . end
+' <<<"$SUBMISSION_JSON")"
+# Belt and braces: fail loudly if the patch did not land (this is exactly the
+# failure mode a silent key-casing mismatch would produce).
+jq -e --arg en "$NOTES_EN" '.Listings["en-us"].BaseListing.ReleaseNotes == $en' >/dev/null <<<"$PATCHED_JSON" || {
+  echo "Release-notes patch did not take effect; aborting." >&2
+  exit 1
+}
+if [[ -n "$NOTES_ZH" ]] && ! jq -e '.Listings["zh-cn"]' >/dev/null <<<"$SUBMISSION_JSON"; then
+  echo "WARNING: no zh-cn listing in the submission — Chinese release notes will NOT be published." >&2
+  echo "         Add Chinese (Simplified) as a listing language in Partner Center first." >&2
 fi
 
-echo "Uploading package into the pending submission ..."
-msstore publish --inputFile "$MSIX" --appId "$PRODUCT_ID" --noCommit
+echo "Updating submission metadata (release notes) ..."
+msstore submission updateMetadata "$PRODUCT_ID" "$PATCHED_JSON"
 
 echo "Committing the submission ..."
 msstore submission publish "$PRODUCT_ID"

--- a/scripts/publish-msstore.sh
+++ b/scripts/publish-msstore.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Publish a CrossPaste release to the Microsoft Store via msstore-cli.
+#
+# What it does, in order:
+#   1. Downloads the Store-identity MSIX for <version> from the OSS release
+#      bucket (or uses --msix <path>) and verifies its SHA256 against
+#      checksum.txt.
+#   2. If msstore/metadata.json exists, patches the per-listing release notes
+#      ("What's new") from whats-new/en.md (en-us) and whats-new/zh.md (zh-cn)
+#      and pushes it with `msstore submission updateMetadata`.
+#   3. Uploads the MSIX into the pending submission (`msstore publish
+#      --noCommit`), then commits it (`msstore submission publish`) and polls
+#      until the Store accepts or rejects it.
+#
+# Prerequisites:
+#   - msstore-cli on PATH (brew install microsoft/msstore-cli/msstore-cli) and
+#     already configured: msstore reconfigure --tenantId ... --sellerId ...
+#     --clientId ... --clientSecret ...
+#   - The app must already be live in the Store; the first submission (listing,
+#     screenshots, age rating, markets) is manual in Partner Center. See
+#     doc/en/MicrosoftStore.md.
+#   - jq, curl, shasum or sha256sum.
+#
+# Usage:
+#   scripts/publish-msstore.sh <full-version> [--msix <path>] [--product-id <id>] [--dry-run]
+#     <full-version>   e.g. 2.1.7.2452 (the git tag / OSS prefix)
+#     --msix <path>    use a local MSIX instead of downloading from OSS
+#     --product-id     Store product ID; defaults to $MSSTORE_PRODUCT_ID
+#     --dry-run        stop before any msstore call that mutates the submission
+
+set -euo pipefail
+
+OSS_BASE="https://oss.crosspaste.com"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WHATS_NEW_DIR="$REPO_ROOT/app/src/desktopMain/resources/whats-new"
+METADATA_BASE="$REPO_ROOT/msstore/metadata.json"
+# Store release notes are capped at 1500 characters per listing. awk length()
+# counts characters on gawk (CI) but bytes on macOS awk, so a local --dry-run
+# truncates CJK notes more aggressively than the real CI run; both stay under
+# the Store limit.
+RELEASE_NOTES_MAX=1490
+
+VERSION="${1:-}"
+[[ -n "$VERSION" && "$VERSION" != --* ]] || {
+  echo "Usage: $0 <full-version> [--msix <path>] [--product-id <id>] [--dry-run]" >&2
+  exit 2
+}
+shift
+
+MSIX=""
+PRODUCT_ID="${MSSTORE_PRODUCT_ID:-}"
+DRY_RUN=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --msix) MSIX="$2"; shift 2 ;;
+    --product-id) PRODUCT_ID="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$PRODUCT_ID" ]] || { echo "Missing Store product ID: set MSSTORE_PRODUCT_ID or pass --product-id." >&2; exit 2; }
+[[ "$DRY_RUN" == 1 ]] || command -v msstore >/dev/null || { echo "msstore-cli not found on PATH." >&2; exit 2; }
+command -v jq >/dev/null || { echo "jq not found on PATH." >&2; exit 2; }
+
+if command -v sha256sum >/dev/null; then
+  SHA256="sha256sum"
+else
+  SHA256="shasum -a 256"
+fi
+
+# 2.1.7.2452 -> version=2.1.7 revision=2452 -> crosspaste-2.1.7-2452.x64.msix
+BASE_VERSION="${VERSION%.*}"
+REVISION="${VERSION##*.}"
+MSIX_NAME="crosspaste-${BASE_VERSION}-${REVISION}.x64.msix"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+if [[ -z "$MSIX" ]]; then
+  echo "Downloading $MSIX_NAME from $OSS_BASE/$VERSION/ ..."
+  curl -fsS -o "$WORK_DIR/$MSIX_NAME" "$OSS_BASE/$VERSION/$MSIX_NAME"
+  curl -fsS -o "$WORK_DIR/checksum.txt" "$OSS_BASE/$VERSION/checksum.txt"
+  EXPECTED="$(awk -v f="$MSIX_NAME" '$2 == f {print $1}' "$WORK_DIR/checksum.txt")"
+  [[ -n "$EXPECTED" ]] || { echo "$MSIX_NAME not found in checksum.txt." >&2; exit 1; }
+  ACTUAL="$($SHA256 "$WORK_DIR/$MSIX_NAME" | awk '{print $1}')"
+  [[ "$ACTUAL" == "$EXPECTED" ]] || { echo "SHA256 mismatch for $MSIX_NAME: expected $EXPECTED, got $ACTUAL." >&2; exit 1; }
+  echo "SHA256 verified: $ACTUAL"
+  MSIX="$WORK_DIR/$MSIX_NAME"
+else
+  [[ -f "$MSIX" ]] || { echo "MSIX not found: $MSIX" >&2; exit 1; }
+fi
+
+# Extract the latest "# [x.y.z] - date" section from a whats-new file as plain
+# text: section titles ("## 🛡️ Title") become bullet lines, paragraphs follow
+# verbatim. Sections that would exceed the Store's release-notes limit are
+# dropped whole, so the output never cuts mid-sentence or mid-character.
+release_notes() {
+  local file="$1"
+  awk -v max="$RELEASE_NOTES_MAX" '
+    function flush() {
+      if (buf == "" || done) { buf = ""; return }
+      candidate = out (out == "" ? "" : "\n\n") buf
+      if (length(candidate) <= max) out = candidate; else done = 1
+      buf = ""
+    }
+    /^# \[/ { if (started) exit; started = 1; next }
+    !started { next }
+    /^## /  { flush(); sub(/^## /, ""); buf = "• " $0; next }
+    NF      { buf = buf (buf == "" ? "" : "\n") $0 }
+    END     { flush(); print out }
+  ' "$file"
+}
+
+NOTES_EN="$(release_notes "$WHATS_NEW_DIR/en.md")"
+NOTES_ZH="$(release_notes "$WHATS_NEW_DIR/zh.md")"
+[[ -n "$NOTES_EN" ]] || { echo "Could not extract release notes from whats-new/en.md." >&2; exit 1; }
+echo "--- en-us release notes (${#NOTES_EN} chars) ---"
+echo "$NOTES_EN"
+echo "-----------------------------------------------"
+
+if [[ -f "$METADATA_BASE" ]]; then
+  # Only patch releaseNotes on listings that already exist in the baseline;
+  # everything else in the submission metadata stays exactly as checked in.
+  jq --arg en "$NOTES_EN" --arg zh "$NOTES_ZH" '
+    if .listings["en-us"] then .listings["en-us"].baseListing.releaseNotes = $en else . end
+    | if .listings["zh-cn"] and ($zh != "") then .listings["zh-cn"].baseListing.releaseNotes = $zh else . end
+  ' "$METADATA_BASE" > "$WORK_DIR/metadata.json"
+  METADATA_JSON="$(cat "$WORK_DIR/metadata.json")"
+else
+  echo "WARNING: $METADATA_BASE not found — skipping release-notes metadata update."
+  echo "         (Run the get-base-metadata workflow once the app is live and check the JSON in as msstore/metadata.json.)"
+  METADATA_JSON=""
+fi
+
+if [[ "$DRY_RUN" == 1 ]]; then
+  echo "Dry run: would upload $MSIX to product $PRODUCT_ID, update metadata ($([[ -n "$METADATA_JSON" ]] && echo yes || echo no)), publish, poll."
+  exit 0
+fi
+
+if [[ -n "$METADATA_JSON" ]]; then
+  echo "Updating submission metadata (release notes) ..."
+  msstore submission updateMetadata "$PRODUCT_ID" "$METADATA_JSON"
+fi
+
+echo "Uploading package into the pending submission ..."
+msstore publish --inputFile "$MSIX" --appId "$PRODUCT_ID" --noCommit
+
+echo "Committing the submission ..."
+msstore submission publish "$PRODUCT_ID"
+
+echo "Polling submission status until the Store finishes processing ..."
+msstore submission poll "$PRODUCT_ID"

--- a/scripts/publish-msstore.sh
+++ b/scripts/publish-msstore.sh
@@ -64,8 +64,8 @@ PRODUCT_ID="${WINDOWS_STORE_ID:-}"
 DRY_RUN=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --msix) MSIX="$2"; shift 2 ;;
-    --product-id) PRODUCT_ID="$2"; shift 2 ;;
+    --msix) [[ $# -ge 2 ]] || { echo "Missing value for --msix." >&2; exit 2; }; MSIX="$2"; shift 2 ;;
+    --product-id) [[ $# -ge 2 ]] || { echo "Missing value for --product-id." >&2; exit 2; }; PRODUCT_ID="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     *) echo "Unknown option: $1" >&2; exit 2 ;;
   esac
@@ -93,7 +93,7 @@ if [[ -z "$MSIX" ]]; then
   echo "Downloading $MSIX_NAME from $OSS_BASE/$VERSION/ ..."
   curl -fsS -o "$WORK_DIR/$MSIX_NAME" "$OSS_BASE/$VERSION/$MSIX_NAME"
   curl -fsS -o "$WORK_DIR/checksum.txt" "$OSS_BASE/$VERSION/checksum.txt"
-  EXPECTED="$(awk -v f="$MSIX_NAME" '$2 == f {print $1}' "$WORK_DIR/checksum.txt")"
+  EXPECTED="$(awk -v f="$MSIX_NAME" '{sub(/^\*/, "", $2)} $2 == f {print $1}' "$WORK_DIR/checksum.txt")"
   [[ -n "$EXPECTED" ]] || { echo "$MSIX_NAME not found in checksum.txt." >&2; exit 1; }
   ACTUAL="$($SHA256 "$WORK_DIR/$MSIX_NAME" | awk '{print $1}')"
   [[ "$ACTUAL" == "$EXPECTED" ]] || { echo "SHA256 mismatch for $MSIX_NAME: expected $EXPECTED, got $ACTUAL." >&2; exit 1; }
@@ -149,7 +149,8 @@ msstore publish --inputFile "$MSIX" --appId "$PRODUCT_ID" --noCommit
 echo "Fetching the pending submission ..."
 # stdout carries human status lines before the pretty-printed JSON object;
 # keep everything from the first line starting with '{'.
-SUBMISSION_JSON="$(msstore submission get "$PRODUCT_ID" | tr -d '\r' | sed -e 's/\x1b\[[0-9;]*m//g' | awk '/^\{/{found=1} found')"
+# $'...' yields a literal ESC byte so the ANSI strip also works with BSD sed.
+SUBMISSION_JSON="$(msstore submission get "$PRODUCT_ID" | tr -d '\r' | sed -e $'s/\x1b\\[[0-9;]*m//g' | awk '/^\{/{found=1} found')"
 jq -e . >/dev/null <<<"$SUBMISSION_JSON" || { echo "Could not parse submission JSON from 'msstore submission get'." >&2; exit 1; }
 
 # `submission get` falls back to the LAST PUBLISHED submission when no pending
@@ -165,7 +166,9 @@ jq -e '.Listings["en-us"].BaseListing' >/dev/null <<<"$SUBMISSION_JSON" || {
   echo "Submission has no en-us listing (or the JSON shape changed); refusing to guess." >&2
   exit 1
 }
-PATCHED_JSON="$(jq --arg en "$NOTES_EN" --arg zh "$NOTES_ZH" '
+# -c keeps the argv line short: the full submission is passed to msstore-cli
+# as a single argument and Windows caps a command line at ~32k characters.
+PATCHED_JSON="$(jq -c --arg en "$NOTES_EN" --arg zh "$NOTES_ZH" '
   .Listings["en-us"].BaseListing.ReleaseNotes = $en
   | if .Listings["zh-cn"] and ($zh != "") then .Listings["zh-cn"].BaseListing.ReleaseNotes = $zh else . end
 ' <<<"$SUBMISSION_JSON")"

--- a/scripts/publish-msstore.sh
+++ b/scripts/publish-msstore.sh
@@ -118,6 +118,8 @@ NOTES_ZH="$(release_notes "$WHATS_NEW_DIR/zh.md")"
 [[ -n "$NOTES_EN" ]] || { echo "Could not extract release notes from whats-new/en.md." >&2; exit 1; }
 echo "--- en-us release notes (${#NOTES_EN} chars) ---"
 echo "$NOTES_EN"
+echo "--- zh-cn release notes ---"
+echo "$NOTES_ZH"
 echo "-----------------------------------------------"
 
 if [[ -f "$METADATA_BASE" ]]; then
@@ -128,6 +130,10 @@ if [[ -f "$METADATA_BASE" ]]; then
     | if .listings["zh-cn"] and ($zh != "") then .listings["zh-cn"].baseListing.releaseNotes = $zh else . end
   ' "$METADATA_BASE" > "$WORK_DIR/metadata.json"
   METADATA_JSON="$(cat "$WORK_DIR/metadata.json")"
+  if [[ -n "$NOTES_ZH" ]] && ! jq -e '.listings["zh-cn"]' "$METADATA_BASE" >/dev/null; then
+    echo "WARNING: no zh-cn listing in $METADATA_BASE — Chinese release notes will NOT be published." >&2
+    echo "         Add Chinese (Simplified) as a listing language in Partner Center, then refresh the baseline." >&2
+  fi
 else
   echo "WARNING: $METADATA_BASE not found — skipping release-notes metadata update."
   echo "         (Run the get-base-metadata workflow once the app is live and check the JSON in as msstore/metadata.json.)"


### PR DESCRIPTION
## Summary

Automates per-release Microsoft Store submissions (package upload + "What's new" release notes) via the official [msstore-cli](https://github.com/microsoft/msstore-cli):

- `scripts/publish-msstore.sh` — downloads the Store-identity MSIX for a given released version from the OSS bucket and verifies its SHA256 against `checksum.txt`; uploads it into a fresh pending submission (`msstore publish --noCommit`); then fetches that submission, patches the release notes for the given version's section of `whats-new/en.md` (`en-us` listing) and `whats-new/zh.md` (`zh-cn` listing) into it, pushes it back with `msstore submission updateMetadata`, commits, and polls certification. Runnable locally on macOS/Linux; supports `--dry-run`.
- `.github/workflows/msstore-publish.yml` — manual `workflow_dispatch` wrapper (modes: `publish` / `get-submission`), based on the official [GitHub Actions guidance](https://learn.microsoft.com/windows/apps/publish/msstore-dev-cli/github-actions). Deliberately not chained to GitHub Release publishing, since Store certification has its own cadence.
- `doc/en/MicrosoftStore.md` — one-time setup steps (first manual submission in Partner Center, protected `msstore-publish` environment) and per-release usage. Credentials reuse the existing `WINDOWS_TENANT_ID` / `WINDOWS_CLIENT_ID` / `WINDOWS_CLIENT_SECRET` / `WINDOWS_STORE_ID` secrets the Conveyor release build already consumes; the only new secret is `WINDOWS_SELLER_ID` (the Partner Center Seller ID, required by `msstore reconfigure`).

## Design notes (verified against msstore-cli sources)

- **Package before metadata.** For a live app, `msstore publish` deletes any existing pending submission and creates a new one ([`IStorePackagedAPIExtensions`](https://github.com/microsoft/msstore-cli/blob/main/MSStore.CLI/Helpers/IStorePackagedAPIExtensions.cs)), so release notes are patched into the submission *after* the package upload, using the freshly fetched submission JSON rather than a static baseline (no checked-in `msstore/metadata.json` needed).
- **PascalCase keys.** msstore-cli serializes submissions with an upper-case-first naming policy (`Listings` / `BaseListing` / `ReleaseNotes`), so the jq patch targets those paths and asserts afterwards that the patch actually landed — a key-shape mismatch fails the run instead of silently no-opping.
- **Draft guard.** `msstore submission get` falls back to the *last published* submission when no pending one exists; the script refuses to touch anything whose `Status` is `Published`.
- **Version-bound notes.** Release notes come from the `# [x.y.z]` section matching the requested version (not blindly the newest section), so re-publishing an older version cannot ship the wrong notes; missing section = hard failure.
- **Workflow hardening.** The `version` input reaches the script only via `env` (never interpolated into script text) and is strictly validated as `N.N.N.N`; the job runs in a `msstore-publish` GitHub Environment whose deployment branches should be restricted to `main`, plus an in-workflow default-branch guard.

## Notes

- The Store submission API can only update apps that are already live, so the first listing (description, screenshots, age rating, markets) must be completed manually in Partner Center once; after that every release is one workflow run.
- Release-notes sections are dropped whole when exceeding the Store's 1500-character limit, never cut mid-sentence. A missing `zh-cn` listing (or missing zh section) only warns; `en-us` is required.
- Verified locally: `--dry-run` against the released 2.1.7.2457 MSIX (SHA256 check, en/zh extraction), per-version section selection (2.1.6.2390 now yields the 2.1.6 notes), and the full get→patch→assert jq pipeline against a representative PascalCase submission JSON including the negative cases (published-fallback rejected, camelCase shape fails loudly).
