### PR TITLE
:bug: implement authenticated WebSocket handshake in the Chrome extension

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/WsRouting.kt
@@ -62,6 +62,14 @@ fun Routing.wsRouting(
             } else {
                 val remoteAddress = runCatching { call.request.origin.remoteAddress }.getOrNull()
                 if (!isLoopbackAddress(remoteAddress)) {
+                    // Deliberately loud: a peer landing here dials without authVersion
+                    // (e.g. an outdated extension) and would otherwise disappear without
+                    // a trace — the peer's own onopen already fired, so it believes it
+                    // is connected while we never register the session.
+                    logger.warn {
+                        "WS connection rejected: $appInstanceId from $remoteAddress " +
+                            "requires authenticated WebSocket (authVersion missing)"
+                    }
                     close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Authenticated WebSocket required"))
                     return@webSocket
                 }

--- a/core/src/jsMain/kotlin/com/crosspaste/web/CrossPasteApi.kt
+++ b/core/src/jsMain/kotlin/com/crosspaste/web/CrossPasteApi.kt
@@ -19,6 +19,7 @@ import com.crosspaste.pairing.v3.Spake2PakeProvider
 import com.crosspaste.paste.PasteData
 import com.crosspaste.secure.ECDHKeyPairImpl
 import com.crosspaste.secure.ECDSAKeyPairImpl
+import com.crosspaste.secure.PeerAuthenticator
 import com.crosspaste.secure.SecureKeyPair
 import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureMessageCipher
@@ -296,15 +297,19 @@ object CrossPasteCrypto {
 }
 
 /**
- * Symmetric message cipher bound to one peer — exposed to TypeScript.
+ * Symmetric message cipher + peer authenticator bound to one peer — exposed
+ * to TypeScript.
  *
- * Byte-compatible with desktop's `SecureMessageProcessor`: used to decrypt
- * WS envelopes flagged `encrypted` (e.g. PASTE_PUSH when the desktop has
- * "Encrypted Sync" enabled). Construct via [createSecureMessageProcessor].
+ * Byte-compatible with desktop's `SecureMessageProcessor`: [encrypt]/[decrypt]
+ * handle WS envelopes flagged `encrypted` (e.g. PASTE_PUSH when the desktop
+ * has "Encrypted Sync" enabled); [authenticationCode]/[verifyAuthentication]
+ * produce and check the HMAC codes used by the authenticated WebSocket
+ * handshake and per-envelope MACs. Construct via [createSecureMessageProcessor].
  */
 @JsExport
 class JsSecureMessageProcessor internal constructor(
     private val cipher: SecureMessageCipher,
+    private val peerAuthenticator: PeerAuthenticator,
 ) {
 
     @Suppress("OPT_IN_USAGE")
@@ -317,6 +322,21 @@ class JsSecureMessageProcessor internal constructor(
     fun decrypt(data: ByteArray): Promise<ByteArray> =
         GlobalScope.promise {
             cipher.decrypt(data)
+        }
+
+    @Suppress("OPT_IN_USAGE")
+    fun authenticationCode(data: ByteArray): Promise<ByteArray> =
+        GlobalScope.promise {
+            peerAuthenticator.authenticationCode(data)
+        }
+
+    @Suppress("OPT_IN_USAGE")
+    fun verifyAuthentication(
+        data: ByteArray,
+        expectedCode: ByteArray,
+    ): Promise<Boolean> =
+        GlobalScope.promise {
+            peerAuthenticator.verify(data, expectedCode)
         }
 }
 
@@ -332,10 +352,16 @@ fun createSecureMessageProcessor(
 ): Promise<JsSecureMessageProcessor> =
     GlobalScope.promise {
         val serializer = SecureKeyPairSerializer()
+        val privateKey = serializer.decodeCryptPrivateKey(cryptPrivateKeyDer)
+        val publicKey = serializer.decodeCryptPublicKey(peerCryptPublicKeyDer)
         JsSecureMessageProcessor(
             SecureMessageCipher(
-                privateKey = serializer.decodeCryptPrivateKey(cryptPrivateKeyDer),
-                publicKey = serializer.decodeCryptPublicKey(peerCryptPublicKeyDer),
+                privateKey = privateKey,
+                publicKey = publicKey,
+            ),
+            PeerAuthenticator(
+                privateKey = privateKey,
+                publicKey = publicKey,
             ),
         )
     }

--- a/web/src/shared/ws/__tests__/ws-auth.test.ts
+++ b/web/src/shared/ws/__tests__/ws-auth.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  type WsAuthChallenge,
+  type WsAuthProcessor,
+  WsAuthContext,
+  base64ToBytes,
+  bytesToBase64,
+  clientProofCode,
+  envelopePayload,
+  handshakePayload,
+  verifyServerProof,
+} from "../ws-auth";
+import type { WsEnvelope } from "../ws-types";
+
+/**
+ * Independent re-encoding of core's CanonicalWriter wire format
+ * ([u32 len][domain utf8] then per field [u8 id][u32 len][payload], all
+ * big-endian), used to golden-check the production encoder.
+ */
+function canonical(domain: string, fields: Array<[number, Uint8Array]>): Uint8Array {
+  const encoder = new TextEncoder();
+  const parts: number[] = [];
+  const pushU32 = (v: number) => parts.push((v >>> 24) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff);
+  const domainBytes = encoder.encode(domain);
+  pushU32(domainBytes.length);
+  parts.push(...domainBytes);
+  for (const [id, payload] of fields) {
+    parts.push(id);
+    pushU32(payload.length);
+    parts.push(...payload);
+  }
+  return new Uint8Array(parts);
+}
+
+const utf8 = (s: string) => new TextEncoder().encode(s);
+const u32bytes = (v: number) => new Uint8Array([(v >>> 24) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff]);
+const u64bytes = (v: number) => {
+  const b = new Uint8Array(8);
+  new DataView(b.buffer).setBigUint64(0, BigInt(v), false);
+  return b;
+};
+
+/** Deterministic fake MAC: (domain-tagged) copy of the input prefixed by a key byte. */
+function fakeProcessor(keyByte: number): WsAuthProcessor {
+  const mac = (data: Int8Array): Int8Array => {
+    const out = new Int8Array(data.length + 1);
+    out[0] = keyByte;
+    out.set(data, 1);
+    return out;
+  };
+  return {
+    authenticationCode: async (data) => mac(data),
+    verifyAuthentication: async (data, expected) => {
+      const computed = mac(data);
+      if (computed.length !== expected.length) return false;
+      for (let i = 0; i < computed.length; i++) {
+        if (computed[i] !== expected[i]) return false;
+      }
+      return true;
+    },
+  };
+}
+
+const challenge: WsAuthChallenge = {
+  sessionId: "session-1",
+  nonce: bytesToBase64(new Uint8Array([1, 2, 3, 4])),
+  pairingVersion: 3,
+};
+
+describe("canonical payload encoding", () => {
+  it("handshakePayload matches the CanonicalWriter wire format", () => {
+    const actual = handshakePayload("client-proof", "ext-id", "desktop-id", challenge);
+    const expected = canonical("crosspaste-ws-handshake-v1", [
+      [1, utf8("client-proof")],
+      [2, utf8("ext-id")],
+      [3, utf8("desktop-id")],
+      [4, utf8("session-1")],
+      [5, new Uint8Array([1, 2, 3, 4])],
+    ]);
+    expect(Array.from(actual)).toEqual(Array.from(expected));
+  });
+
+  it("envelopePayload matches the CanonicalWriter wire format", () => {
+    const envelope: WsEnvelope = {
+      type: "paste_push",
+      payload: new Uint8Array([9, 8, 7]),
+      encrypted: true,
+      requestId: "req-1",
+    };
+    const actual = envelopePayload("session-1", 5, "ext-id", "desktop-id", envelope);
+    const expected = canonical("crosspaste-ws-envelope-v1", [
+      [1, utf8("session-1")],
+      [2, u64bytes(5)],
+      [3, utf8("ext-id")],
+      [4, utf8("desktop-id")],
+      [5, utf8("paste_push")],
+      [6, u32bytes(1)],
+      [7, utf8("req-1")],
+      [8, new Uint8Array([9, 8, 7])],
+    ]);
+    expect(Array.from(actual)).toEqual(Array.from(expected));
+  });
+
+  it("encodes a missing requestId as an empty string field", () => {
+    const envelope: WsEnvelope = { type: "heartbeat", payload: new Uint8Array(0), encrypted: false };
+    const actual = envelopePayload("s", 0, "a", "b", envelope);
+    const expected = canonical("crosspaste-ws-envelope-v1", [
+      [1, utf8("s")],
+      [2, u64bytes(0)],
+      [3, utf8("a")],
+      [4, utf8("b")],
+      [5, utf8("heartbeat")],
+      [6, u32bytes(0)],
+      [7, new Uint8Array(0)],
+      [8, new Uint8Array(0)],
+    ]);
+    expect(Array.from(actual)).toEqual(Array.from(expected));
+  });
+});
+
+describe("WsAuthContext", () => {
+  function contextPair(): { sender: WsAuthContext; receiver: WsAuthContext } {
+    const processor = fakeProcessor(42);
+    return {
+      sender: new WsAuthContext("session", "first", "second", processor),
+      receiver: new WsAuthContext("session", "second", "first", processor),
+    };
+  }
+
+  it("round-trips an authenticated envelope and rejects replay", async () => {
+    const { sender, receiver } = contextPair();
+    const envelope: WsEnvelope = { type: "heartbeat", payload: new Uint8Array(0), encrypted: false };
+
+    const header = await sender.createHeader(envelope);
+    expect(header.authSessionId).toBe("session");
+    expect(header.authSequence).toBe(0);
+    expect(await receiver.verify(header, envelope.payload)).toBe(true);
+    // Same header again = replay: the receive sequence has moved on.
+    expect(await receiver.verify(header, envelope.payload)).toBe(false);
+  });
+
+  it("rejects tampered payloads without advancing the receive sequence", async () => {
+    const { sender, receiver } = contextPair();
+    const envelope: WsEnvelope = {
+      type: "paste_push",
+      payload: utf8("payload"),
+      encrypted: false,
+    };
+
+    const header = await sender.createHeader(envelope);
+    expect(await receiver.verify(header, utf8("tampered"))).toBe(false);
+    // The genuine payload still verifies afterwards.
+    expect(await receiver.verify(header, envelope.payload)).toBe(true);
+  });
+
+  it("increments the send sequence per envelope and enforces receive order", async () => {
+    const { sender, receiver } = contextPair();
+    const envelope: WsEnvelope = { type: "heartbeat", payload: new Uint8Array(0), encrypted: false };
+
+    const first = await sender.createHeader(envelope);
+    const second = await sender.createHeader(envelope);
+    expect(first.authSequence).toBe(0);
+    expect(second.authSequence).toBe(1);
+
+    // Out-of-order delivery fails; in-order succeeds.
+    expect(await receiver.verify(second, envelope.payload)).toBe(false);
+    expect(await receiver.verify(first, envelope.payload)).toBe(true);
+    expect(await receiver.verify(second, envelope.payload)).toBe(true);
+  });
+
+  it("rejects headers from another session or without auth fields", async () => {
+    const { sender, receiver } = contextPair();
+    const envelope: WsEnvelope = { type: "heartbeat", payload: new Uint8Array(0), encrypted: false };
+
+    const header = await sender.createHeader(envelope);
+    expect(await receiver.verify({ ...header, authSessionId: "other" }, envelope.payload)).toBe(false);
+    expect(await receiver.verify({ ...header, authenticationCode: null }, envelope.payload)).toBe(false);
+    expect(await receiver.verify({ ...header, authSequence: null }, envelope.payload)).toBe(false);
+    // Untouched header still verifies (no sequence was consumed by the failures).
+    expect(await receiver.verify(header, envelope.payload)).toBe(true);
+  });
+});
+
+describe("handshake proofs", () => {
+  it("client proof and server proof cover mirrored directions", async () => {
+    const extension = fakeProcessor(7);
+    const desktop = fakeProcessor(7);
+
+    const proofB64 = await clientProofCode(extension, "ext-id", "desktop-id", challenge);
+    // The desktop verifies the client proof with source=ext, target=desktop.
+    expect(
+      await desktop.verifyAuthentication(
+        new Int8Array(handshakePayload("client-proof", "ext-id", "desktop-id", challenge).buffer),
+        new Int8Array(base64ToBytes(proofB64).buffer),
+      ),
+    ).toBe(true);
+
+    // The server's ack signs source=desktop, target=ext; the extension verifies it.
+    const ackCode = await desktop.authenticationCode(
+      new Int8Array(handshakePayload("server-proof", "desktop-id", "ext-id", challenge).buffer),
+    );
+    const ackB64 = bytesToBase64(new Uint8Array(ackCode.buffer, ackCode.byteOffset, ackCode.byteLength));
+    expect(
+      await verifyServerProof(extension, "ext-id", "desktop-id", challenge, {
+        authenticationCode: ackB64,
+      }),
+    ).toBe(true);
+
+    // A proof for the wrong role never validates as the server ack.
+    expect(
+      await verifyServerProof(extension, "ext-id", "desktop-id", challenge, {
+        authenticationCode: proofB64,
+      }),
+    ).toBe(false);
+  });
+});

--- a/web/src/shared/ws/__tests__/ws-client-auth.test.ts
+++ b/web/src/shared/ws/__tests__/ws-client-auth.test.ts
@@ -32,6 +32,47 @@ function fakeProcessor(): WsAuthProcessor {
   };
 }
 
+function gatedVerificationProcessor(): {
+  processor: WsAuthProcessor;
+  release: () => void;
+  firstVerificationStarted: Promise<void>;
+  firstVerificationCompleted: Promise<void>;
+} {
+  const delegate = fakeProcessor();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let markStarted!: () => void;
+  const firstVerificationStarted = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  let markCompleted!: () => void;
+  const firstVerificationCompleted = new Promise<void>((resolve) => {
+    markCompleted = resolve;
+  });
+  let gateNextVerification = true;
+  return {
+    processor: {
+      authenticationCode: (data) => delegate.authenticationCode(data),
+      verifyAuthentication: async (data, expected) => {
+        if (gateNextVerification) {
+          gateNextVerification = false;
+          markStarted();
+          await gate;
+          const valid = await delegate.verifyAuthentication(data, expected);
+          markCompleted();
+          return valid;
+        }
+        return delegate.verifyAuthentication(data, expected);
+      },
+    },
+    release,
+    firstVerificationStarted,
+    firstVerificationCompleted,
+  };
+}
+
 class MockWebSocket {
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;
@@ -151,6 +192,35 @@ async function completeHandshake(
   );
 }
 
+/** Sends a valid challenge and ack without verifying the client's proof. */
+async function sendChallengeAndAck(
+  ws: MockWebSocket,
+  processor: WsAuthProcessor,
+): Promise<void> {
+  ws.serverOpen();
+  ws.serverSend(
+    { type: WsMessageType.AUTH_CHALLENGE, encrypted: false, hasPayload: true },
+    new TextEncoder().encode(JSON.stringify(CHALLENGE)),
+  );
+  await waitForSent(ws, 2);
+
+  const ackCode = await processor.authenticationCode(
+    new Int8Array(
+      handshakePayload("server-proof", "desktop-id", "ext-id", CHALLENGE).buffer,
+    ),
+  );
+  const ack: WsAuthProofMessage = {
+    authenticationCode: bytesToBase64(
+      new Uint8Array(ackCode.buffer, ackCode.byteOffset, ackCode.byteLength),
+    ),
+    pairingVersion: 3,
+  };
+  ws.serverSend(
+    { type: WsMessageType.AUTH_ACK, encrypted: false, hasPayload: true },
+    new TextEncoder().encode(JSON.stringify(ack)),
+  );
+}
+
 describe("WsClient authentication", () => {
   beforeEach(() => {
     MockWebSocket.instances = [];
@@ -173,6 +243,38 @@ describe("WsClient authentication", () => {
     await completeHandshake(ws, processor);
 
     await expect(connectPromise).resolves.toBe(true);
+    expect(client.isActive).toBe(true);
+  });
+
+  it("cancels a pending connection when closed before the socket opens", async () => {
+    const client = makeClient(fakeProcessor());
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    client.close();
+
+    await expect(connectPromise).resolves.toBe(false);
+    expect(client.currentState).toBe("closed");
+    expect(ws.closedWith).toEqual({ code: 1000, reason: "Normal closure" });
+  });
+
+  it("cancels a pending connection after a socket error", async () => {
+    const processor = fakeProcessor();
+    const client = makeClient(processor);
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    ws.onerror?.();
+
+    await expect(connectPromise).resolves.toBe(false);
+    expect(client.currentState).toBe("closed");
+    expect(ws.closedWith).toEqual({ code: 1000, reason: "Connection error" });
+
+    const retryPromise = client.connect();
+    const retryWs = MockWebSocket.instances[1];
+    await completeHandshake(retryWs, processor);
+
+    await expect(retryPromise).resolves.toBe(true);
     expect(client.isActive).toBe(true);
   });
 
@@ -199,6 +301,60 @@ describe("WsClient authentication", () => {
 
     await expect(connectPromise).resolves.toBe(false);
     expect(client.isActive).toBe(false);
+  });
+
+  it("drains authenticated messages received while the server proof is being verified", async () => {
+    const { processor, release, firstVerificationStarted } = gatedVerificationProcessor();
+    const client = makeClient(processor);
+    const received: WsEnvelope[] = [];
+    client.onMessage = (envelope) => received.push(envelope);
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    await sendChallengeAndAck(ws, processor);
+    await firstVerificationStarted;
+
+    const desktopContext = new WsAuthContext("session-1", "desktop-id", "ext-id", processor);
+    const envelope: WsEnvelope = {
+      type: WsMessageType.SYNC_INFO,
+      payload: new TextEncoder().encode("first authenticated message"),
+      encrypted: false,
+    };
+    ws.serverSend(
+      { ...(await desktopContext.createHeader(envelope)), hasPayload: true },
+      envelope.payload,
+    );
+
+    release();
+
+    await expect(connectPromise).resolves.toBe(true);
+    expect(received).toEqual([envelope]);
+  });
+
+  it("does not publish connected after the socket closes during server proof verification", async () => {
+    const {
+      processor,
+      release,
+      firstVerificationStarted,
+      firstVerificationCompleted,
+    } = gatedVerificationProcessor();
+    const client = makeClient(processor);
+    const onConnect = vi.fn();
+    client.onConnect = onConnect;
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    await sendChallengeAndAck(ws, processor);
+    await firstVerificationStarted;
+
+    ws.close(1006, "Connection lost");
+    release();
+    await firstVerificationCompleted;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(connectPromise).resolves.toBe(false);
+    expect(client.currentState).toBe("closed");
+    expect(onConnect).not.toHaveBeenCalled();
   });
 
   it("resolves false when the server closes during the handshake (policy rejection)", async () => {

--- a/web/src/shared/ws/__tests__/ws-client-auth.test.ts
+++ b/web/src/shared/ws/__tests__/ws-client-auth.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WsClient } from "../ws-client";
+import {
+  type WsAuthChallenge,
+  type WsAuthProcessor,
+  type WsAuthProofMessage,
+  WsAuthContext,
+  base64ToBytes,
+  bytesToBase64,
+  handshakePayload,
+} from "../ws-auth";
+import { WsMessageType, type WsEnvelope, type WsEnvelopeHeader } from "../ws-types";
+
+/** Deterministic fake MAC shared by "extension" and "desktop" in these tests. */
+function fakeProcessor(): WsAuthProcessor {
+  const mac = (data: Int8Array): Int8Array => {
+    const out = new Int8Array(data.length + 1);
+    out[0] = 42;
+    out.set(data, 1);
+    return out;
+  };
+  return {
+    authenticationCode: async (data) => mac(data),
+    verifyAuthentication: async (data, expected) => {
+      const computed = mac(data);
+      if (computed.length !== expected.length) return false;
+      for (let i = 0; i < computed.length; i++) {
+        if (computed[i] !== expected[i]) return false;
+      }
+      return true;
+    },
+  };
+}
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  binaryType = "blob";
+  readyState = MockWebSocket.CONNECTING;
+  sent: Array<string | ArrayBuffer> = [];
+  closedWith: { code?: number; reason?: string } | null = null;
+
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string | ArrayBuffer): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closedWith = { code, reason };
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: code ?? 1000, reason: reason ?? "" });
+  }
+
+  // Test helpers
+  serverOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  serverSend(header: WsEnvelopeHeader, payload?: Uint8Array): void {
+    this.onmessage?.({ data: JSON.stringify(header) });
+    if (payload && payload.length > 0) {
+      const buf = new ArrayBuffer(payload.byteLength);
+      new Uint8Array(buf).set(payload);
+      this.onmessage?.({ data: buf });
+    }
+  }
+}
+
+/** Waits until the client has written `count` frames to the socket. */
+async function waitForSent(ws: MockWebSocket, count: number): Promise<void> {
+  await vi.waitFor(() => {
+    expect(ws.sent.length).toBeGreaterThanOrEqual(count);
+  });
+}
+
+function sentEnvelope(ws: MockWebSocket, index: number): { header: WsEnvelopeHeader; payload: Uint8Array } {
+  const header = JSON.parse(ws.sent[index] as string) as WsEnvelopeHeader;
+  if (!header.hasPayload) return { header, payload: new Uint8Array(0) };
+  return { header, payload: new Uint8Array(ws.sent[index + 1] as ArrayBuffer) };
+}
+
+const CHALLENGE: WsAuthChallenge = {
+  sessionId: "session-1",
+  nonce: bytesToBase64(new Uint8Array([9, 9, 9, 9])),
+  pairingVersion: 3,
+};
+
+function makeClient(processor: WsAuthProcessor): WsClient {
+  return new WsClient({
+    host: "192.168.0.109",
+    port: 13129,
+    appInstanceId: "ext-id",
+    targetAppInstanceId: "desktop-id",
+    createAuthProcessor: async () => processor,
+    pairingVersion: 3,
+  });
+}
+
+/** Drives the desktop side of the handshake against the mock socket. */
+async function completeHandshake(
+  ws: MockWebSocket,
+  processor: WsAuthProcessor,
+): Promise<void> {
+  ws.serverOpen();
+  ws.serverSend(
+    { type: WsMessageType.AUTH_CHALLENGE, encrypted: false, hasPayload: true },
+    new TextEncoder().encode(JSON.stringify(CHALLENGE)),
+  );
+
+  // Client answers with AUTH_PROOF (header + payload frames).
+  await waitForSent(ws, 2);
+  const { header, payload } = sentEnvelope(ws, 0);
+  expect(header.type).toBe(WsMessageType.AUTH_PROOF);
+  const proof = JSON.parse(new TextDecoder().decode(payload)) as WsAuthProofMessage;
+  expect(proof.pairingVersion).toBe(3);
+  expect(
+    await processor.verifyAuthentication(
+      new Int8Array(handshakePayload("client-proof", "ext-id", "desktop-id", CHALLENGE).buffer),
+      new Int8Array(base64ToBytes(proof.authenticationCode).buffer),
+    ),
+  ).toBe(true);
+
+  // Desktop acks with its own proof.
+  const ackCode = await processor.authenticationCode(
+    new Int8Array(handshakePayload("server-proof", "desktop-id", "ext-id", CHALLENGE).buffer),
+  );
+  const ack: WsAuthProofMessage = {
+    authenticationCode: bytesToBase64(
+      new Uint8Array(ackCode.buffer, ackCode.byteOffset, ackCode.byteLength),
+    ),
+    pairingVersion: 3,
+  };
+  ws.serverSend(
+    { type: WsMessageType.AUTH_ACK, encrypted: false, hasPayload: true },
+    new TextEncoder().encode(JSON.stringify(ack)),
+  );
+}
+
+describe("WsClient authentication", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("dials with authVersion and connects only after the handshake verifies", async () => {
+    const processor = fakeProcessor();
+    const client = makeClient(processor);
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    expect(ws.url).toContain("authVersion=1");
+
+    expect(client.isActive).toBe(false);
+    await completeHandshake(ws, processor);
+
+    await expect(connectPromise).resolves.toBe(true);
+    expect(client.isActive).toBe(true);
+  });
+
+  it("fails the connect when the server ack proof is invalid", async () => {
+    const processor = fakeProcessor();
+    const client = makeClient(processor);
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    ws.serverOpen();
+    ws.serverSend(
+      { type: WsMessageType.AUTH_CHALLENGE, encrypted: false, hasPayload: true },
+      new TextEncoder().encode(JSON.stringify(CHALLENGE)),
+    );
+    await waitForSent(ws, 2);
+
+    const forgedAck: WsAuthProofMessage = {
+      authenticationCode: bytesToBase64(new Uint8Array([1, 2, 3])),
+    };
+    ws.serverSend(
+      { type: WsMessageType.AUTH_ACK, encrypted: false, hasPayload: true },
+      new TextEncoder().encode(JSON.stringify(forgedAck)),
+    );
+
+    await expect(connectPromise).resolves.toBe(false);
+    expect(client.isActive).toBe(false);
+  });
+
+  it("resolves false when the server closes during the handshake (policy rejection)", async () => {
+    const client = makeClient(fakeProcessor());
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    ws.serverOpen();
+    ws.close(1008, "Authenticated WebSocket required");
+
+    await expect(connectPromise).resolves.toBe(false);
+    expect(client.isActive).toBe(false);
+  });
+
+  it("MACs outgoing envelopes with ordered sequences and verifies incoming ones", async () => {
+    const processor = fakeProcessor();
+    const client = makeClient(processor);
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    await completeHandshake(ws, processor);
+    await connectPromise;
+
+    // Desktop-side mirror of the client's auth context.
+    const desktopContext = new WsAuthContext("session-1", "desktop-id", "ext-id", processor);
+
+    const sentBefore = ws.sent.length;
+    await client.sendEnvelope({
+      type: WsMessageType.SYNC_INFO,
+      payload: new TextEncoder().encode("{}"),
+      encrypted: false,
+    });
+    await client.sendEnvelope({
+      type: WsMessageType.HEARTBEAT,
+      payload: new Uint8Array(0),
+      encrypted: false,
+    });
+
+    const first = sentEnvelope(ws, sentBefore);
+    expect(first.header.authSequence).toBe(0);
+    // ext -> desktop verifies against a receiver context mirroring the desktop.
+    const desktopReceiver = new WsAuthContext("session-1", "desktop-id", "ext-id", processor);
+    expect(await desktopReceiver.verify(first.header, first.payload)).toBe(true);
+
+    const second = sentEnvelope(ws, sentBefore + 2);
+    expect(second.header.authSequence).toBe(1);
+    expect(await desktopReceiver.verify(second.header, second.payload)).toBe(true);
+
+    // Incoming authenticated message dispatches to onMessage.
+    const received: WsEnvelope[] = [];
+    client.onMessage = (envelope) => received.push(envelope);
+    const pushPayload = new TextEncoder().encode("pushed");
+    const pushEnvelope: WsEnvelope = {
+      type: WsMessageType.PASTE_PUSH,
+      payload: pushPayload,
+      encrypted: false,
+    };
+    const pushHeader = await desktopContext.createHeader(pushEnvelope);
+    ws.serverSend({ ...pushHeader, hasPayload: true }, pushPayload);
+    await vi.waitFor(() => {
+      expect(received).toHaveLength(1);
+    });
+    expect(received[0].type).toBe(WsMessageType.PASTE_PUSH);
+
+    // A tampered incoming message closes the connection.
+    const tamperedHeader = await desktopContext.createHeader(pushEnvelope);
+    ws.serverSend({ ...tamperedHeader, hasPayload: true }, new TextEncoder().encode("evil!!"));
+    await vi.waitFor(() => {
+      expect(ws.closedWith?.code).toBe(1008);
+    });
+  });
+
+  it("reassembles chunked payloads before verification", async () => {
+    const processor = fakeProcessor();
+    const client = makeClient(processor);
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    await completeHandshake(ws, processor);
+    await connectPromise;
+
+    const desktopContext = new WsAuthContext("session-1", "desktop-id", "ext-id", processor);
+    const payload = new TextEncoder().encode("abcdef");
+    const envelope: WsEnvelope = {
+      type: WsMessageType.PASTE_PUSH,
+      payload,
+      encrypted: false,
+    };
+    const header = await desktopContext.createHeader(envelope);
+
+    const received: WsEnvelope[] = [];
+    client.onMessage = (e) => received.push(e);
+
+    ws.onmessage?.({
+      data: JSON.stringify({ ...header, hasPayload: true, payloadChunkCount: 2 }),
+    });
+    const firstChunk = new ArrayBuffer(3);
+    new Uint8Array(firstChunk).set(payload.subarray(0, 3));
+    ws.onmessage?.({ data: firstChunk });
+    const secondChunk = new ArrayBuffer(3);
+    new Uint8Array(secondChunk).set(payload.subarray(3));
+    ws.onmessage?.({ data: secondChunk });
+
+    await vi.waitFor(() => {
+      expect(received).toHaveLength(1);
+    });
+    expect(new TextDecoder().decode(received[0].payload)).toBe("abcdef");
+  });
+});

--- a/web/src/shared/ws/ws-auth.ts
+++ b/web/src/shared/ws/ws-auth.ts
@@ -1,0 +1,273 @@
+import type { WsEnvelope, WsEnvelopeHeader } from "./ws-types";
+import { toHeader } from "./ws-types";
+
+/**
+ * WebSocket authentication for the extension, byte-compatible with desktop's
+ * `WsAuthenticationCodec` / `WsAuthenticationContext`
+ * (app/src/commonMain/kotlin/com/crosspaste/net/ws/WsAuthentication.kt).
+ *
+ * The desktop requires `authVersion=1` plus an AUTH_CHALLENGE → AUTH_PROOF →
+ * AUTH_ACK handshake for any WebSocket that does not originate from loopback;
+ * afterwards every envelope carries an HMAC over a canonical encoding of the
+ * session, per-direction sequence number, and envelope contents. The HMAC
+ * itself comes from the Kotlin/JS core (`SecureMessageProcessor`
+ * authenticationCode / verifyAuthentication), so only the canonical byte
+ * layout is ported here.
+ */
+
+export const WS_AUTH_VERSION = 1;
+
+export const WS_AUTH_ROLE_CLIENT_PROOF = "client-proof";
+export const WS_AUTH_ROLE_SERVER_PROOF = "server-proof";
+
+const HANDSHAKE_DOMAIN = "crosspaste-ws-handshake-v1";
+const ENVELOPE_DOMAIN = "crosspaste-ws-envelope-v1";
+
+/** Subset of the K/JS `JsSecureMessageProcessor` surface used for MACs. */
+export interface WsAuthProcessor {
+  authenticationCode(data: Int8Array): Promise<Int8Array>;
+  verifyAuthentication(data: Int8Array, expectedCode: Int8Array): Promise<boolean>;
+}
+
+/** `WsAuthChallenge` JSON payload of an AUTH_CHALLENGE envelope. */
+export interface WsAuthChallenge {
+  sessionId: string;
+  /** base64 (Kotlin Base64ByteArraySerializer) */
+  nonce: string;
+  pairingVersion?: number | null;
+}
+
+/** `WsAuthProof` JSON payload of AUTH_PROOF / AUTH_ACK envelopes. */
+export interface WsAuthProofMessage {
+  /** base64 (Kotlin Base64ByteArraySerializer) */
+  authenticationCode: string;
+  pairingVersion?: number | null;
+}
+
+export function base64ToBytes(b64: string): Uint8Array {
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Deterministic encoder mirroring core's `CanonicalWriter`: the domain
+ * separator as `[u32 length][utf8]`, then each field as `[u8 id][u32
+ * length][payload]`; integers big-endian, strings UTF-8, Long as 8 bytes.
+ */
+class CanonicalWriter {
+  private chunks: Uint8Array[] = [];
+  private size = 0;
+
+  constructor(domain: string) {
+    const domainBytes = new TextEncoder().encode(domain);
+    this.append(u32(domainBytes.length));
+    this.append(domainBytes);
+  }
+
+  fieldBytes(id: number, bytes: Uint8Array): this {
+    this.append(new Uint8Array([id]));
+    this.append(u32(bytes.length));
+    this.append(bytes);
+    return this;
+  }
+
+  fieldString(id: number, value: string): this {
+    return this.fieldBytes(id, new TextEncoder().encode(value));
+  }
+
+  fieldInt(id: number, value: number): this {
+    return this.fieldBytes(id, u32(value));
+  }
+
+  fieldLong(id: number, value: number): this {
+    return this.fieldBytes(id, u64(value));
+  }
+
+  build(): Uint8Array {
+    const result = new Uint8Array(this.size);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return result;
+  }
+
+  private append(bytes: Uint8Array): void {
+    this.chunks.push(bytes);
+    this.size += bytes.length;
+  }
+}
+
+function u32(value: number): Uint8Array {
+  const bytes = new Uint8Array(4);
+  new DataView(bytes.buffer).setUint32(0, value, false);
+  return bytes;
+}
+
+function u64(value: number): Uint8Array {
+  const bytes = new Uint8Array(8);
+  new DataView(bytes.buffer).setBigUint64(0, BigInt(value), false);
+  return bytes;
+}
+
+/** Mirror of `WsAuthenticationCodec.handshakePayload`. */
+export function handshakePayload(
+  role: string,
+  sourceAppInstanceId: string,
+  targetAppInstanceId: string,
+  challenge: WsAuthChallenge,
+): Uint8Array {
+  return new CanonicalWriter(HANDSHAKE_DOMAIN)
+    .fieldString(1, role)
+    .fieldString(2, sourceAppInstanceId)
+    .fieldString(3, targetAppInstanceId)
+    .fieldString(4, challenge.sessionId)
+    .fieldBytes(5, base64ToBytes(challenge.nonce))
+    .build();
+}
+
+/** Mirror of `WsAuthenticationCodec.envelopePayload`. */
+export function envelopePayload(
+  sessionId: string,
+  sequence: number,
+  sourceAppInstanceId: string,
+  targetAppInstanceId: string,
+  envelope: WsEnvelope,
+): Uint8Array {
+  return new CanonicalWriter(ENVELOPE_DOMAIN)
+    .fieldString(1, sessionId)
+    .fieldLong(2, sequence)
+    .fieldString(3, sourceAppInstanceId)
+    .fieldString(4, targetAppInstanceId)
+    .fieldString(5, envelope.type)
+    .fieldInt(6, envelope.encrypted ? 1 : 0)
+    .fieldString(7, envelope.requestId ?? "")
+    .fieldBytes(8, envelope.payload)
+    .build();
+}
+
+function toInt8(bytes: Uint8Array): Int8Array {
+  return new Int8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function toUint8(bytes: Int8Array): Uint8Array {
+  return new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+/**
+ * Post-handshake per-envelope MAC state, mirroring desktop's
+ * `WsAuthenticationContext`: independent send/receive sequence counters, so a
+ * replayed or reordered envelope fails verification.
+ */
+export class WsAuthContext {
+  private nextSendSequence = 0;
+  private nextReceiveSequence = 0;
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly localAppInstanceId: string,
+    private readonly remoteAppInstanceId: string,
+    private readonly processor: WsAuthProcessor,
+  ) {}
+
+  async createHeader(envelope: WsEnvelope): Promise<WsEnvelopeHeader> {
+    const sequence = this.nextSendSequence++;
+    const code = await this.processor.authenticationCode(
+      toInt8(
+        envelopePayload(
+          this.sessionId,
+          sequence,
+          this.localAppInstanceId,
+          this.remoteAppInstanceId,
+          envelope,
+        ),
+      ),
+    );
+    return {
+      ...toHeader(envelope),
+      authSessionId: this.sessionId,
+      authSequence: sequence,
+      authenticationCode: bytesToBase64(toUint8(code)),
+    };
+  }
+
+  async verify(header: WsEnvelopeHeader, payload: Uint8Array): Promise<boolean> {
+    if (
+      header.authSequence == null ||
+      header.authenticationCode == null ||
+      header.authSessionId !== this.sessionId ||
+      header.authSequence !== this.nextReceiveSequence
+    ) {
+      return false;
+    }
+    const envelope: WsEnvelope = {
+      type: header.type,
+      payload,
+      encrypted: header.encrypted,
+      requestId: header.requestId,
+    };
+    const valid = await this.processor.verifyAuthentication(
+      toInt8(
+        envelopePayload(
+          this.sessionId,
+          header.authSequence,
+          this.remoteAppInstanceId,
+          this.localAppInstanceId,
+          envelope,
+        ),
+      ),
+      toInt8(base64ToBytes(header.authenticationCode)),
+    );
+    if (valid) this.nextReceiveSequence++;
+    return valid;
+  }
+}
+
+/** Compute the AUTH_PROOF authentication code for the client side. */
+export async function clientProofCode(
+  processor: WsAuthProcessor,
+  localAppInstanceId: string,
+  targetAppInstanceId: string,
+  challenge: WsAuthChallenge,
+): Promise<string> {
+  const code = await processor.authenticationCode(
+    toInt8(
+      handshakePayload(
+        WS_AUTH_ROLE_CLIENT_PROOF,
+        localAppInstanceId,
+        targetAppInstanceId,
+        challenge,
+      ),
+    ),
+  );
+  return bytesToBase64(toUint8(code));
+}
+
+/** Verify the AUTH_ACK server proof. */
+export async function verifyServerProof(
+  processor: WsAuthProcessor,
+  localAppInstanceId: string,
+  targetAppInstanceId: string,
+  challenge: WsAuthChallenge,
+  ack: WsAuthProofMessage,
+): Promise<boolean> {
+  return processor.verifyAuthentication(
+    toInt8(
+      handshakePayload(
+        WS_AUTH_ROLE_SERVER_PROOF,
+        targetAppInstanceId,
+        localAppInstanceId,
+        challenge,
+      ),
+    ),
+    toInt8(base64ToBytes(ack.authenticationCode)),
+  );
+}

--- a/web/src/shared/ws/ws-client.ts
+++ b/web/src/shared/ws/ws-client.ts
@@ -3,12 +3,27 @@ import {
   type WsEnvelopeHeader,
   WsMessageType,
   simpleEnvelope,
-  toHeader,
 } from "./ws-types";
+import {
+  type WsAuthChallenge,
+  type WsAuthProcessor,
+  type WsAuthProofMessage,
+  WS_AUTH_VERSION,
+  WsAuthContext,
+  clientProofCode,
+  verifyServerProof,
+} from "./ws-auth";
 
 const HEARTBEAT_INTERVAL_MS = 20_000;
 const HEARTBEAT_ACK_TIMEOUT_MS = 10_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Mirrors desktop WS_AUTHENTICATION_TIMEOUT (5s). */
+const AUTHENTICATION_TIMEOUT_MS = 5_000;
+
+/** Mirrors desktop WS_MAX_PAYLOAD_SIZE / WS_MAX_PAYLOAD_CHUNK_COUNT. */
+const MAX_PAYLOAD_SIZE = 128 * 1024 * 1024;
+const MAX_PAYLOAD_CHUNK_COUNT = 128;
 
 export type WsClientState = "idle" | "connecting" | "connected" | "closed";
 
@@ -17,6 +32,14 @@ export interface WsClientConfig {
   port: number;
   appInstanceId: string;
   targetAppInstanceId: string;
+  /**
+   * Builds the per-peer MAC processor (K/JS SecureMessageProcessor) from the
+   * stored key material. Called once per connection attempt; a rejection
+   * fails the connect (no key material -> cannot authenticate).
+   */
+  createAuthProcessor: () => Promise<WsAuthProcessor>;
+  /** Advertised in AUTH_PROOF; >= 3 lets the peer send chunked payloads. */
+  pairingVersion: number;
 }
 
 interface PendingRequest {
@@ -25,12 +48,22 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
+/** A fully reassembled incoming message: wire header + payload bytes. */
+interface IncomingMessage {
+  header: WsEnvelopeHeader;
+  payload: Uint8Array;
+}
+
 /**
  * Single-device WebSocket client.
  * Manages one WebSocket connection to one desktop device.
  *
- * Wire protocol: Text frame (JSON WsEnvelopeHeader) + optional Binary frame (payload).
- * A send queue ensures frame pairs are not interleaved by concurrent callers.
+ * Wire protocol: Text frame (JSON WsEnvelopeHeader) + `payloadChunkCount`
+ * Binary frames (payload). The connection is only reported as connected after
+ * the desktop's authentication handshake (AUTH_CHALLENGE → AUTH_PROOF →
+ * AUTH_ACK) succeeds; from then on every envelope in both directions carries
+ * a sequence-numbered HMAC (see ws-auth.ts). A send queue ensures sequence
+ * numbers are assigned in the exact order frames hit the wire.
  */
 export class WsClient {
   private ws: WebSocket | null = null;
@@ -38,14 +71,28 @@ export class WsClient {
 
   // Frame parsing state
   private pendingHeader: WsEnvelopeHeader | null = null;
+  private pendingChunks: Uint8Array[] = [];
+  private pendingChunksSize = 0;
+
+  // Authentication
+  private authContext: WsAuthContext | null = null;
+  private handshakeWaiter: ((message: IncomingMessage) => void) | null = null;
+  // Messages that arrive while the handshake logic is between awaits (e.g.
+  // the server's AUTH_CHALLENGE lands while createAuthProcessor is still
+  // deriving keys). Bounded; drained by nextHandshakeMessage.
+  private handshakeBuffer: IncomingMessage[] = [];
+  // Serializes incoming verification so receive sequence numbers are checked
+  // in arrival order even though verification is async.
+  private incomingChain: Promise<void> = Promise.resolve();
 
   // Heartbeat
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private heartbeatAckTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // Send queue — each entry is a group of frames that must be sent atomically
+  // Send queue — envelopes are MAC'd and written strictly one at a time so
+  // auth sequence numbers match wire order and frame groups never interleave.
   private sendQueue: Array<{
-    frames: Array<ArrayBuffer | string>;
+    envelope: WsEnvelope;
     resolve: () => void;
     reject: (e: Error) => void;
   }> = [];
@@ -65,7 +112,9 @@ export class WsClient {
   }
 
   get isActive(): boolean {
-    return this.ws !== null && this.ws.readyState === WebSocket.OPEN;
+    return (
+      this.state === "connected" && this.ws !== null && this.ws.readyState === WebSocket.OPEN
+    );
   }
 
   get currentState(): WsClientState {
@@ -73,7 +122,8 @@ export class WsClient {
   }
 
   /**
-   * Open a WebSocket connection. Resolves true on success, false on failure.
+   * Open a WebSocket connection and run the authentication handshake.
+   * Resolves true only after AUTH_ACK verifies; false on any failure.
    */
   connect(): Promise<boolean> {
     if (this.state === "connected" || this.state === "connecting") {
@@ -83,27 +133,45 @@ export class WsClient {
     this.state = "connecting";
 
     return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const settle = (value: boolean) => {
+        if (!settled) {
+          settled = true;
+          resolve(value);
+        }
+      };
+
       const url =
         `ws://${this.config.host}:${this.config.port}/ws/sync` +
         `?appInstanceId=${encodeURIComponent(this.config.appInstanceId)}` +
-        `&targetAppInstanceId=${encodeURIComponent(this.config.targetAppInstanceId)}`;
+        `&targetAppInstanceId=${encodeURIComponent(this.config.targetAppInstanceId)}` +
+        `&authVersion=${WS_AUTH_VERSION}`;
 
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
 
       ws.onopen = () => {
         this.ws = ws;
-        this.state = "connected";
         this.pendingHeader = null;
-        this.startHeartbeat();
-        this.onConnect?.();
-        resolve(true);
+        this.runHandshake()
+          .then(() => {
+            this.state = "connected";
+            this.startHeartbeat();
+            this.onConnect?.();
+            settle(true);
+          })
+          .catch((e) => {
+            console.warn(`[WsClient] Authentication handshake failed: ${e}`);
+            this.cleanup();
+            ws.close(1000, "Authentication failed");
+            settle(false);
+          });
       };
 
       ws.onerror = () => {
         if (this.state === "connecting") {
           this.state = "closed";
-          resolve(false);
+          settle(false);
         }
       };
 
@@ -112,9 +180,8 @@ export class WsClient {
         this.cleanup();
         if (wasConnected) {
           this.onDisconnect?.(event.reason || "Connection closed");
-        } else if (this.state === "connecting") {
-          this.state = "closed";
-          resolve(false);
+        } else {
+          settle(false);
         }
       };
 
@@ -125,24 +192,92 @@ export class WsClient {
   }
 
   /**
-   * Send a logical envelope (header Text frame + optional Binary payload frame).
-   * The frame group is enqueued atomically so concurrent callers cannot interleave.
+   * Desktop-mirroring client side of the handshake (WsClientConnector.kt):
+   * receive AUTH_CHALLENGE, answer with our HMAC proof, verify the server's
+   * proof in AUTH_ACK, then arm the per-envelope MAC context.
+   */
+  private async runHandshake(): Promise<void> {
+    const processor = await this.config.createAuthProcessor();
+
+    const challengeMessage = await this.nextHandshakeMessage();
+    if (challengeMessage.header.type !== WsMessageType.AUTH_CHALLENGE) {
+      throw new Error(`Expected auth challenge, got ${challengeMessage.header.type}`);
+    }
+    const challenge = JSON.parse(
+      new TextDecoder().decode(challengeMessage.payload),
+    ) as WsAuthChallenge;
+
+    const proof: WsAuthProofMessage = {
+      authenticationCode: await clientProofCode(
+        processor,
+        this.config.appInstanceId,
+        this.config.targetAppInstanceId,
+        challenge,
+      ),
+      pairingVersion: this.config.pairingVersion,
+    };
+    await this.sendRawEnvelope({
+      type: WsMessageType.AUTH_PROOF,
+      payload: new TextEncoder().encode(JSON.stringify(proof)),
+      encrypted: false,
+    });
+
+    const ackMessage = await this.nextHandshakeMessage();
+    if (ackMessage.header.type !== WsMessageType.AUTH_ACK) {
+      throw new Error(`Expected auth ack, got ${ackMessage.header.type}`);
+    }
+    const ack = JSON.parse(new TextDecoder().decode(ackMessage.payload)) as WsAuthProofMessage;
+    const serverVerified = await verifyServerProof(
+      processor,
+      this.config.appInstanceId,
+      this.config.targetAppInstanceId,
+      challenge,
+      ack,
+    );
+    if (!serverVerified) {
+      throw new Error("Server authentication proof invalid");
+    }
+
+    this.authContext = new WsAuthContext(
+      challenge.sessionId,
+      this.config.appInstanceId,
+      this.config.targetAppInstanceId,
+      processor,
+    );
+  }
+
+  private nextHandshakeMessage(): Promise<IncomingMessage> {
+    const buffered = this.handshakeBuffer.shift();
+    if (buffered) {
+      return Promise.resolve(buffered);
+    }
+    return new Promise<IncomingMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.handshakeWaiter = null;
+        reject(new Error("Authentication handshake timed out"));
+      }, AUTHENTICATION_TIMEOUT_MS);
+      this.handshakeWaiter = (message) => {
+        clearTimeout(timer);
+        this.handshakeWaiter = null;
+        resolve(message);
+      };
+    });
+  }
+
+  /**
+   * Send a logical envelope with an authenticated header.
+   * The envelope is enqueued atomically so concurrent callers cannot
+   * interleave frames or reorder auth sequence numbers.
    */
   async sendEnvelope(envelope: WsEnvelope): Promise<void> {
     if (!this.isActive) {
       throw new Error("WebSocket not connected");
     }
 
-    const headerJson = JSON.stringify(toHeader(envelope));
-    const frames: Array<ArrayBuffer | string> = [headerJson];
-
-    if (envelope.payload.length > 0) {
-      const buf = new ArrayBuffer(envelope.payload.byteLength);
-      new Uint8Array(buf).set(envelope.payload);
-      frames.push(buf);
-    }
-
-    await this.enqueueFrameGroup(frames);
+    return new Promise((resolve, reject) => {
+      this.sendQueue.push({ envelope, resolve, reject });
+      void this.drainQueue();
+    });
   }
 
   /**
@@ -193,35 +328,90 @@ export class WsClient {
       try {
         const header = JSON.parse(data) as WsEnvelopeHeader;
         if (header.hasPayload) {
-          // Wait for the next Binary frame
+          const chunkCount = header.payloadChunkCount ?? 1;
+          if (chunkCount < 1 || chunkCount > MAX_PAYLOAD_CHUNK_COUNT) {
+            console.error(`[WsClient] Invalid payload chunk count: ${chunkCount}`);
+            this.ws?.close(1008, "Invalid payload chunk count");
+            return;
+          }
+          // Wait for the next `chunkCount` Binary frames
           this.pendingHeader = header;
+          this.pendingChunks = [];
+          this.pendingChunksSize = 0;
         } else {
-          // Complete message with no payload
-          this.dispatchEnvelope({
-            type: header.type,
-            payload: new Uint8Array(0),
-            encrypted: header.encrypted,
-            requestId: header.requestId,
-          });
+          this.handleIncoming({ header, payload: new Uint8Array(0) });
         }
       } catch {
         console.error("[WsClient] Failed to parse text frame");
       }
     } else if (data instanceof ArrayBuffer) {
-      // Binary frame: payload for the pending header
-      if (this.pendingHeader) {
-        const header = this.pendingHeader;
-        this.pendingHeader = null;
-        this.dispatchEnvelope({
-          type: header.type,
-          payload: new Uint8Array(data),
-          encrypted: header.encrypted,
-          requestId: header.requestId,
-        });
-      } else {
+      // Binary frame: payload chunk for the pending header
+      const header = this.pendingHeader;
+      if (!header) {
         console.warn("[WsClient] Received unexpected binary frame");
+        return;
       }
+      this.pendingChunksSize += data.byteLength;
+      if (this.pendingChunksSize > MAX_PAYLOAD_SIZE) {
+        console.error("[WsClient] Payload exceeds maximum size");
+        this.ws?.close(1009, "Payload too large");
+        return;
+      }
+      this.pendingChunks.push(new Uint8Array(data));
+      if (this.pendingChunks.length < (header.payloadChunkCount ?? 1)) {
+        return;
+      }
+
+      const chunks = this.pendingChunks;
+      this.pendingHeader = null;
+      this.pendingChunks = [];
+      let payload: Uint8Array;
+      if (chunks.length === 1) {
+        payload = chunks[0];
+      } else {
+        payload = new Uint8Array(this.pendingChunksSize);
+        let offset = 0;
+        for (const chunk of chunks) {
+          payload.set(chunk, offset);
+          offset += chunk.length;
+        }
+      }
+      this.pendingChunksSize = 0;
+      this.handleIncoming({ header, payload });
     }
+  }
+
+  private handleIncoming(message: IncomingMessage): void {
+    const authContext = this.authContext;
+    if (!authContext) {
+      // Handshake in progress: route to the pending handshake step (these
+      // messages are authenticated by their proof payloads, not header MACs)
+      // or buffer briefly until the handshake logic asks for the next one.
+      if (this.handshakeWaiter) {
+        this.handshakeWaiter(message);
+      } else if (this.state === "connecting" && this.handshakeBuffer.length < 4) {
+        this.handshakeBuffer.push(message);
+      }
+      return;
+    }
+
+    // Verification is async; chain it so sequence checks run in arrival order.
+    this.incomingChain = this.incomingChain.then(async () => {
+      const valid = await authContext.verify(message.header, message.payload);
+      // A cleanup (disconnect) may have run while verifying; drop stale messages.
+      if (this.authContext !== authContext) return;
+      if (!valid) {
+        console.warn("[WsClient] Rejected envelope with invalid authentication");
+        this.ws?.close(1008, "Invalid message authentication");
+        return;
+      }
+      this.dispatchEnvelope({
+        type: message.header.type,
+        payload: message.payload,
+        encrypted: message.header.encrypted,
+        requestId: message.header.requestId,
+      });
+    });
   }
 
   private dispatchEnvelope(envelope: WsEnvelope): void {
@@ -280,32 +470,55 @@ export class WsClient {
 
   // ─── Send queue ─────────────────────────────────────────────────────
 
-  private enqueueFrameGroup(frames: Array<ArrayBuffer | string>): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.sendQueue.push({ frames, resolve, reject });
-      this.drainQueue();
-    });
+  /**
+   * Sends without authentication — only valid for the handshake's AUTH_PROOF,
+   * which is authenticated by its payload rather than a header MAC.
+   */
+  private async sendRawEnvelope(envelope: WsEnvelope): Promise<void> {
+    const header: WsEnvelopeHeader = {
+      type: envelope.type,
+      encrypted: envelope.encrypted,
+      hasPayload: envelope.payload.length > 0,
+      requestId: envelope.requestId,
+    };
+    this.sendFrames(header, envelope.payload);
   }
 
-  private drainQueue(): void {
-    if (this.isSending || this.sendQueue.length === 0) return;
+  private sendFrames(header: WsEnvelopeHeader, payload: Uint8Array): void {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error("WebSocket not connected");
+    }
+    ws.send(JSON.stringify(header));
+    if (payload.length > 0) {
+      const buf = new ArrayBuffer(payload.byteLength);
+      new Uint8Array(buf).set(payload);
+      ws.send(buf);
+    }
+  }
+
+  private async drainQueue(): Promise<void> {
+    if (this.isSending) return;
     this.isSending = true;
 
-    const item = this.sendQueue.shift()!;
-    try {
-      // Send all frames in the group synchronously to guarantee atomicity
-      for (const frame of item.frames) {
-        this.ws!.send(frame);
+    while (this.sendQueue.length > 0) {
+      const item = this.sendQueue.shift()!;
+      try {
+        // The MAC covers a per-direction sequence number, so header creation
+        // and the actual send must happen together, one envelope at a time.
+        const authContext = this.authContext;
+        if (!authContext) {
+          throw new Error("WebSocket not authenticated");
+        }
+        const header = await authContext.createHeader(item.envelope);
+        this.sendFrames(header, item.envelope.payload);
+        item.resolve();
+      } catch (e) {
+        item.reject(e instanceof Error ? e : new Error(String(e)));
       }
-      item.resolve();
-    } catch (e) {
-      item.reject(e instanceof Error ? e : new Error(String(e)));
     }
 
     this.isSending = false;
-    if (this.sendQueue.length > 0) {
-      this.drainQueue();
-    }
   }
 
   // ─── Cleanup ────────────────────────────────────────────────────────
@@ -321,6 +534,12 @@ export class WsClient {
     this.ws = null;
     this.state = "closed";
     this.pendingHeader = null;
+    this.pendingChunks = [];
+    this.pendingChunksSize = 0;
+    this.authContext = null;
+    this.handshakeWaiter = null;
+    this.handshakeBuffer = [];
+    this.incomingChain = Promise.resolve();
     // Reject any pending sends
     for (const item of this.sendQueue) {
       item.reject(new Error("Connection closed"));

--- a/web/src/shared/ws/ws-client.ts
+++ b/web/src/shared/ws/ws-client.ts
@@ -21,6 +21,9 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 /** Mirrors desktop WS_AUTHENTICATION_TIMEOUT (5s). */
 const AUTHENTICATION_TIMEOUT_MS = 5_000;
 
+/** Bound messages received before the server proof finishes verification. */
+const MAX_HANDSHAKE_BUFFERED_MESSAGES = 4;
+
 /** Mirrors desktop WS_MAX_PAYLOAD_SIZE / WS_MAX_PAYLOAD_CHUNK_COUNT. */
 const MAX_PAYLOAD_SIZE = 128 * 1024 * 1024;
 const MAX_PAYLOAD_CHUNK_COUNT = 128;
@@ -54,6 +57,17 @@ interface IncomingMessage {
   payload: Uint8Array;
 }
 
+interface HandshakeWaiter {
+  resolve: (message: IncomingMessage) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface ActiveConnect {
+  generation: number;
+  settle: (connected: boolean) => void;
+}
+
 /**
  * Single-device WebSocket client.
  * Manages one WebSocket connection to one desktop device.
@@ -76,11 +90,15 @@ export class WsClient {
 
   // Authentication
   private authContext: WsAuthContext | null = null;
-  private handshakeWaiter: ((message: IncomingMessage) => void) | null = null;
+  private handshakeWaiter: HandshakeWaiter | null = null;
   // Messages that arrive while the handshake logic is between awaits (e.g.
   // the server's AUTH_CHALLENGE lands while createAuthProcessor is still
-  // deriving keys). Bounded; drained by nextHandshakeMessage.
+  // deriving keys). Bounded; handshake frames are drained by
+  // nextHandshakeMessage and post-ACK frames by runHandshake.
   private handshakeBuffer: IncomingMessage[] = [];
+  // Invalidates async work from a socket that closed or was superseded.
+  private connectionGeneration = 0;
+  private activeConnect: ActiveConnect | null = null;
   // Serializes incoming verification so receive sequence numbers are checked
   // in arrival order even though verification is async.
   private incomingChain: Promise<void> = Promise.resolve();
@@ -131,15 +149,20 @@ export class WsClient {
     }
 
     this.state = "connecting";
+    const connectionGeneration = ++this.connectionGeneration;
 
     return new Promise<boolean>((resolve) => {
       let settled = false;
       const settle = (value: boolean) => {
         if (!settled) {
           settled = true;
+          if (this.activeConnect?.generation === connectionGeneration) {
+            this.activeConnect = null;
+          }
           resolve(value);
         }
       };
+      this.activeConnect = { generation: connectionGeneration, settle };
 
       const url =
         `ws://${this.config.host}:${this.config.port}/ws/sync` +
@@ -149,35 +172,62 @@ export class WsClient {
 
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
+      this.ws = ws;
+      const isCurrentConnection = () =>
+        this.connectionGeneration === connectionGeneration && this.ws === ws;
 
       ws.onopen = () => {
-        this.ws = ws;
+        if (!isCurrentConnection()) return;
         this.pendingHeader = null;
-        this.runHandshake()
+        this.runHandshake(ws, connectionGeneration)
           .then(() => {
+            if (
+              !isCurrentConnection() ||
+              this.state !== "connecting" ||
+              ws.readyState !== WebSocket.OPEN
+            ) {
+              settle(false);
+              return;
+            }
             this.state = "connected";
             this.startHeartbeat();
             this.onConnect?.();
             settle(true);
           })
           .catch((e) => {
+            if (!isCurrentConnection()) {
+              settle(false);
+              return;
+            }
             console.warn(`[WsClient] Authentication handshake failed: ${e}`);
-            this.cleanup();
-            ws.close(1000, "Authentication failed");
+            this.cleanup("Authentication failed");
+            if (ws.readyState === WebSocket.OPEN) {
+              ws.close(1000, "Authentication failed");
+            }
             settle(false);
           });
       };
 
       ws.onerror = () => {
-        if (this.state === "connecting") {
-          this.state = "closed";
+        if (isCurrentConnection() && this.state === "connecting") {
+          this.cleanup("WebSocket connection error");
+          if (
+            ws.readyState === WebSocket.CONNECTING ||
+            ws.readyState === WebSocket.OPEN
+          ) {
+            ws.close(1000, "Connection error");
+          }
           settle(false);
         }
       };
 
       ws.onclose = (event) => {
+        if (!isCurrentConnection()) {
+          settle(false);
+          return;
+        }
         const wasConnected = this.state === "connected";
-        this.cleanup();
+        this.cleanup(event.reason || "Connection closed");
         if (wasConnected) {
           this.onDisconnect?.(event.reason || "Connection closed");
         } else {
@@ -186,6 +236,7 @@ export class WsClient {
       };
 
       ws.onmessage = (event) => {
+        if (!isCurrentConnection()) return;
         this.handleFrame(event.data);
       };
     });
@@ -196,10 +247,12 @@ export class WsClient {
    * receive AUTH_CHALLENGE, answer with our HMAC proof, verify the server's
    * proof in AUTH_ACK, then arm the per-envelope MAC context.
    */
-  private async runHandshake(): Promise<void> {
+  private async runHandshake(ws: WebSocket, connectionGeneration: number): Promise<void> {
     const processor = await this.config.createAuthProcessor();
+    this.ensureCurrentHandshake(ws, connectionGeneration);
 
     const challengeMessage = await this.nextHandshakeMessage();
+    this.ensureCurrentHandshake(ws, connectionGeneration);
     if (challengeMessage.header.type !== WsMessageType.AUTH_CHALLENGE) {
       throw new Error(`Expected auth challenge, got ${challengeMessage.header.type}`);
     }
@@ -216,6 +269,7 @@ export class WsClient {
       ),
       pairingVersion: this.config.pairingVersion,
     };
+    this.ensureCurrentHandshake(ws, connectionGeneration);
     await this.sendRawEnvelope({
       type: WsMessageType.AUTH_PROOF,
       payload: new TextEncoder().encode(JSON.stringify(proof)),
@@ -223,6 +277,7 @@ export class WsClient {
     });
 
     const ackMessage = await this.nextHandshakeMessage();
+    this.ensureCurrentHandshake(ws, connectionGeneration);
     if (ackMessage.header.type !== WsMessageType.AUTH_ACK) {
       throw new Error(`Expected auth ack, got ${ackMessage.header.type}`);
     }
@@ -234,16 +289,40 @@ export class WsClient {
       challenge,
       ack,
     );
+    this.ensureCurrentHandshake(ws, connectionGeneration);
     if (!serverVerified) {
       throw new Error("Server authentication proof invalid");
     }
 
-    this.authContext = new WsAuthContext(
+    const authContext = new WsAuthContext(
       challenge.sessionId,
       this.config.appInstanceId,
       this.config.targetAppInstanceId,
       processor,
     );
+    this.authContext = authContext;
+
+    // AUTH_ACK is the server's final handshake frame. The server publishes the
+    // session immediately afterwards, so authenticated application envelopes
+    // can arrive while verifyServerProof is still awaiting WebCrypto. Move any
+    // such frames into the authenticated receive chain without losing order.
+    const bufferedMessages = this.handshakeBuffer.splice(0);
+    for (const message of bufferedMessages) {
+      this.handleIncoming(message);
+    }
+    await this.incomingChain;
+    this.ensureCurrentHandshake(ws, connectionGeneration);
+  }
+
+  private ensureCurrentHandshake(ws: WebSocket, connectionGeneration: number): void {
+    if (
+      this.connectionGeneration !== connectionGeneration ||
+      this.ws !== ws ||
+      this.state !== "connecting" ||
+      ws.readyState !== WebSocket.OPEN
+    ) {
+      throw new Error("WebSocket connection changed during authentication");
+    }
   }
 
   private nextHandshakeMessage(): Promise<IncomingMessage> {
@@ -256,11 +335,7 @@ export class WsClient {
         this.handshakeWaiter = null;
         reject(new Error("Authentication handshake timed out"));
       }, AUTHENTICATION_TIMEOUT_MS);
-      this.handshakeWaiter = (message) => {
-        clearTimeout(timer);
-        this.handshakeWaiter = null;
-        resolve(message);
-      };
+      this.handshakeWaiter = { resolve, reject, timer };
     });
   }
 
@@ -315,7 +390,10 @@ export class WsClient {
     const ws = this.ws;
     this.cleanup();
     // Send close frame after cleanup to prevent onclose from firing again
-    if (ws && ws.readyState === WebSocket.OPEN) {
+    if (
+      ws &&
+      (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)
+    ) {
       ws.close(1000, "Normal closure");
     }
   }
@@ -388,8 +466,16 @@ export class WsClient {
       // messages are authenticated by their proof payloads, not header MACs)
       // or buffer briefly until the handshake logic asks for the next one.
       if (this.handshakeWaiter) {
-        this.handshakeWaiter(message);
-      } else if (this.state === "connecting" && this.handshakeBuffer.length < 4) {
+        const waiter = this.handshakeWaiter;
+        this.handshakeWaiter = null;
+        clearTimeout(waiter.timer);
+        waiter.resolve(message);
+      } else if (this.state === "connecting") {
+        if (this.handshakeBuffer.length >= MAX_HANDSHAKE_BUFFERED_MESSAGES) {
+          console.warn("[WsClient] Authentication message buffer overflow");
+          this.ws?.close(1008, "Authentication message buffer overflow");
+          return;
+        }
         this.handshakeBuffer.push(message);
       }
       return;
@@ -523,7 +609,11 @@ export class WsClient {
 
   // ─── Cleanup ────────────────────────────────────────────────────────
 
-  private cleanup(): void {
+  private cleanup(reason: string = "Connection closed"): void {
+    const activeConnect = this.activeConnect;
+    this.activeConnect = null;
+    activeConnect?.settle(false);
+    this.connectionGeneration++;
     this.stopHeartbeat();
     if (this.ws) {
       this.ws.onopen = null;
@@ -537,7 +627,12 @@ export class WsClient {
     this.pendingChunks = [];
     this.pendingChunksSize = 0;
     this.authContext = null;
-    this.handshakeWaiter = null;
+    if (this.handshakeWaiter) {
+      const waiter = this.handshakeWaiter;
+      this.handshakeWaiter = null;
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error(reason));
+    }
     this.handshakeBuffer = [];
     this.incomingChain = Promise.resolve();
     // Reject any pending sends

--- a/web/src/shared/ws/ws-manager.ts
+++ b/web/src/shared/ws/ws-manager.ts
@@ -1,7 +1,11 @@
 import { WsClient } from "./ws-client";
+import type { WsAuthProcessor } from "./ws-auth";
 import type { WsEnvelope, WsConnectionStatus } from "./ws-types";
 import type { StoredDevice } from "@/shared/storage/device-store";
 import { DeviceStore } from "@/shared/storage/device-store";
+import { KeyStore, toInt8Array } from "@/shared/storage/key-store";
+import { CrossPasteHash, createSecureMessageProcessor } from "@/shared/core";
+import { ADVERTISED_PAIRING_VERSION } from "@/shared/sync/protocol-version";
 
 const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_MAX_MS = 30_000;
@@ -17,6 +21,33 @@ interface DeviceConnection {
   consecutiveFailures: number;
 }
 
+/** Injectable key access so tests can run without chrome.storage / K/JS core. */
+export interface WsManagerDeps {
+  /** Build the per-peer MAC processor used by the WS authentication handshake. */
+  createAuthProcessor: (targetAppInstanceId: string) => Promise<WsAuthProcessor>;
+  /** The pairing version advertised in AUTH_PROOF. */
+  pairingVersion: number;
+}
+
+const defaultDeps: WsManagerDeps = {
+  createAuthProcessor: async (targetAppInstanceId) => {
+    const keys = await KeyStore.getKeys();
+    if (!keys) {
+      throw new Error("Extension key pair not initialized");
+    }
+    const device = await DeviceStore.get(targetAppInstanceId);
+    const peerKeyB64 = device?.serverKeys?.cryptPublicKey;
+    if (!peerKeyB64) {
+      throw new Error(`No trusted crypt public key for device ${targetAppInstanceId}`);
+    }
+    return createSecureMessageProcessor(
+      toInt8Array(keys.cryptPrivateKey),
+      CrossPasteHash.base64Decode(peerKeyB64),
+    );
+  },
+  pairingVersion: ADVERTISED_PAIRING_VERSION,
+};
+
 /**
  * Multi-device WebSocket connection manager.
  * Manages connections to all paired desktop devices with reconnection and fallback.
@@ -24,12 +55,14 @@ interface DeviceConnection {
 export class WsManager {
   private sessions = new Map<string, DeviceConnection>();
   private appInstanceId: string;
+  private deps: WsManagerDeps;
 
   onMessage: ((targetAppInstanceId: string, envelope: WsEnvelope) => void) | null = null;
   onStatusChange: ((targetAppInstanceId: string, status: WsConnectionStatus) => void) | null = null;
 
-  constructor(appInstanceId: string) {
+  constructor(appInstanceId: string, deps: WsManagerDeps = defaultDeps) {
     this.appInstanceId = appInstanceId;
+    this.deps = deps;
   }
 
   /**
@@ -50,6 +83,8 @@ export class WsManager {
       port: device.port,
       appInstanceId: this.appInstanceId,
       targetAppInstanceId: device.targetAppInstanceId,
+      createAuthProcessor: () => this.deps.createAuthProcessor(device.targetAppInstanceId),
+      pairingVersion: this.deps.pairingVersion,
     });
 
     const conn: DeviceConnection = {

--- a/web/src/shared/ws/ws-types.ts
+++ b/web/src/shared/ws/ws-types.ts
@@ -14,6 +14,9 @@ export const WsMessageType = {
   FILE_PULL_RESPONSE: "file_pull_response",
   PASTE_REJECTED_OVERSIZE: "paste_rejected_oversize",
   ERROR: "error",
+  AUTH_CHALLENGE: "auth_challenge",
+  AUTH_PROOF: "auth_proof",
+  AUTH_ACK: "auth_ack",
 } as const;
 
 export type WsMessageTypeValue = (typeof WsMessageType)[keyof typeof WsMessageType];
@@ -24,6 +27,16 @@ export interface WsEnvelopeHeader {
   encrypted: boolean;
   hasPayload: boolean;
   requestId?: string | null;
+  authSessionId?: string | null;
+  authSequence?: number | null;
+  /** base64 (Kotlin Base64ByteArraySerializer) */
+  authenticationCode?: string | null;
+  /**
+   * Number of Binary frames whose concatenation forms the payload. Absent or
+   * 1 on legacy senders; > 1 only after this side advertised pairing
+   * version >= 3 in its AUTH_PROOF.
+   */
+  payloadChunkCount?: number;
 }
 
 /** In-memory envelope combining header + raw payload bytes. */


### PR DESCRIPTION
Closes #4748

## Summary

Since #4710, non-loopback WebSockets must dial with `authVersion=1` and complete the AUTH_CHALLENGE → AUTH_PROOF → AUTH_ACK handshake — but the extension's `WsClient` never implemented it. The server closes the socket (1008) right after the upgrade, `registerSession` is never reached, and the paired client shows the extension offline forever while the extension itself (whose `onopen` already fired, and whose HTTP sync works) believes everything is fine. This also made #4747 a no-op for extensions.

## Changes

**K/JS core (`CrossPasteApi.kt`)**
- `JsSecureMessageProcessor` now also exposes `authenticationCode` / `verifyAuthentication`, backed by the same `PeerAuthenticator` the desktop uses — extension MACs are byte-identical by construction.

**Extension (`web/src/shared/ws/`)**
- New `ws-auth.ts`: TS port of the `WsAuthenticationCodec` canonical payload layout (golden-tested against an independent re-encoding) plus `WsAuthContext` with per-direction sequence numbers (replay / tamper / reorder rejection), and the client/server handshake proof helpers.
- `ws-client.ts`: dials with `authVersion=1`; runs the handshake before flipping to connected (no more "connected" UI on a socket the server is about to reject); MACs every outgoing envelope with wire-ordered sequences (send queue assigns sequence + writes frames atomically); verifies every incoming envelope in arrival order and closes on invalid MACs; reassembles chunked payloads (`payloadChunkCount`, gated by the advertised pairing version). Handshake messages that land while key derivation is still in flight are buffered, not dropped.
- `ws-manager.ts`: injects the per-device auth processor built from the stored key material (`KeyStore` + `serverKeys.cryptPublicKey`); deps injectable for tests.
- `ws-types.ts`: auth header fields, `payloadChunkCount`, AUTH_* message types.

**Server (`WsRouting.kt`)**
- The non-loopback legacy rejection now logs a warn. It used to close silently, which is why this bug left no trace in either side's logs.

## Compatibility

- Desktop/mobile ≥ #4710 (incl. released 2.1.7): handshake succeeds, extension devices finally resolve CONNECTED via #4747's `onSessionOpened` path.
- Peers older than #4710 never send AUTH_CHALLENGE; the handshake times out and the extension falls back to HTTP-only — the same de-facto state it is in today. No unauthenticated fallback is offered (that would reintroduce the downgrade #4710 closed).

## Testing

- `web`: `pnpm test` — 127 tests pass, including new suites: canonical-encoding golden tests, `WsAuthContext` replay/tamper/reorder, full mock-server handshake (success, forged ack, policy close during handshake), MAC'd send/receive round-trip mirrored by a desktop-side context, chunked reassembly.
- `pnpm build` (tsc + vite) with the rebuilt `@crosspaste/core` — clean.
- Kotlin: `ktlintFormat`, `:app:desktopTest --tests "com.crosspaste.net.ws.*"`, `:core:jsTest` — all pass.