### PR TITLE
:construction_worker: suppress expected Kotlin/Native disabled-target and cinterop commonization warnings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,13 @@ development=true
 
 kotlin.mpp.stability.nowarn=true
 
+# :cli declares all five release targets statically; targets the current host
+# cannot run are disabled by design, so silence the per-task warnings.
+kotlin.native.ignoreDisabledTargets=true
+# The :cli 'execpath' cinterop is only consumed from per-target leaf sources,
+# never from a shared native source set, so commonization has nothing to do.
+kotlin.mpp.enableCInteropCommonization.nowarn=true
+
 # Https Proxy
 # systemProp.https.proxyHost=localhost
 # systemProp.https.proxyPort=8080


### PR DESCRIPTION
Closes #4783

## Summary

Every Gradle sync/build emits ~10 warnings (`Native task 'xxx' is disabled` × 9 plus `CInterop Commonization Disabled`) because `:cli` statically declares all five release targets and the current host can only run its own. Both warnings flag intentional, documented behavior, so this adds the official suppression properties to `gradle.properties`:

- `kotlin.native.ignoreDisabledTargets=true` — the five-target declaration in `cli/build.gradle.kts` is deliberate (one Gradle invocation builds every target the host toolchain supports); non-host targets being disabled is by design. This is the suppression the Kotlin Gradle plugin's own diagnostic recommends (verified against KGP 2.4.10 sources — the same property covers both the target-level and the per-task warnings).
- `kotlin.mpp.enableCInteropCommonization.nowarn=true` — suppress rather than enable: the `:cli` `execpath` cinterop is only consumed from per-target leaf source sets, never from a shared native source set, so commonization would only add build time with nothing for consumers to gain.

## Verification

`./gradlew :cli:tasks` reproduced all 10 warnings before the change; after the change the output is clean and configuration succeeds.