### PR TITLE
:bug: give blocked CLI config keys accurate per-key hints

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -216,17 +216,20 @@ private suspend fun handleTagCreate(
 }
 
 // These settings require workflows beyond persisting one config field. Storage
-// changes migrate data and restart the app; port, pasteboard, and MCP changes
-// must start, stop, or restart their running services. A generic config write
+// changes migrate data and restart the app; pasteboard and MCP changes must
+// start, stop, or restart their running services. A generic config write
 // would report success while leaving the process in a contradictory state.
+// Each entry carries the hint shown to the user; the sync port is special in
+// that no app setting exists either — the server binds the configured port at
+// startup and writes the actually-bound port back on conflict.
 private val cliBlockedConfigKeys =
-    setOf(
-        "storagePath",
-        "useDefaultStoragePath",
-        "port",
-        "enablePasteboardListening",
-        "enableMcpServer",
-        "mcpServerPort",
+    mapOf(
+        "storagePath" to "use the storage settings in the app instead.",
+        "useDefaultStoragePath" to "use the storage settings in the app instead.",
+        "port" to "the sync port is managed automatically by the app.",
+        "enablePasteboardListening" to "use the pasteboard controls in the app instead.",
+        "enableMcpServer" to "use the MCP server settings in the app instead.",
+        "mcpServerPort" to "use the MCP server settings in the app instead.",
     )
 
 private suspend fun handleConfigSet(
@@ -234,13 +237,11 @@ private suspend fun handleConfigSet(
     configManager: DesktopConfigManager,
 ) {
     val request = call.receive<CliConfigSetRequest>()
-    if (request.key in cliBlockedConfigKeys) {
+    val blockedHint = cliBlockedConfigKeys[request.key]
+    if (blockedHint != null) {
         call.respond(
             HttpStatusCode.BadRequest,
-            CliMessageDto(
-                "Config key '${request.key}' cannot be changed via the CLI; " +
-                    "use the corresponding settings in the app instead.",
-            ),
+            CliMessageDto("Config key '${request.key}' cannot be changed via the CLI; $blockedHint"),
         )
         return
     }

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -335,7 +335,15 @@ class CliRoutingTest {
             // their dedicated workflows in the app.
             assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"storagePath","value":"/tmp/x"}"""))
             assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"useDefaultStoragePath","value":"false"}"""))
-            assertEquals(HttpStatusCode.BadRequest, putConfig("""{"key":"port","value":"13130"}"""))
+            // The sync port has no app setting to point at; the hint must say
+            // the app manages it rather than send users hunting for one
+            val portResponse =
+                client.put("/cli/config") {
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"key":"port","value":"13130"}""")
+                }
+            assertEquals(HttpStatusCode.BadRequest, portResponse.status)
+            assertTrue(portResponse.bodyAsText().contains("managed automatically"))
             assertEquals(
                 HttpStatusCode.BadRequest,
                 putConfig("""{"key":"enablePasteboardListening","value":"false"}"""),


### PR DESCRIPTION
Follow-up to #4773.

## Problem

Every blocked config key answered with the same hint: "use the corresponding settings in the app instead." For `port` that hint is wrong — the app has no sync-port setting. The server binds the configured port at startup, falls back to a random port on conflict, and writes the actually-bound port back to the config, so the message sent users hunting for a setting that does not exist.

## Change

- `cliBlockedConfigKeys` becomes a key → hint map, so each rejection points at the real workflow: storage settings for the storage keys, pasteboard controls, MCP server settings — and for `port`, "the sync port is managed automatically by the app."
- Test pins the `port` hint text so a future rewording cannot silently regress back to pointing at a nonexistent setting.

## Verification

`./gradlew :app:desktopTest --tests com.crosspaste.cli.CliRoutingTest` — 15/15, plus `:app:ktlintFormat` clean.
