### PR TITLE
:bug: resolve device state immediately when an inbound WebSocket session opens

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
@@ -11,8 +11,14 @@ class WsSessionManager {
 
     private var onSessionClosed: ((String) -> Unit)? = null
 
+    private var onSessionOpened: ((String) -> Unit)? = null
+
     fun setOnSessionClosed(callback: (String) -> Unit) {
         onSessionClosed = callback
+    }
+
+    fun setOnSessionOpened(callback: (String) -> Unit) {
+        onSessionOpened = callback
     }
 
     suspend fun registerSession(
@@ -27,6 +33,7 @@ class WsSessionManager {
         } else {
             logger.info { "Registered WebSocket session for $appInstanceId" }
         }
+        onSessionOpened?.invoke(appInstanceId)
     }
 
     fun unregisterSession(appInstanceId: String) {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -100,6 +100,19 @@ class GeneralSyncManager(
             }
         }
 
+        // Inbound WebSocket registration is a reachability edge the polling loop would
+        // otherwise only notice on its next cycle (up to ~60s away with backoff). This
+        // matters most for client-only peers (browser extensions): they initiate the
+        // connection toward us, so without this hook the device sits visibly offline
+        // until the poll flips it to CONNECTED.
+        wsSessionManager.setOnSessionOpened { appInstanceId ->
+            internalSyncHandlers[appInstanceId]?.let { handler ->
+                realTimeSyncScope.launch {
+                    handler.fastReconnect()
+                }
+            }
+        }
+
         realTimeSyncScope.launch {
             for (event in eventChannel) {
                 launch {
@@ -142,8 +155,22 @@ class GeneralSyncManager(
                     }
 
                     newSet.forEach { appInstanceId ->
-                        internalSyncHandlers[appInstanceId] =
+                        val handler =
                             createSyncHandler(list.first { it.appInstanceId == appInstanceId })
+                        internalSyncHandlers[appInstanceId] = handler
+                        // Closes the race with the onSessionOpened hook: a WS session
+                        // registered before this map write found no handler and was
+                        // dropped (typical for a fresh pairing — the peer opens its
+                        // socket while trustSyncInfo's DB write is still in flight).
+                        // Re-checking after the write guarantees one of the two sides
+                        // always fires. In a narrow interleaving BOTH may fire; that
+                        // yields one redundant ForceResolve, which is idempotent and
+                        // serialized per device — deliberately not deduplicated.
+                        if (wsSessionManager.isConnected(appInstanceId)) {
+                            launch {
+                                handler.fastReconnect()
+                            }
+                        }
                     }
 
                     list

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
@@ -87,6 +87,32 @@ class WsSessionManagerTest {
         }
 
     @Test
+    fun registerSession_invokesOnSessionOpened() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionOpened { fired.add(it) }
+
+            mgr.registerSession("A", fakeSession())
+
+            assertEquals(listOf("A"), fired)
+        }
+
+    @Test
+    fun registerSession_replacingSession_invokesOnSessionOpenedAgain() =
+        runTest {
+            val mgr = WsSessionManager()
+            val fired = mutableListOf<String>()
+            mgr.setOnSessionOpened { fired.add(it) }
+
+            mgr.registerSession("A", fakeSession())
+            mgr.registerSession("A", fakeSession())
+
+            assertEquals(listOf("A", "A"), fired)
+            assertTrue(mgr.isConnected("A"))
+        }
+
+    @Test
     fun unregisterSession_doesNotInvokeCallback() =
         runTest {
             val mgr = WsSessionManager()

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
@@ -7,10 +7,12 @@ import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.net.clientapi.RequestTimeout
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
+import com.crosspaste.net.ws.WsSession
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.pairing.v3.PairingCapabilityFlag
 import com.crosspaste.platform.Platform
 import com.crosspaste.ui.devices.DeviceScopeFactory
+import io.ktor.websocket.WebSocketSession
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -98,6 +100,102 @@ class GeneralSyncManagerTest {
                     match {
                         it is SyncEvent.ExchangeKeysForPairing &&
                             it.generation == generation
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun wsSessionOpened_triggersImmediateForceResolve() =
+        runTest {
+            val mocks = createMocks()
+            val syncRuntimeInfo =
+                createTestSyncRuntimeInfo(
+                    connectState = SyncState.DISCONNECTED,
+                )
+            every { mocks.syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow() } returns
+                MutableStateFlow(listOf(syncRuntimeInfo))
+            coEvery { mocks.syncResolver.emitEvent(any()) } just runs
+            val wsSessionManager = WsSessionManager()
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager =
+                GeneralSyncManager(
+                    realTimeSyncScope = childScope,
+                    pendingExchangeLedger = PendingExchangeLedger(),
+                    syncResolver = mocks.syncResolver,
+                    syncRuntimeInfoDao = mocks.syncRuntimeInfoDao,
+                    syncClientApi = mocks.syncClientApi,
+                    wsSessionManager = wsSessionManager,
+                    pairingCapabilityFlag = PairingCapabilityFlag(2),
+                )
+            syncManager.start()
+            advanceUntilIdle()
+
+            val wsSession =
+                WsSession(
+                    mockk<WebSocketSession>(relaxed = true) {
+                        every { coroutineContext } returns Job()
+                    },
+                    syncRuntimeInfo.appInstanceId,
+                )
+            wsSessionManager.registerSession(syncRuntimeInfo.appInstanceId, wsSession)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                mocks.syncResolver.emitEvent(
+                    match {
+                        it is SyncEvent.ForceResolve &&
+                            it.syncRuntimeInfo.appInstanceId == syncRuntimeInfo.appInstanceId
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun wsSessionRegisteredBeforeHandlerCreation_stillTriggersForceResolve() =
+        runTest {
+            val mocks = createMocks()
+            val syncRuntimeInfo =
+                createTestSyncRuntimeInfo(
+                    connectState = SyncState.DISCONNECTED,
+                )
+            every { mocks.syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow() } returns
+                MutableStateFlow(listOf(syncRuntimeInfo))
+            coEvery { mocks.syncResolver.emitEvent(any()) } just runs
+            val wsSessionManager = WsSessionManager()
+            // Register the session BEFORE start(): the onSessionOpened hook is not
+            // wired yet, so the open event is dropped — exactly the interleaving
+            // where the peer's socket lands while its handler does not exist yet.
+            val wsSession =
+                WsSession(
+                    mockk<WebSocketSession>(relaxed = true) {
+                        every { coroutineContext } returns Job()
+                    },
+                    syncRuntimeInfo.appInstanceId,
+                )
+            wsSessionManager.registerSession(syncRuntimeInfo.appInstanceId, wsSession)
+
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager =
+                GeneralSyncManager(
+                    realTimeSyncScope = childScope,
+                    pendingExchangeLedger = PendingExchangeLedger(),
+                    syncResolver = mocks.syncResolver,
+                    syncRuntimeInfoDao = mocks.syncRuntimeInfoDao,
+                    syncClientApi = mocks.syncClientApi,
+                    wsSessionManager = wsSessionManager,
+                    pairingCapabilityFlag = PairingCapabilityFlag(2),
+                )
+            syncManager.start()
+            advanceUntilIdle()
+
+            // The post-write isConnected re-check must fire even though the
+            // opened callback never saw a handler.
+            coVerify(exactly = 1) {
+                mocks.syncResolver.emitEvent(
+                    match {
+                        it is SyncEvent.ForceResolve &&
+                            it.syncRuntimeInfo.appInstanceId == syncRuntimeInfo.appInstanceId
                     },
                 )
             }


### PR DESCRIPTION
Closes #4746

## Summary

Session close already triggers an immediate `forceResolve` via `WsSessionManager.setOnSessionClosed`, but session open had no counterpart: the host only flipped a device to CONNECTED on the next `SyncPollingManager` cycle (default interval 60s; failure backoff also caps at ~60s). Client-only peers (browser extensions) are the worst hit — the host can only observe their liveness through the WebSocket session, so after a manual IP:port connection the device sat visibly offline for up to a minute while the socket was already up.

## Changes

- `WsSessionManager`: add `setOnSessionOpened`; `registerSession` fires it on every registration, including replacement of an existing session.
- `GeneralSyncManager.start()`: wire the hook to `fastReconnect()` (clear polling backoff + immediate resolve), mirroring the mDNS `serviceResolved` reachability-edge semantics. For extensions this runs `SyncResolver.resolveExtension`'s WS probe and flips the device to CONNECTED right away; for regular peers an inbound session on the passive side resolves immediately as well.
- Session-before-handler race: on a fresh pairing the peer often opens its socket while `trustSyncInfo`'s DB write is still in flight, so the opened callback can fire before the handler exists in `internalSyncHandlers` and would be dropped. After publishing a new handler, re-check `wsSessionManager.isConnected(...)` and trigger `fastReconnect()` if a session is already active, so one of the two sides always fires. In a narrow interleaving both may fire; the redundant `ForceResolve` is idempotent and serialized per device, deliberately not deduplicated.

All changes are in `commonMain`; mobile projects pick them up by syncing the shared sources.

## Tests

- `WsSessionManagerTest`: opened hook fires on registration and again on session replacement.
- `GeneralSyncManagerTest`: registering a WS session triggers an immediate `ForceResolve` for the matching handler; reverse-order test registers the session before `start()` (opened callback necessarily lost) and asserts the post-publish re-check still triggers `ForceResolve`.
- `./gradlew app:desktopTest` for the affected suites and `ktlintCheck` pass.