### PR TITLE
:bug: clamp the main window height to the usable screen area

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
@@ -41,9 +41,11 @@ class DesktopAppSize(
         const val MIN_SEARCH_WINDOW_HEIGHT: Int = 250
         const val MAX_SEARCH_WINDOW_HEIGHT: Int = 420
 
-        // Gap kept between a clamped main window and the usable screen edge, so the
-        // window never renders edge-to-edge even when the platform reports no screen
-        // insets (common under XWayland, where panel/taskbar insets are unavailable).
+        // Gap kept between a clamped dimension and the usable screen edge, so a
+        // dimension that had to be clamped never renders edge-to-edge even when the
+        // platform reports no screen insets (common under XWayland, where
+        // panel/taskbar insets are unavailable). Dimensions that already fit keep
+        // the design size and may sit closer to the edge.
         private val SCREEN_CLAMP_MARGIN = xxLarge
 
         // Usable areas below this are treated as implausible platform reports
@@ -217,7 +219,7 @@ class DesktopAppSize(
             position = WindowPosition(Alignment.Center),
         )
 
-    private fun getClampedMainWindowSize(): DpSize {
+    fun getClampedMainWindowSize(): DpSize {
         val designSize = _appSizeValue.value.mainWindowSize
         return getUsableScreenSize()
             ?.let { clampMainWindowSize(designSize, it) }

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
@@ -13,6 +13,7 @@ import com.crosspaste.platform.Platform
 import com.crosspaste.ui.theme.AppUISize.huge
 import com.crosspaste.ui.theme.AppUISize.medium
 import com.crosspaste.ui.theme.AppUISize.small3X
+import com.crosspaste.ui.theme.AppUISize.xxLarge
 import com.crosspaste.utils.GlobalCoroutineScope.ioCoroutineDispatcher
 import com.crosspaste.utils.contains
 import com.github.kwhat.jnativehook.mouse.NativeMouseEvent
@@ -25,6 +26,7 @@ import kotlinx.coroutines.launch
 import java.awt.GraphicsDevice
 import java.awt.GraphicsEnvironment
 import java.awt.Point
+import java.awt.Toolkit
 
 class DesktopAppSize(
     private val platform: Platform,
@@ -38,6 +40,38 @@ class DesktopAppSize(
         // Reasonable range around the 332dp default (roughly ±25%)
         const val MIN_SEARCH_WINDOW_HEIGHT: Int = 250
         const val MAX_SEARCH_WINDOW_HEIGHT: Int = 420
+
+        // Gap kept between a clamped main window and the usable screen edge, so the
+        // window never renders edge-to-edge even when the platform reports no screen
+        // insets (common under XWayland, where panel/taskbar insets are unavailable).
+        private val SCREEN_CLAMP_MARGIN = xxLarge
+
+        // Usable areas below this are treated as implausible platform reports
+        // (headless quirks, transient display configs) rather than real screens,
+        // in which case clamping is skipped entirely.
+        private val MIN_PLAUSIBLE_USABLE_SIZE = 200.dp
+
+        /**
+         * The design size assumes it always fits on screen, which breaks on small or
+         * heavily scaled displays (e.g. XWayland misreporting a 2.5x scale, #4759):
+         * a 700dp-tall window can exceed the physical screen and gets pinned to full
+         * height. Clamping against the usable screen area keeps the declared window
+         * size valid regardless of what scale factor the runtime detected.
+         */
+        fun clampMainWindowSize(
+            designSize: DpSize,
+            usableScreenSize: DpSize,
+        ): DpSize {
+            if (usableScreenSize.width < MIN_PLAUSIBLE_USABLE_SIZE ||
+                usableScreenSize.height < MIN_PLAUSIBLE_USABLE_SIZE
+            ) {
+                return designSize
+            }
+            return DpSize(
+                width = minOf(designSize.width, usableScreenSize.width - SCREEN_CLAMP_MARGIN),
+                height = minOf(designSize.height, usableScreenSize.height - SCREEN_CLAMP_MARGIN),
+            )
+        }
 
         // Title bar height as a fixed proportion of the square paste card,
         // matching the original 60dp title on a 252dp card at the 332dp default
@@ -179,9 +213,33 @@ class DesktopAppSize(
     override fun getMainWindowState(): WindowState =
         WindowState(
             isMinimized = false,
-            size = _appSizeValue.value.mainWindowSize,
+            size = getClampedMainWindowSize(),
             position = WindowPosition(Alignment.Center),
         )
+
+    private fun getClampedMainWindowSize(): DpSize {
+        val designSize = _appSizeValue.value.mainWindowSize
+        return getUsableScreenSize()
+            ?.let { clampMainWindowSize(designSize, it) }
+            ?: designSize
+    }
+
+    // The main window is centered via WindowPosition(Alignment.Center), which
+    // resolves against the default screen, so the clamp uses the same screen.
+    private fun getUsableScreenSize(): DpSize? =
+        runCatching {
+            val configuration =
+                GraphicsEnvironment
+                    .getLocalGraphicsEnvironment()
+                    .defaultScreenDevice
+                    .defaultConfiguration
+            val bounds = configuration.bounds
+            val insets = Toolkit.getDefaultToolkit().getScreenInsets(configuration)
+            DpSize(
+                width = (bounds.width - insets.left - insets.right).dp,
+                height = (bounds.height - insets.top - insets.bottom).dp,
+            )
+        }.getOrNull()
 
     override fun getSearchWindowState(init: Boolean): WindowState {
         val graphicsDevice = getGraphicsDevice()

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppSize.kt
@@ -41,14 +41,12 @@ class DesktopAppSize(
         const val MIN_SEARCH_WINDOW_HEIGHT: Int = 250
         const val MAX_SEARCH_WINDOW_HEIGHT: Int = 420
 
-        // Gap kept between a clamped dimension and the usable screen edge, so a
-        // dimension that had to be clamped never renders edge-to-edge even when the
-        // platform reports no screen insets (common under XWayland, where
-        // panel/taskbar insets are unavailable). Dimensions that already fit keep
-        // the design size and may sit closer to the edge.
+        // Gap kept between a clamped height and the usable screen edge, so the
+        // window never renders edge-to-edge even when the platform reports no screen
+        // insets (common under XWayland, where panel/taskbar insets are unavailable).
         private val SCREEN_CLAMP_MARGIN = xxLarge
 
-        // Usable areas below this are treated as implausible platform reports
+        // Usable heights below this are treated as implausible platform reports
         // (headless quirks, transient display configs) rather than real screens,
         // in which case clamping is skipped entirely.
         private val MIN_PLAUSIBLE_USABLE_SIZE = 200.dp
@@ -57,21 +55,26 @@ class DesktopAppSize(
          * The design size assumes it always fits on screen, which breaks on small or
          * heavily scaled displays (e.g. XWayland misreporting a 2.5x scale, #4759):
          * a 700dp-tall window can exceed the physical screen and gets pinned to full
-         * height. Clamping against the usable screen area keeps the declared window
-         * size valid regardless of what scale factor the runtime detected.
+         * height. Clamping the height against the usable screen area keeps the
+         * declared window size valid regardless of what scale factor the runtime
+         * detected. The width is deliberately left at the design value: the
+         * two-column 600dp layout does not reflow, and height overflow is the
+         * failure mode observed in practice.
          */
         fun clampMainWindowSize(
             designSize: DpSize,
             usableScreenSize: DpSize,
         ): DpSize {
-            if (usableScreenSize.width < MIN_PLAUSIBLE_USABLE_SIZE ||
-                usableScreenSize.height < MIN_PLAUSIBLE_USABLE_SIZE
-            ) {
+            if (usableScreenSize.height < MIN_PLAUSIBLE_USABLE_SIZE) {
                 return designSize
             }
             return DpSize(
-                width = minOf(designSize.width, usableScreenSize.width - SCREEN_CLAMP_MARGIN),
-                height = minOf(designSize.height, usableScreenSize.height - SCREEN_CLAMP_MARGIN),
+                width = designSize.width,
+                height =
+                    minOf(
+                        designSize.height,
+                        usableScreenSize.height - SCREEN_CLAMP_MARGIN,
+                    ),
             )
         }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
@@ -1,8 +1,6 @@
 package com.crosspaste.app
 
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.awt.ComposeWindow
-import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.listener.ShortcutKeys
@@ -106,12 +104,7 @@ abstract class DesktopAppWindowManager(
         MutableStateFlow(
             WindowInfo(
                 show = false,
-                state =
-                    WindowState(
-                        isMinimized = false,
-                        size = appSize.appSizeValue.value.mainWindowSize,
-                        position = WindowPosition(Alignment.Center),
-                    ),
+                state = appSize.getMainWindowState(),
                 trigger = WindowTrigger.INIT,
             ),
         )

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/DesktopAppWindowManager.kt
@@ -183,6 +183,10 @@ abstract class DesktopAppWindowManager(
     }
 
     fun showMainWindow(windowTrigger: WindowTrigger) {
+        // Re-clamp on every show: resolution, scale, taskbar size or the active
+        // display may have changed since the last one. Only the size is updated,
+        // so a position the user dragged the window to is preserved.
+        _mainWindowInfo.value.state.size = appSize.getClampedMainWindowSize()
         _mainWindowInfo.value =
             _mainWindowInfo.value.copy(
                 show = true,

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/MainMenuView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/MainMenuView.kt
@@ -4,15 +4,19 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -135,100 +139,108 @@ fun MainMenuView() {
     val rootRouteName = backStackEntry?.let { getRootRouteName(it.destination) }
     val exitApplication = LocalExitApplication.current
 
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(bottom = medium),
-        verticalArrangement = Arrangement.SpaceBetween,
-    ) {
+    // The menu is designed for the full 700dp window, but the window height is
+    // clamped to the usable screen area on small/heavily scaled displays (#4759).
+    // heightIn(min = viewport) keeps SpaceBetween pinning the bottom group when
+    // everything fits, while verticalScroll takes over once it no longer does.
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = tiny),
-            verticalArrangement = Arrangement.spacedBy(tiny4X),
+                    .verticalScroll(rememberScrollState())
+                    .heightIn(min = maxHeight)
+                    .padding(bottom = medium),
+            verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            primaryMenuList.forEach { item ->
-                MainMenuItemView(
-                    title = item.title,
-                    icon = item.icon,
-                    selected = rootRouteName == item.route.name,
-                    onClick = { navigateManage.navigateAndClearStack(item.route) },
-                )
-            }
-        }
-
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(start = tiny, end = tiny),
-            verticalArrangement = Arrangement.spacedBy(tiny4X),
-        ) {
-            if (showNetworkWarning) {
-                MainMenuItemView(
-                    title = "network_warning",
-                    icon = MaterialSymbols.Rounded.Warning,
-                    selected = false,
-                    onClick = { networkProfileService.showWarning() },
-                    tintColor = LocalThemeExtState.current.warning.color,
-                )
-            }
-
-            HorizontalDivider(
-                modifier = Modifier.padding(horizontal = tiny3X),
-                thickness = tiny5X,
-                color = MaterialTheme.colorScheme.outlineVariant,
-            )
-
-            Spacer(modifier = Modifier.height(tiny3X))
-
-            if (firstLaunchCompleted && config.showTutorial) {
-                Box(modifier = Modifier.padding(horizontal = tiny, vertical = tiny3X)) {
-                    TutorialButton()
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = tiny),
+                verticalArrangement = Arrangement.spacedBy(tiny4X),
+            ) {
+                primaryMenuList.forEach { item ->
+                    MainMenuItemView(
+                        title = item.title,
+                        icon = item.icon,
+                        selected = rootRouteName == item.route.name,
+                        onClick = { navigateManage.navigateAndClearStack(item.route) },
+                    )
                 }
             }
 
-            secondaryMenuList.forEach { item ->
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(start = tiny, end = tiny),
+                verticalArrangement = Arrangement.spacedBy(tiny4X),
+            ) {
+                if (showNetworkWarning) {
+                    MainMenuItemView(
+                        title = "network_warning",
+                        icon = MaterialSymbols.Rounded.Warning,
+                        selected = false,
+                        onClick = { networkProfileService.showWarning() },
+                        tintColor = LocalThemeExtState.current.warning.color,
+                    )
+                }
+
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = tiny3X),
+                    thickness = tiny5X,
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+
+                Spacer(modifier = Modifier.height(tiny3X))
+
+                if (firstLaunchCompleted && config.showTutorial) {
+                    Box(modifier = Modifier.padding(horizontal = tiny, vertical = tiny3X)) {
+                        TutorialButton()
+                    }
+                }
+
+                secondaryMenuList.forEach { item ->
+                    MainMenuItemView(
+                        title = item.title,
+                        icon = item.icon,
+                        selected = rootRouteName == item.route.name,
+                        onClick = { navigateManage.navigateAndClearStack(item.route) },
+                        compact = true,
+                    )
+                }
+
                 MainMenuItemView(
-                    title = item.title,
-                    icon = item.icon,
-                    selected = rootRouteName == item.route.name,
-                    onClick = { navigateManage.navigateAndClearStack(item.route) },
+                    title = "change_log",
+                    icon = MaterialSymbols.Rounded.Auto_awesome,
+                    selected = rootRouteName == ChangeLog.NAME,
+                    onClick = { navigateManage.navigateAndClearStack(ChangeLog) },
+                    compact = true,
+                    showBadge = showChangelogBadge,
+                )
+
+                MainMenuItemView(
+                    title = "check_for_updates",
+                    icon = MaterialSymbols.Rounded.Refresh,
+                    selected = false,
+                    // Single entry point for every channel (same as the tray's check):
+                    // portable-zip re-arms the update dialog (or reports "no new version"),
+                    // others delegate to Store / Conveyor / browser. Avoids a "fake check"
+                    // that only navigated without any feedback.
+                    onClick = { appUpdateService.tryTriggerUpdate() },
                     compact = true,
                 )
+
+                MainMenuItemView(
+                    title = "quit",
+                    icon = MaterialSymbols.Rounded.Exit_to_app,
+                    selected = false,
+                    onClick = { exitApplication(ExitMode.EXIT) },
+                    compact = true,
+                    tintColor = MaterialTheme.colorScheme.error,
+                )
             }
-
-            MainMenuItemView(
-                title = "change_log",
-                icon = MaterialSymbols.Rounded.Auto_awesome,
-                selected = rootRouteName == ChangeLog.NAME,
-                onClick = { navigateManage.navigateAndClearStack(ChangeLog) },
-                compact = true,
-                showBadge = showChangelogBadge,
-            )
-
-            MainMenuItemView(
-                title = "check_for_updates",
-                icon = MaterialSymbols.Rounded.Refresh,
-                selected = false,
-                // Single entry point for every channel (same as the tray's check):
-                // portable-zip re-arms the update dialog (or reports "no new version"),
-                // others delegate to Store / Conveyor / browser. Avoids a "fake check"
-                // that only navigated without any feedback.
-                onClick = { appUpdateService.tryTriggerUpdate() },
-                compact = true,
-            )
-
-            MainMenuItemView(
-                title = "quit",
-                icon = MaterialSymbols.Rounded.Exit_to_app,
-                selected = false,
-                onClick = { exitApplication(ExitMode.EXIT) },
-                compact = true,
-                tintColor = MaterialTheme.colorScheme.error,
-            )
         }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/DesktopAppSizeTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/DesktopAppSizeTest.kt
@@ -1,0 +1,49 @@
+package com.crosspaste.app
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import com.crosspaste.app.DesktopAppSize.Companion.clampMainWindowSize
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopAppSizeTest {
+
+    private val designSize = DpSize(width = 600.dp, height = 700.dp)
+
+    @Test
+    fun `design size is kept when the usable screen is large enough`() {
+        val usable = DpSize(width = 1920.dp, height = 1080.dp)
+
+        assertEquals(designSize, clampMainWindowSize(designSize, usable))
+    }
+
+    @Test
+    fun `height is clamped when the usable screen is too short`() {
+        // e.g. a 1366x768 laptop at 125% scale -> ~614dp usable height
+        val usable = DpSize(width = 1092.dp, height = 614.dp)
+
+        val clamped = clampMainWindowSize(designSize, usable)
+
+        assertEquals(designSize.width, clamped.width)
+        assertEquals(614.dp - 32.dp, clamped.height)
+    }
+
+    @Test
+    fun `both dimensions are clamped when the usable screen is smaller than the design size`() {
+        // e.g. XWayland misreporting a 2.5x scale on a 1440p screen (#4759)
+        val usable = DpSize(width = 1024.dp, height = 576.dp)
+        val small = DpSize(width = 1100.dp, height = 700.dp)
+
+        val clamped = clampMainWindowSize(small, usable)
+
+        assertEquals(1024.dp - 32.dp, clamped.width)
+        assertEquals(576.dp - 32.dp, clamped.height)
+    }
+
+    @Test
+    fun `implausibly small usable sizes are ignored`() {
+        val usable = DpSize(width = 100.dp, height = 50.dp)
+
+        assertEquals(designSize, clampMainWindowSize(designSize, usable))
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/DesktopAppSizeTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/DesktopAppSizeTest.kt
@@ -29,20 +29,19 @@ class DesktopAppSizeTest {
     }
 
     @Test
-    fun `both dimensions are clamped when the usable screen is smaller than the design size`() {
+    fun `width keeps the design value even on a narrow screen`() {
         // e.g. XWayland misreporting a 2.5x scale on a 1440p screen (#4759)
-        val usable = DpSize(width = 1024.dp, height = 576.dp)
-        val small = DpSize(width = 1100.dp, height = 700.dp)
+        val usable = DpSize(width = 500.dp, height = 576.dp)
 
-        val clamped = clampMainWindowSize(small, usable)
+        val clamped = clampMainWindowSize(designSize, usable)
 
-        assertEquals(1024.dp - 32.dp, clamped.width)
+        assertEquals(designSize.width, clamped.width)
         assertEquals(576.dp - 32.dp, clamped.height)
     }
 
     @Test
-    fun `implausibly small usable sizes are ignored`() {
-        val usable = DpSize(width = 100.dp, height = 50.dp)
+    fun `implausibly small usable heights are ignored`() {
+        val usable = DpSize(width = 1920.dp, height = 50.dp)
 
         assertEquals(designSize, clampMainWindowSize(designSize, usable))
     }


### PR DESCRIPTION
Closes #4760. Addresses the full-screen-height symptom reported in #4759.

## What

- `DesktopAppSize`: new pure `clampMainWindowSize(designSize, usableScreenSize)` clamps the window height to `min(design, usable - 32dp margin)`; usable heights below 200dp are treated as implausible platform reports and skip clamping. `getUsableScreenSize()` reads the default screen bounds minus `Toolkit.getScreenInsets()`, wrapped in `runCatching` so headless environments fall back to the design size. The previously dead `getMainWindowState()` is now the single construction point for the main window state.
- `DesktopAppWindowManager`: the initial `_mainWindowInfo` state reuses `getMainWindowState()` instead of duplicating it inline, and `showMainWindow()` re-clamps the size on every show so runtime changes to resolution, scale, taskbar or displays are picked up without a restart. Only the size is updated, preserving a user-dragged position.
- `MainMenuView`: `BoxWithConstraints` + `verticalScroll` + `heightIn(min = viewport)` so the menu scrolls when the clamped window is too short, while `SpaceBetween` keeps pinning the bottom group at normal heights (the large diff is re-indentation from the wrapper; see `-w`).
- New `DesktopAppSizeTest` covers the pure clamp function (no clamp / height clamp / narrow screen keeps design width / implausible report ignored).

## Review notes

An independent strict review found no blocking issues. Key decisions:

- **Width is deliberately not clamped** (decided at the human gate): the fixed two-column 600dp layout does not reflow, so shrinking the width would clip the content column without making anything more reachable; height overflow is the failure mode observed in practice.
- Constructing the window manager now touches AWT during DI setup; accepted because the search window state already did so, and the clamp is fully guarded with a design-size fallback.
- Known theoretical caveat: on some platforms `GraphicsConfiguration.bounds` (logical) and `getScreenInsets` (sometimes physical) can disagree under HiDPI; the target scenario (XWayland reporting zero insets) is unaffected. Worth watching during real-device verification on Linux.

## Test

`./gradlew app:desktopTest` passes in full, including the four new clamp tests.
