### PR TITLE
:sparkles: probe app liveness and auto-start the desktop app from the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       # Pure Kotlin since the CLI went all-HTTP; only needs the Kotlin/Native
       # toolchain already set up above.
       - name: Build CLI native binary
-        run: ./gradlew :cli:ktlintCheck :cli:linkDebugExecutableCliNative
+        run: ./gradlew :cli:ktlintCheck :cli:cliNativeTest :cli:linkDebugExecutableCliNative
 
   web-build:
     needs: changes

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -117,9 +117,18 @@ kotlin {
         }
     }
 
+    // Platform-split sources keyed on the selected target (not the host,
+    // which would break -Pcli.target cross-compilation)
+    val isMingwTarget = cliTarget == "mingwX64" || (cliTarget == null && isMingwX64)
+
     sourceSets {
         val cliNativeMain by getting {
             kotlin.srcDir(generateCliVersion)
+            if (isMingwTarget) {
+                kotlin.srcDir("src/mingwNativeMain/kotlin")
+            } else {
+                kotlin.srcDir("src/posixNativeMain/kotlin")
+            }
             dependencies {
                 implementation(libs.clikt)
                 implementation(libs.kotlinx.coroutines.core)

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -138,5 +138,14 @@ kotlin {
                 implementation(libs.okio)
             }
         }
+        val cliNativeTest by getting {
+            if (!isMingwTarget) {
+                kotlin.srcDir("src/posixNativeTest/kotlin")
+            }
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -114,6 +114,12 @@ kotlin {
                     linkerOpts("--allow-multiple-definition")
                 }
             }
+            // The test binary needs the same Clikt duplicate-symbol workaround;
+            // GNU ld only hits it when konan compiler caches are enabled (host
+            // builds), which is why cross-links from macOS don't reproduce it
+            if (!isMacosTarget) {
+                getTest("debug").linkerOpts("--allow-multiple-definition")
+            }
         }
     }
 

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
@@ -17,6 +17,7 @@ import com.github.ajalt.clikt.core.obj
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.switch
 
 class CrossPasteCommand : CliktCommand(name = "crosspaste") {
 
@@ -24,8 +25,18 @@ class CrossPasteCommand : CliktCommand(name = "crosspaste") {
 
     val json by option("--json", help = "Output in JSON format for machine consumption").flag()
 
+    val autoStart by option(
+        help =
+            "When CrossPaste is not running: --start launches it without asking, --no-start " +
+                "never launches it. Default is to ask on an interactive terminal and to fail " +
+                "with exit code 3 otherwise.",
+    ).switch(
+        "--start" to true,
+        "--no-start" to false,
+    )
+
     override fun run() {
-        currentContext.obj = CliContext(json = json)
+        currentContext.obj = CliContext(json = json, autoStart = autoStart)
     }
 
     init {
@@ -47,4 +58,6 @@ class CrossPasteCommand : CliktCommand(name = "crosspaste") {
 
 data class CliContext(
     val json: Boolean = false,
+    /** Tri-state launch consent: true = always start, false = never, null = ask. */
+    val autoStart: Boolean? = null,
 )

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/AppAutoStarter.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/AppAutoStarter.kt
@@ -3,28 +3,33 @@ package com.crosspaste.cli.commands
 import com.crosspaste.cli.platform.AppLauncher
 import com.crosspaste.cli.platform.AppReadinessChecker
 
+/**
+ * Launches the desktop app and waits for its CLI endpoint to come up.
+ * Progress messages are emitted through [echo] so callers can keep them
+ * out of stdout (pipes must only receive command output).
+ */
 class AppAutoStarter(
     private val launcher: AppLauncher,
     private val readinessChecker: AppReadinessChecker,
 ) {
 
-    suspend fun startAndWait(echo: (message: String, isError: Boolean) -> Unit): Boolean {
-        echo("CrossPaste is not running. Starting CrossPaste...", false)
+    suspend fun startAndWait(echo: (message: String) -> Unit): Boolean {
+        echo("Starting CrossPaste...")
 
         val launched = launcher.launch()
         if (!launched) {
-            echo("Failed to start CrossPaste. Please start it manually.", true)
+            echo("Failed to start CrossPaste. Please start it manually.")
             return false
         }
 
-        echo("Waiting for CrossPaste to become ready...", false)
+        echo("Waiting for CrossPaste to become ready...")
         val ready = readinessChecker.waitForAppReady()
         if (!ready) {
-            echo("Timed out waiting for CrossPaste to become ready.", true)
+            echo("Timed out waiting for CrossPaste to become ready. Please check the application manually.")
             return false
         }
 
-        echo("CrossPaste is now running.", false)
+        echo("CrossPaste is now running.")
         return true
     }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -45,12 +45,13 @@ fun CliktCommand.runCli(block: suspend (CliClient) -> Unit) {
         val readinessChecker = AppReadinessChecker(configReader)
         ensureAppRunning(readinessChecker)
         var retriedAfterRestart = false
+        var versionWarningShown = false
         while (true) {
             var client: CliClient? = null
             try {
                 client = CliClient(configReader)
-                if (!retriedAfterRestart) {
-                    warnOnApiVersionMismatch(client)
+                if (!versionWarningShown) {
+                    versionWarningShown = warnOnApiVersionMismatch(client)
                 }
                 block(client)
                 return@runBlocking
@@ -164,14 +165,15 @@ private fun CliktCommand.promptStartConfirmation(): Boolean {
     }
 }
 
-private fun CliktCommand.warnOnApiVersionMismatch(client: CliClient) {
-    if (client.hasApiVersionMismatch()) {
-        echo(
-            "Warning: CLI API version $CLI_API_VERSION does not match the running " +
-                "app's version ${client.endpoint.apiVersion}; consider updating both.",
-            err = true,
-        )
-    }
+/** Returns true when a warning was emitted, so callers can avoid repeats. */
+internal fun CliktCommand.warnOnApiVersionMismatch(client: CliClient): Boolean {
+    if (!client.hasApiVersionMismatch()) return false
+    echo(
+        "Warning: CLI API version $CLI_API_VERSION does not match the running " +
+            "app's version ${client.endpoint.apiVersion}; consider updating both.",
+        err = true,
+    )
+    return true
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -1,15 +1,26 @@
 package com.crosspaste.cli.commands
 
+import com.crosspaste.cli.CliContext
 import com.crosspaste.cli.api.AppNotRunningException
 import com.crosspaste.cli.api.CLI_API_VERSION
 import com.crosspaste.cli.api.CliClient
+import com.crosspaste.cli.platform.AppLiveness
+import com.crosspaste.cli.platform.AppReadinessChecker
+import com.crosspaste.cli.platform.CliAppPathProvider
 import com.crosspaste.cli.platform.CliConfigReader
+import com.crosspaste.cli.platform.createAppLauncher
 import com.crosspaste.cli.platform.createNativePlatformPathProvider
+import com.crosspaste.cli.platform.isGuiEnvironment
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.findObject
+import com.github.ajalt.clikt.core.terminal
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+
+/** Scripts can rely on this exit code to mean "CrossPaste is not running". */
+const val EXIT_CODE_APP_NOT_RUNNING = 3
 
 val cliJson =
     Json {
@@ -19,33 +30,147 @@ val cliJson =
 
 /**
  * Runs [block] with a connected [CliClient]. Every command goes through this:
- * it discovers the app's socket, surfaces "app not running" uniformly, and
- * warns (without failing) when the CLI and app disagree on the API version.
+ * it runs the D5 liveness sequence first (waiting out a starting app, and
+ * offering to launch a stopped one — see [ensureAppRunning]), surfaces
+ * "app not running" uniformly, and warns (without failing) when the CLI and
+ * app disagree on the API version.
+ *
+ * If the app goes away mid-command, the connection failure means the request
+ * never reached it, so after re-running the liveness sequence the command is
+ * retried once.
  */
 fun CliktCommand.runCli(block: suspend (CliClient) -> Unit) {
     runBlocking {
-        var client: CliClient? = null
-        try {
-            client = CliClient(CliConfigReader(createNativePlatformPathProvider()))
-            if (client.hasApiVersionMismatch()) {
+        val configReader = CliConfigReader(createNativePlatformPathProvider())
+        val readinessChecker = AppReadinessChecker(configReader)
+        ensureAppRunning(readinessChecker)
+        var retriedAfterRestart = false
+        while (true) {
+            var client: CliClient? = null
+            try {
+                client = CliClient(configReader)
+                if (!retriedAfterRestart) {
+                    warnOnApiVersionMismatch(client)
+                }
+                block(client)
+                return@runBlocking
+            } catch (e: ProgramResult) {
+                throw e
+            } catch (e: AppNotRunningException) {
+                if (retriedAfterRestart) {
+                    echo("Error: ${e.message}", err = true)
+                    throw ProgramResult(EXIT_CODE_APP_NOT_RUNNING)
+                }
+                retriedAfterRestart = true
+                ensureAppRunning(readinessChecker)
+            } catch (e: Exception) {
+                echo("Error: ${e.message}", err = true)
+                throw ProgramResult(1)
+            } finally {
+                client?.close()
+            }
+        }
+    }
+}
+
+/**
+ * D5 unified pre-flight: running → proceed; starting (endpoint file present,
+ * pid alive, socket not answering yet) → wait for readiness; not running →
+ * offer to launch (see [startApp]). Throws [ProgramResult] when the command
+ * cannot proceed.
+ */
+private suspend fun CliktCommand.ensureAppRunning(readinessChecker: AppReadinessChecker) {
+    when (readinessChecker.probe()) {
+        AppLiveness.RUNNING -> Unit
+        AppLiveness.STARTING -> {
+            echo("CrossPaste is starting; waiting for it to become ready...", err = true)
+            if (!readinessChecker.waitForAppReady()) {
                 echo(
-                    "Warning: CLI API version $CLI_API_VERSION does not match the running " +
-                        "app's version ${client.endpoint.apiVersion}; consider updating both.",
+                    "Error: Timed out waiting for CrossPaste to become ready. " +
+                        "Please check the application manually.",
                     err = true,
                 )
+                throw ProgramResult(1)
             }
-            block(client)
-        } catch (e: ProgramResult) {
-            throw e
-        } catch (e: AppNotRunningException) {
-            echo("Error: ${e.message}", err = true)
-            throw ProgramResult(1)
-        } catch (e: Exception) {
-            echo("Error: ${e.message}", err = true)
-            throw ProgramResult(1)
-        } finally {
-            client?.close()
         }
+        AppLiveness.NOT_RUNNING -> startApp(readinessChecker)
+    }
+}
+
+/**
+ * Launch consent follows the --start / --no-start tri-state: forced yes,
+ * forced no, or (the default) a TTY prompt. A non-interactive caller is never
+ * blocked on input: it fails fast with [EXIT_CODE_APP_NOT_RUNNING].
+ */
+private suspend fun CliktCommand.startApp(readinessChecker: AppReadinessChecker) {
+    if (!isGuiEnvironment()) {
+        echo(
+            "Error: CrossPaste is not running, and this looks like a headless environment " +
+                "(no DISPLAY or WAYLAND_DISPLAY), so the desktop application cannot be " +
+                "started here. Headless daemon support is not available yet.",
+            err = true,
+        )
+        throw ProgramResult(EXIT_CODE_APP_NOT_RUNNING)
+    }
+    if (!consentToStart()) {
+        throw ProgramResult(EXIT_CODE_APP_NOT_RUNNING)
+    }
+    val starter = AppAutoStarter(createAppLauncher(CliAppPathProvider()), readinessChecker)
+    val started = starter.startAndWait { message -> echo(message, err = true) }
+    if (!started) {
+        throw ProgramResult(1)
+    }
+}
+
+private fun CliktCommand.consentToStart(): Boolean =
+    when (currentContext.findObject<CliContext>()?.autoStart) {
+        true -> true
+        false -> {
+            echo("Error: CrossPaste is not running.", err = true)
+            false
+        }
+        null -> {
+            if (terminal.terminalInfo.inputInteractive) {
+                val confirmed = promptStartConfirmation()
+                if (!confirmed) {
+                    echo("Error: CrossPaste is not running.", err = true)
+                }
+                confirmed
+            } else {
+                echo(
+                    "Error: CrossPaste is not running. " +
+                        "Use 'crosspaste --start <command>' to launch it automatically.",
+                    err = true,
+                )
+                false
+            }
+        }
+    }
+
+/**
+ * Hand-rolled instead of Mordant's YesNoPrompt so the prompt goes to stderr:
+ * stdout must stay pipe-clean even when stdin is a TTY but stdout is
+ * redirected (e.g. `crosspaste --json paste > out`).
+ */
+private fun CliktCommand.promptStartConfirmation(): Boolean {
+    while (true) {
+        echo("CrossPaste is not running. Start it now? [Y/n]: ", trailingNewline = false, err = true)
+        val answer = readlnOrNull()?.trim()?.lowercase() ?: return false
+        when (answer) {
+            "", "y", "yes" -> return true
+            "n", "no" -> return false
+            else -> echo("Please answer y or n.", err = true)
+        }
+    }
+}
+
+private fun CliktCommand.warnOnApiVersionMismatch(client: CliClient) {
+    if (client.hasApiVersionMismatch()) {
+        echo(
+            "Warning: CLI API version $CLI_API_VERSION does not match the running " +
+                "app's version ${client.endpoint.apiVersion}; consider updating both.",
+            err = true,
+        )
     }
 }
 

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/StatusCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/StatusCommand.kt
@@ -60,26 +60,39 @@ class StatusCommand : CliktCommand(name = "status") {
     override fun run() {
         runBlocking {
             val configReader = CliConfigReader(createNativePlatformPathProvider())
-            when (AppReadinessChecker(configReader).probe()) {
-                AppLiveness.RUNNING -> printRunning(configReader)
+            val readinessChecker = AppReadinessChecker(configReader)
+            when (readinessChecker.probe()) {
+                AppLiveness.RUNNING -> printRunning(configReader, readinessChecker)
                 AppLiveness.STARTING -> printNotReady("Starting", "starting")
                 AppLiveness.NOT_RUNNING -> printNotReady("Not running", "not_running")
             }
         }
     }
 
-    private suspend fun printRunning(configReader: CliConfigReader) {
+    private suspend fun printRunning(
+        configReader: CliConfigReader,
+        readinessChecker: AppReadinessChecker,
+    ) {
         var client: CliClient? = null
         try {
             client = CliClient(configReader)
+            warnOnApiVersionMismatch(client)
             val status = client.getBody("/cli/status", StatusResponse.serializer())
             printStatus(status)
         } catch (_: AppNotRunningException) {
             // The app went away between the probe and the status request
             printNotReady("Not running", "not_running")
         } catch (e: Exception) {
-            echo("Error: ${e.message}", err = true)
-            throw ProgramResult(1)
+            // An EOF/reset from an app that died mid-request is still "not
+            // running"; only keep exit 1 when the app demonstrably serves
+            when (readinessChecker.probe()) {
+                AppLiveness.RUNNING -> {
+                    echo("Error: ${e.message}", err = true)
+                    throw ProgramResult(1)
+                }
+                AppLiveness.STARTING -> printNotReady("Starting", "starting")
+                AppLiveness.NOT_RUNNING -> printNotReady("Not running", "not_running")
+            }
         } finally {
             client?.close()
         }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/StatusCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/StatusCommand.kt
@@ -1,10 +1,19 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
+import com.crosspaste.cli.api.AppNotRunningException
+import com.crosspaste.cli.api.CliClient
+import com.crosspaste.cli.platform.AppLiveness
+import com.crosspaste.cli.platform.AppReadinessChecker
+import com.crosspaste.cli.platform.CliConfigReader
+import com.crosspaste.cli.platform.createNativePlatformPathProvider
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.requireObject
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 @Serializable
 data class StatusResponse(
@@ -17,24 +26,82 @@ data class StatusResponse(
     val pasteCount: Long,
 )
 
+@Serializable
+data class StatusOutput(
+    val running: Boolean,
+    val state: String,
+    val appVersion: String? = null,
+    val appInstanceId: String? = null,
+    val apiVersion: Int? = null,
+    val port: Int? = null,
+    val pasteboardListening: Boolean? = null,
+    val deviceCount: Int? = null,
+    val pasteCount: Long? = null,
+)
+
+/**
+ * Unlike every other command, status never triggers auto-start: it reports
+ * the app's actual state (Running / Starting / Not running) and exits with
+ * [EXIT_CODE_APP_NOT_RUNNING] unless the app is ready to serve.
+ */
 class StatusCommand : CliktCommand(name = "status") {
 
-    override fun help(context: Context): String = "Show the status of the running CrossPaste application"
+    override fun help(context: Context): String =
+        "Show the status of the CrossPaste application (never starts it; " +
+            "exit code $EXIT_CODE_APP_NOT_RUNNING when it is not running)"
 
     private val ctx by requireObject<CliContext>()
 
-    override fun run() =
-        runCli { client ->
-            val status = client.getBody("/cli/status", StatusResponse.serializer())
-
-            if (ctx.json) {
-                echo(cliJson.encodeToString(StatusResponse.serializer(), status))
-            } else {
-                printStatus(status)
-            }
+    private val statusJson =
+        Json(cliJson) {
+            explicitNulls = false
         }
 
+    override fun run() {
+        runBlocking {
+            val configReader = CliConfigReader(createNativePlatformPathProvider())
+            when (AppReadinessChecker(configReader).probe()) {
+                AppLiveness.RUNNING -> printRunning(configReader)
+                AppLiveness.STARTING -> printNotReady("Starting", "starting")
+                AppLiveness.NOT_RUNNING -> printNotReady("Not running", "not_running")
+            }
+        }
+    }
+
+    private suspend fun printRunning(configReader: CliConfigReader) {
+        var client: CliClient? = null
+        try {
+            client = CliClient(configReader)
+            val status = client.getBody("/cli/status", StatusResponse.serializer())
+            printStatus(status)
+        } catch (_: AppNotRunningException) {
+            // The app went away between the probe and the status request
+            printNotReady("Not running", "not_running")
+        } catch (e: Exception) {
+            echo("Error: ${e.message}", err = true)
+            throw ProgramResult(1)
+        } finally {
+            client?.close()
+        }
+    }
+
     private fun printStatus(status: StatusResponse) {
+        if (ctx.json) {
+            val output =
+                StatusOutput(
+                    running = true,
+                    state = "running",
+                    appVersion = status.appVersion,
+                    appInstanceId = status.appInstanceId,
+                    apiVersion = status.apiVersion,
+                    port = status.port,
+                    pasteboardListening = status.pasteboardListening,
+                    deviceCount = status.deviceCount,
+                    pasteCount = status.pasteCount,
+                )
+            echo(statusJson.encodeToString(StatusOutput.serializer(), output))
+            return
+        }
         val listening = if (status.pasteboardListening) "Active" else "Inactive"
         echo("CrossPaste v${status.appVersion}")
         echo("  Status:      Running")
@@ -43,5 +110,19 @@ class StatusCommand : CliktCommand(name = "status") {
         echo("  Devices:     ${status.deviceCount}")
         echo("  Pastes:      ${status.pasteCount}")
         echo("  Instance:    ${status.appInstanceId}")
+    }
+
+    private fun printNotReady(
+        label: String,
+        state: String,
+    ): Nothing {
+        if (ctx.json) {
+            val output = StatusOutput(running = false, state = state)
+            echo(statusJson.encodeToString(StatusOutput.serializer(), output))
+        } else {
+            echo("CrossPaste")
+            echo("  Status:      $label")
+        }
+        throw ProgramResult(EXIT_CODE_APP_NOT_RUNNING)
     }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppLauncher.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppLauncher.kt
@@ -1,6 +1,8 @@
 package com.crosspaste.cli.platform
 
 import kotlinx.cinterop.ExperimentalForeignApi
+import okio.FileSystem
+import okio.Path
 import platform.posix.system
 import kotlin.experimental.ExperimentalNativeApi
 
@@ -8,6 +10,13 @@ interface AppLauncher {
 
     fun launch(): Boolean
 }
+
+/**
+ * The shell commands below background the start script, so a missing script
+ * would still "succeed" and leave the caller waiting out the full readiness
+ * timeout — check it up front instead.
+ */
+private fun startScriptExists(script: Path): Boolean = FileSystem.SYSTEM.exists(script)
 
 @OptIn(ExperimentalNativeApi::class)
 fun createAppLauncher(appPathProvider: CliAppPathProvider): AppLauncher {
@@ -27,6 +36,7 @@ class MacosAppLauncher(
 
     override fun launch(): Boolean {
         val script = appPathProvider.startScriptPath
+        if (!startScriptExists(script)) return false
         val exitCode = system("nohup bash \"$script\" > /dev/null 2>&1 &")
         return exitCode == 0
     }
@@ -39,6 +49,7 @@ class LinuxAppLauncher(
 
     override fun launch(): Boolean {
         val script = appPathProvider.startScriptPath
+        if (!startScriptExists(script)) return false
         val exitCode = system("nohup bash \"$script\" > /dev/null 2>&1 &")
         return exitCode == 0
     }
@@ -51,6 +62,7 @@ class WindowsAppLauncher(
 
     override fun launch(): Boolean {
         val script = appPathProvider.startScriptPath
+        if (!startScriptExists(script)) return false
         val exePath = appPathProvider.resolveAppExePath()
         val exitCode = system("\"$script\" \"$exePath\"")
         return exitCode == 0

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppReadinessChecker.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppReadinessChecker.kt
@@ -1,20 +1,28 @@
 package com.crosspaste.cli.platform
 
+import com.crosspaste.cli.api.CliEndpoint
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.get
 import io.ktor.client.request.unixSocket
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.delay
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okio.FileSystem
 import kotlin.time.Duration.Companion.milliseconds
 
+enum class AppLiveness {
+    RUNNING,
+    STARTING,
+    NOT_RUNNING,
+}
+
 /**
- * Polls until the app's CLI endpoint is ready: the endpoint file must exist
- * (re-read every round — the app writes it only once the socket is live) and
- * GET /cli/status over that socket must answer 200.
+ * Implements the design D5 liveness sequence over the app's cli-endpoint.json
+ * discovery file: no readable file means the app is not running; a 200 from
+ * GET /cli/status over the declared socket means it is running; otherwise the
+ * recorded pid disambiguates an app that is still starting up from a stale
+ * crash leftover.
  */
 class AppReadinessChecker(
     private val configReader: CliConfigReader,
@@ -31,16 +39,30 @@ class AppReadinessChecker(
             isLenient = true
         }
 
-    suspend fun waitForAppReady(): Boolean {
-        val client =
-            HttpClient(CIO) {
-                engine {
-                    requestTimeout = 2000
-                }
+    suspend fun probe(): AppLiveness {
+        val endpoint = readEndpoint() ?: return AppLiveness.NOT_RUNNING
+        val client = createClient()
+        try {
+            if (isReady(client, endpoint.socketPath)) {
+                return AppLiveness.RUNNING
             }
+        } finally {
+            client.close()
+        }
+        return if (isProcessAlive(endpoint.pid)) AppLiveness.STARTING else AppLiveness.NOT_RUNNING
+    }
+
+    /**
+     * Polls until the app's CLI endpoint is ready: the endpoint file must exist
+     * (re-read every round — the app writes it only once the socket is live) and
+     * GET /cli/status over that socket must answer 200.
+     */
+    suspend fun waitForAppReady(): Boolean {
+        val client = createClient()
         try {
             repeat(MAX_POLLS) {
-                if (isReady(client)) {
+                val endpoint = readEndpoint()
+                if (endpoint != null && isReady(client, endpoint.socketPath)) {
                     return true
                 }
                 delay(POLL_INTERVAL)
@@ -51,9 +73,18 @@ class AppReadinessChecker(
         }
     }
 
-    private suspend fun isReady(client: HttpClient): Boolean {
-        val socketPath = readSocketPath() ?: return false
-        return try {
+    private fun createClient(): HttpClient =
+        HttpClient(CIO) {
+            engine {
+                requestTimeout = 2000
+            }
+        }
+
+    private suspend fun isReady(
+        client: HttpClient,
+        socketPath: String,
+    ): Boolean =
+        try {
             val response =
                 client.get("http://localhost/cli/status") {
                     unixSocket(socketPath)
@@ -62,19 +93,13 @@ class AppReadinessChecker(
         } catch (_: Exception) {
             false
         }
-    }
 
-    private fun readSocketPath(): String? =
+    private fun readEndpoint(): CliEndpoint? =
         try {
             val content =
                 FileSystem.SYSTEM.read(configReader.resolveEndpointFilePath()) { readUtf8() }
-            json.decodeFromString<EndpointSocket>(content).socketPath
+            json.decodeFromString<CliEndpoint>(content)
         } catch (_: Exception) {
             null
         }
 }
-
-@Serializable
-private data class EndpointSocket(
-    val socketPath: String,
-)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppReadinessChecker.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppReadinessChecker.kt
@@ -5,11 +5,15 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.get
 import io.ktor.client.request.unixSocket
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okio.FileSystem
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 enum class AppLiveness {
     RUNNING,
@@ -20,17 +24,21 @@ enum class AppLiveness {
 /**
  * Implements the design D5 liveness sequence over the app's cli-endpoint.json
  * discovery file: no readable file means the app is not running; a 200 from
- * GET /cli/status over the declared socket means it is running; otherwise the
- * recorded pid disambiguates an app that is still starting up from a stale
- * crash leftover.
+ * GET /cli/status over the declared socket whose appInstanceId matches the
+ * file means it is running; otherwise the recorded pid disambiguates an app
+ * that is still starting up from a stale crash leftover.
+ *
+ * [socketProber] and [processAlive] are injectable for tests only.
  */
 class AppReadinessChecker(
     private val configReader: CliConfigReader,
+    private val socketProber: suspend (CliEndpoint) -> Boolean = ::probeOverUnixSocket,
+    private val processAlive: (Long) -> Boolean = ::isProcessAlive,
 ) {
 
     companion object {
         private val POLL_INTERVAL = 500.milliseconds
-        private const val MAX_POLLS = 60
+        private val READY_TIMEOUT = 30.seconds
     }
 
     private val json =
@@ -41,58 +49,30 @@ class AppReadinessChecker(
 
     suspend fun probe(): AppLiveness {
         val endpoint = readEndpoint() ?: return AppLiveness.NOT_RUNNING
-        val client = createClient()
-        try {
-            if (isReady(client, endpoint.socketPath)) {
-                return AppLiveness.RUNNING
-            }
-        } finally {
-            client.close()
+        if (socketProber(endpoint)) {
+            return AppLiveness.RUNNING
         }
-        return if (isProcessAlive(endpoint.pid)) AppLiveness.STARTING else AppLiveness.NOT_RUNNING
+        return if (processAlive(endpoint.pid)) AppLiveness.STARTING else AppLiveness.NOT_RUNNING
     }
 
     /**
-     * Polls until the app's CLI endpoint is ready: the endpoint file must exist
-     * (re-read every round — the app writes it only once the socket is live) and
-     * GET /cli/status over that socket must answer 200.
+     * Polls until the app's CLI endpoint is ready, bounded by a hard 30s
+     * deadline regardless of how long individual probes take. The endpoint
+     * file is re-read every round — the app writes it only once the socket
+     * is live, and a restart may change its contents.
      */
-    suspend fun waitForAppReady(): Boolean {
-        val client = createClient()
-        try {
-            repeat(MAX_POLLS) {
-                val endpoint = readEndpoint()
-                if (endpoint != null && isReady(client, endpoint.socketPath)) {
-                    return true
-                }
+    suspend fun waitForAppReady(): Boolean =
+        withTimeoutOrNull(READY_TIMEOUT) {
+            while (!isEndpointReady()) {
                 delay(POLL_INTERVAL)
             }
-            return false
-        } finally {
-            client.close()
-        }
+            true
+        } ?: false
+
+    private suspend fun isEndpointReady(): Boolean {
+        val endpoint = readEndpoint() ?: return false
+        return socketProber(endpoint)
     }
-
-    private fun createClient(): HttpClient =
-        HttpClient(CIO) {
-            engine {
-                requestTimeout = 2000
-            }
-        }
-
-    private suspend fun isReady(
-        client: HttpClient,
-        socketPath: String,
-    ): Boolean =
-        try {
-            val response =
-                client.get("http://localhost/cli/status") {
-                    unixSocket(socketPath)
-                }
-            response.status == HttpStatusCode.OK
-        } catch (_: Exception) {
-            false
-        }
 
     private fun readEndpoint(): CliEndpoint? =
         try {
@@ -103,3 +83,53 @@ class AppReadinessChecker(
             null
         }
 }
+
+/**
+ * One probe = one short-lived request; the 500ms timeout (design D5) keeps a
+ * single probe from stalling the caller's overall deadline.
+ */
+private suspend fun probeOverUnixSocket(endpoint: CliEndpoint): Boolean {
+    val client =
+        HttpClient(CIO) {
+            engine {
+                requestTimeout = 500
+            }
+        }
+    return try {
+        val response =
+            client.get("http://localhost/cli/status") {
+                unixSocket(endpoint.socketPath)
+            }
+        response.status == HttpStatusCode.OK &&
+            matchesEndpointInstance(response.bodyAsText(), endpoint)
+    } catch (_: Exception) {
+        false
+    } finally {
+        client.close()
+    }
+}
+
+/**
+ * D5: a 200 only counts as "running" when the responder is the instance the
+ * endpoint file describes — a stale file must not vouch for a different peer.
+ */
+internal fun matchesEndpointInstance(
+    statusBody: String,
+    endpoint: CliEndpoint,
+): Boolean =
+    try {
+        instanceJson.decodeFromString<StatusInstance>(statusBody).appInstanceId == endpoint.appInstanceId
+    } catch (_: Exception) {
+        false
+    }
+
+private val instanceJson =
+    Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+@Serializable
+private data class StatusInstance(
+    val appInstanceId: String,
+)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/GuiEnvironment.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/GuiEnvironment.kt
@@ -1,0 +1,23 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+import kotlin.experimental.ExperimentalNativeApi
+
+/**
+ * macOS and Windows always have a graphical session the desktop app can
+ * attach to; on Linux the CLI may be running on a headless server where
+ * launching the desktop app is impossible (headless daemon support is a
+ * separate future deliverable, design P6).
+ */
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+fun isGuiEnvironment(): Boolean =
+    when (Platform.osFamily) {
+        OsFamily.MACOSX, OsFamily.WINDOWS -> true
+        OsFamily.LINUX -> hasEnv("DISPLAY") || hasEnv("WAYLAND_DISPLAY")
+        else -> false
+    }
+
+@OptIn(ExperimentalForeignApi::class)
+private fun hasEnv(name: String): Boolean = getenv(name)?.toKString()?.isNotEmpty() == true

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/AppReadinessCheckerTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/AppReadinessCheckerTest.kt
@@ -1,0 +1,202 @@
+package com.crosspaste.cli.platform
+
+import com.crosspaste.cli.api.CliEndpoint
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import okio.FileSystem
+import okio.Path
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+private class FakePathProvider(
+    private val dir: Path,
+) : NativePlatformPathProvider {
+    override fun getDefaultUserDataPath(): Path = dir
+}
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class AppReadinessCheckerTest {
+
+    private fun tempDir(): Path {
+        val dir =
+            FileSystem.SYSTEM_TEMPORARY_DIRECTORY
+                .resolve("cli-readiness-test-${Random.nextBits(31)}")
+        FileSystem.SYSTEM.createDirectories(dir)
+        return dir
+    }
+
+    private fun writeEndpoint(
+        dir: Path,
+        pid: Long = 1234,
+        socketPath: String = "/tmp/does-not-matter.sock",
+        appInstanceId: String = "instance-a",
+    ) {
+        FileSystem.SYSTEM.write(dir.resolve(CliConfigReader.CLI_ENDPOINT_FILE_NAME)) {
+            writeUtf8(
+                """{"pid":$pid,"socketPath":"$socketPath","apiVersion":1,"appInstanceId":"$appInstanceId"}""",
+            )
+        }
+    }
+
+    private fun checker(
+        dir: Path,
+        socketProber: suspend (CliEndpoint) -> Boolean = { false },
+        processAlive: (Long) -> Boolean = { false },
+    ): AppReadinessChecker =
+        AppReadinessChecker(
+            configReader = CliConfigReader(FakePathProvider(dir)),
+            socketProber = socketProber,
+            processAlive = processAlive,
+        )
+
+    @Test
+    fun probeReportsNotRunningWithoutEndpointFile() =
+        runTest {
+            val dir = tempDir()
+            assertEquals(AppLiveness.NOT_RUNNING, checker(dir, socketProber = { true }).probe())
+        }
+
+    @Test
+    fun probeReportsNotRunningForCorruptedEndpointFile() =
+        runTest {
+            val dir = tempDir()
+            FileSystem.SYSTEM.write(dir.resolve(CliConfigReader.CLI_ENDPOINT_FILE_NAME)) {
+                writeUtf8("not json at all")
+            }
+            assertEquals(AppLiveness.NOT_RUNNING, checker(dir, socketProber = { true }).probe())
+        }
+
+    @Test
+    fun probeReportsRunningWhenSocketAnswers() =
+        runTest {
+            val dir = tempDir()
+            writeEndpoint(dir)
+            assertEquals(AppLiveness.RUNNING, checker(dir, socketProber = { true }).probe())
+        }
+
+    @Test
+    fun probeReportsStartingWhenSocketDeadButPidAlive() =
+        runTest {
+            val dir = tempDir()
+            writeEndpoint(dir, pid = 4321)
+            val liveness =
+                checker(dir, socketProber = { false }, processAlive = { pid -> pid == 4321L }).probe()
+            assertEquals(AppLiveness.STARTING, liveness)
+        }
+
+    @Test
+    fun probeReportsNotRunningForStaleEndpointWithDeadPid() =
+        runTest {
+            val dir = tempDir()
+            writeEndpoint(dir, pid = 4321)
+            assertEquals(
+                AppLiveness.NOT_RUNNING,
+                checker(dir, socketProber = { false }, processAlive = { false }).probe(),
+            )
+        }
+
+    @Test
+    fun waitForAppReadyGivesUpAtHardDeadline() =
+        runTest {
+            val dir = tempDir()
+            writeEndpoint(dir)
+            val start = currentTime
+            assertFalse(checker(dir, socketProber = { false }).waitForAppReady())
+            assertEquals(30.seconds.inWholeMilliseconds, currentTime - start)
+        }
+
+    @Test
+    fun waitForAppReadyDeadlineHoldsEvenWhenProbesAreSlow() =
+        runTest {
+            val dir = tempDir()
+            writeEndpoint(dir)
+            // A server that accepts connections but never answers: each probe
+            // burns 2s. The overall deadline must still cap the wait at 30s.
+            val start = currentTime
+            val ready =
+                checker(
+                    dir,
+                    socketProber = {
+                        kotlinx.coroutines.delay(2.seconds)
+                        false
+                    },
+                ).waitForAppReady()
+            assertFalse(ready)
+            assertEquals(30.seconds.inWholeMilliseconds, currentTime - start)
+        }
+
+    @Test
+    fun waitForAppReadySucceedsOnceSocketComesUp() =
+        runTest {
+            val dir = tempDir()
+            writeEndpoint(dir)
+            var attempts = 0
+            val ready =
+                checker(
+                    dir,
+                    socketProber = {
+                        attempts++
+                        attempts >= 3
+                    },
+                ).waitForAppReady()
+            assertTrue(ready)
+        }
+
+    @Test
+    fun waitForAppReadyRereadsEndpointFileEveryRound() =
+        runTest {
+            val dir = tempDir()
+            // File does not exist yet: the app writes it only once the socket
+            // is live, so the checker must pick it up mid-wait.
+            launch {
+                kotlinx.coroutines.delay(2.seconds)
+                writeEndpoint(dir)
+            }
+            assertTrue(checker(dir, socketProber = { true }).waitForAppReady())
+        }
+
+    @Test
+    fun matchingInstanceIdIsAccepted() {
+        val endpoint = endpoint(appInstanceId = "instance-a")
+        assertTrue(
+            matchesEndpointInstance("""{"appInstanceId":"instance-a","appVersion":"x"}""", endpoint),
+        )
+    }
+
+    @Test
+    fun differentInstanceIdIsRejected() {
+        val endpoint = endpoint(appInstanceId = "instance-a")
+        assertFalse(matchesEndpointInstance("""{"appInstanceId":"instance-b"}""", endpoint))
+    }
+
+    @Test
+    fun unknownStatusFieldsAreTolerated() {
+        val endpoint = endpoint(appInstanceId = "instance-a")
+        assertTrue(
+            matchesEndpointInstance(
+                """{"appInstanceId":"instance-a","futureField":123,"nested":{"a":1}}""",
+                endpoint,
+            ),
+        )
+    }
+
+    @Test
+    fun unparseableStatusBodyIsRejected() {
+        val endpoint = endpoint(appInstanceId = "instance-a")
+        assertFalse(matchesEndpointInstance("<html>proxy error</html>", endpoint))
+        assertFalse(matchesEndpointInstance("""{"noInstanceId":true}""", endpoint))
+    }
+
+    private fun endpoint(appInstanceId: String): CliEndpoint =
+        CliEndpoint(
+            pid = 1,
+            socketPath = "/tmp/x.sock",
+            apiVersion = 1,
+            appInstanceId = appInstanceId,
+        )
+}

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/ProcessLiveness.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/ProcessLiveness.kt
@@ -1,0 +1,38 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.windows.CloseHandle
+import platform.windows.DWORDVar
+import platform.windows.ERROR_ACCESS_DENIED
+import platform.windows.GetExitCodeProcess
+import platform.windows.GetLastError
+import platform.windows.OpenProcess
+import platform.windows.PROCESS_QUERY_LIMITED_INFORMATION
+import platform.windows.STILL_ACTIVE
+
+@OptIn(ExperimentalForeignApi::class)
+internal fun isProcessAlive(pid: Long): Boolean {
+    if (pid <= 0) return false
+    val handle =
+        OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION.toUInt(), 0, pid.toUInt())
+            // ACCESS_DENIED still proves a live process owns this pid
+            ?: return GetLastError() == ERROR_ACCESS_DENIED.toUInt()
+    try {
+        memScoped {
+            val exitCode = alloc<DWORDVar>()
+            if (GetExitCodeProcess(handle, exitCode.ptr) == 0) {
+                // We could open the handle, so assume it is alive
+                return true
+            }
+            // A process that really exited with code 259 (STILL_ACTIVE) is
+            // misread as alive — a known Windows API ambiguity we accept
+            return exitCode.value == STILL_ACTIVE
+        }
+    } finally {
+        CloseHandle(handle)
+    }
+}

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/ProcessLiveness.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/ProcessLiveness.kt
@@ -1,0 +1,16 @@
+package com.crosspaste.cli.platform
+
+import platform.posix.ESRCH
+import platform.posix.errno
+import platform.posix.kill
+
+/**
+ * Signal 0 performs error checking only, without delivering a signal.
+ * EPERM (not allowed to signal) still proves the process exists; only
+ * ESRCH means the pid is gone.
+ */
+internal fun isProcessAlive(pid: Long): Boolean {
+    if (pid <= 0) return false
+    if (kill(pid.toInt(), 0) == 0) return true
+    return errno != ESRCH
+}

--- a/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/CliExitCodeTest.kt
+++ b/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/CliExitCodeTest.kt
@@ -1,0 +1,61 @@
+package com.crosspaste.cli
+
+import com.github.ajalt.clikt.testing.test
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.FileSystem
+import platform.posix.setenv
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+/**
+ * Pins the exit-code contract with an isolated HOME (no endpoint file →
+ * app not running): non-interactive callers must fail fast with exit code 3,
+ * never hang on input.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class CliExitCodeTest {
+
+    private fun isolatedHome(): String {
+        val dir =
+            FileSystem.SYSTEM_TEMPORARY_DIRECTORY
+                .resolve("cli-exit-code-test-${Random.nextBits(31)}")
+        FileSystem.SYSTEM.createDirectories(dir)
+        setenv("HOME", dir.toString(), 1)
+        return dir.toString()
+    }
+
+    @Test
+    fun commandFailsFastWithExitCodeThreeWhenAppNotRunning() {
+        isolatedHome()
+        val result = CrossPasteCommand().test("paste")
+        assertEquals(3, result.statusCode)
+        assertContains(result.stderr, "CrossPaste is not running")
+    }
+
+    @Test
+    fun noStartSkipsThePromptAndExitsThree() {
+        isolatedHome()
+        val result = CrossPasteCommand().test("--no-start paste")
+        assertEquals(3, result.statusCode)
+        assertContains(result.stderr, "CrossPaste is not running")
+    }
+
+    @Test
+    fun statusReportsNotRunningWithExitCodeThree() {
+        isolatedHome()
+        val result = CrossPasteCommand().test("status")
+        assertEquals(3, result.statusCode)
+        assertContains(result.output, "Not running")
+    }
+
+    @Test
+    fun statusJsonReportsRunningFalse() {
+        isolatedHome()
+        val result = CrossPasteCommand().test("--json status")
+        assertEquals(3, result.statusCode)
+        assertContains(result.output, "\"running\": false")
+        assertContains(result.output, "\"state\": \"not_running\"")
+    }
+}

--- a/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/platform/ProcessLivenessTest.kt
+++ b/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/platform/ProcessLivenessTest.kt
@@ -1,0 +1,27 @@
+package com.crosspaste.cli.platform
+
+import platform.posix.getpid
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProcessLivenessTest {
+
+    @Test
+    fun ownProcessIsAlive() {
+        assertTrue(isProcessAlive(getpid().toLong()))
+    }
+
+    @Test
+    fun initProcessCountsAsAliveDespiteEperm() {
+        // pid 1 exists on every POSIX system; kill(1, 0) fails with EPERM for
+        // unprivileged callers, which must still be reported as alive
+        assertTrue(isProcessAlive(1))
+    }
+
+    @Test
+    fun invalidPidsAreDead() {
+        assertFalse(isProcessAlive(0))
+        assertFalse(isProcessAlive(-1))
+    }
+}


### PR DESCRIPTION
Closes #4770. Part of the CLI completion effort (P2, follows #4769).

## Summary

- **D5 liveness probe** (`AppReadinessChecker.probe()`): endpoint file → HTTP over the Unix socket → pid disambiguation (POSIX `kill(pid,0)` / Windows `OpenProcess`+`GetExitCodeProcess`), yielding an honest three-state result (running / starting / not running). The pid check is the only platform-specific code, in `posixNativeMain` / `mingwNativeMain` srcDirs keyed on the compilation target (not the host, so `-Pcli.target` cross-builds pick the right one).
- **Unified pre-flight in `runCli`** for every command: running → proceed; starting → wait for readiness (≤30 s); not running → consent flow, then launch via the previously unwired `AppLauncher`/`AppAutoStarter` and wait.
- **Consent flow**: interactive TTY asks `Start it now? [Y/n]` (prompt hand-rolled to stderr so stdout stays pipe-clean even with stdout redirected); non-interactive callers never block — exit code **3** ("app not running") with a `--start` hint. Root options `--start` / `--no-start` force the answer (tri-state, default = ask). Headless Linux (no `DISPLAY`/`WAYLAND_DISPLAY`) gets a clear error instead of a doomed launch (headless daemon is P6).
- **Mid-command resilience**: a connection failure means the request never reached the app, so the CLI re-probes (including consent) and retries once; requests that were delivered and then failed exit 1 without retry, so non-idempotent calls are never doubled.
- **`status` rework**: never auto-starts; prints `Running` / `Starting` / `Not running`; `--json` gains `running: bool` + `state`; exits 3 unless running.
- **Launcher hardening**: pre-check that the packaged start script exists — the backgrounded shell can't report a missing script, which previously meant a silent 30 s timeout.
- All progress/prompt messages go to stderr; stdout carries command output only.

## Verification

All five K/N targets compile (`macosArm64` native + `mingwX64`/`linuxX64`/`linuxArm64` cross). Exercised for real (macOS binary + scripted UDS server + `expect` PTY; Docker Ubuntu for headless):

- three probe states; live/dead pid disambiguation; stale endpoint (dead pid) treated as not running
- TTY prompt accept / decline / invalid-input reprompt; prompt lands on stderr with stdout redirected to a file (file stays empty)
- non-TTY fail-fast exit 3 with `--start` hint; `--no-start`; `--start` full launch chain via a packaged-layout start script ending in the original command succeeding
- starting state (pid alive, socket not yet up): waits ~3 s until the socket appears, then proceeds
- mid-command server death: re-probe path exits cleanly (3) instead of a raw error
- API version mismatch → single stderr warning, command still succeeds; Linux headless error branch in Docker

Real-app launch on a packaged install needs a build that contains the `/cli` server (first release including #4769), covered by the P3 packaging phase's release smoke test.
