### PR TITLE
:bug: reject CLI config keys requiring runtime workflows

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -215,10 +215,19 @@ private suspend fun handleTagCreate(
     call.respond(CliTagDto(id = id, name = request.name, color = color))
 }
 
-// Storage location changes need the app's migration flow (move data, restart);
-// setting the raw keys here would desynchronize the running app from its own
-// data directory and break endpoint-file discovery for the CLI itself.
-private val cliBlockedConfigKeys = setOf("storagePath", "useDefaultStoragePath")
+// These settings require workflows beyond persisting one config field. Storage
+// changes migrate data and restart the app; port, pasteboard, and MCP changes
+// must start, stop, or restart their running services. A generic config write
+// would report success while leaving the process in a contradictory state.
+private val cliBlockedConfigKeys =
+    setOf(
+        "storagePath",
+        "useDefaultStoragePath",
+        "port",
+        "enablePasteboardListening",
+        "enableMcpServer",
+        "mcpServerPort",
+    )
 
 private suspend fun handleConfigSet(
     call: ApplicationCall,
@@ -230,7 +239,7 @@ private suspend fun handleConfigSet(
             HttpStatusCode.BadRequest,
             CliMessageDto(
                 "Config key '${request.key}' cannot be changed via the CLI; " +
-                    "use the storage settings in the app instead.",
+                    "use the corresponding settings in the app instead.",
             ),
         )
         return

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -329,17 +329,25 @@ class CliRoutingTest {
 
             assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"nope","value":"1"}"""))
             assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"enableSoundEffect","value":"maybe"}"""))
-            assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"port","value":"abc"}"""))
+            assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"searchWindowHeight","value":"abc"}"""))
 
-            // Storage location keys need the app's migration flow, never the CLI
+            // Settings with migration or service-lifecycle side effects must use
+            // their dedicated workflows in the app.
             assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"storagePath","value":"/tmp/x"}"""))
             assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"useDefaultStoragePath","value":"false"}"""))
+            assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"port","value":"13130"}"""))
+            assertEquals(
+                HttpStatusCode.BadRequest,
+                putConfig("""{"key":"enablePasteboardListening","value":"false"}"""),
+            )
+            assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"enableMcpServer","value":"true"}"""))
+            assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"mcpServerPort","value":"13131"}"""))
 
             assertEquals(HttpStatusCode.OK, putConfig("""{"key":"enableSoundEffect","value":"false"}"""))
             verify { fixture.configManager.updateConfig("enableSoundEffect", false) }
 
-            assertEquals(HttpStatusCode.OK, putConfig("""{"key":"port","value":"13130"}"""))
-            verify { fixture.configManager.updateConfig("port", 13130L) }
+            assertEquals(HttpStatusCode.OK, putConfig("""{"key":"searchWindowHeight","value":"400"}"""))
+            verify { fixture.configManager.updateConfig("searchWindowHeight", 400L) }
 
             assertEquals(HttpStatusCode.OK, putConfig("""{"key":"language","value":"zh"}"""))
             verify { fixture.configManager.updateConfig("language", "zh") }


### PR DESCRIPTION
## Summary
- reject config keys whose correct application requires migration or service lifecycle work
- include sync port, pasteboard monitoring, and MCP server settings
- return an explicit error instead of persisting config that contradicts the running process

## Verification
- ./gradlew :app:desktopTest --tests com.crosspaste.cli.CliRoutingTest :app:ktlintCheck --no-daemon