### PR TITLE
:art: drain the v2 token countdown bar to match v3 pairing cards

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TokenView.kt
@@ -62,7 +62,11 @@ fun TokenView(intOffset: IntOffset) {
     val copywriter = koinInject<GlobalCopywriter>()
     val pairingV3UiController = koinInject<PairingV3UiController>()
     val showToken by appTokenApi.showToken.collectAsState()
-    val progress by appTokenApi.refreshProgress.collectAsState()
+    // refreshProgress runs 0f -> 1f as the current token ages toward the next
+    // refresh. TokenPopupCard expects the fraction *remaining* (it drains the bar
+    // as v3 pairing cards do), so invert it at the call site to keep both styles
+    // counting down the same direction.
+    val refreshProgress by appTokenApi.refreshProgress.collectAsState()
     val token by appTokenApi.token.collectAsState()
     val pairingSessions by pairingV3UiController.sessions.collectAsState()
     val incomingPairingSessions = acceptorPairingSessions(pairingSessions)
@@ -101,7 +105,7 @@ fun TokenView(intOffset: IntOffset) {
                 TokenPopupCard(
                     title = copywriter.getText("token"),
                     token = token.map(Char::toString),
-                    progress = progress,
+                    progress = 1f - refreshProgress,
                     onClose = {
                         // Manual dismissal releases each pending verifier's count
                         // through the atomic primitive, so a later server-side


### PR DESCRIPTION
Closes #4753

## Summary

The v2 SAS token popup and the v3 pairing token cards render through the same `TokenPopupCard` progress bar, but drove it in opposite directions: the v2 bar filled up (0→1) as the token aged, while the v3 bar drained (1→0) as the PIN lifetime ran out. Side by side the two countdowns moved opposite ways.

This inverts the value v2 passes so its bar also drains toward the next refresh, matching v3.

## Change

`TokenView.kt` now passes `1f - refreshProgress` to `TokenPopupCard`. The `refreshProgress` source (elapsed fraction, 0→1) is unchanged, so `PairingCodeContentView`, which already derives remaining seconds as `(1 - refreshProgress) * 30`, keeps working — the inversion is applied only at the v2 token bar call site.