### PR TITLE
:bug: harden the headless mode startup and shutdown paths for daemon use

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -173,7 +173,18 @@ class CrossPaste {
                     koin.get<SyncManager>().start()
                     koin.get<PastePullService>().init()
                     koin.get<Server>().start()
-                    ioCoroutineDispatcher.launch { koin.get<CliServer>().start() }
+                    if (headless) {
+                        // The UDS CLI API is the daemon's only control plane, so a
+                        // CliServer startup failure is a daemon startup failure
+                        // (fail-closed, propagates to the headless exit-1 path).
+                        koin.get<CliServer>().start()
+                    } else {
+                        // The GUI tolerates a degraded CLI and keeps running.
+                        ioCoroutineDispatcher.launch {
+                            runCatching { koin.get<CliServer>().start() }
+                                .onFailure { logger.warn { "CLI unavailable for this session" } }
+                        }
+                    }
                     if (configManager.getCurrentConfig().enableMcpServer) {
                         ioCoroutineDispatcher.launch { koin.get<McpServer>().start() }
                     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -163,6 +163,14 @@ class CrossPaste {
                 val koin = koinApplication.koin
                 val appLaunchState = koin.get<AppLaunchState>()
                 if (appLaunchState.acquiredLock) {
+                    if (headless) {
+                        // Register as soon as the single-instance lock is held (and
+                        // never earlier: a second instance must not run this hook and
+                        // delete the running daemon's files): from here on SIGTERM and
+                        // the startup-failure exitProcess(1) run the same shutdown
+                        // chain even while services are still starting.
+                        registerHeadlessShutdownHook()
+                    }
                     val configManager = koin.get<DesktopConfigManager>()
                     val notificationManager = koin.get<NotificationManager>()
                     configManager.notificationManager = notificationManager
@@ -239,16 +247,9 @@ class CrossPaste {
             }.onFailure { e ->
                 logger.error(e) { "cant start crosspaste" }
                 if (headless) {
-                    // The shutdown hook is only registered later in runHeadless(), so
-                    // run the exit hooks (e.g. pid-file removal) best-effort here; if
-                    // the failure happened before any hook was registered the list is
-                    // simply empty.
-                    runCatching {
-                        koinApplication.koin
-                            .get<AppExitService>()
-                            .beforeExitList
-                            .forEach { hook -> runCatching { hook.invoke() } }
-                    }
+                    // exitProcess(1) triggers the headless shutdown hook (registered
+                    // once the lock was acquired), which runs the full cleanup chain;
+                    // before lock acquisition there is nothing to clean up.
                     System.err.println("Error: CrossPaste failed to start in headless mode: ${e.message}")
                     exitProcess(1)
                 }
@@ -355,33 +356,51 @@ class CrossPaste {
             }
         }
 
-        private fun runHeadless() {
-            logger.info { "Running in headless mode" }
-            val latch = java.util.concurrent.CountDownLatch(1)
+        private val headlessLatch = java.util.concurrent.CountDownLatch(1)
+
+        private val headlessShutdownStarted =
+            java.util.concurrent.atomic
+                .AtomicBoolean(false)
+
+        /**
+         * The daemon counterpart of [exitCrossPasteApplication]: runs the exit
+         * hooks around [shutdownAllServices] and releases the lock. Idempotent,
+         * and each step is guarded, so the SIGTERM hook and the startup-failure
+         * path cannot double-clean and one failing step cannot skip the rest.
+         */
+        private fun headlessShutdown() {
+            if (!headlessShutdownStarted.compareAndSet(false, true)) {
+                return
+            }
+            val koin = koinApplication.koin
+            val appExitService = runCatching { koin.get<AppExitService>() }.getOrNull()
+            appExitService?.beforeExitList?.forEach { hook ->
+                runCatching { hook.invoke() }
+                    .onFailure { e -> logger.error(e) { "beforeExit hook failed" } }
+            }
+            runCatching { runBlocking { shutdownAllServices() } }
+                .onFailure { e -> logger.error(e) { "shutdownAllServices failed" } }
+            appExitService?.beforeReleaseLockList?.forEach { hook ->
+                runCatching { hook.invoke() }
+                    .onFailure { e -> logger.error(e) { "beforeReleaseLock hook failed" } }
+            }
+            runCatching { koin.get<AppLock>().releaseLock() }
+                .onFailure { e -> logger.error(e) { "releaseLock failed" } }
+        }
+
+        private fun registerHeadlessShutdownHook() {
             Runtime.getRuntime().addShutdownHook(
                 Thread {
                     logger.info { "Shutdown signal received" }
-                    val koin = koinApplication.koin
-                    // Mirror exitCrossPasteApplication(): run the exit hooks around
-                    // shutdownAllServices() so that cleanup registered via
-                    // AppExitService (e.g. the pid-file removal) also happens on the
-                    // daemon path. Each hook is guarded so one failure cannot skip
-                    // the remaining cleanup or the lock release.
-                    val appExitService = koin.get<AppExitService>()
-                    appExitService.beforeExitList.forEach { hook ->
-                        runCatching { hook.invoke() }
-                            .onFailure { e -> logger.error(e) { "beforeExit hook failed" } }
-                    }
-                    runBlocking { shutdownAllServices() }
-                    appExitService.beforeReleaseLockList.forEach { hook ->
-                        runCatching { hook.invoke() }
-                            .onFailure { e -> logger.error(e) { "beforeReleaseLock hook failed" } }
-                    }
-                    koin.get<AppLock>().releaseLock()
-                    latch.countDown()
+                    headlessShutdown()
+                    headlessLatch.countDown()
                 },
             )
-            latch.await()
+        }
+
+        private fun runHeadless() {
+            logger.info { "Running in headless mode" }
+            headlessLatch.await()
         }
 
         @OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -225,6 +225,16 @@ class CrossPaste {
             }.onFailure { e ->
                 logger.error(e) { "cant start crosspaste" }
                 if (headless) {
+                    // The shutdown hook is only registered later in runHeadless(), so
+                    // run the exit hooks (e.g. pid-file removal) best-effort here; if
+                    // the failure happened before any hook was registered the list is
+                    // simply empty.
+                    runCatching {
+                        koinApplication.koin
+                            .get<AppExitService>()
+                            .beforeExitList
+                            .forEach { hook -> runCatching { hook.invoke() } }
+                    }
                     System.err.println("Error: CrossPaste failed to start in headless mode: ${e.message}")
                     exitProcess(1)
                 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -181,14 +181,17 @@ class CrossPaste {
                     koin.get<PasteBonjourService>()
                     koin.get<CleanScheduler>().start()
                     koin.get<DesktopPidFileService>().start()
-                    koin.get<AppUpdateService>().start()
 
                     if (!headless) {
                         // These only serve an interactive desktop session: OS login-item
                         // autostart would relaunch the GUI app on login, native-messaging
                         // manifests target local browsers, guide pastes are onboarding
-                        // content, and the CLI symlink probe drives the install prompt
-                        // and the extension-page entry.
+                        // content, the CLI symlink probe drives the install prompt and
+                        // the extension-page entry, and the update service drives the
+                        // in-app update UI (its DesktopAppUpdateService implementation
+                        // requires the GUI-only DesktopAppWindowManager binding; server
+                        // updates are an OS package-manager concern).
+                        koin.get<AppUpdateService>().start()
                         koin.get<AppStartUpService>().followConfig()
                         koin.get<NativeMessagingHostService>().register()
                         koin.get<GuidePasteDataService>().initData()
@@ -281,7 +284,6 @@ class CrossPaste {
                 supervisorScope {
                     val jobs =
                         buildList {
-                            add(async { stopService<AppUpdateService>("AppUpdateService") { it.stop() } })
                             add(async { stopService<TaskExecutor>("TaskExecutor") { it.shutdown() } })
                             add(
                                 async {
@@ -299,6 +301,7 @@ class CrossPaste {
                             add(async { stopService<SyncManager>("SyncManager") { it.stop() } })
                             add(async { stopService<CleanScheduler>("CleanPasteScheduler") { it.stop() } })
                             if (!headless) {
+                                add(async { stopService<AppUpdateService>("AppUpdateService") { it.stop() } })
                                 add(
                                     async {
                                         stopService<DesktopAppWindowManager>("DesktopAppWindowManager") {

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -74,6 +74,7 @@ import org.koin.compose.koinInject
 import org.koin.core.KoinApplication
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.named
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.system.exitProcess
 import kotlin.time.Duration.Companion.seconds
 
@@ -133,6 +134,29 @@ class CrossPaste {
         lateinit var koinApplication: KoinApplication
             private set
 
+        private enum class ManagedService {
+            APP_UPDATE,
+            CLEAN_SCHEDULER,
+            CLI_SERVER,
+            DRIVER_FACTORY,
+            GLOBAL_LISTENER,
+            MCP_SERVER,
+            PASTE_CLIENT,
+            PASTE_SERVER,
+            PASTEBOARD,
+            PASTE_BONJOUR,
+            RENDERING,
+            RESOURCES_CLIENT,
+            SYNC_MANAGER,
+            TASK_EXECUTOR,
+            USER_DATA_PATH,
+            WINDOW_MANAGER,
+        }
+
+        /** Services are registered when startup first resolves them. Shutdown must
+         * never use Koin to create a service that was not part of this lifecycle. */
+        private val managedServices = ConcurrentHashMap<ManagedService, Any>()
+
         private fun initModule() {
             module =
                 DesktopModule(
@@ -171,34 +195,60 @@ class CrossPaste {
                         // chain even while services are still starting.
                         registerHeadlessShutdownHook()
                     }
+                    getManagedService<UserDataPathProvider>(ManagedService.USER_DATA_PATH)
+                    getManagedService<DriverFactory>(ManagedService.DRIVER_FACTORY)
+                    getManagedService<ResourcesClient>(ManagedService.RESOURCES_CLIENT)
                     val configManager = koin.get<DesktopConfigManager>()
                     val notificationManager = koin.get<NotificationManager>()
                     configManager.notificationManager = notificationManager
+                    // Register runtime-toggleable services even when initially
+                    // disabled. Settings can start these Koin singletons later,
+                    // and shutdown must still perform their ordered cleanup.
+                    val pasteboardService =
+                        getManagedService<PasteboardService>(ManagedService.PASTEBOARD)
                     if (configManager.getCurrentConfig().enablePasteboardListening) {
-                        koin.get<PasteboardService>().start()
+                        pasteboardService.start()
                     }
                     koin.get<QRCodeGenerator>()
-                    koin.get<SyncManager>().start()
+                    getManagedService<SyncManager>(ManagedService.SYNC_MANAGER).start()
                     koin.get<PastePullService>().init()
-                    koin.get<Server>().start()
+                    val pasteServer = getManagedService<Server>(ManagedService.PASTE_SERVER)
+                    if (headless) {
+                        // A daemon without its sync endpoint is not operational.
+                        pasteServer.start()
+                    } else {
+                        // Preserve the desktop app's degraded mode: local pasteboard
+                        // management remains usable when the sync endpoint cannot bind.
+                        runCatching { pasteServer.start() }
+                            .onFailure { e -> logger.warn(e) { "Sync server unavailable for this session" } }
+                    }
                     if (headless) {
                         // The UDS CLI API is the daemon's only control plane, so a
                         // CliServer startup failure is a daemon startup failure
                         // (fail-closed, propagates to the headless exit-1 path).
-                        koin.get<CliServer>().start()
+                        getManagedService<CliServer>(ManagedService.CLI_SERVER).start()
                     } else {
                         // The GUI tolerates a degraded CLI and keeps running.
                         ioCoroutineDispatcher.launch {
-                            runCatching { koin.get<CliServer>().start() }
-                                .onFailure { logger.warn { "CLI unavailable for this session" } }
+                            runCatching {
+                                getManagedService<CliServer>(ManagedService.CLI_SERVER).start()
+                            }.onFailure { logger.warn { "CLI unavailable for this session" } }
                         }
                     }
+                    val mcpServer = getManagedService<McpServer>(ManagedService.MCP_SERVER)
                     if (configManager.getCurrentConfig().enableMcpServer) {
-                        ioCoroutineDispatcher.launch { koin.get<McpServer>().start() }
+                        ioCoroutineDispatcher.launch {
+                            mcpServer.start()
+                        }
                     }
-                    koin.get<PasteClient>()
-                    koin.get<PasteBonjourService>()
-                    koin.get<CleanScheduler>().start()
+                    getManagedService<PasteClient>(ManagedService.PASTE_CLIENT)
+                    getManagedService<PasteBonjourService>(ManagedService.PASTE_BONJOUR)
+                    val cleanScheduler =
+                        getManagedService<CleanScheduler>(ManagedService.CLEAN_SCHEDULER)
+                    // CleanScheduler resolves TaskExecutor as a dependency. Record the
+                    // existing singleton so its worker scope is closed on shutdown.
+                    getManagedService<TaskExecutor>(ManagedService.TASK_EXECUTOR)
+                    cleanScheduler.start()
                     koin.get<DesktopPidFileService>().start()
 
                     if (!headless) {
@@ -210,13 +260,17 @@ class CrossPaste {
                         // in-app update UI (its DesktopAppUpdateService implementation
                         // requires the GUI-only DesktopAppWindowManager binding; server
                         // updates are an OS package-manager concern).
-                        koin.get<AppUpdateService>().start()
+                        // Register the window manager before AppUpdateService resolves it
+                        // as a dependency, so partial GUI startup can still stop it.
+                        val appWindowManager =
+                            getManagedService<DesktopAppWindowManager>(ManagedService.WINDOW_MANAGER)
+                        getManagedService<AppUpdateService>(ManagedService.APP_UPDATE).start()
                         koin.get<AppStartUpService>().followConfig()
                         koin.get<NativeMessagingHostService>().register()
                         koin.get<GuidePasteDataService>().initData()
                         ioCoroutineDispatcher.launch { koin.get<CliSymlinkService>().refresh() }
 
-                        koin.get<DesktopAppWindowManager>().startWindowService()
+                        appWindowManager.startWindowService()
                         FileKit.init(appId = AppName)
                     }
 
@@ -224,7 +278,10 @@ class CrossPaste {
                         val jobs =
                             listOf(
                                 async(ioDispatcher) {
-                                    koin.get<RenderingService<String>>(named("urlRendering")).start()
+                                    getManagedService<RenderingService<String>>(
+                                        service = ManagedService.RENDERING,
+                                        qualifier = named("urlRendering"),
+                                    ).start()
                                 },
                             )
 
@@ -296,40 +353,125 @@ class CrossPaste {
                 supervisorScope {
                     val jobs =
                         buildList {
-                            add(async { stopService<TaskExecutor>("TaskExecutor") { it.shutdown() } })
                             add(
                                 async {
-                                    stopService<RenderingService<String>>(
-                                        qualifier = named("urlRendering"),
+                                    stopManagedService<TaskExecutor>(
+                                        ManagedService.TASK_EXECUTOR,
+                                        "TaskExecutor",
+                                    ) { it.shutdown() }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<RenderingService<String>>(
+                                        service = ManagedService.RENDERING,
                                         serviceName = "RenderingService",
                                     ) { it.stop() }
                                 },
                             )
-                            add(async { stopService<PasteboardService>("PasteboardService") { it.stop() } })
-                            add(async { stopService<PasteBonjourService>("PasteBonjourService") { it.close() } })
-                            add(async { stopService<Server>("PasteServer") { it.stop() } })
-                            add(async { stopService<CliServer>("CliServer") { it.stop() } })
-                            add(async { stopService<McpServer>("McpServer") { it.stop() } })
-                            add(async { stopService<SyncManager>("SyncManager") { it.stop() } })
-                            add(async { stopService<CleanScheduler>("CleanPasteScheduler") { it.stop() } })
+                            add(
+                                async {
+                                    stopManagedService<PasteboardService>(
+                                        ManagedService.PASTEBOARD,
+                                        "PasteboardService",
+                                    ) { it.stop() }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<PasteBonjourService>(
+                                        ManagedService.PASTE_BONJOUR,
+                                        "PasteBonjourService",
+                                    ) { it.close() }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<Server>(ManagedService.PASTE_SERVER, "PasteServer") {
+                                        it.stop()
+                                    }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<CliServer>(ManagedService.CLI_SERVER, "CliServer") {
+                                        it.stop()
+                                    }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<McpServer>(ManagedService.MCP_SERVER, "McpServer") {
+                                        it.stop()
+                                    }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<SyncManager>(ManagedService.SYNC_MANAGER, "SyncManager") {
+                                        it.stop()
+                                    }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<CleanScheduler>(
+                                        ManagedService.CLEAN_SCHEDULER,
+                                        "CleanPasteScheduler",
+                                    ) { it.stop() }
+                                },
+                            )
                             if (!headless) {
-                                add(async { stopService<AppUpdateService>("AppUpdateService") { it.stop() } })
                                 add(
                                     async {
-                                        stopService<DesktopAppWindowManager>("DesktopAppWindowManager") {
+                                        stopManagedService<AppUpdateService>(
+                                            ManagedService.APP_UPDATE,
+                                            "AppUpdateService",
+                                        ) { it.stop() }
+                                    },
+                                )
+                                add(
+                                    async {
+                                        stopManagedService<DesktopAppWindowManager>(
+                                            ManagedService.WINDOW_MANAGER,
+                                            "DesktopAppWindowManager",
+                                        ) {
                                             it.stopWindowService()
                                         }
                                     },
                                 )
-                                add(async { stopService<GlobalListener>("GlobalListener") { it.stop() } })
+                                add(
+                                    async {
+                                        stopManagedService<GlobalListener>(
+                                            ManagedService.GLOBAL_LISTENER,
+                                            "GlobalListener",
+                                        ) { it.stop() }
+                                    },
+                                )
                             }
                             add(
                                 async {
-                                    stopService<UserDataPathProvider>("UserDataPathProvider") { it.cleanTemp() }
+                                    stopManagedService<UserDataPathProvider>(
+                                        ManagedService.USER_DATA_PATH,
+                                        "UserDataPathProvider",
+                                    ) { it.cleanTemp() }
                                 },
                             )
-                            add(async { stopService<PasteClient>("PasteClient") { it.close() } })
-                            add(async { stopService<ResourcesClient>("ResourcesClient") { it.close() } })
+                            add(
+                                async {
+                                    stopManagedService<PasteClient>(ManagedService.PASTE_CLIENT, "PasteClient") {
+                                        it.close()
+                                    }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<ResourcesClient>(
+                                        ManagedService.RESOURCES_CLIENT,
+                                        "ResourcesClient",
+                                    ) { it.close() }
+                                },
+                            )
                         }
 
                     jobs.awaitAll()
@@ -337,18 +479,33 @@ class CrossPaste {
             }
 
             runCatching {
-                stopService<DriverFactory>("DriverFactory") { it.closeDriver() }
+                stopManagedService<DriverFactory>(ManagedService.DRIVER_FACTORY, "DriverFactory") {
+                    it.closeDriver()
+                }
             }
         }
 
-        private inline fun <reified T : Any> stopService(
-            serviceName: String,
+        private inline fun <reified T : Any> getManagedService(
+            service: ManagedService,
             qualifier: Qualifier? = null,
+        ): T =
+            koinApplication.koin.get<T>(qualifier = qualifier).also { instance ->
+                managedServices[service] = instance
+            }
+
+        private fun <T : Any> manageService(
+            service: ManagedService,
+            instance: T,
+        ): T = instance.also { managedServices[service] = it }
+
+        private inline fun <reified T : Any> stopManagedService(
+            service: ManagedService,
+            serviceName: String,
             stopAction: (T) -> Unit,
         ) {
+            val instance = managedServices.remove(service) as? T ?: return
             runCatching {
-                val service = koinApplication.koin.get<T>(qualifier = qualifier)
-                stopAction(service)
+                stopAction(instance)
             }.onSuccess {
                 logger.info { "$serviceName stop completed" }
             }.onFailure { e ->
@@ -423,7 +580,8 @@ class CrossPaste {
                 application {
                     val appWindowManager = koinInject<DesktopAppWindowManager>()
                     val appSize = koinInject<DesktopAppSize>()
-                    val globalListener = koinInject<GlobalListener>()
+                    val globalListener =
+                        manageService(ManagedService.GLOBAL_LISTENER, koinInject<GlobalListener>())
 
                     val appSizeValue by appSize.appSizeValue.collectAsState()
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -174,22 +174,26 @@ class CrossPaste {
                     koin.get<PastePullService>().init()
                     koin.get<Server>().start()
                     ioCoroutineDispatcher.launch { koin.get<CliServer>().start() }
-                    // Probe the CLI symlink state once at startup; it drives
-                    // the install prompt and the extension-page entry
-                    ioCoroutineDispatcher.launch { koin.get<CliSymlinkService>().refresh() }
                     if (configManager.getCurrentConfig().enableMcpServer) {
                         ioCoroutineDispatcher.launch { koin.get<McpServer>().start() }
                     }
                     koin.get<PasteClient>()
                     koin.get<PasteBonjourService>()
                     koin.get<CleanScheduler>().start()
-                    koin.get<AppStartUpService>().followConfig()
                     koin.get<DesktopPidFileService>().start()
-                    koin.get<NativeMessagingHostService>().register()
                     koin.get<AppUpdateService>().start()
-                    koin.get<GuidePasteDataService>().initData()
 
                     if (!headless) {
+                        // These only serve an interactive desktop session: OS login-item
+                        // autostart would relaunch the GUI app on login, native-messaging
+                        // manifests target local browsers, guide pastes are onboarding
+                        // content, and the CLI symlink probe drives the install prompt
+                        // and the extension-page entry.
+                        koin.get<AppStartUpService>().followConfig()
+                        koin.get<NativeMessagingHostService>().register()
+                        koin.get<GuidePasteDataService>().initData()
+                        ioCoroutineDispatcher.launch { koin.get<CliSymlinkService>().refresh() }
+
                         koin.get<DesktopAppWindowManager>().startWindowService()
                         FileKit.init(appId = AppName)
                     }
@@ -205,13 +209,39 @@ class CrossPaste {
                         jobs.awaitAll()
                     }
                 } else {
+                    // The GUI second instance keeps its historic silent exit(0); a
+                    // headless daemon must fail loudly with a non-zero code so that
+                    // service managers (systemd) and scripts can detect the conflict.
+                    if (headless) {
+                        val runningPid = readRunningPid()?.let { " (pid $it)" }.orEmpty()
+                        System.err.println(
+                            "Error: another CrossPaste instance is already running$runningPid. " +
+                                "Only one CrossPaste process (desktop app or headless daemon) can run per user.",
+                        )
+                        exitProcess(1)
+                    }
                     exitProcess(0)
                 }
             }.onFailure { e ->
                 logger.error(e) { "cant start crosspaste" }
+                if (headless) {
+                    System.err.println("Error: CrossPaste failed to start in headless mode: ${e.message}")
+                    exitProcess(1)
+                }
                 exitProcess(0)
             }
         }
+
+        private fun readRunningPid(): String? =
+            runCatching {
+                koinApplication.koin
+                    .get<DesktopPidFileService>()
+                    .pidFilePath
+                    .toFile()
+                    .readText()
+                    .trim()
+                    .takeIf { it.isNotEmpty() }
+            }.getOrNull()
 
         private suspend fun exitCrossPasteApplication(
             exitMode: ExitMode,
@@ -307,8 +337,22 @@ class CrossPaste {
             Runtime.getRuntime().addShutdownHook(
                 Thread {
                     logger.info { "Shutdown signal received" }
-                    runBlocking { shutdownAllServices() }
                     val koin = koinApplication.koin
+                    // Mirror exitCrossPasteApplication(): run the exit hooks around
+                    // shutdownAllServices() so that cleanup registered via
+                    // AppExitService (e.g. the pid-file removal) also happens on the
+                    // daemon path. Each hook is guarded so one failure cannot skip
+                    // the remaining cleanup or the lock release.
+                    val appExitService = koin.get<AppExitService>()
+                    appExitService.beforeExitList.forEach { hook ->
+                        runCatching { hook.invoke() }
+                            .onFailure { e -> logger.error(e) { "beforeExit hook failed" } }
+                    }
+                    runBlocking { shutdownAllServices() }
+                    appExitService.beforeReleaseLockList.forEach { hook ->
+                        runCatching { hook.invoke() }
+                            .onFailure { e -> logger.error(e) { "beforeReleaseLock hook failed" } }
+                    }
                     koin.get<AppLock>().releaseLock()
                     latch.countDown()
                 },
@@ -327,11 +371,12 @@ class CrossPaste {
             runBlocking { startApplication() }
             logger.info { "CrossPaste started" }
 
-            logger.info { "SkikoProperties.renderApi=${SkikoProperties.renderApi}" }
-
             if (headless) {
                 runHeadless()
             } else {
+                // Reading SkikoProperties loads skiko; keep it off the headless path.
+                logger.info { "SkikoProperties.renderApi=${SkikoProperties.renderApi}" }
+
                 application {
                     val appWindowManager = koinInject<DesktopAppWindowManager>()
                     val appSize = koinInject<DesktopAppSize>()

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -61,6 +61,7 @@ import com.crosspaste.utils.getAppEnvUtils
 import io.github.oshai.kotlinlogging.KLogger
 import org.koin.core.KoinApplication
 import org.koin.core.context.GlobalContext
+import org.koin.core.module.Module
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -170,33 +171,36 @@ class DesktopModule(
             single<PasteSelectionViewModel> { PasteSelectionViewModel(get(), get(), get()) }
         }
 
+    fun modules(): List<Module> =
+        if (headless) {
+            listOf(
+                appModule(),
+                extensionModule(),
+                sqlDelightModule(),
+                networkModule(),
+                securityModule(),
+                pasteTypePluginModule(),
+                pasteComponentModule(),
+                headlessUiModule(),
+                headlessViewModelModule(),
+            )
+        } else {
+            listOf(
+                appModule(),
+                extensionModule(),
+                sqlDelightModule(),
+                networkModule(),
+                securityModule(),
+                pasteTypePluginModule(),
+                pasteComponentModule(),
+                uiModule(),
+                viewModelModule(),
+            )
+        }
+
     fun initKoinApplication(): KoinApplication =
         GlobalContext.startKoin {
-            if (headless) {
-                modules(
-                    appModule(),
-                    extensionModule(),
-                    sqlDelightModule(),
-                    networkModule(),
-                    securityModule(),
-                    pasteTypePluginModule(),
-                    pasteComponentModule(),
-                    headlessUiModule(),
-                    headlessViewModelModule(),
-                )
-            } else {
-                modules(
-                    appModule(),
-                    extensionModule(),
-                    sqlDelightModule(),
-                    networkModule(),
-                    securityModule(),
-                    pasteTypePluginModule(),
-                    pasteComponentModule(),
-                    uiModule(),
-                    viewModelModule(),
-                )
-            }
+            modules(this@DesktopModule.modules())
         }
 }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliServer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliServer.kt
@@ -95,6 +95,12 @@ class CliServer(
 
     private var socketPath: Path? = null
 
+    /**
+     * Starts the CLI server. On failure the partially created resources are
+     * cleaned up and the failure is rethrown: callers decide whether a missing
+     * CLI control plane is fatal (headless daemon) or a degraded-but-running
+     * state (GUI).
+     */
     suspend fun start() {
         withContext(ioDispatcher) {
             lifecycleMutex.withLock {
@@ -129,6 +135,7 @@ class CliServer(
                 }.onFailure { e ->
                     logger.error(e) { "Failed to start CLI server" }
                     cleanup()
+                    throw e
                 }
             }
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/headless/HeadlessModule.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.headless
 
+import coil3.PlatformContext
 import com.crosspaste.app.AppTokenApi
 import com.crosspaste.app.AppWindowManager
 import com.crosspaste.app.DesktopRatingPromptManager
@@ -20,6 +21,11 @@ fun headlessUiModule() =
         single<AppWindowManager> { HeadlessAppWindowManager() }
         single<GlobalCopywriter> { DesktopGlobalCopywriter(get(), lazy { get() }, get()) }
         single<NotificationManager> { HeadlessNotificationManager(get()) }
+        // The coil ImageLoader/MemoryCache singles in desktopAppModule resolve
+        // PlatformContext, which is otherwise only bound by uiModule; without this
+        // binding any lazy resolution of them in headless mode crashes with
+        // NoDefinitionFoundException.
+        single<PlatformContext> { PlatformContext.INSTANCE }
         single<RatingPromptManager> { DesktopRatingPromptManager() }
         single<SoundService> { HeadlessSoundService() }
         single<TokenCacheApi> { TokenCache }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
@@ -13,13 +13,18 @@ import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.*
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import java.net.InetAddress
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceEvent
@@ -43,6 +48,7 @@ class DesktopPasteBonjourService(
         private const val DEVICE_RESOLVE_INTERVAL = 2000L // Throttle for specific device resolution
         private const val MIN_SEARCH_DURATION = 2000L // Minimum duration for searching
         private const val CLOSE_TIMEOUT = 10000L // Maximum time to wait for close
+        private const val LIFECYCLE_CLOSE_TIMEOUT = 4000L // Must stay below the app's 5s shutdown budget
 
         private val dateUtils = getDateUtils()
     }
@@ -227,9 +233,9 @@ class DesktopPasteBonjourService(
     /**
      * Suspending teardown of all registered jmDNS instances. Used on the network-change
      * hot path ([processNetworkChange]) so a rebuild never blocks the consumer coroutine.
-     * jmDNS unregister/close are themselves blocking calls — they run on [scope]'s IO
-     * dispatcher inside [withTimeout] so a single misbehaving interface can't stall the
-     * rebuild past [CLOSE_TIMEOUT].
+     * jmDNS unregister/close are themselves blocking calls. [withTimeout] bounds
+     * cooperative work, but cannot interrupt a native/blocking jmDNS call; lifecycle
+     * shutdown therefore also has a hard wait bound in [close].
      */
     private suspend fun closeServices() {
         runCatching {
@@ -253,13 +259,31 @@ class DesktopPasteBonjourService(
     }
 
     /**
-     * Lifecycle teardown (interface contract). Bridges the suspend [closeServices] to the
-     * synchronous shutdown path via [runBlocking]. This is a one-shot app-exit call, not
-     * the per-network-change hot path, so the brief block here is acceptable.
+     * Lifecycle teardown (interface contract). The cleanup job is deliberately detached
+     * from the synchronous caller: jmDNS scans and close calls may ignore coroutine
+     * cancellation, so application shutdown waits at most [LIFECYCLE_CLOSE_TIMEOUT] and
+     * then proceeds while the daemon-backed IO cleanup is allowed to finish.
      */
     override fun close() {
+        val cleanupScope = CoroutineScope(ioDispatcher + SupervisorJob())
+        val cleanupJob =
+            cleanupScope.launch {
+                scope.coroutineContext.job.cancelAndJoin()
+                closeServices()
+            }
+        cleanupJob.invokeOnCompletion { cleanupScope.cancel() }
+
         runBlocking {
-            closeServices()
+            val completed =
+                withTimeoutOrNull(LIFECYCLE_CLOSE_TIMEOUT) {
+                    cleanupJob.join()
+                    true
+                } ?: false
+            if (!completed) {
+                logger.warn {
+                    "Bonjour lifecycle cleanup exceeded ${LIFECYCLE_CLOSE_TIMEOUT}ms; continuing shutdown"
+                }
+            }
         }
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteServer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteServer.kt
@@ -23,30 +23,49 @@ class DesktopPasteServer(
 
     override suspend fun start() =
         withContext(ioDispatcher) {
-            runCatching {
-                server = createServer(port = readWritePort.getValue())
-                server?.start(wait = false)
-            }.onFailure { e ->
-                if (exceptionHandler.isPortAlreadyInUse(e)) {
-                    logger.warn { "Port ${readWritePort.getValue()} is already in use, retrying on random port" }
-                    runCatching {
-                        server = createServer(port = 0)
-                        server?.start(wait = false)
-                    }.onFailure { retryError ->
-                        logger.error(retryError) { "Failed to start server on random port" }
+            val configuredPort = readWritePort.getValue()
+            try {
+                try {
+                    startServer(configuredPort)
+                } catch (e: Throwable) {
+                    cleanupFailedServer()
+                    if (!exceptionHandler.isPortAlreadyInUse(e)) {
+                        logger.error(e) { "Failed to start server" }
+                        throw e
                     }
-                } else {
-                    logger.error(e) { "Failed to start server" }
+
+                    logger.warn { "Port $configuredPort is already in use, retrying on random port" }
+                    startServer(0)
                 }
+
+                port =
+                    checkNotNull(server)
+                        .application.engine
+                        .resolvedConnectors()
+                        .firstOrNull()
+                        ?.port
+                        ?: error("Started server has no resolved connector")
+                if (port != configuredPort) {
+                    readWritePort.setValue(port)
+                }
+                logger.info { "Server started at port $port" }
+            } catch (e: Throwable) {
+                cleanupFailedServer()
+                logger.error(e) { "Server startup failed" }
+                throw e
             }
-            server?.application?.engine?.resolvedConnectors()?.first()?.port?.let {
-                port = it
-            }
-            if (port != readWritePort.getValue()) {
-                readWritePort.setValue(port)
-            }
-            logger.info { "Server started at port $port" }
         }
+
+    private fun startServer(port: Int) {
+        server = createServer(port = port)
+        checkNotNull(server).start(wait = false)
+    }
+
+    private suspend fun cleanupFailedServer() {
+        runCatching { server?.stop() }
+            .onFailure { e -> logger.warn(e) { "Failed to clean up partially started server" } }
+        server = null
+    }
 
     override suspend fun stop() {
         server?.stop()

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliServerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliServerTest.kt
@@ -32,6 +32,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -166,6 +167,33 @@ class CliServerTest {
             } finally {
                 server.stop()
             }
+        }
+
+        socketBaseDir.toFile().deleteRecursively()
+    }
+
+    /**
+     * The headless daemon treats a CLI-server startup failure as a startup
+     * failure of the whole process (the UDS API is its only control plane),
+     * so start() must propagate the failure after cleaning up instead of
+     * swallowing it into a log line.
+     */
+    @Test
+    fun `start rethrows after cleanup when the socket path is unusable`() {
+        val userDataDir = Files.createTempDirectory("cli-server-data")
+        // Exceeds the 100-byte socket-path guard in resolveSocketPath
+        val socketBaseDir =
+            Path
+                .of(System.getProperty("java.io.tmpdir"), "cs-long-${"x".repeat(120)}")
+                .also { Files.createDirectories(it) }
+        val (server, endpointFile) = createServer(userDataDir, socketBaseDir)
+
+        runBlocking {
+            assertFailsWith<IllegalStateException> { server.start() }
+            assertFalse(
+                endpointFile.getPath().exists(),
+                "endpoint file must not be published after a failed start",
+            )
         }
 
         socketBaseDir.toFile().deleteRecursively()

--- a/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessDaemonProcessTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessDaemonProcessTest.kt
@@ -1,0 +1,198 @@
+package com.crosspaste.headless
+
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Black-box tests for the headless daemon lifecycle: each test boots the real
+ * application (`CrossPaste --headless`) as a subprocess in DEVELOPMENT mode
+ * with an isolated working directory, so all state (`.user` data dir, lock,
+ * pid file, CLI endpoint) stays inside a temp dir. The socket directory is
+ * isolated per test via `java.io.tmpdir` so a developer's live instance is
+ * never touched.
+ *
+ * POSIX-only: `Process.destroy()` must deliver SIGTERM so that JVM shutdown
+ * hooks run; on Windows it terminates the process without running hooks.
+ */
+class HeadlessDaemonProcessTest {
+
+    private fun isPosix(): Boolean =
+        FileSystems
+            .getDefault()
+            .supportedFileAttributeViews()
+            .contains("posix")
+
+    private fun newWorkDir(): Path = Files.createTempDirectory("crosspaste-daemon-test")
+
+    /** Short base for AF_UNIX sockets: must keep the socket path under 100 bytes. */
+    private fun newSocketTmpDir(): Path {
+        val dir = Path.of("/tmp", "cs-dt-${Random.nextInt(100000, 999999)}")
+        Files.createDirectories(dir)
+        return dir
+    }
+
+    private fun launchDaemon(
+        workDir: Path,
+        socketTmpDir: Path,
+    ): Process {
+        val javaBin = Path.of(System.getProperty("java.home"), "bin", "java").toString()
+        val command =
+            listOf(
+                javaBin,
+                "-DappEnv=DEVELOPMENT",
+                "-Djava.net.preferIPv4Stack=true",
+                "-Djava.io.tmpdir=$socketTmpDir",
+                "-cp",
+                System.getProperty("java.class.path"),
+                "com.crosspaste.CrossPaste",
+                "--headless",
+            )
+        return ProcessBuilder(command)
+            .directory(workDir.toFile())
+            .redirectOutput(workDir.resolve("stdout.log").toFile())
+            .redirectError(workDir.resolve("stderr.log").toFile())
+            .start()
+    }
+
+    private fun awaitFile(
+        path: Path,
+        timeoutMs: Long = 120_000,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (path.exists()) return true
+            Thread.sleep(200)
+        }
+        return false
+    }
+
+    private fun endpointFile(workDir: Path): Path = workDir.resolve(".user").resolve("cli-endpoint.json")
+
+    private fun pidFile(workDir: Path): Path = workDir.resolve(".user").resolve("crosspaste.pid")
+
+    private fun stderr(workDir: Path): String =
+        workDir
+            .resolve("stderr.log")
+            .takeIf { it.exists() }
+            ?.readText()
+            .orEmpty()
+
+    @Test
+    fun `daemon publishes its control plane and SIGTERM cleans everything up`() {
+        if (!isPosix()) return
+        val workDir = newWorkDir()
+        val socketTmpDir = newSocketTmpDir()
+        val daemon = launchDaemon(workDir, socketTmpDir)
+        try {
+            assertTrue(
+                awaitFile(endpointFile(workDir)),
+                "daemon must publish the CLI endpoint file; stderr: ${stderr(workDir)}",
+            )
+            assertTrue(awaitFile(pidFile(workDir)), "daemon must write its pid file")
+
+            val socketPath =
+                Regex("\"socketPath\"\\s*:\\s*\"([^\"]+)\"")
+                    .find(endpointFile(workDir).readText())
+                    ?.groupValues
+                    ?.get(1)
+            assertTrue(!socketPath.isNullOrEmpty(), "endpoint file must contain the socket path")
+            assertTrue(Path.of(socketPath).exists(), "unix socket must exist while the daemon runs")
+
+            daemon.destroy() // SIGTERM
+            assertTrue(daemon.waitFor(30, java.util.concurrent.TimeUnit.SECONDS), "daemon must exit on SIGTERM")
+
+            assertFalse(pidFile(workDir).exists(), "pid file must be removed on SIGTERM")
+            assertFalse(endpointFile(workDir).exists(), "endpoint file must be removed on SIGTERM")
+            assertFalse(Path.of(socketPath).exists(), "socket file must be removed on SIGTERM")
+        } finally {
+            daemon.destroyForcibly()
+            socketTmpDir.toFile().deleteRecursively()
+            workDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `second headless instance fails loudly with exit code 1`() {
+        if (!isPosix()) return
+        val workDir = newWorkDir()
+        val socketTmpDir = newSocketTmpDir()
+        val first = launchDaemon(workDir, socketTmpDir)
+        try {
+            assertTrue(
+                awaitFile(endpointFile(workDir)),
+                "first daemon must start; stderr: ${stderr(workDir)}",
+            )
+
+            val secondDir = Files.createDirectory(workDir.resolve("second-logs"))
+            val second =
+                ProcessBuilder(
+                    Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                    "-DappEnv=DEVELOPMENT",
+                    "-Djava.net.preferIPv4Stack=true",
+                    "-Djava.io.tmpdir=$socketTmpDir",
+                    "-cp",
+                    System.getProperty("java.class.path"),
+                    "com.crosspaste.CrossPaste",
+                    "--headless",
+                ).directory(workDir.toFile()) // same data dir -> same app.lock
+                    .redirectOutput(secondDir.resolve("stdout.log").toFile())
+                    .redirectError(secondDir.resolve("stderr.log").toFile())
+                    .start()
+            try {
+                assertTrue(
+                    second.waitFor(120, java.util.concurrent.TimeUnit.SECONDS),
+                    "second instance must exit",
+                )
+                assertEquals(1, second.exitValue(), "second headless instance must exit with code 1")
+                assertTrue(
+                    secondDir.resolve("stderr.log").readText().contains("already running"),
+                    "second instance must report the conflict on stderr",
+                )
+                // The second instance must not have destroyed the first one's files.
+                assertTrue(endpointFile(workDir).exists(), "running daemon's endpoint file must survive")
+                assertTrue(pidFile(workDir).exists(), "running daemon's pid file must survive")
+            } finally {
+                second.destroyForcibly()
+            }
+        } finally {
+            first.destroy()
+            first.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)
+            first.destroyForcibly()
+            socketTmpDir.toFile().deleteRecursively()
+            workDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `daemon exits with code 1 when the CLI control plane cannot start`() {
+        if (!isPosix()) return
+        val workDir = newWorkDir()
+        // A tmpdir long enough that the socket path exceeds the 100-byte guard
+        val longTmpDir = workDir.resolve("x".repeat(130))
+        Files.createDirectories(longTmpDir)
+        val daemon = launchDaemon(workDir, longTmpDir)
+        try {
+            assertTrue(
+                daemon.waitFor(120, java.util.concurrent.TimeUnit.SECONDS),
+                "daemon must exit when the CLI server cannot start",
+            )
+            assertEquals(1, daemon.exitValue(), "CLI control-plane failure must be a daemon startup failure")
+            assertTrue(
+                stderr(workDir).contains("failed to start in headless mode"),
+                "daemon must report the startup failure on stderr; stderr: ${stderr(workDir)}",
+            )
+            assertFalse(endpointFile(workDir).exists(), "no endpoint file may be left behind")
+        } finally {
+            daemon.destroyForcibly()
+            workDir.toFile().deleteRecursively()
+        }
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessModuleTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessModuleTest.kt
@@ -1,8 +1,15 @@
 package com.crosspaste.headless
 
 import coil3.PlatformContext
+import coil3.memory.MemoryCache
+import com.crosspaste.app.AppEnv
+import com.crosspaste.desktopAppModule
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.mockk.mockk
 import org.koin.dsl.koinApplication
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 
 class HeadlessModuleTest {
@@ -17,5 +24,33 @@ class HeadlessModuleTest {
     fun testHeadlessUiModuleProvidesPlatformContext() {
         val koin = koinApplication { modules(headlessUiModule()) }.koin
         assertSame(PlatformContext.INSTANCE, koin.get<PlatformContext>())
+    }
+
+    /**
+     * Regression pin across modules: resolving the MemoryCache single defined in
+     * desktopAppModule pulls PlatformContext at build time, which is exactly the
+     * lazy path that crashed under the headless assembly before headlessUiModule
+     * bound PlatformContext.
+     */
+    @Test
+    fun testMemoryCacheResolvesUnderHeadlessAssembly() {
+        val koin =
+            koinApplication {
+                modules(
+                    desktopAppModule(
+                        appEnv = AppEnv.TEST,
+                        appMetadataRepository = mockk(relaxed = true),
+                        appPathProvider = mockk(relaxed = true),
+                        configManager = mockk(relaxed = true),
+                        crossPasteLogger = mockk(relaxed = true),
+                        deviceUtils = mockk(relaxed = true),
+                        klogger = KotlinLogging.logger {},
+                        platform = mockk(relaxed = true),
+                        pairingCapabilityFlag = PairingCapabilityFlag(2),
+                    ),
+                    headlessUiModule(),
+                )
+            }.koin
+        assertNotNull(koin.get<MemoryCache>())
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessModuleTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessModuleTest.kt
@@ -1,0 +1,21 @@
+package com.crosspaste.headless
+
+import coil3.PlatformContext
+import org.koin.dsl.koinApplication
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+class HeadlessModuleTest {
+
+    /**
+     * The coil ImageLoader/MemoryCache singles in desktopAppModule resolve
+     * PlatformContext, which uiModule provides for the GUI assembly. The headless
+     * assembly must provide it too, or any lazy resolution of those singles
+     * (favicon/app-source/thumbnail loading) crashes with NoDefinitionFoundException.
+     */
+    @Test
+    fun testHeadlessUiModuleProvidesPlatformContext() {
+        val koin = koinApplication { modules(headlessUiModule()) }.koin
+        assertSame(PlatformContext.INSTANCE, koin.get<PlatformContext>())
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessStartupResolutionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessStartupResolutionTest.kt
@@ -13,10 +13,12 @@ import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.db.DriverFactory
 import com.crosspaste.log.CrossPasteLogger
 import com.crosspaste.mcp.McpServer
+import com.crosspaste.net.NetworkInterfaceService
 import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.net.PasteClient
 import com.crosspaste.net.ResourcesClient
 import com.crosspaste.net.Server
+import com.crosspaste.net.TestNetworkInterfaceService
 import com.crosspaste.notification.NotificationManager
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.path.AppPathProvider
@@ -24,6 +26,7 @@ import com.crosspaste.path.DesktopPathProvider
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FilePersist
 import com.crosspaste.rendering.RenderingService
+import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.PastePullService
 import com.crosspaste.sync.QRCodeGenerator
 import com.crosspaste.sync.SyncManager
@@ -33,10 +36,13 @@ import com.crosspaste.utils.DesktopLocaleUtils
 import com.crosspaste.utils.getPlatformUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import okio.Path
 import okio.Path.Companion.toOkioPath
 import org.koin.core.qualifier.named
 import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import java.nio.file.Files
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -72,56 +78,110 @@ class HeadlessStartupResolutionTest {
     }
 
     @Test
-    fun testHeadlessStartupAndShutdownServicesResolve() {
-        val tempRoot = createTempDirectory("crosspaste-headless-di").toOkioPath(normalize = true)
-        val platform = getPlatformUtils().platform
-        val appPathProvider = TempAppPathProvider(tempRoot)
-        val configManager =
-            DesktopConfigManager(
-                FilePersist.createOneFilePersist(appPathProvider.resolve("appConfig.json", AppFileType.USER)),
-                DesktopLocaleUtils,
-            )
-        val module =
-            DesktopModule(
-                appEnv = AppEnv.TEST,
-                appMetadataRepository =
-                    AppMetadataRepository(
-                        FilePersist.createOneFilePersist(appPathProvider.resolve(".metadata", AppFileType.USER)),
-                        DesktopDeviceUtils(platform),
-                    ),
-                appPathProvider = appPathProvider,
-                configManager = configManager,
-                crossPasteLogger = mockk<CrossPasteLogger>(relaxed = true),
-                deviceUtils = DesktopDeviceUtils(platform),
-                klogger = KotlinLogging.logger {},
-                platform = platform,
-                headless = true,
-            )
+    fun testHeadlessStartupAndShutdownServicesResolve(): Unit =
+        runBlocking {
+            val tempRoot = createTempDirectory("crosspaste-headless-di").toOkioPath(normalize = true)
+            val platform = getPlatformUtils().platform
+            val appPathProvider = TempAppPathProvider(tempRoot)
+            val configManager =
+                DesktopConfigManager(
+                    FilePersist.createOneFilePersist(appPathProvider.resolve("appConfig.json", AppFileType.USER)),
+                    DesktopLocaleUtils,
+                )
+            val desktopModule =
+                DesktopModule(
+                    appEnv = AppEnv.TEST,
+                    appMetadataRepository =
+                        AppMetadataRepository(
+                            FilePersist.createOneFilePersist(appPathProvider.resolve(".metadata", AppFileType.USER)),
+                            DesktopDeviceUtils(platform),
+                        ),
+                    appPathProvider = appPathProvider,
+                    configManager = configManager,
+                    crossPasteLogger = mockk<CrossPasteLogger>(relaxed = true),
+                    deviceUtils = DesktopDeviceUtils(platform),
+                    klogger = KotlinLogging.logger {},
+                    platform = platform,
+                    headless = true,
+                )
 
-        val koin = koinApplication { modules(module.modules()) }.koin
+            val testOverrides =
+                module {
+                    single<SecureStore> { mockk(relaxed = true) }
+                    single<NetworkInterfaceService> { TestNetworkInterfaceService() }
+                }
+            val koinApplication =
+                koinApplication {
+                    allowOverride(true)
+                    modules(desktopModule.modules() + testOverrides)
+                }
+            val koin = koinApplication.koin
+            var pasteboardService: PasteboardService? = null
+            var syncManager: SyncManager? = null
+            var server: Server? = null
+            var cliServer: CliServer? = null
+            var mcpServer: McpServer? = null
+            var pasteClient: PasteClient? = null
+            var pasteBonjourService: PasteBonjourService? = null
+            var cleanScheduler: CleanScheduler? = null
+            var renderingService: RenderingService<String>? = null
+            var taskExecutor: TaskExecutor? = null
+            var resourcesClient: ResourcesClient? = null
+            var driverFactory: DriverFactory? = null
 
-        // The startApplication() service set on the headless path.
-        assertNotNull(koin.get<DesktopConfigManager>())
-        assertNotNull(koin.get<NotificationManager>())
-        assertNotNull(koin.get<PasteboardService>())
-        assertNotNull(koin.get<QRCodeGenerator>())
-        assertNotNull(koin.get<SyncManager>())
-        assertNotNull(koin.get<PastePullService>())
-        assertNotNull(koin.get<Server>())
-        assertNotNull(koin.get<CliServer>())
-        assertNotNull(koin.get<McpServer>())
-        assertNotNull(koin.get<PasteClient>())
-        assertNotNull(koin.get<PasteBonjourService>())
-        assertNotNull(koin.get<CleanScheduler>())
-        assertNotNull(koin.get<DesktopPidFileService>())
-        assertNotNull(koin.get<RenderingService<String>>(named("urlRendering")))
+            try {
+                // The startApplication() service set on the headless path.
+                assertNotNull(koin.get<DesktopConfigManager>())
+                assertNotNull(koin.get<NotificationManager>())
+                pasteboardService = koin.get()
+                assertNotNull(pasteboardService)
+                assertNotNull(koin.get<QRCodeGenerator>())
+                syncManager = koin.get()
+                assertNotNull(syncManager)
+                assertNotNull(koin.get<PastePullService>())
+                server = koin.get()
+                assertNotNull(server)
+                cliServer = koin.get()
+                assertNotNull(cliServer)
+                mcpServer = koin.get()
+                assertNotNull(mcpServer)
+                pasteClient = koin.get()
+                assertNotNull(pasteClient)
+                pasteBonjourService = koin.get()
+                assertNotNull(pasteBonjourService)
+                cleanScheduler = koin.get()
+                assertNotNull(cleanScheduler)
+                assertNotNull(koin.get<DesktopPidFileService>())
+                renderingService = koin.get(named("urlRendering"))
+                assertNotNull(renderingService)
 
-        // The shutdownAllServices()/runHeadless() service set on the headless path.
-        assertNotNull(koin.get<AppExitService>())
-        assertNotNull(koin.get<AppLock>())
-        assertNotNull(koin.get<TaskExecutor>())
-        assertNotNull(koin.get<UserDataPathProvider>())
-        assertNotNull(koin.get<ResourcesClient>())
-        assertNotNull(koin.get<DriverFactory>())
-    }
+                // The shutdownAllServices()/runHeadless() service set on the headless path.
+                assertNotNull(koin.get<AppExitService>())
+                assertNotNull(koin.get<AppLock>())
+                taskExecutor = koin.get()
+                assertNotNull(taskExecutor)
+                assertNotNull(koin.get<UserDataPathProvider>())
+                resourcesClient = koin.get()
+                assertNotNull(resourcesClient)
+                driverFactory = koin.get()
+                assertNotNull(driverFactory)
+            } finally {
+                runCatching { cleanScheduler?.stop() }
+                runCatching { taskExecutor?.shutdown() }
+                runCatching { renderingService?.stop() }
+                runCatching { pasteboardService?.stop() }
+                runCatching { pasteBonjourService?.close() }
+                runCatching { server?.stop() }
+                runCatching { cliServer?.stop() }
+                runCatching { mcpServer?.stop() }
+                runCatching { syncManager?.stop() }
+                runCatching { pasteClient?.close() }
+                runCatching { resourcesClient?.close() }
+                runCatching { driverFactory?.closeDriver() }
+                koinApplication.close()
+                Files.walk(tempRoot.toNioPath()).use { paths ->
+                    paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+                }
+            }
+        }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessStartupResolutionTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessStartupResolutionTest.kt
@@ -1,0 +1,127 @@
+package com.crosspaste.headless
+
+import com.crosspaste.DesktopModule
+import com.crosspaste.app.AppEnv
+import com.crosspaste.app.AppExitService
+import com.crosspaste.app.AppFileType
+import com.crosspaste.app.AppLock
+import com.crosspaste.app.DesktopPidFileService
+import com.crosspaste.clean.CleanScheduler
+import com.crosspaste.cli.CliServer
+import com.crosspaste.config.AppMetadataRepository
+import com.crosspaste.config.DesktopConfigManager
+import com.crosspaste.db.DriverFactory
+import com.crosspaste.log.CrossPasteLogger
+import com.crosspaste.mcp.McpServer
+import com.crosspaste.net.PasteBonjourService
+import com.crosspaste.net.PasteClient
+import com.crosspaste.net.ResourcesClient
+import com.crosspaste.net.Server
+import com.crosspaste.notification.NotificationManager
+import com.crosspaste.paste.PasteboardService
+import com.crosspaste.path.AppPathProvider
+import com.crosspaste.path.DesktopPathProvider
+import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.presist.FilePersist
+import com.crosspaste.rendering.RenderingService
+import com.crosspaste.sync.PastePullService
+import com.crosspaste.sync.QRCodeGenerator
+import com.crosspaste.sync.SyncManager
+import com.crosspaste.task.TaskExecutor
+import com.crosspaste.utils.DesktopDeviceUtils
+import com.crosspaste.utils.DesktopLocaleUtils
+import com.crosspaste.utils.getPlatformUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.mockk.mockk
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Resolves every service the headless startup and shutdown paths in
+ * [com.crosspaste.CrossPaste] touch against the complete headless Koin
+ * assembly ([DesktopModule.modules] with headless = true).
+ *
+ * This is the regression pin for definition gaps that only surface at
+ * runtime on a server: a GUI-only binding referenced from a service that
+ * headless mode starts (e.g. DesktopAppUpdateService requiring the
+ * uiModule-only DesktopAppWindowManager) crashes the daemon with
+ * NoDefinitionFoundException after it has already written its pid file.
+ */
+class HeadlessStartupResolutionTest {
+
+    private class TempAppPathProvider(
+        root: Path,
+    ) : AppPathProvider {
+        override val userHome: Path = root
+        override val pasteAppPath: Path = root
+        override val pasteAppJarPath: Path = root
+        override val pasteAppExePath: Path = root
+        override val pasteUserPath: Path = root
+
+        private val pathProvider = DesktopPathProvider(pasteAppPath, pasteUserPath)
+
+        override fun resolve(
+            fileName: String?,
+            appFileType: AppFileType,
+        ): Path = pathProvider.resolve(fileName, appFileType)
+    }
+
+    @Test
+    fun testHeadlessStartupAndShutdownServicesResolve() {
+        val tempRoot = createTempDirectory("crosspaste-headless-di").toOkioPath(normalize = true)
+        val platform = getPlatformUtils().platform
+        val appPathProvider = TempAppPathProvider(tempRoot)
+        val configManager =
+            DesktopConfigManager(
+                FilePersist.createOneFilePersist(appPathProvider.resolve("appConfig.json", AppFileType.USER)),
+                DesktopLocaleUtils,
+            )
+        val module =
+            DesktopModule(
+                appEnv = AppEnv.TEST,
+                appMetadataRepository =
+                    AppMetadataRepository(
+                        FilePersist.createOneFilePersist(appPathProvider.resolve(".metadata", AppFileType.USER)),
+                        DesktopDeviceUtils(platform),
+                    ),
+                appPathProvider = appPathProvider,
+                configManager = configManager,
+                crossPasteLogger = mockk<CrossPasteLogger>(relaxed = true),
+                deviceUtils = DesktopDeviceUtils(platform),
+                klogger = KotlinLogging.logger {},
+                platform = platform,
+                headless = true,
+            )
+
+        val koin = koinApplication { modules(module.modules()) }.koin
+
+        // The startApplication() service set on the headless path.
+        assertNotNull(koin.get<DesktopConfigManager>())
+        assertNotNull(koin.get<NotificationManager>())
+        assertNotNull(koin.get<PasteboardService>())
+        assertNotNull(koin.get<QRCodeGenerator>())
+        assertNotNull(koin.get<SyncManager>())
+        assertNotNull(koin.get<PastePullService>())
+        assertNotNull(koin.get<Server>())
+        assertNotNull(koin.get<CliServer>())
+        assertNotNull(koin.get<McpServer>())
+        assertNotNull(koin.get<PasteClient>())
+        assertNotNull(koin.get<PasteBonjourService>())
+        assertNotNull(koin.get<CleanScheduler>())
+        assertNotNull(koin.get<DesktopPidFileService>())
+        assertNotNull(koin.get<RenderingService<String>>(named("urlRendering")))
+
+        // The shutdownAllServices()/runHeadless() service set on the headless path.
+        assertNotNull(koin.get<AppExitService>())
+        assertNotNull(koin.get<AppLock>())
+        assertNotNull(koin.get<TaskExecutor>())
+        assertNotNull(koin.get<UserDataPathProvider>())
+        assertNotNull(koin.get<ResourcesClient>())
+        assertNotNull(koin.get<DriverFactory>())
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopPasteServerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopPasteServerTest.kt
@@ -1,0 +1,46 @@
+package com.crosspaste.net
+
+import com.crosspaste.config.TestReadWritePort
+import com.crosspaste.net.exception.ExceptionHandler
+import io.ktor.server.netty.NettyApplicationEngine
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DesktopPasteServerTest {
+
+    @Test
+    fun startPropagatesFailureWhenConfiguredAndFallbackPortsBothFail() =
+        runTest {
+            val startupFailure = IllegalStateException("server factory unavailable")
+            val exceptionHandler =
+                mockk<ExceptionHandler> {
+                    every { isPortAlreadyInUse(any()) } returns true
+                }
+            val serverFactory =
+                mockk<
+                    ServerFactory<
+                        NettyApplicationEngine,
+                        NettyApplicationEngine.Configuration,
+                    >,
+                > {
+                    every { getFactory() } throws startupFailure
+                }
+            val server =
+                DesktopPasteServer(
+                    readWritePort = TestReadWritePort().apply { port = 12_345 },
+                    exceptionHandler = exceptionHandler,
+                    serverFactory = serverFactory,
+                    serverModule = mockk(relaxed = true),
+                )
+
+            val thrown = assertFailsWith<IllegalStateException> { server.start() }
+
+            assertEquals(startupFailure.message, thrown.message)
+            verify(exactly = 2) { serverFactory.getFactory() }
+        }
+}


### PR DESCRIPTION
Closes #4781. First implementation phase (P6.1) of the CLI daemon plan: make the existing `--headless` mode robust enough to serve as the per-machine peer process on servers.

## What changed

**Startup (CrossPaste.kt)**
- Interactive-only services now start only in GUI mode: `AppUpdateService` (its `DesktopAppUpdateService` requires the GUI-only `DesktopAppWindowManager` binding and previously crashed every headless startup with `NoDefinitionFoundException`), OS login-item autostart, browser native-messaging manifests, onboarding guide pastes, and the CLI symlink probe. Skiko loading moved off the headless path.
- A second headless instance now reports the conflict on stderr (with the running pid) and exits 1; a headless startup failure also exits 1. GUI keeps its historic silent exit(0).
- `CliServer.start()` now cleans up and rethrows on failure. Headless starts it synchronously and fails closed (the UDS API is the daemon's only control plane); the GUI keeps the asynchronous, degraded-CLI behavior.
- `DesktopPasteServer.start()` now cleans up partial state and propagates failures (retaining the random-port retry for port conflicts). Headless fails closed; the GUI degrades with a warning, preserving local pasteboard management when the sync endpoint cannot bind.

**Shutdown (CrossPaste.kt, DesktopPasteBonjourService.kt)**
- New idempotent `headlessShutdown()` runs the same chain as the GUI exit path (`beforeExitList` → `shutdownAllServices()` → `beforeReleaseLockList` → lock release), each step guarded. The shutdown hook is registered the moment the single-instance lock is acquired — never earlier, so a losing second instance cannot delete the running daemon's files — which makes SIGTERM during initialization safe.
- Shutdown now stops only services registered in an explicit lifecycle registry (`ManagedService`), instead of resolving via Koin (which could instantiate services that never ran). Services behind runtime toggles (pasteboard listening, MCP) are registered unconditionally and started conditionally, so instances started later through settings are still stopped.
- `DesktopPasteBonjourService.close()` cancels the network-change consumer before teardown and bounds the lifecycle wait to 4s (below the app's 5s shutdown budget), letting a stuck jmDNS call finish in the background.

**Headless DI (HeadlessModule.kt, DesktopModule.kt)**
- `headlessUiModule` now binds `PlatformContext`, closing the coil `ImageLoader`/`MemoryCache` lazy-resolution gap.
- `DesktopModule` exposes `modules(): List<Module>` so tests can build the exact headless assembly.

## Tests

- `HeadlessStartupResolutionTest`: resolves every service the headless startup/shutdown paths touch against the complete headless Koin assembly (this pins the `AppUpdateService` class of bug; verified it fails before the fix).
- `HeadlessDaemonProcessTest` (POSIX): black-box subprocess tests booting the real app with an isolated data dir — endpoint/pid/socket published on start and all removed on SIGTERM; second instance exits 1 without touching the running daemon's files; a CLI control-plane failure exits 1 with no endpoint left behind.
- `HeadlessModuleTest`: pins the `PlatformContext` binding, including cross-module resolution.
- `CliServerTest`: start() rethrows after cleanup on an unusable socket path.
- `DesktopPasteServerTest`: startup failure propagates after the port-retry path.
- Full `:app:desktopTest` suite green.

## Review notes

Independent review plus three follow-up review rounds; all P1/P2 findings fixed (headless `AppUpdateService` crash, CLI fail-closed, early shutdown hook, lifecycle registry gaps for runtime-toggled services, GUI degraded mode for the sync server, bounded Bonjour close). Intentionally unchanged: browser native-messaging manifests are not registered in headless mode (a headless server has no local browser); GUI second-instance and failure exits keep their historic silent exit(0) semantics; stale-pid detection in the second-instance message is out of scope (AppLock semantics).