### PR TITLE
:bug: reject lossy CLI config conversions

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -257,13 +257,22 @@ private suspend fun handleConfigSet(
         )
         return
     }
+    val expected = expectedPrimitive(parsed)
+    val candidate = configManager.getCurrentConfig().copy(request.key, parsed)
+    val candidateValue = configFieldOf(candidate, request.key) as? JsonPrimitive
+    if (!candidateValue.matches(expected)) {
+        call.respond(
+            HttpStatusCode.BadRequest,
+            CliMessageDto("Invalid value '${request.value}' for config key '${request.key}'."),
+        )
+        return
+    }
     configManager.updateConfig(request.key, parsed)
     // updateConfig gives no result and rolls back silently when persisting
     // fails (and DesktopAppConfig.copy ignores keys it does not map), so trust
     // only the observed value
-    val expected = expectedPrimitive(parsed)
     val actual = configFieldOf(configManager, request.key) as? JsonPrimitive
-    if (actual == null || actual.content != expected.content || actual.isString != expected.isString) {
+    if (!actual.matches(expected)) {
         call.respond(
             HttpStatusCode.InternalServerError,
             CliMessageDto("Config '${request.key}' was not applied."),
@@ -276,12 +285,20 @@ private suspend fun handleConfigSet(
 private fun configFieldOf(
     configManager: DesktopConfigManager,
     key: String,
+): kotlinx.serialization.json.JsonElement? = configFieldOf(configManager.getCurrentConfig(), key)
+
+private fun configFieldOf(
+    config: DesktopAppConfig,
+    key: String,
 ): kotlinx.serialization.json.JsonElement? =
     configJson
         .encodeToJsonElement(
             DesktopAppConfig.serializer(),
-            configManager.getCurrentConfig(),
+            config,
         ).jsonObject[key]
+
+private fun JsonPrimitive?.matches(expected: JsonPrimitive): Boolean =
+    this != null && content == expected.content && isString == expected.isString
 
 private fun expectedPrimitive(parsed: Any): JsonPrimitive =
     when (parsed) {

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -382,11 +382,11 @@ class CliRoutingTest {
             val response =
                 client.put("/cli/config") {
                     contentType(ContentType.Application.Json)
-                    setBody("""{"key":"port","value":"2147483648"}""")
+                    setBody("""{"key":"searchWindowHeight","value":"2147483648"}""")
                 }
 
             assertEquals(HttpStatusCode.BadRequest, response.status)
-            assertEquals(13129, fixture.currentConfig.port)
+            assertEquals(332, fixture.currentConfig.searchWindowHeight)
             verify(exactly = 0) { fixture.configManager.updateConfig(any<String>(), any()) }
         }
     }

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -375,6 +375,23 @@ class CliRoutingTest {
     }
 
     @Test
+    fun `config put rejects int overflow before updating config`() {
+        val fixture = Fixture()
+
+        withCliRouting(fixture) {
+            val response =
+                client.put("/cli/config") {
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"key":"port","value":"2147483648"}""")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            assertEquals(13129, fixture.currentConfig.port)
+            verify(exactly = 0) { fixture.configManager.updateConfig(any<String>(), any()) }
+        }
+    }
+
+    @Test
     fun `copy goes through the standard local release lifecycle`() {
         val fixture = Fixture()
         val pasteDataSlot = slot<PasteData>()


### PR DESCRIPTION
## Summary
- validate a candidate DesktopAppConfig before persisting a CLI config update
- reject values that do not round-trip through the target field type
- cover Int overflow without mutating the config

## Verification
- ./gradlew :app:desktopTest --tests com.crosspaste.cli.CliRoutingTest :app:ktlintCheck --no-daemon