### PR TITLE
:art: auto-close v3 pairing card when the session is cancelled

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3TokenCards.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3TokenCards.kt
@@ -51,11 +51,14 @@ fun PairingV3AcceptorTokenCards(
     val copywriter = koinInject<GlobalCopywriter>()
     val coroutineScope = rememberCoroutineScope()
 
-    // v3 pairs per device: once a session reaches TRUSTED that device is connected,
-    // so its card closes itself; cards of other devices still pairing are untouched.
-    val trustedSessionIds = trustedPairingSessionIds(sessions)
-    LaunchedEffect(trustedSessionIds) {
-        trustedSessionIds.forEach { sessionId ->
+    // v3 pairs per device. A session that reaches a self-dismissing state closes
+    // its own card: TRUSTED (the device connected) and CANCELLED (the peer
+    // abandoned the handshake) are both non-actionable, so lingering on screen is
+    // just noise. REJECTED/EXPIRED/FAILED stay so the user sees why it failed.
+    // Cards of other devices still pairing are untouched.
+    val selfDismissingIds = selfDismissingSessionIds(sessions)
+    LaunchedEffect(selfDismissingIds) {
+        selfDismissingIds.forEach { sessionId ->
             controller.dismiss(sessionId)
         }
     }
@@ -130,12 +133,20 @@ private fun PairingV3SessionTokenCard(
 internal fun acceptorPairingSessions(sessions: List<PairingSessionUiState>): List<PairingSessionUiState> =
     sessions.filter { it.role == PakeRole.ACCEPTOR }
 
-/** Sessions that still need a visible token card; TRUSTED ones auto-dismiss instead. */
-internal fun pairingTokenCardSessions(sessions: List<PairingSessionUiState>): List<PairingSessionUiState> =
-    sessions.filterNot { it.state == PairingSessionState.TRUSTED }
+/**
+ * TRUSTED (connected) and CANCELLED (peer abandoned the handshake) close their own
+ * card — both are non-actionable, so there is nothing for the user to read or act
+ * on. REJECTED/EXPIRED/FAILED are surfaced so the user learns why pairing failed.
+ */
+private fun PairingSessionState.isSelfDismissing(): Boolean =
+    this == PairingSessionState.TRUSTED || this == PairingSessionState.CANCELLED
 
-internal fun trustedPairingSessionIds(sessions: List<PairingSessionUiState>): List<String> =
-    sessions.filter { it.state == PairingSessionState.TRUSTED }.map { it.sessionId }
+/** Sessions that still need a visible token card; self-dismissing states auto-close instead. */
+internal fun pairingTokenCardSessions(sessions: List<PairingSessionUiState>): List<PairingSessionUiState> =
+    sessions.filterNot { it.state.isSelfDismissing() }
+
+internal fun selfDismissingSessionIds(sessions: List<PairingSessionUiState>): List<String> =
+    sessions.filter { it.state.isSelfDismissing() }.map { it.sessionId }
 
 @Composable
 internal fun rememberPairingSecondsRemaining(

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3UiControllerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3UiControllerTest.kt
@@ -217,14 +217,16 @@ class PairingV3UiControllerTest {
     }
 
     @Test
-    fun trustedSessionAutoDismissesWithoutClosingOtherDeviceCards() {
+    fun trustedAndCancelledSessionsAutoDismissWithoutClosingOtherDeviceCards() {
         val trusted = pairingSession("trusted", PakeRole.ACCEPTOR, null, PairingSessionState.TRUSTED)
+        val cancelled = pairingSession("cancelled", PakeRole.ACCEPTOR, null, PairingSessionState.CANCELLED)
         val stillPairing = pairingSession("pairing", PakeRole.ACCEPTOR, "123456")
         val rejected = pairingSession("rejected", PakeRole.ACCEPTOR, null, PairingSessionState.REJECTED)
-        val sessions = listOf(trusted, stillPairing, rejected)
+        val sessions = listOf(trusted, cancelled, stillPairing, rejected)
 
-        assertEquals(listOf("trusted"), trustedPairingSessionIds(sessions))
-        // Rejected stays visible so the user sees the failure; only TRUSTED closes itself.
+        // TRUSTED (connected) and CANCELLED (peer abandoned) close themselves.
+        assertEquals(listOf("trusted", "cancelled"), selfDismissingSessionIds(sessions))
+        // Rejected stays visible so the user sees the failure.
         assertEquals(listOf("pairing", "rejected"), pairingTokenCardSessions(sessions).map { it.sessionId })
     }
 


### PR DESCRIPTION
Closes #4755

## Summary

A cancelled v3 pairing session kept its token card on screen showing "Pairing cancelled" until the user manually dismissed it. A cancelled pairing is non-actionable (the peer abandoned the handshake), so the card should close itself like a `TRUSTED` (connected) card does.

## Change

`PairingV3TokenCards.kt`: adds an `isSelfDismissing()` predicate — `TRUSTED` **or** `CANCELLED` — used both to filter out cards (`pairingTokenCardSessions`) and to drive the auto-dismiss effect (renamed `trustedPairingSessionIds` → `selfDismissingSessionIds`). `REJECTED`/`EXPIRED`/`FAILED` still stay visible so the user sees why pairing failed.

Test updated: a `CANCELLED` session now auto-dismisses alongside `TRUSTED`, while `REJECTED` stays in the visible card list.