### PR TITLE
:construction_worker: ship the CLI binary in all desktop packages

### DIFF
--- a/.github/scripts/package_appimage.sh
+++ b/.github/scripts/package_appimage.sh
@@ -40,6 +40,20 @@ build_appimage() {
     # (e.g. crosspaste-1.2.4/) and extract contents directly into BUILD_DIR
     tar -xzf "$TAR_FILE" -C "$BUILD_DIR" --strip-components=1
 
+    # The Conveyor tarball never carries root-inputs (they are deb-only), so
+    # the CLI binary must be copied in from the staged dist explicitly or the
+    # AppImage would silently ship without it. The CI workflows build the
+    # Linux CLI targets before this script runs; set -e turns a missing
+    # binary into a hard failure instead of a silent drop.
+    local CLI_TARGET
+    case "$ARCH_TOKEN" in
+        amd64) CLI_TARGET="linuxX64" ;;
+        aarch64) CLI_TARGET="linuxArm64" ;;
+        *) echo "Error: no CLI target mapping for arch ${ARCH_TOKEN}"; exit 1 ;;
+    esac
+    install -m 755 "cli/dist/${CLI_TARGET}/crosspaste-cli" "$BUILD_DIR/bin/crosspaste-cli"
+    test -x "$BUILD_DIR/bin/crosspaste-cli"
+
     # Configure AppImage metadata (AppRun, Desktop file, Icon) inside a subshell
     # so the working directory stays at the workspace root for appimagetool.
     (

--- a/.github/scripts/package_appimage.sh
+++ b/.github/scripts/package_appimage.sh
@@ -40,19 +40,11 @@ build_appimage() {
     # (e.g. crosspaste-1.2.4/) and extract contents directly into BUILD_DIR
     tar -xzf "$TAR_FILE" -C "$BUILD_DIR" --strip-components=1
 
-    # The Conveyor tarball never carries root-inputs (they are deb-only), so
-    # the CLI binary must be copied in from the staged dist explicitly or the
-    # AppImage would silently ship without it. The CI workflows build the
-    # Linux CLI targets before this script runs; set -e turns a missing
-    # binary into a hard failure instead of a silent drop.
-    local CLI_TARGET
-    case "$ARCH_TOKEN" in
-        amd64) CLI_TARGET="linuxX64" ;;
-        aarch64) CLI_TARGET="linuxArm64" ;;
-        *) echo "Error: no CLI target mapping for arch ${ARCH_TOKEN}"; exit 1 ;;
-    esac
-    install -m 755 "cli/dist/${CLI_TARGET}/crosspaste-cli" "$BUILD_DIR/bin/crosspaste-cli"
-    test -x "$BUILD_DIR/bin/crosspaste-cli"
+    # The CLI arrives with the tarball itself (it is an app input landing in
+    # lib/app/bin/ — decision D6); just verify it is really there so a
+    # packaging regression fails the build instead of silently shipping an
+    # AppImage without the CLI.
+    test -x "$BUILD_DIR/lib/app/bin/crosspaste-cli"
 
     # Configure AppImage metadata (AppRun, Desktop file, Icon) inside a subshell
     # so the working directory stays at the workspace root for appimagetool.

--- a/.github/workflows/build-beta-linux.yml
+++ b/.github/workflows/build-beta-linux.yml
@@ -98,6 +98,17 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew app:build
 
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+
+      - name: Build CLI binaries (Linux targets)
+        run: |
+          VERSION=$(grep '^version=' app/src/desktopMain/resources/crosspaste-version.properties | cut -d= -f2)
+          ./gradlew :cli:assembleDistLinuxX64 :cli:assembleDistLinuxArm64 "-PcliVersion=${VERSION}.${REVISION}"
+
       - name: Prepare Conveyor config (Linux only)
         run: |
           ./gradlew -q writeConveyorConfig -PappEnv=PRODUCTION
@@ -109,6 +120,7 @@ jobs:
           # so mac/windows signing secrets are never needed.
           cat > beta.conveyor.conf <<CONF
           include required("conveyor.conf")
+          include required("cli.conveyor.conf")
           app.machines = [ "linux.amd64.glibc", "linux.aarch64.glibc" ]
           app.revision = ${REVISION}
           CONF

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -85,6 +85,27 @@ jobs:
             ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*',
             '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
 
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+
+      # Apple targets can only be compiled on a macOS host; the remaining CLI
+      # targets are cross-compiled in build-ubuntu. The full version is taken
+      # from the git tag because validateAndUpdateVersion.js only rewrites the
+      # version file later, in build-ubuntu (an artifact is used instead of a
+      # cache because the binaries change on every release).
+      - name: Build CLI binaries (macOS targets)
+        run: ./gradlew :cli:assembleDistMacosArm64 :cli:assembleDistMacosX64 "-PcliVersion=${GITHUB_REF_NAME}"
+
+      - name: Upload macOS CLI binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-dist-macos
+          path: cli/dist/
+          if-no-files-found: error
+
   build-ubuntu:
     needs: [check-dylib-cache, build-macos]
     runs-on: ubuntu-latest
@@ -192,6 +213,30 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew app:build
+
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+
+      - name: Download macOS CLI binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: cli-dist-macos
+          path: cli/dist/
+
+      # GitHub artifacts drop the executable bit; restore it or the packaged
+      # mac CLI would ship unexecutable.
+      - name: Restore CLI executable permissions
+        run: chmod +x cli/dist/*/crosspaste-cli
+
+      # Same version source as the build-macos CLI step, so every platform's
+      # CLI reports the identical full version by construction.
+      - name: Build CLI binaries (Linux and Windows targets)
+        run: >
+          ./gradlew :cli:assembleDistLinuxX64 :cli:assembleDistLinuxArm64
+          :cli:assembleDistMingwX64 "-PcliVersion=${GITHUB_REF_NAME}"
 
       - name: Check Dylib Files
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,13 @@ jobs:
 
       # Compile gate for the CLI native binary (host target = linuxX64).
       # Pure Kotlin since the CLI went all-HTTP; only needs the Kotlin/Native
-      # toolchain already set up above.
+      # toolchain already set up above. The release links for linuxArm64 and
+      # mingwX64 guard the cross-compilation path build-release.yml depends on
+      # (its ubuntu job cross-compiles both before Conveyor packaging).
       - name: Build CLI native binary
-        run: ./gradlew :cli:ktlintCheck :cli:cliNativeTest :cli:linkDebugExecutableCliNative
+        run: >
+          ./gradlew :cli:ktlintCheck :cli:cliNativeTest :cli:linkDebugExecutableLinuxX64
+          :cli:linkReleaseExecutableLinuxArm64 :cli:linkReleaseExecutableMingwX64
 
   web-build:
     needs: changes

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ output*/
 web/dist/
 scheduled_tasks.lock
 skills-lock.json
+
+# CLI release binaries staged for packaging (P3)
+/cli/dist/

--- a/build.conveyor.conf
+++ b/build.conveyor.conf
@@ -1,4 +1,5 @@
 include required("conveyor.conf")
+include required("cli.conveyor.conf")
 
 app {
   // Conveyor's default machine set excludes linux.aarch64.glibc, so list all

--- a/cli.conveyor.conf
+++ b/cli.conveyor.conf
@@ -5,39 +5,36 @@
 // generated conf. Before packaging, populate cli/dist/ via the Gradle tasks:
 //   ./gradlew :cli:assembleDist          (host-buildable targets)
 //   ./gradlew :cli:assembleDist<Target>  (single target)
+//
+// Design decision D6: the CLI is application payload, imported with plain
+// per-arch `inputs` like any other app file, so it reaches every channel
+// (deb, tarball, AppImage, mac zip, win zip, MSIX) through one mechanism.
+// It lands in the JVM payload area (linux lib/app/bin/, windows app\bin\,
+// mac Contents/app/bin/) — an address users never see. The user-facing entry
+// point is PATH, wired per channel below (deb symlink, MSIX alias, and a
+// first-launch prompt on macOS handled by the app itself).
 app {
-  // macOS: lands in CrossPaste.app/Contents/bin/ next to start.sh, matching
-  // CliAppPathProvider's bundle layout. Signed and notarized together with
-  // the rest of the bundle by Conveyor's normal mac signing pass.
-  mac.aarch64.bundle-extras += "cli/dist/macosArm64/crosspaste-cli" -> "bin/crosspaste-cli"
-  mac.amd64.bundle-extras += "cli/dist/macosX64/crosspaste-cli" -> "bin/crosspaste-cli"
+  mac.aarch64.inputs += "cli/dist/macosArm64/crosspaste-cli" -> "bin/crosspaste-cli"
+  mac.amd64.inputs += "cli/dist/macosX64/crosspaste-cli" -> "bin/crosspaste-cli"
 
-  // Windows: package-extras (not inputs) so the binary lands at the package
-  // root's bin/ next to CrossPaste.exe instead of under app/ where JVM-app
-  // inputs go.
-  windows.amd64.package-extras += "cli/dist/mingwX64/crosspaste-cli.exe" -> "bin/crosspaste-cli.exe"
+  windows.amd64.inputs += "cli/dist/mingwX64/crosspaste-cli.exe" -> "bin/crosspaste-cli.exe"
 
   // Conveyor already generates an app execution alias `crosspaste.exe` that
   // points at updatecheck.exe (GUI launch) and offers no config key to
   // repoint it, so the CLI gets its own alias: after install, `crosspaste-cli`
   // works in any terminal without PATH changes.
   windows.manifests.msix.extensions-xml = """
-    <uap3:Extension Category="windows.appExecutionAlias" Executable="bin\crosspaste-cli.exe" EntryPoint="Windows.FullTrustApplication">
+    <uap3:Extension Category="windows.appExecutionAlias" Executable="app\bin\crosspaste-cli.exe" EntryPoint="Windows.FullTrustApplication">
       <uap3:AppExecutionAlias><uap8:ExecutionAlias Alias="crosspaste-cli.exe"/></uap3:AppExecutionAlias>
     </uap3:Extension>
   """
 
-  // Linux: same bin/ directory as start.sh and the JVM launcher. root-inputs
-  // reach only the deb; the plain tarball has never carried root-inputs
-  // (start.sh precedent), which is accepted. The AppImage is repacked from
-  // that tarball, so package_appimage.sh copies the CLI in from cli/dist/
-  // itself — keep the two in sync when changing paths here.
-  linux.amd64.root-inputs += "cli/dist/linuxX64/crosspaste-cli" -> "/usr/lib/crosspaste/bin/crosspaste-cli"
-  linux.aarch64.root-inputs += "cli/dist/linuxArm64/crosspaste-cli" -> "/usr/lib/crosspaste/bin/crosspaste-cli"
+  linux.amd64.inputs += "cli/dist/linuxX64/crosspaste-cli" -> "bin/crosspaste-cli"
+  linux.aarch64.inputs += "cli/dist/linuxArm64/crosspaste-cli" -> "bin/crosspaste-cli"
 
   // The terminal command `crosspaste` is the CLI (design decision D4).
   // Re-declaring the default launcher symlink's link path overrides it, so
   // /usr/bin/crosspaste points at the CLI; the GUI stays reachable via the
   // desktop entry, whose Exec uses the absolute launcher path.
-  linux.symlinks += "/usr/bin/crosspaste" -> "/usr/lib/crosspaste/bin/crosspaste-cli"
+  linux.symlinks += "/usr/bin/crosspaste" -> "/usr/lib/crosspaste/lib/app/bin/crosspaste-cli"
 }

--- a/cli.conveyor.conf
+++ b/cli.conveyor.conf
@@ -10,9 +10,10 @@
 // per-arch `inputs` like any other app file, so it reaches every channel
 // (deb, tarball, AppImage, mac zip, win zip, MSIX) through one mechanism.
 // It lands in the JVM payload area (linux lib/app/bin/, windows app\bin\,
-// mac Contents/app/bin/) — an address users never see. The user-facing entry
-// point is PATH, wired per channel below (deb symlink, MSIX alias, and a
-// first-launch prompt on macOS handled by the app itself).
+// mac Contents/Resources/bin/) — an address users never see. The user-facing
+// entry point is PATH, wired per channel: the deb symlink and MSIX alias
+// below (install time), and on macOS a first-launch symlink prompt in the
+// app (not implemented yet — planned as a follow-up PR).
 app {
   mac.aarch64.inputs += "cli/dist/macosArm64/crosspaste-cli" -> "bin/crosspaste-cli"
   mac.amd64.inputs += "cli/dist/macosX64/crosspaste-cli" -> "bin/crosspaste-cli"

--- a/cli.conveyor.conf
+++ b/cli.conveyor.conf
@@ -1,0 +1,41 @@
+// Ships the Kotlin/Native CLI binary inside every desktop package (P3 of the
+// CLI completion plan). Deliberately NOT included from conveyor.conf: a plain
+// local `conveyor make app` must keep working without pre-building the CLI.
+// Consumers: build.conveyor.conf (release CI) and the beta workflow's
+// generated conf. Before packaging, populate cli/dist/ via the Gradle tasks:
+//   ./gradlew :cli:assembleDist          (host-buildable targets)
+//   ./gradlew :cli:assembleDist<Target>  (single target)
+app {
+  // macOS: lands in CrossPaste.app/Contents/bin/ next to start.sh, matching
+  // CliAppPathProvider's bundle layout. Signed and notarized together with
+  // the rest of the bundle by Conveyor's normal mac signing pass.
+  mac.aarch64.bundle-extras += "cli/dist/macosArm64/crosspaste-cli" -> "bin/crosspaste-cli"
+  mac.amd64.bundle-extras += "cli/dist/macosX64/crosspaste-cli" -> "bin/crosspaste-cli"
+
+  // Windows: package-extras (not inputs) so the binary lands at the package
+  // root's bin/ next to CrossPaste.exe instead of under app/ where JVM-app
+  // inputs go.
+  windows.amd64.package-extras += "cli/dist/mingwX64/crosspaste-cli.exe" -> "bin/crosspaste-cli.exe"
+
+  // Conveyor already generates an app execution alias `crosspaste.exe` that
+  // points at updatecheck.exe (GUI launch) and offers no config key to
+  // repoint it, so the CLI gets its own alias: after install, `crosspaste-cli`
+  // works in any terminal without PATH changes.
+  windows.manifests.msix.extensions-xml = """
+    <uap3:Extension Category="windows.appExecutionAlias" Executable="bin\crosspaste-cli.exe" EntryPoint="Windows.FullTrustApplication">
+      <uap3:AppExecutionAlias><uap8:ExecutionAlias Alias="crosspaste-cli.exe"/></uap3:AppExecutionAlias>
+    </uap3:Extension>
+  """
+
+  // Linux: same bin/ directory as start.sh and the JVM launcher. root-inputs
+  // reach the deb (and AppImage built from it); the plain tarball has never
+  // carried root-inputs (start.sh precedent), which is accepted.
+  linux.amd64.root-inputs += "cli/dist/linuxX64/crosspaste-cli" -> "/usr/lib/crosspaste/bin/crosspaste-cli"
+  linux.aarch64.root-inputs += "cli/dist/linuxArm64/crosspaste-cli" -> "/usr/lib/crosspaste/bin/crosspaste-cli"
+
+  // The terminal command `crosspaste` is the CLI (design decision D4).
+  // Re-declaring the default launcher symlink's link path overrides it, so
+  // /usr/bin/crosspaste points at the CLI; the GUI stays reachable via the
+  // desktop entry, whose Exec uses the absolute launcher path.
+  linux.symlinks += "/usr/bin/crosspaste" -> "/usr/lib/crosspaste/bin/crosspaste-cli"
+}

--- a/cli.conveyor.conf
+++ b/cli.conveyor.conf
@@ -28,8 +28,10 @@ app {
   """
 
   // Linux: same bin/ directory as start.sh and the JVM launcher. root-inputs
-  // reach the deb (and AppImage built from it); the plain tarball has never
-  // carried root-inputs (start.sh precedent), which is accepted.
+  // reach only the deb; the plain tarball has never carried root-inputs
+  // (start.sh precedent), which is accepted. The AppImage is repacked from
+  // that tarball, so package_appimage.sh copies the CLI in from cli/dist/
+  // itself — keep the two in sync when changing paths here.
   linux.amd64.root-inputs += "cli/dist/linuxX64/crosspaste-cli" -> "/usr/lib/crosspaste/bin/crosspaste-cli"
   linux.aarch64.root-inputs += "cli/dist/linuxArm64/crosspaste-cli" -> "/usr/lib/crosspaste/bin/crosspaste-cli"
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DEPRECATION", "DEPRECATION_ERROR")
 
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.konan.target.Family
+import org.jetbrains.kotlin.konan.target.HostManager
 import java.io.FileReader
 import java.util.Properties
 
@@ -64,94 +68,138 @@ val generateCliVersion by tasks.registering {
 }
 
 kotlin {
-    val hostOs = System.getProperty("os.name")
-    val isArm64 = System.getProperty("os.arch") == "aarch64"
-    val isMingwX64 = hostOs.startsWith("Windows")
+    // All five release targets are declared statically so a single Gradle
+    // invocation can build every target the host toolchain supports (Apple
+    // targets need a macOS host; everything else cross-compiles from any
+    // host). Targets unsupported on the current host are disabled by the
+    // Kotlin plugin with a warning and simply skipped.
+    val cliTargets =
+        listOf(
+            macosArm64(),
+            macosX64(),
+            linuxX64(),
+            linuxArm64(),
+            mingwX64(),
+        )
 
-    val cliTarget = project.findProperty("cli.target") as? String
-    val isMacosTarget =
-        when (cliTarget) {
-            "macosArm64", "macosX64" -> true
-            null -> hostOs == "Mac OS X"
-            else -> false
-        }
+    cliTargets.forEach { target ->
+        val isMacosTarget = target.konanTarget.family == Family.OSX
+        val isMingwTarget = target.konanTarget.family == Family.MINGW
 
-    val nativeTarget =
-        if (cliTarget != null) {
-            when (cliTarget) {
-                "macosArm64" -> macosArm64("cliNative")
-                "macosX64" -> macosX64("cliNative")
-                "linuxArm64" -> linuxArm64("cliNative")
-                "linuxX64" -> linuxX64("cliNative")
-                "mingwX64" -> mingwX64("cliNative")
-                else -> throw GradleException("Unsupported CLI target: $cliTarget")
-            }
-        } else {
-            when {
-                hostOs == "Mac OS X" && isArm64 -> macosArm64("cliNative")
-                hostOs == "Mac OS X" && !isArm64 -> macosX64("cliNative")
-                hostOs == "Linux" && isArm64 -> linuxArm64("cliNative")
-                hostOs == "Linux" && !isArm64 -> linuxX64("cliNative")
-                isMingwX64 -> mingwX64("cliNative")
-                else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-            }
-        }
-
-    nativeTarget.apply {
-        compilations.getByName("main") {
+        target.compilations.getByName("main") {
             cinterops {
                 val execpath by creating
             }
         }
-        binaries {
+        // Workaround for Clikt duplicate symbol bug in Kotlin/Native
+        // See: https://github.com/ajalt/clikt/issues/598
+        // Apple ld does not support --allow-multiple-definition (GNU ld only).
+        // Konan invokes the linker directly for Linux targets (bare flag) but
+        // goes through the clang++ driver for mingw, which needs -Wl, to
+        // forward the flag.
+        val allowMultipleDefinition =
+            when {
+                isMacosTarget -> null
+                isMingwTarget -> "-Wl,--allow-multiple-definition"
+                else -> "--allow-multiple-definition"
+            }
+
+        target.binaries {
             executable {
                 entryPoint = "com.crosspaste.cli.main"
                 baseName = "crosspaste-cli"
-                // Workaround for Clikt duplicate symbol bug in Kotlin/Native
-                // See: https://github.com/ajalt/clikt/issues/598
-                // Apple ld does not support --allow-multiple-definition (GNU ld only)
-                if (!isMacosTarget) {
-                    linkerOpts("--allow-multiple-definition")
-                }
+                allowMultipleDefinition?.let { linkerOpts(it) }
             }
             // The test binary needs the same Clikt duplicate-symbol workaround;
             // GNU ld only hits it when konan compiler caches are enabled (host
             // builds), which is why cross-links from macOS don't reproduce it
-            if (!isMacosTarget) {
-                getTest("debug").linkerOpts("--allow-multiple-definition")
-            }
+            allowMultipleDefinition?.let { getTest("debug").linkerOpts(it) }
         }
-    }
 
-    // Platform-split sources keyed on the selected target (not the host,
-    // which would break -Pcli.target cross-compilation)
-    val isMingwTarget = cliTarget == "mingwX64" || (cliTarget == null && isMingwX64)
-
-    sourceSets {
-        val cliNativeMain by getting {
+        // The CLI sources predate the five-target split and are written as
+        // leaf sources (free use of target-specific APIs, no expect/actual),
+        // so each target compiles the same source-directory union directly
+        // instead of going through shared intermediate source sets.
+        sourceSets.getByName("${target.name}Main") {
+            kotlin.srcDir("src/cliNativeMain/kotlin")
             kotlin.srcDir(generateCliVersion)
             if (isMingwTarget) {
                 kotlin.srcDir("src/mingwNativeMain/kotlin")
             } else {
                 kotlin.srcDir("src/posixNativeMain/kotlin")
             }
-            dependencies {
-                implementation(libs.clikt)
-                implementation(libs.kotlinx.coroutines.core)
-                implementation(libs.kotlinx.serialization.json)
-                implementation(libs.ktor.client.core)
-                implementation(libs.ktor.client.cio)
-                implementation(libs.okio)
-            }
         }
-        val cliNativeTest by getting {
+        sourceSets.getByName("${target.name}Test") {
+            kotlin.srcDir("src/cliNativeTest/kotlin")
             if (!isMingwTarget) {
                 kotlin.srcDir("src/posixNativeTest/kotlin")
             }
-            dependencies {
-                implementation(libs.kotlin.test)
-                implementation(libs.kotlinx.coroutines.test)
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.clikt)
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.cio)
+            implementation(libs.okio)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+        }
+    }
+}
+
+// Runs the CLI test suite for the host's own target — a stable task name for
+// CI and local use that doesn't depend on which machine invokes it.
+val hostTestTaskName =
+    kotlin.targets
+        .withType<KotlinNativeTarget>()
+        .firstOrNull { it.konanTarget == HostManager.host }
+        ?.let { "${it.name}Test" }
+
+tasks.register("cliNativeTest") {
+    group = "verification"
+    description = "Runs CLI tests for the host target."
+    hostTestTaskName?.let { dependsOn(it) }
+}
+
+// Collects release executables under cli/dist/<target>/crosspaste-cli(.exe),
+// the layout the packaging pipeline (Conveyor + release workflow) consumes.
+kotlin.targets.withType<KotlinNativeTarget>().forEach { target ->
+    val capitalizedName = target.name.replaceFirstChar { it.uppercase() }
+    val executable = target.binaries.getExecutable(NativeBuildType.RELEASE)
+    tasks.register<Copy>("assembleDist$capitalizedName") {
+        group = "distribution"
+        description = "Copies the ${target.name} release executable to cli/dist/${target.name}/."
+        dependsOn(executable.linkTaskProvider)
+        from(executable.outputFile)
+        into(layout.projectDirectory.dir("dist/${target.name}"))
+        // Kotlin/Native emits crosspaste-cli.kexe on POSIX targets;
+        // ship it under the bare command name (mingw keeps .exe)
+        rename { name -> name.removeSuffix(".kexe") }
+    }
+}
+
+tasks.register("assembleDist") {
+    group = "distribution"
+    description = "Builds CLI release executables for every target the host can compile."
+    // Explicit host → buildable-target map: Apple targets need a macOS host,
+    // Linux hosts cross-compile everything else, Windows hosts build only
+    // their own target. (HostManager.isEnabled is not used here: it reports
+    // mingwX64 as disabled on macOS even though cross-linking it works.)
+    kotlin.targets.withType<KotlinNativeTarget>().forEach { target ->
+        val buildable =
+            when {
+                HostManager.hostIsMac -> true
+                HostManager.hostIsLinux -> target.konanTarget.family != Family.OSX
+                else -> target.konanTarget.family == Family.MINGW
             }
+        if (buildable) {
+            dependsOn("assembleDist${target.name.replaceFirstChar { it.uppercase() }}")
         }
     }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
@@ -18,8 +18,19 @@ import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.switch
+import kotlin.experimental.ExperimentalNativeApi
 
-class CrossPasteCommand : CliktCommand(name = "crosspaste") {
+/**
+ * The name users actually invoke, shown in usage/help output and hints. On
+ * Windows the MSIX execution alias is `crosspaste-cli` (`crosspaste` is
+ * hardwired by Conveyor to launch the GUI); on macOS/Linux the terminal
+ * command is `crosspaste` (symlink to the bundled crosspaste-cli binary).
+ */
+@OptIn(ExperimentalNativeApi::class)
+internal val cliCommandName: String =
+    if (Platform.osFamily == OsFamily.WINDOWS) "crosspaste-cli" else "crosspaste"
+
+class CrossPasteCommand : CliktCommand(name = cliCommandName) {
 
     override fun help(context: Context): String = "CrossPaste CLI - interact with your local CrossPaste application"
 

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -4,6 +4,7 @@ import com.crosspaste.cli.CliContext
 import com.crosspaste.cli.api.AppNotRunningException
 import com.crosspaste.cli.api.CLI_API_VERSION
 import com.crosspaste.cli.api.CliClient
+import com.crosspaste.cli.cliCommandName
 import com.crosspaste.cli.platform.AppLiveness
 import com.crosspaste.cli.platform.AppReadinessChecker
 import com.crosspaste.cli.platform.CliAppPathProvider
@@ -140,7 +141,7 @@ private fun CliktCommand.consentToStart(): Boolean =
             } else {
                 echo(
                     "Error: CrossPaste is not running. " +
-                        "Use 'crosspaste --start <command>' to launch it automatically.",
+                        "Use '$cliCommandName --start <command>' to launch it automatically.",
                     err = true,
                 )
                 false

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppLauncher.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppLauncher.kt
@@ -12,11 +12,18 @@ interface AppLauncher {
 }
 
 /**
- * The shell commands below background the start script, so a missing script
- * would still "succeed" and leave the caller waiting out the full readiness
- * timeout — check it up front instead.
+ * Launches the desktop app directly (decision D6): `open` on the .app bundle
+ * on macOS, the Conveyor JVM launcher executable elsewhere. The start.sh /
+ * start.bat scripts are NOT used here — their job is the app's own
+ * wait-for-old-pid update restart (DesktopAppRestartService), and unlike the
+ * launcher they don't exist in every channel (the Linux tarball has no
+ * root-inputs, so no start.sh).
+ *
+ * The shell commands below background or detach the launch, so a missing
+ * target would still "succeed" and leave the caller waiting out the full
+ * readiness timeout — check it up front instead.
  */
-private fun startScriptExists(script: Path): Boolean = FileSystem.SYSTEM.exists(script)
+private fun launchTargetExists(target: Path): Boolean = FileSystem.SYSTEM.exists(target)
 
 @OptIn(ExperimentalNativeApi::class)
 fun createAppLauncher(appPathProvider: CliAppPathProvider): AppLauncher {
@@ -35,9 +42,9 @@ class MacosAppLauncher(
 ) : AppLauncher {
 
     override fun launch(): Boolean {
-        val script = appPathProvider.startScriptPath
-        if (!startScriptExists(script)) return false
-        val exitCode = system("nohup bash \"$script\" > /dev/null 2>&1 &")
+        val bundle = appPathProvider.resolveGuiLaunchTarget()
+        if (!launchTargetExists(bundle)) return false
+        val exitCode = system("open \"$bundle\"")
         return exitCode == 0
     }
 }
@@ -48,9 +55,9 @@ class LinuxAppLauncher(
 ) : AppLauncher {
 
     override fun launch(): Boolean {
-        val script = appPathProvider.startScriptPath
-        if (!startScriptExists(script)) return false
-        val exitCode = system("nohup bash \"$script\" > /dev/null 2>&1 &")
+        val launcher = appPathProvider.resolveGuiLaunchTarget()
+        if (!launchTargetExists(launcher)) return false
+        val exitCode = system("nohup \"$launcher\" > /dev/null 2>&1 &")
         return exitCode == 0
     }
 }
@@ -61,10 +68,11 @@ class WindowsAppLauncher(
 ) : AppLauncher {
 
     override fun launch(): Boolean {
-        val script = appPathProvider.startScriptPath
-        if (!startScriptExists(script)) return false
-        val exePath = appPathProvider.resolveAppExePath()
-        val exitCode = system("\"$script\" \"$exePath\"")
+        val exe = appPathProvider.resolveGuiLaunchTarget()
+        if (!launchTargetExists(exe)) return false
+        // system() runs via cmd.exe; `start ""` detaches so the CLI does not
+        // block on the app process (the empty "" is the window title slot).
+        val exitCode = system("start \"\" \"$exe\"")
         return exitCode == 0
     }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/CliAppPathProvider.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/CliAppPathProvider.kt
@@ -9,32 +9,28 @@ import kotlin.experimental.ExperimentalNativeApi
 
 /**
  * Provides application paths for the CLI binary, derived from the
- * executable's own location. The CLI binary is bundled inside the
- * app package with a fixed directory structure relative to start scripts.
+ * executable's own location. The CLI ships as application payload
+ * (decision D6): a plain Conveyor input that lands in the JVM payload
+ * area of every package and channel.
  *
  * macOS (.app bundle):
- *   CrossPaste.app/                     ← appPath
+ *   CrossPaste.app/                     ← appPath (launch via `open`)
  *     Contents/
- *       bin/
- *         crosspaste-cli                ← CLI binary (binDir)
- *         start.sh                      ← start script
+ *       Resources/
+ *         bin/crosspaste-cli            ← CLI binary (binDir)
  *       MacOS/CrossPaste                ← JVM launcher
  *
- * Linux:
- *   /usr/lib/crosspaste/               ← appPath
- *     bin/
- *       crosspaste-cli                  ← CLI binary (binDir)
- *       start.sh                        ← start script
- *       crosspaste                      ← JVM launcher
+ * Linux (deb: /usr/lib/crosspaste; tarball/AppImage: the extracted root):
+ *   <root>/                             ← appPath
+ *     bin/crosspaste                    ← JVM launcher
+ *     lib/app/
+ *       bin/crosspaste-cli              ← CLI binary (binDir)
  *
- * Windows (Conveyor puts JVM-app inputs under app/, so the start script
- * does not sit next to the executables):
- *   CrossPaste/                         ← appPath
- *     bin/
- *       crosspaste-cli.exe              ← CLI binary (binDir)
- *       CrossPaste.exe                  ← JVM launcher
+ * Windows (installed MSIX tree or extracted portable zip):
+ *   <root>/                             ← appPath
+ *     bin/CrossPaste.exe                ← JVM launcher
  *     app/
- *       bin/start.bat                   ← start script
+ *       bin/crosspaste-cli.exe          ← CLI binary (binDir)
  */
 class CliAppPathProvider {
 
@@ -42,46 +38,44 @@ class CliAppPathProvider {
 
     val appPath: Path
 
-    val startScriptPath: Path
-
     init {
         val execDir = resolveExecutableDir()
         binDir = execDir
-        val os = getPlatformOsFamily()
-        appPath = resolveAppPath(execDir, os)
-        startScriptPath = resolveStartScriptPath(execDir, os)
+        appPath = resolveAppPath(execDir, getPlatformOsFamily())
     }
 
     private fun resolveAppPath(
         binDir: Path,
         os: OsFamilyCompat,
     ): Path {
-        val parent = binDir.parent ?: binDir
+        fun up(
+            path: Path,
+            levels: Int,
+        ): Path {
+            var current = path
+            repeat(levels) { current = current.parent ?: current }
+            return current
+        }
         return when (os) {
-            // bin/ → Contents/ → CrossPaste.app/
-            OsFamilyCompat.MACOSX -> parent.parent ?: parent
-            // bin/ → /usr/lib/crosspaste/
-            OsFamilyCompat.LINUX -> parent
-            // bin/ → CrossPaste/
-            OsFamilyCompat.WINDOWS -> parent
+            // Resources/bin/ → Resources/ → Contents/ → CrossPaste.app/
+            OsFamilyCompat.MACOSX -> up(binDir, 3)
+            // lib/app/bin/ → lib/app/ → lib/ → <root>/
+            OsFamilyCompat.LINUX -> up(binDir, 3)
+            // app\bin\ → app\ → <root>\
+            OsFamilyCompat.WINDOWS -> up(binDir, 2)
         }
     }
 
-    private fun resolveStartScriptPath(
-        binDir: Path,
-        os: OsFamilyCompat,
-    ): Path =
-        when (os) {
-            OsFamilyCompat.MACOSX -> binDir.resolve("start.sh")
-            OsFamilyCompat.LINUX -> binDir.resolve("start.sh")
-            // bin/ → CrossPaste/ → app/bin/start.bat
-            OsFamilyCompat.WINDOWS -> (binDir.parent ?: binDir).resolve("app/bin/start.bat")
-        }
-
     /**
-     * On Windows, start.bat requires the exe path as its first argument.
+     * The thing to launch to bring up the desktop app: the .app bundle on
+     * macOS (started via `open`), the Conveyor JVM launcher elsewhere.
      */
-    fun resolveAppExePath(): Path = binDir.resolve("CrossPaste.exe")
+    fun resolveGuiLaunchTarget(): Path =
+        when (getPlatformOsFamily()) {
+            OsFamilyCompat.MACOSX -> appPath
+            OsFamilyCompat.LINUX -> appPath.resolve("bin/crosspaste")
+            OsFamilyCompat.WINDOWS -> appPath.resolve("bin/CrossPaste.exe")
+        }
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/CliAppPathProvider.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/CliAppPathProvider.kt
@@ -27,12 +27,14 @@ import kotlin.experimental.ExperimentalNativeApi
  *       start.sh                        ← start script
  *       crosspaste                      ← JVM launcher
  *
- * Windows:
+ * Windows (Conveyor puts JVM-app inputs under app/, so the start script
+ * does not sit next to the executables):
  *   CrossPaste/                         ← appPath
  *     bin/
  *       crosspaste-cli.exe              ← CLI binary (binDir)
  *       CrossPaste.exe                  ← JVM launcher
- *       start.bat                       ← start script
+ *     app/
+ *       bin/start.bat                   ← start script
  */
 class CliAppPathProvider {
 
@@ -72,7 +74,8 @@ class CliAppPathProvider {
         when (os) {
             OsFamilyCompat.MACOSX -> binDir.resolve("start.sh")
             OsFamilyCompat.LINUX -> binDir.resolve("start.sh")
-            OsFamilyCompat.WINDOWS -> binDir.resolve("start.bat")
+            // bin/ → CrossPaste/ → app/bin/start.bat
+            OsFamilyCompat.WINDOWS -> (binDir.parent ?: binDir).resolve("app/bin/start.bat")
         }
 
     /**


### PR DESCRIPTION
Closes #4775

## Summary

Ships the Kotlin/Native CLI inside every desktop package (P3 of the CLI completion plan, after #4767 / #4769 / #4771).

Core design (decision D6, revised during review): **the CLI is application payload, and where it lives inside a package is decoupled from how users reach it.** The binary is imported with plain per-arch Conveyor `inputs` like any other app file, so one mechanism covers every channel — deb, Linux tarball, AppImage, mac zip, Windows zip, and MSIX — with no repacking. The user-facing entry point is PATH, wired per channel at the most appropriate time.

### Gradle: five static targets

- `cli/build.gradle.kts` drops the single dynamic `-Pcli.target` target (one target per invocation, clashing output paths) and statically declares `macosArm64` / `macosX64` / `linuxX64` / `linuxArm64` / `mingwX64`. The existing source layout is reused as leaf source dirs per target, so no expect/actual split is needed.
- New `assembleDist<Target>` tasks stage release executables under `cli/dist/<target>/crosspaste-cli(.exe)`; `assembleDist` builds the host-buildable subset (local convenience, CI calls per-target tasks). `cliNativeTest` is a stable umbrella for the host target's test task.
- Linker-flag fix discovered by actually cross-linking: mingw links go through the clang++ driver, so the Clikt duplicate-symbol workaround must be passed as `-Wl,--allow-multiple-definition` there, while Linux targets keep the bare flag (konan invokes the linker directly for them).

### Packaging (`cli.conveyor.conf`)

New config included from `build.conveyor.conf` (release CI) and the beta workflow's generated conf — deliberately not from `conveyor.conf`, so a plain local `conveyor make app` keeps working without pre-building the CLI.

- **Placement** — per-arch `inputs`, landing in the JVM payload area of each platform: `lib/app/bin/crosspaste-cli` on Linux, `app\bin\crosspaste-cli.exe` on Windows, `Contents/Resources/bin/crosspaste-cli` on macOS. This reaches the Linux tarball (previously it could not carry the CLI at all: `root-inputs` are deb-only, and Conveyor has no package-root injection mechanism for tarballs) and, through it, the AppImage — `package_appimage.sh` only keeps a `test -x` regression check.
- **PATH entry points**:
  - Linux deb: the default launcher symlink is overridden so `/usr/bin/crosspaste` points at the CLI payload path (install time). The desktop entry launches the GUI via its absolute path and is unaffected. Tarball users wire PATH manually.
  - Windows MSIX: a second app execution alias `crosspaste-cli.exe` → `app\bin\crosspaste-cli.exe` is injected via `manifests.msix.extensions-xml`, so `crosspaste-cli` works in any terminal right after install. (Conveyor hardcodes the `crosspaste.exe` alias to the GUI launch path with no config key to repoint it, hence the separate name; the CLI's help/hints use a platform-aware command name so Windows users are never pointed at the GUI alias.)
  - macOS: a first-launch prompt offering a `/usr/local/bin/crosspaste` symlink is a follow-up PR; until then the binary is reachable inside the bundle.

### Direct app launch (start.sh decoupling)

`AppLauncher` no longer reuses `start.sh` / `start.bat` — their real job is the updater's wait-for-old-pid restart (`DesktopAppRestartService`), and they don't exist in every channel (the tarball has no `root-inputs`, hence no `start.sh`). The CLI now launches the app directly: `open <bundle>` on macOS, the Conveyor launcher `bin/crosspaste` on Linux, `start "" bin\CrossPaste.exe` on Windows. The launcher executable exists in every channel, so auto-start also works for tarball/zip installs. `CliAppPathProvider` derives paths from the payload-area location and exposes a single `resolveGuiLaunchTarget()`.

### Release workflow topology

- `build-macos` compiles both Apple targets and hands them to `build-ubuntu` as an artifact (same hand-off pattern as the Swift dylib; artifact instead of cache because the binaries change every release). Executable bits are restored after download — GitHub artifacts drop them.
- `build-ubuntu` cross-compiles `linuxX64` / `linuxArm64` / `mingwX64` before running Conveyor. Both jobs stamp the CLI with `-PcliVersion=${GITHUB_REF_NAME}` (the full tag), because `validateAndUpdateVersion.js` only rewrites the version file on the Ubuntu job after `build-macos` has already run.
- `build-beta-linux` builds the two Linux targets and includes the new Conveyor config.
- The PR CI gate now also release-links `linuxArm64` and `mingwX64`, guarding the cross-compilation path the release depends on.

## Verification

- All five targets compile from a macOS host; `:cli:cliNativeTest` passes (20 tests); ktlint clean; CI green including the Linux-host cross-links.
- Local Conveyor builds inspected for all channels: mac `.app` (CLI at `Contents/Resources/bin/`, auto-signed, bundle passes `codesign -v --strict --deep`, runnable), Linux tarball (CLI present with exec bit, launcher alongside), deb (payload binary + single overridden `/usr/bin/crosspaste` symlink), MSIX (`app\bin\crosspaste-cli.exe` + both execution aliases in `AppxManifest.xml`).
- Binary sizes: 5.8–7.7 MB per target; each package carries exactly one.
- Deferred to release smoke (documented in the release checklist): notarization over the bundled CLI, MSIX double-alias install validation on a real Windows machine, and the packaged-app auto-start chain from P2.

## Follow-ups (out of scope)

- macOS PATH integration (first-launch prompt to symlink into `/usr/local/bin`) — remaining P3 item, separate PR.
- P4 terminal experience (stdin copy, `--raw`, exit-code docs, CLI docs page).
