### PR TITLE
:white_check_mark: add --advertise-address option to the e2e harness

### DIFF
--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/cli/Main.kt
@@ -26,6 +26,8 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.long
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import java.net.Inet4Address
+import java.net.InetAddress
 import kotlin.coroutines.cancellation.CancellationException
 
 class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
@@ -92,6 +94,16 @@ class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
         help = "Optional path to write a JUnit XML report.",
     )
 
+    private val advertiseAddress by option(
+        "--advertise-address",
+        help =
+            "Force mDNS advertising on this IPv4 address (optionally IP/prefixLength, default /24) " +
+                "instead of auto-enumerated interfaces. Use when the peer's real interface toward the " +
+                "target is filtered out as virtual — e.g. a Parallels host-only vnic when the target is " +
+                "a VM reached over host-only networking. The address must be on the target's subnet so " +
+                "the target can subnet-match and register a SyncHandler (required for push scenarios).",
+    )
+
     override fun run() {
         val pairingVersion =
             if (scenario.lowercase() in V3_SCENARIOS) {
@@ -99,10 +111,18 @@ class E2eCommand : CliktCommand(name = "crosspaste-e2e") {
             } else {
                 SyncApi.PAIRING_VERSION
             }
+        val advertiseAddresses = advertiseAddress?.let { listOf(parseAdvertiseAddress(it)) }
         val peer =
             appInstanceId?.let {
-                HeadlessPeer(appInstanceId = it, pairingVersion = pairingVersion)
-            } ?: HeadlessPeer(pairingVersion = pairingVersion)
+                HeadlessPeer(
+                    appInstanceId = it,
+                    pairingVersion = pairingVersion,
+                    advertiseAddresses = advertiseAddresses,
+                )
+            } ?: HeadlessPeer(
+                pairingVersion = pairingVersion,
+                advertiseAddresses = advertiseAddresses,
+            )
         try {
             val ctx =
                 ScenarioContext(
@@ -224,6 +244,25 @@ private fun parseTarget(spec: String): TargetSpec {
             spec to DEFAULT_PORT
         }
     return TargetSpec(host = host, port = port, appInstanceId = null)
+}
+
+/**
+ * Parse an `--advertise-address` value: a bare IPv4 (`10.37.129.2`, prefix defaults to /24)
+ * or IPv4 with an explicit prefix length (`10.37.129.2/24`).
+ */
+private fun parseAdvertiseAddress(spec: String): Pair<Inet4Address, Short> {
+    val (ipPart, prefixPart) =
+        if (spec.contains("/")) {
+            val (ip, p) = spec.split("/", limit = 2)
+            ip to p.toShort()
+        } else {
+            spec to 24.toShort()
+        }
+    val addr =
+        InetAddress.getByName(ipPart) as? Inet4Address
+            ?: error("--advertise-address must be an IPv4 address: $spec")
+    require(prefixPart in 0..32) { "--advertise-address prefix length must be 0..32: $spec" }
+    return addr to prefixPart
 }
 
 private fun parseColor(raw: String): Int {

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/BonjourAdvertiser.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/BonjourAdvertiser.kt
@@ -5,6 +5,7 @@ import com.crosspaste.db.sync.HostInfo
 import com.crosspaste.e2e.net.NetworkUtils
 import com.crosspaste.utils.TxtRecordUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.net.Inet4Address
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceInfo
 
@@ -21,6 +22,11 @@ import javax.jmdns.ServiceInfo
 class BonjourAdvertiser(
     private val appInfo: AppInfo,
     private val advertisedPort: Int = ADVERTISED_PORT,
+    // When set, advertise on exactly these (address, prefixLength) pairs instead of the
+    // auto-enumerated LAN interfaces. Needed to advertise an address the target can
+    // subnet-match when the peer's real interface is filtered out by enumerateLanInet4()
+    // (e.g. a Parallels host-only vnic when testing a VM target over host-only networking).
+    private val overrideAddresses: List<Pair<Inet4Address, Short>>? = null,
 ) {
 
     companion object {
@@ -35,7 +41,7 @@ class BonjourAdvertiser(
     private val instances: MutableList<JmDNS> = mutableListOf()
 
     fun start() {
-        val addresses = NetworkUtils.enumerateLanInet4()
+        val addresses = overrideAddresses ?: NetworkUtils.enumerateLanInet4()
         if (addresses.isEmpty()) {
             logger.warn { "No usable LAN IPv4 addresses; mDNS advertising skipped." }
             return

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/peer/HeadlessPeer.kt
@@ -39,6 +39,9 @@ class HeadlessPeer(
     appVersion: String = "0.0.0-e2e",
     appRevision: String = "Unknown",
     pairingVersion: Int = SyncApi.PAIRING_VERSION,
+    // When set, mDNS-advertise on exactly these (address, prefixLength) pairs instead of the
+    // auto-enumerated LAN interfaces (see BonjourAdvertiser.overrideAddresses).
+    advertiseAddresses: List<Pair<java.net.Inet4Address, Short>>? = null,
 ) {
     // Force JsonUtils to fully initialize before anything else touches PasteItem
     // serializer registration. See MEMORY.md "PasteItem / JsonUtils Circular Class
@@ -116,7 +119,8 @@ class HeadlessPeer(
 
     val pullClientApi: PullClientApi = PullClientApi(pasteClient, configManager, exceptionHandler)
 
-    val bonjourAdvertiser: BonjourAdvertiser = BonjourAdvertiser(appInfo).also { it.start() }
+    val bonjourAdvertiser: BonjourAdvertiser =
+        BonjourAdvertiser(appInfo, overrideAddresses = advertiseAddresses).also { it.start() }
 
     fun close() {
         pairingV3Scope?.cancel()


### PR DESCRIPTION
Closes #4751

## Summary

Adds an `--advertise-address <IPv4[/prefixLength]>` CLI option (prefix defaults to /24) that forces the headless peer to mDNS-advertise on exactly the given address instead of the auto-enumerated LAN interfaces.

- `BonjourAdvertiser` gains an optional `overrideAddresses` list that bypasses `NetworkUtils.enumerateLanInet4()` (which deliberately filters likely-virtual interfaces).
- `HeadlessPeer` threads the override through to the advertiser.
- `Main.kt` parses and validates the option (IPv4 only, prefix 0–32).

## Why

`enumerateLanInet4()` filters virtual interfaces, so when the only route to the target is one of them — e.g. a Parallels host-only vnic while verifying a release build inside a VM — the peer advertises only its Wi-Fi address, the target's subnet-matched SyncInfo handling (#4509) never records a reachable address, no SyncHandler is created, and every push scenario fails with `NOT_FOUND_APP_INSTANCE_ID` despite successful pairing. Details in #4751.

## Verification

Against a Windows 2.1.7.2461 release build in a Parallels VM over host-only networking (`--target 10.37.129.3:13129 --advertise-address 10.37.129.2/24`): wrong-token, telnet, and push-text/url/html/rtf/color all PASS with real transfers; the VM's device list shows the advertised peer. Test-infrastructure only; no production code changes.