### PR TITLE
:arrow_up: bump postcss to 8.5.26 to fix source map disclosure advisories

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2834,9 +2834,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2922,9 +2922,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2942,7 +2942,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

Lockfile-only bump of `postcss` in `web/package-lock.json` from **8.5.15** to **8.5.26**, resolving both open Dependabot alerts:

- **High** — Path Traversal in previous source map auto-loading (`sourceMappingURL`) leads to arbitrary `.map` file disclosure (patched in 8.5.18)
- **Medium** — Incomplete fix of the above: attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset (patched in 8.5.23)

The `package.json` range `^8.5.15` already covers 8.5.26, so only the lockfile changes (postcss + its transitive `nanoid` 3.3.12 → 3.3.18). This is a manual bump because Dependabot cannot resolve the `file:../core/build/dist/js/productionLibrary` dependency in `web/`.

## Verification

- `npm audit` reports 0 vulnerabilities after the bump
- `npm run build` in `web/` succeeds