### PR TITLE
:art: focus the first token input box when the pairing dialog opens

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/TrustDeviceDialog.kt
@@ -402,9 +402,17 @@ fun TokenInputBox(
         }
     }
 
+    // Focus the first box as soon as it is actually focusable, so the cursor
+    // blinks there on open and the user can type without clicking first. Keyed on
+    // the FocusRequester (recreated once the pairing credential type resolves) and
+    // on isLoading (boxes are disabled until the type is known): a plain
+    // LaunchedEffect(Unit) fired once against the disabled box and never retried on
+    // the enabled one, so focus was silently lost.
     if (index == 0) {
-        LaunchedEffect(Unit) {
-            focusRequester.requestFocus()
+        LaunchedEffect(focusRequester, isLoading) {
+            if (!isLoading) {
+                focusRequester.requestFocus()
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #4757

## Summary

The token input dialog did not place the cursor in the first digit box on open, so the user had to click before typing.

The first box requested focus with `LaunchedEffect(Unit)`, but that fired once against the **disabled** box (inputs are disabled until the pairing credential type resolves) and never retried after the box became enabled — and the `focusRequesters` list is recreated when the type resolves, so the original request targeted a stale requester.

## Change

`TokenInputBox` now keys the focus effect on `(focusRequester, isLoading)` and requests focus only when `!isLoading`, so the first box is focused as soon as it is actually focusable — on the enabled box, and again if the requester is recreated. Shared by v2 and v3 pairing, so both flows get the cursor on open.