### PR TITLE
:sparkles: pair devices from the terminal via the /cli pairing API

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -738,7 +738,7 @@ class SyncResolver(
 
             if (code.value != localSAS) {
                 logger.warn {
-                    "v2 SAS mismatch for $appInstanceId: expected $localSAS, got ${code.value} (possible MITM)"
+                    "v2 SAS mismatch for $appInstanceId (possible MITM)"
                 }
                 callback(false)
                 return

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -2,6 +2,7 @@ package com.crosspaste
 
 import com.crosspaste.app.AppEnv
 import com.crosspaste.cli.CliEndpointFile
+import com.crosspaste.cli.CliPairingService
 import com.crosspaste.cli.CliServer
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.image.DesktopFaviconLoader
@@ -72,6 +73,8 @@ import com.crosspaste.sync.SyncDeviceManager
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.sync.SyncResolver
 import com.crosspaste.sync.SyncResolverApi
+import com.crosspaste.ui.devices.DefaultPairingV3UiController
+import com.crosspaste.ui.devices.PairingV3UiController
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.websocket.WebSockets
@@ -84,9 +87,19 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
     module {
         // region CLI
         single<CliEndpointFile> { CliEndpointFile(get()) }
+        single<CliPairingService> {
+            CliPairingService(
+                nearbyDeviceManager = get(),
+                pairingCapabilityFlag = get(),
+                pairingV3UiController = get(),
+                pasteBonjourService = get(),
+                syncManager = get(),
+            )
+        }
         single<CliServer> {
             CliServer(
                 appInfo = get(),
+                cliPairingService = get(),
                 configManager = get(),
                 cliEndpointFile = get(),
                 pasteboardService = get(),
@@ -190,6 +203,10 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
 
         // region Pairing v3
         single<PairingAcceptanceWindow> { PairingAcceptanceWindow() }
+        // Despite the ui.devices package, this controller has no Compose
+        // dependency; it lives here so the headless daemon (which swaps the UI
+        // module for stubs) can drive initiator-side pairing through the CLI
+        single<PairingV3UiController> { DefaultPairingV3UiController(get(), get()) }
         single<PairingProtocolV3Service> {
             val pairingCapabilityFlag = get<PairingCapabilityFlag>()
             PairingProtocolV3Service(

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopUiModule.kt
@@ -43,11 +43,9 @@ import com.crosspaste.ui.base.DesktopUISupport
 import com.crosspaste.ui.base.MenuHelper
 import com.crosspaste.ui.base.SmartImageDisplayStrategy
 import com.crosspaste.ui.base.UISupport
-import com.crosspaste.ui.devices.DefaultPairingV3UiController
 import com.crosspaste.ui.devices.DesktopDeviceScopeFactory
 import com.crosspaste.ui.devices.DesktopSyncScopeFactory
 import com.crosspaste.ui.devices.DeviceScopeFactory
-import com.crosspaste.ui.devices.PairingV3UiController
 import com.crosspaste.ui.devices.SyncScopeFactory
 import com.crosspaste.ui.settings.DesktopStoragePathManager
 import com.crosspaste.ui.settings.StoragePathManager
@@ -102,7 +100,6 @@ fun desktopUiModule(): Module =
         single<GlobalCopywriter> { DesktopGlobalCopywriter(get(), lazy { get() }, get()) }
         single<MenuHelper> { MenuHelper(get(), get(), get(), get(), get(), get()) }
         single<NavigationManager> { get<DesktopScreenProvider>() }
-        single<PairingV3UiController> { DefaultPairingV3UiController(get(), get()) }
         single<ScreenProvider> { get<DesktopScreenProvider>() }
         single<SmartImageDisplayStrategy> { SmartImageDisplayStrategy() }
         single<StoragePathManager> { DesktopStoragePathManager() }

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
@@ -110,3 +110,51 @@ data class CliConfigSetRequest(
 data class CliMessageDto(
     val message: String,
 )
+
+@Serializable
+data class CliNearbyDeviceDto(
+    val appInstanceId: String,
+    val deviceName: String,
+    val platform: String,
+    val appVersion: String,
+    val pairingVersion: Int?,
+    /** [com.crosspaste.sync.PairingCredentialType] name the local peer would negotiate. */
+    val credentialType: String,
+)
+
+@Serializable
+data class CliPairInitiateRequest(
+    val appInstanceId: String,
+)
+
+@Serializable
+data class CliPairSessionDto(
+    val sessionId: String,
+    val appInstanceId: String,
+    val deviceName: String,
+    /** "SAS_CODE" or "V3_PIN"; QR-only peers are refused at initiate. */
+    val credentialType: String,
+    /** v3 only: acceptor identity-key fingerprint for out-of-band comparison. */
+    val peerFingerprint: String?,
+    /** v3 only: epoch millis after which the displayed PIN rotates. */
+    val pinExpiresAt: Long?,
+)
+
+@Serializable
+data class CliPairSubmitRequest(
+    val sessionId: String,
+    val code: String,
+)
+
+@Serializable
+data class CliPairSubmitResultDto(
+    val paired: Boolean,
+    /** When false the session is closed; a new `initiate` is required. */
+    val retryable: Boolean,
+    val message: String,
+)
+
+@Serializable
+data class CliPairCancelRequest(
+    val sessionId: String,
+)

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliPairingService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliPairingService.kt
@@ -17,10 +17,13 @@ import com.crosspaste.ui.devices.PairingV3UiController
 import com.crosspaste.ui.devices.PairingV3UiError
 import com.crosspaste.ui.devices.PairingV3UiResult
 import com.crosspaste.utils.DateUtils
+import com.crosspaste.utils.StripedMutex
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -59,6 +62,7 @@ class CliPairingService(
         private val SESSION_TTL = 10.minutes
         private val RESOLVE_TIMEOUT = 15.seconds
         private val TRUST_TIMEOUT = 30.seconds
+        private val RECOVERY_TIMEOUT = 10.seconds
         private val SCAN_START_TIMEOUT = 2.seconds
         private val SCAN_FINISH_TIMEOUT = 10.seconds
 
@@ -74,16 +78,17 @@ class CliPairingService(
         val credentialType: PairingCredentialType,
         val v3SessionId: String?,
         val createdAt: Long,
-        /**
-         * v3 only: the PIN was verified but the commit round-trip failed, so
-         * the next submit must drive retryCommit (via recover) instead of
-         * submitPin — a second submitPin against a COMMITTING session fails
-         * with PAIRING_INVALID_STATE and would force a full re-initiate.
-         */
-        val commitPending: Boolean = false,
+        val nextV3Action: V3Action = V3Action.SUBMIT_PIN,
+        val operationMutex: Mutex = Mutex(),
     )
 
+    private enum class V3Action {
+        SUBMIT_PIN,
+        RECOVER,
+    }
+
     private val sessions = ConcurrentHashMap<String, PairSession>()
+    private val initiateMutex = StripedMutex()
 
     sealed interface InitiateOutcome {
         data class Started(
@@ -133,7 +138,10 @@ class CliPairingService(
         return nearbyDeviceManager.nearbySyncInfos.value.map { it.toNearbyDto() }
     }
 
-    suspend fun initiate(appInstanceId: String): InitiateOutcome {
+    suspend fun initiate(appInstanceId: String): InitiateOutcome =
+        initiateMutex.withLock(appInstanceId) { initiateLocked(appInstanceId) }
+
+    private suspend fun initiateLocked(appInstanceId: String): InitiateOutcome {
         evictExpiredSessions()
         // A re-initiate for the same device supersedes the previous attempt;
         // cancel it so the peer's pending exchange / v3 session is released
@@ -234,20 +242,26 @@ class CliPairingService(
         code: String,
     ): SubmitOutcome {
         evictExpiredSessions()
-        val session = sessions[sessionId] ?: return SubmitOutcome.SessionNotFound
-        if (!SIX_DIGITS.matches(code)) {
-            return SubmitOutcome.InvalidCode
-        }
-        return when (session.credentialType) {
-            PairingCredentialType.SAS_CODE -> submitSas(session, code)
-            PairingCredentialType.V3_PIN -> submitV3(session, code)
-            PairingCredentialType.QR_BEARER_TOKEN ->
-                // Unreachable: initiate refuses QR peers
-                SubmitOutcome.SessionNotFound
+        val entry = sessions[sessionId] ?: return SubmitOutcome.SessionNotFound
+        return entry.operationMutex.withLock {
+            val session = sessions[sessionId] ?: return@withLock SubmitOutcome.SessionNotFound
+            if (!SIX_DIGITS.matches(code)) {
+                return@withLock SubmitOutcome.InvalidCode
+            }
+            when (session.credentialType) {
+                PairingCredentialType.SAS_CODE -> submitSas(session, code)
+                PairingCredentialType.V3_PIN -> submitV3(session, code)
+                PairingCredentialType.QR_BEARER_TOKEN ->
+                    // Unreachable: initiate refuses QR peers
+                    SubmitOutcome.SessionNotFound
+            }
         }
     }
 
     fun cancel(sessionId: String): Boolean {
+        // Cancellation wins ownership immediately instead of waiting behind a
+        // potentially hung submit. An in-flight submit cannot resurrect the
+        // removed entry because every state update uses computeIfPresent.
         val session = sessions.remove(sessionId) ?: return false
         when (session.credentialType) {
             PairingCredentialType.SAS_CODE -> syncManager.cancelPairing(session.appInstanceId)
@@ -307,86 +321,91 @@ class CliPairingService(
     private suspend fun submitV3(
         session: PairSession,
         code: String,
-    ): SubmitOutcome =
+    ): SubmitOutcome {
         // Symmetric to the SAS TRUST_TIMEOUT: the route must always answer
         // within the CLI's own budget even if a v3 round-trip hangs
-        withTimeoutOrNull(TRUST_TIMEOUT) { submitV3Steps(session, code) }
-            ?: SubmitOutcome.Completed(
+        val outcome = withTimeoutOrNull(TRUST_TIMEOUT) { submitV3Steps(session, code) }
+        if (outcome != null) {
+            return outcome
+        }
+
+        // Cancellation can leave the protocol session in PAKE_NEGOTIATING or
+        // COMMITTING. Recover on a fresh timeout scope before claiming the CLI
+        // session is retryable; if recovery also hangs, the next submit must
+        // retry recovery rather than feed another PIN into an unknown state.
+        if (!setNextV3Action(session, V3Action.RECOVER)) {
+            return SubmitOutcome.SessionNotFound
+        }
+        val recovered =
+            withTimeoutOrNull(RECOVERY_TIMEOUT) {
+                pairingV3UiController.recover(checkNotNull(session.v3SessionId))
+            }
+        return when (recovered) {
+            PairingV3UiResult.Paired -> completeV3Pairing(session)
+            is PairingV3UiResult.SessionReady -> {
+                if (setNextV3Action(session, V3Action.SUBMIT_PIN)) {
+                    retryableV3Failure(session, "Pairing timed out; check the connection and try again.")
+                } else {
+                    SubmitOutcome.SessionNotFound
+                }
+            }
+            is PairingV3UiResult.Error -> finishV3Error(session, recovered)
+            null ->
+                retryableV3Failure(session, "Pairing timed out; check the connection and try again.")
+        }
+    }
+
+    private fun retryableV3Failure(
+        session: PairSession,
+        message: String,
+    ): SubmitOutcome =
+        if (sessions.containsKey(session.sessionId)) {
+            SubmitOutcome.Completed(
                 CliPairSubmitResultDto(
                     paired = false,
                     retryable = true,
-                    message = "Pairing timed out; check the connection and try again.",
+                    message = message,
                 ),
             )
+        } else {
+            SubmitOutcome.SessionNotFound
+        }
 
     private suspend fun submitV3Steps(
         session: PairSession,
         code: String,
     ): SubmitOutcome {
         val v3SessionId = checkNotNull(session.v3SessionId)
+        var submittedPin = session.nextV3Action == V3Action.SUBMIT_PIN
         var result =
-            if (session.commitPending) {
-                // The previous attempt left the v3 session COMMITTING; recover
-                // drives retryCommit — a submitPin here would fail with
-                // PAIRING_INVALID_STATE and kill the session
-                pairingV3UiController.recover(v3SessionId)
-            } else {
+            if (submittedPin) {
                 pairingV3UiController.submitPin(v3SessionId, V3Pin(code))
+            } else {
+                pairingV3UiController.recover(v3SessionId)
             }
         if (result is PairingV3UiResult.SessionReady) {
-            // recover found the session back on a fresh offer instead of
-            // COMMITTING; the code the user just typed applies to that offer
-            setCommitPending(session, false)
+            if (!setNextV3Action(session, V3Action.SUBMIT_PIN)) {
+                return SubmitOutcome.SessionNotFound
+            }
             result = pairingV3UiController.submitPin(v3SessionId, V3Pin(code))
+            submittedPin = true
         }
-        if (result is PairingV3UiResult.Error && result.recovery == PairingV3Recovery.RETRY_COMMIT) {
-            // The PIN was verified but the commit round-trip failed; retryCommit
-            // can finish the pairing without asking for a new PIN.
+        if (submittedPin && result is PairingV3UiResult.Error && result.recovery.requiresRecovery()) {
+            val originalError = result
+            if (!setNextV3Action(session, V3Action.RECOVER)) {
+                return SubmitOutcome.SessionNotFound
+            }
             result = pairingV3UiController.recover(v3SessionId)
+            if (result is PairingV3UiResult.SessionReady) {
+                if (!setNextV3Action(session, V3Action.SUBMIT_PIN)) {
+                    return SubmitOutcome.SessionNotFound
+                }
+                return retryableV3Failure(session, describeV3Error(originalError.reason))
+            }
         }
         return when (result) {
-            PairingV3UiResult.Paired -> {
-                sessions.remove(session.sessionId)
-                // Converge the sync state machine to CONNECTED now that the
-                // peer key is persisted (same as the dialog's completePairing)
-                syncManager.refresh(listOf(session.appInstanceId))
-                SubmitOutcome.Completed(
-                    CliPairSubmitResultDto(
-                        paired = true,
-                        retryable = false,
-                        message = "Paired with ${session.deviceName}.",
-                    ),
-                )
-            }
-
-            is PairingV3UiResult.Error -> {
-                val retryable =
-                    when (result.reason) {
-                        PairingV3UiError.INCORRECT_PIN,
-                        PairingV3UiError.PIN_EXPIRED,
-                        PairingV3UiError.RATE_LIMITED,
-                        PairingV3UiError.NETWORK_FAILURE,
-                        -> true
-
-                        else -> false
-                    }
-                setCommitPending(session, retryable && result.recovery == PairingV3Recovery.RETRY_COMMIT)
-                if (retryable && result.recovery == PairingV3Recovery.REFRESH_OFFER) {
-                    // The failed generation is dead; fetch the next offer so the
-                    // retry matches the (possibly rotated) PIN on the peer.
-                    pairingV3UiController.recover(v3SessionId)
-                }
-                if (!retryable) {
-                    sessions.remove(session.sessionId)
-                }
-                SubmitOutcome.Completed(
-                    CliPairSubmitResultDto(
-                        paired = false,
-                        retryable = retryable,
-                        message = describeV3Error(result.reason),
-                    ),
-                )
-            }
+            PairingV3UiResult.Paired -> completeV3Pairing(session)
+            is PairingV3UiResult.Error -> finishV3Error(session, result)
 
             is PairingV3UiResult.SessionReady ->
                 // submitPin never returns SessionReady; treat defensively
@@ -399,6 +418,44 @@ class CliPairingService(
                 )
         }
     }
+
+    private fun completeV3Pairing(session: PairSession): SubmitOutcome {
+        sessions.remove(session.sessionId)
+        // Converge the sync state machine to CONNECTED now that the peer key is
+        // persisted (same as the dialog's completePairing).
+        syncManager.refresh(listOf(session.appInstanceId))
+        return SubmitOutcome.Completed(
+            CliPairSubmitResultDto(
+                paired = true,
+                retryable = false,
+                message = "Paired with ${session.deviceName}.",
+            ),
+        )
+    }
+
+    private fun finishV3Error(
+        session: PairSession,
+        error: PairingV3UiResult.Error,
+    ): SubmitOutcome {
+        val retryable = error.recovery.requiresRecovery()
+        if (retryable) {
+            if (!setNextV3Action(session, V3Action.RECOVER)) {
+                return SubmitOutcome.SessionNotFound
+            }
+        } else {
+            sessions.remove(session.sessionId)
+        }
+        return SubmitOutcome.Completed(
+            CliPairSubmitResultDto(
+                paired = false,
+                retryable = retryable,
+                message = describeV3Error(error.reason),
+            ),
+        )
+    }
+
+    private fun PairingV3Recovery.requiresRecovery(): Boolean =
+        this == PairingV3Recovery.REFRESH_OFFER || this == PairingV3Recovery.RETRY_COMMIT
 
     private suspend fun awaitPairableState(appInstanceId: String): SyncRuntimeInfo? =
         withTimeoutOrNull(RESOLVE_TIMEOUT) {
@@ -424,14 +481,17 @@ class CliPairingService(
         syncManager.realTimeSyncRuntimeInfos.value.firstOrNull { it.appInstanceId == appInstanceId }
 
     // Always writes through to the map: the caller's PairSession is a snapshot
-    // from submit entry and may be stale after an earlier update in the same call
-    private fun setCommitPending(
+    // from submit entry and may be stale after an earlier update in the same call.
+    private fun setNextV3Action(
         session: PairSession,
-        commitPending: Boolean,
-    ) {
+        action: V3Action,
+    ): Boolean {
+        var updated = false
         sessions.computeIfPresent(session.sessionId) { _, current ->
-            current.copy(commitPending = commitPending)
+            updated = true
+            current.copy(nextV3Action = action)
         }
+        return updated
     }
 
     private fun newSession(

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliPairingService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliPairingService.kt
@@ -1,0 +1,535 @@
+package com.crosspaste.cli
+
+import com.crosspaste.db.sync.SyncRuntimeInfo
+import com.crosspaste.db.sync.SyncState
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.net.PasteBonjourService
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
+import com.crosspaste.sync.NearbyDeviceManager
+import com.crosspaste.sync.PairingCredentialRefreshResult
+import com.crosspaste.sync.PairingCredentialType
+import com.crosspaste.sync.SasCode
+import com.crosspaste.sync.SyncManager
+import com.crosspaste.sync.V3Pin
+import com.crosspaste.sync.selectPairingCredentialType
+import com.crosspaste.ui.devices.PairingV3Recovery
+import com.crosspaste.ui.devices.PairingV3UiController
+import com.crosspaste.ui.devices.PairingV3UiError
+import com.crosspaste.ui.devices.PairingV3UiResult
+import com.crosspaste.utils.DateUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Initiator-side pairing driver for the /cli/pair routes (P6.2, D-P6-3).
+ *
+ * The CLI is a one-shot process, so pairing state between `initiate` and
+ * `submit` lives here as a short-lived in-memory session. Both credential
+ * flows reuse the exact call sequences the desktop dialogs use:
+ *
+ * - v2 SAS: persist the discovered peer ([SyncManager.updateSyncInfo]), wait
+ *   for the resolver to reach UNVERIFIED with a resolved host, warm up via
+ *   [SyncManager.exchangeKeysForPairing] (makes the peer display its SAS), then
+ *   confirm with [SyncManager.trustBySasCode].
+ * - v3 PIN: [PairingV3UiController.startPairing] / submitPin / recover, which
+ *   also makes the peer surface its pairing UI (showPairingCode) so a closed
+ *   acceptance window opens the same way it does for a GUI initiator.
+ *
+ * Abandoned sessions are the peer's responsibility to expire (v2 pending
+ * exchange TTL, v3 session TTL); the local [SESSION_TTL] only bounds this map.
+ * Pairing codes are never logged.
+ */
+class CliPairingService(
+    private val nearbyDeviceManager: NearbyDeviceManager,
+    private val pairingCapabilityFlag: PairingCapabilityFlag,
+    private val pairingV3UiController: PairingV3UiController,
+    private val pasteBonjourService: PasteBonjourService,
+    private val syncManager: SyncManager,
+) {
+
+    companion object {
+        private val SESSION_TTL = 10.minutes
+        private val RESOLVE_TIMEOUT = 15.seconds
+        private val TRUST_TIMEOUT = 30.seconds
+        private val SCAN_START_TIMEOUT = 2.seconds
+        private val SCAN_FINISH_TIMEOUT = 10.seconds
+
+        private val SIX_DIGITS = Regex("\\d{6}")
+    }
+
+    private val logger = KotlinLogging.logger {}
+
+    private data class PairSession(
+        val sessionId: String,
+        val appInstanceId: String,
+        val deviceName: String,
+        val credentialType: PairingCredentialType,
+        val v3SessionId: String?,
+        val createdAt: Long,
+        /**
+         * v3 only: the PIN was verified but the commit round-trip failed, so
+         * the next submit must drive retryCommit (via recover) instead of
+         * submitPin — a second submitPin against a COMMITTING session fails
+         * with PAIRING_INVALID_STATE and would force a full re-initiate.
+         */
+        val commitPending: Boolean = false,
+    )
+
+    private val sessions = ConcurrentHashMap<String, PairSession>()
+
+    sealed interface InitiateOutcome {
+        data class Started(
+            val session: CliPairSessionDto,
+        ) : InitiateOutcome
+
+        data class DeviceNotFound(
+            val message: String,
+        ) : InitiateOutcome
+
+        data class AlreadyPaired(
+            val message: String,
+        ) : InitiateOutcome
+
+        data class UnsupportedPeer(
+            val message: String,
+        ) : InitiateOutcome
+
+        data class Unavailable(
+            val message: String,
+        ) : InitiateOutcome
+    }
+
+    sealed interface SubmitOutcome {
+        data class Completed(
+            val result: CliPairSubmitResultDto,
+        ) : SubmitOutcome
+
+        data object SessionNotFound : SubmitOutcome
+
+        data object InvalidCode : SubmitOutcome
+    }
+
+    suspend fun nearbyDevices(refresh: Boolean): List<CliNearbyDeviceDto> {
+        if (refresh) {
+            pasteBonjourService.refreshAll()
+            // refreshAll is fire-and-forget; `searching` flips true for the
+            // scan and back. Tolerate a scan that finished before we started
+            // observing (start-flip timeout) or that never ran at all.
+            withTimeoutOrNull(SCAN_START_TIMEOUT) {
+                nearbyDeviceManager.searching.first { it }
+            }
+            withTimeoutOrNull(SCAN_FINISH_TIMEOUT) {
+                nearbyDeviceManager.searching.first { !it }
+            }
+        }
+        return nearbyDeviceManager.nearbySyncInfos.value.map { it.toNearbyDto() }
+    }
+
+    suspend fun initiate(appInstanceId: String): InitiateOutcome {
+        evictExpiredSessions()
+        // A re-initiate for the same device supersedes the previous attempt;
+        // cancel it so the peer's pending exchange / v3 session is released
+        // instead of lingering until its TTL.
+        sessions.values
+            .filter { it.appInstanceId == appInstanceId }
+            .forEach { cancel(it.sessionId) }
+
+        val nearby =
+            nearbyDeviceManager.nearbySyncInfos.value
+                .firstOrNull { it.appInfo.appInstanceId == appInstanceId }
+        val existing = findRuntimeInfo(appInstanceId)
+        when {
+            existing?.connectState == SyncState.CONNECTED ->
+                return InitiateOutcome.AlreadyPaired(
+                    "Device is already paired.",
+                )
+
+            nearby != null -> syncManager.updateSyncInfo(nearby)
+
+            existing != null -> syncManager.refresh(listOf(appInstanceId))
+
+            else ->
+                return InitiateOutcome.DeviceNotFound(
+                    "Device '$appInstanceId' was not found nearby. " +
+                        "Make sure CrossPaste is running on it and both are on the same network.",
+                )
+        }
+
+        val resolved = awaitPairableState(appInstanceId)
+        when {
+            resolved == null ->
+                return InitiateOutcome.Unavailable(
+                    "Device did not become reachable within ${RESOLVE_TIMEOUT.inWholeSeconds}s.",
+                )
+
+            resolved.connectState == SyncState.CONNECTED ->
+                return InitiateOutcome.AlreadyPaired("Device is already paired.")
+
+            resolved.connectState != SyncState.UNVERIFIED ->
+                return InitiateOutcome.Unavailable(
+                    "Device is in an unexpected state (${connectStateName(resolved.connectState)}); " +
+                        "check it in the CrossPaste app and retry.",
+                )
+        }
+
+        val credentialType =
+            when (val result = syncManager.refreshPairingCredentialType(appInstanceId)) {
+                is PairingCredentialRefreshResult.Resolved -> result.credentialType
+                else ->
+                    return InitiateOutcome.Unavailable(
+                        "Could not determine the pairing method for the device; retry in a moment.",
+                    )
+            }
+
+        val deviceName = resolved.getDeviceDisplayName()
+        return when (credentialType) {
+            PairingCredentialType.QR_BEARER_TOKEN ->
+                InitiateOutcome.UnsupportedPeer(
+                    "The device only supports QR pairing (app too old for CLI pairing); " +
+                        "update CrossPaste on it first.",
+                )
+
+            PairingCredentialType.SAS_CODE -> {
+                // Warm-up exchange so the peer displays its SAS before the
+                // user is asked to type it (same as the desktop dialog).
+                syncManager.exchangeKeysForPairing(appInstanceId)
+                InitiateOutcome.Started(
+                    newSession(appInstanceId, deviceName, credentialType, v3SessionId = null),
+                )
+            }
+
+            PairingCredentialType.V3_PIN ->
+                when (val result = pairingV3UiController.startPairing(appInstanceId)) {
+                    is PairingV3UiResult.SessionReady ->
+                        InitiateOutcome.Started(
+                            newSession(
+                                appInstanceId = appInstanceId,
+                                deviceName = deviceName,
+                                credentialType = credentialType,
+                                v3SessionId = result.sessionId,
+                                peerFingerprint = result.peerKeyFingerprintDisplay,
+                                pinExpiresAt = result.pinExpiresAt,
+                            ),
+                        )
+
+                    is PairingV3UiResult.Error ->
+                        InitiateOutcome.Unavailable(describeV3Error(result.reason))
+
+                    PairingV3UiResult.Paired ->
+                        InitiateOutcome.AlreadyPaired("Device is already paired.")
+                }
+        }
+    }
+
+    suspend fun submit(
+        sessionId: String,
+        code: String,
+    ): SubmitOutcome {
+        evictExpiredSessions()
+        val session = sessions[sessionId] ?: return SubmitOutcome.SessionNotFound
+        if (!SIX_DIGITS.matches(code)) {
+            return SubmitOutcome.InvalidCode
+        }
+        return when (session.credentialType) {
+            PairingCredentialType.SAS_CODE -> submitSas(session, code)
+            PairingCredentialType.V3_PIN -> submitV3(session, code)
+            PairingCredentialType.QR_BEARER_TOKEN ->
+                // Unreachable: initiate refuses QR peers
+                SubmitOutcome.SessionNotFound
+        }
+    }
+
+    fun cancel(sessionId: String): Boolean {
+        val session = sessions.remove(sessionId) ?: return false
+        when (session.credentialType) {
+            PairingCredentialType.SAS_CODE -> syncManager.cancelPairing(session.appInstanceId)
+            PairingCredentialType.V3_PIN ->
+                session.v3SessionId?.let { pairingV3UiController.cancelDetached(it) }
+            PairingCredentialType.QR_BEARER_TOKEN -> Unit
+        }
+        logger.info { "Cancelled CLI pairing session for ${session.appInstanceId}" }
+        return true
+    }
+
+    private suspend fun submitSas(
+        session: PairSession,
+        code: String,
+    ): SubmitOutcome {
+        val callbackResult =
+            withTimeoutOrNull(TRUST_TIMEOUT) {
+                suspendCancellableCoroutine { cont ->
+                    syncManager.trustBySasCode(session.appInstanceId, SasCode(code.toInt())) { ok ->
+                        cont.resume(ok)
+                    }
+                }
+            }
+        // trustBySasCode runs on the sync manager's own scope, so a timeout
+        // here does not cancel it — and it also reports false when the device
+        // is no longer UNVERIFIED, which includes "already CONNECTED" (e.g. a
+        // slow trust that finished after our timeout, then the user retried).
+        // Trust the observed state over the callback before reporting failure.
+        val trusted =
+            callbackResult == true ||
+                findRuntimeInfo(session.appInstanceId)?.connectState == SyncState.CONNECTED
+        return if (trusted) {
+            sessions.remove(session.sessionId)
+            SubmitOutcome.Completed(
+                CliPairSubmitResultDto(
+                    paired = true,
+                    retryable = false,
+                    message = "Paired with ${session.deviceName}.",
+                ),
+            )
+        } else {
+            // trustBySasCode reports one flag for mismatch, state change, and
+            // transport failure alike; each retry runs a fresh exchange, so the
+            // session stays usable.
+            SubmitOutcome.Completed(
+                CliPairSubmitResultDto(
+                    paired = false,
+                    retryable = true,
+                    message =
+                        "Pairing failed: the code did not match or the device is no longer ready. " +
+                            "Check the code shown on ${session.deviceName} and try again.",
+                ),
+            )
+        }
+    }
+
+    private suspend fun submitV3(
+        session: PairSession,
+        code: String,
+    ): SubmitOutcome =
+        // Symmetric to the SAS TRUST_TIMEOUT: the route must always answer
+        // within the CLI's own budget even if a v3 round-trip hangs
+        withTimeoutOrNull(TRUST_TIMEOUT) { submitV3Steps(session, code) }
+            ?: SubmitOutcome.Completed(
+                CliPairSubmitResultDto(
+                    paired = false,
+                    retryable = true,
+                    message = "Pairing timed out; check the connection and try again.",
+                ),
+            )
+
+    private suspend fun submitV3Steps(
+        session: PairSession,
+        code: String,
+    ): SubmitOutcome {
+        val v3SessionId = checkNotNull(session.v3SessionId)
+        var result =
+            if (session.commitPending) {
+                // The previous attempt left the v3 session COMMITTING; recover
+                // drives retryCommit — a submitPin here would fail with
+                // PAIRING_INVALID_STATE and kill the session
+                pairingV3UiController.recover(v3SessionId)
+            } else {
+                pairingV3UiController.submitPin(v3SessionId, V3Pin(code))
+            }
+        if (result is PairingV3UiResult.SessionReady) {
+            // recover found the session back on a fresh offer instead of
+            // COMMITTING; the code the user just typed applies to that offer
+            setCommitPending(session, false)
+            result = pairingV3UiController.submitPin(v3SessionId, V3Pin(code))
+        }
+        if (result is PairingV3UiResult.Error && result.recovery == PairingV3Recovery.RETRY_COMMIT) {
+            // The PIN was verified but the commit round-trip failed; retryCommit
+            // can finish the pairing without asking for a new PIN.
+            result = pairingV3UiController.recover(v3SessionId)
+        }
+        return when (result) {
+            PairingV3UiResult.Paired -> {
+                sessions.remove(session.sessionId)
+                // Converge the sync state machine to CONNECTED now that the
+                // peer key is persisted (same as the dialog's completePairing)
+                syncManager.refresh(listOf(session.appInstanceId))
+                SubmitOutcome.Completed(
+                    CliPairSubmitResultDto(
+                        paired = true,
+                        retryable = false,
+                        message = "Paired with ${session.deviceName}.",
+                    ),
+                )
+            }
+
+            is PairingV3UiResult.Error -> {
+                val retryable =
+                    when (result.reason) {
+                        PairingV3UiError.INCORRECT_PIN,
+                        PairingV3UiError.PIN_EXPIRED,
+                        PairingV3UiError.RATE_LIMITED,
+                        PairingV3UiError.NETWORK_FAILURE,
+                        -> true
+
+                        else -> false
+                    }
+                setCommitPending(session, retryable && result.recovery == PairingV3Recovery.RETRY_COMMIT)
+                if (retryable && result.recovery == PairingV3Recovery.REFRESH_OFFER) {
+                    // The failed generation is dead; fetch the next offer so the
+                    // retry matches the (possibly rotated) PIN on the peer.
+                    pairingV3UiController.recover(v3SessionId)
+                }
+                if (!retryable) {
+                    sessions.remove(session.sessionId)
+                }
+                SubmitOutcome.Completed(
+                    CliPairSubmitResultDto(
+                        paired = false,
+                        retryable = retryable,
+                        message = describeV3Error(result.reason),
+                    ),
+                )
+            }
+
+            is PairingV3UiResult.SessionReady ->
+                // submitPin never returns SessionReady; treat defensively
+                SubmitOutcome.Completed(
+                    CliPairSubmitResultDto(
+                        paired = false,
+                        retryable = true,
+                        message = "Pairing is not complete yet; enter the PIN shown on ${session.deviceName}.",
+                    ),
+                )
+        }
+    }
+
+    private suspend fun awaitPairableState(appInstanceId: String): SyncRuntimeInfo? =
+        withTimeoutOrNull(RESOLVE_TIMEOUT) {
+            syncManager.realTimeSyncRuntimeInfos
+                .map { infos -> infos.firstOrNull { it.appInstanceId == appInstanceId } }
+                .first { info ->
+                    info != null &&
+                        when (info.connectState) {
+                            SyncState.CONNECTED,
+                            SyncState.UNMATCHED,
+                            SyncState.INCOMPATIBLE,
+                            -> true
+
+                            SyncState.UNVERIFIED -> info.connectHostAddress != null
+                            // DISCONNECTED can be a transient probe result while
+                            // the resolver walks the host list; keep waiting
+                            else -> false
+                        }
+                }
+        }
+
+    private fun findRuntimeInfo(appInstanceId: String): SyncRuntimeInfo? =
+        syncManager.realTimeSyncRuntimeInfos.value.firstOrNull { it.appInstanceId == appInstanceId }
+
+    // Always writes through to the map: the caller's PairSession is a snapshot
+    // from submit entry and may be stale after an earlier update in the same call
+    private fun setCommitPending(
+        session: PairSession,
+        commitPending: Boolean,
+    ) {
+        sessions.computeIfPresent(session.sessionId) { _, current ->
+            current.copy(commitPending = commitPending)
+        }
+    }
+
+    private fun newSession(
+        appInstanceId: String,
+        deviceName: String,
+        credentialType: PairingCredentialType,
+        v3SessionId: String?,
+        peerFingerprint: String? = null,
+        pinExpiresAt: Long? = null,
+    ): CliPairSessionDto {
+        val session =
+            PairSession(
+                sessionId = UUID.randomUUID().toString(),
+                appInstanceId = appInstanceId,
+                deviceName = deviceName,
+                credentialType = credentialType,
+                v3SessionId = v3SessionId,
+                createdAt = DateUtils.nowEpochMilliseconds(),
+            )
+        sessions[session.sessionId] = session
+        return CliPairSessionDto(
+            sessionId = session.sessionId,
+            appInstanceId = appInstanceId,
+            deviceName = deviceName,
+            credentialType = credentialType.name,
+            peerFingerprint = peerFingerprint,
+            pinExpiresAt = pinExpiresAt,
+        )
+    }
+
+    private fun evictExpiredSessions() {
+        val cutoff = DateUtils.nowEpochMilliseconds() - SESSION_TTL.inWholeMilliseconds
+        sessions.values
+            .filter { it.createdAt < cutoff }
+            .forEach { sessions.remove(it.sessionId) }
+    }
+
+    private fun SyncInfo.toNearbyDto(): CliNearbyDeviceDto =
+        CliNearbyDeviceDto(
+            appInstanceId = appInfo.appInstanceId,
+            deviceName = endpointInfo.deviceName,
+            platform = endpointInfo.platform.name,
+            appVersion = appInfo.appVersion,
+            pairingVersion = appInfo.pairingVersion,
+            credentialType =
+                selectPairingCredentialType(
+                    localPairingVersion = pairingCapabilityFlag.advertisedPairingVersion,
+                    remotePairingVersion = appInfo.pairingVersion,
+                ).name,
+        )
+
+    private fun connectStateName(state: Int): String =
+        when (state) {
+            SyncState.CONNECTED -> "connected"
+            SyncState.CONNECTING -> "connecting"
+            SyncState.DISCONNECTED -> "disconnected"
+            SyncState.UNMATCHED -> "unmatched"
+            SyncState.UNVERIFIED -> "unverified"
+            SyncState.INCOMPATIBLE -> "incompatible"
+            else -> "unknown($state)"
+        }
+
+    private fun describeV3Error(reason: PairingV3UiError): String =
+        when (reason) {
+            PairingV3UiError.NOT_ACCEPTING ->
+                "The device is not accepting pairing right now; open CrossPaste on it and retry."
+
+            PairingV3UiError.INCORRECT_PIN ->
+                "Incorrect PIN. The device now shows a new PIN; enter that one."
+
+            PairingV3UiError.PIN_EXPIRED ->
+                "The PIN expired. The device now shows a new PIN; enter that one."
+
+            PairingV3UiError.REJECTED ->
+                "Pairing was rejected on the device."
+
+            PairingV3UiError.CANCELLED ->
+                "Pairing was cancelled."
+
+            PairingV3UiError.SESSION_EXPIRED ->
+                "The pairing session expired; start pairing again."
+
+            PairingV3UiError.RATE_LIMITED ->
+                "Too many attempts; wait a moment and try again."
+
+            PairingV3UiError.CAPACITY_EXCEEDED ->
+                "The device has too many pairing sessions in progress; try again shortly."
+
+            PairingV3UiError.UNSUPPORTED ->
+                "The device does not support this pairing protocol."
+
+            PairingV3UiError.IDENTITY_INVALID ->
+                "Identity verification failed; aborting pairing (possible interference)."
+
+            PairingV3UiError.NETWORK_FAILURE ->
+                "Network failure while pairing; check the connection and try again."
+
+            PairingV3UiError.FAILED ->
+                "Pairing failed; start pairing again."
+        }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -38,6 +38,7 @@ private val configJson = Json { encodeDefaults = true }
 
 fun Routing.cliRouting(
     appInfo: AppInfo,
+    cliPairingService: CliPairingService,
     configManager: DesktopConfigManager,
     pasteboardService: PasteboardService,
     pasteDao: PasteDao,
@@ -119,6 +120,97 @@ fun Routing.cliRouting(
             val id = call.requireLongParameter("id", "Invalid paste id.") ?: return@delete
             handlePasteDelete(call, id, pasteDao)
         }
+
+        route("/pair") {
+            get("/nearby") {
+                handlePairNearby(call, cliPairingService)
+            }
+
+            post("/initiate") {
+                handlePairInitiate(call, cliPairingService)
+            }
+
+            post("/submit") {
+                handlePairSubmit(call, cliPairingService)
+            }
+
+            post("/cancel") {
+                handlePairCancel(call, cliPairingService)
+            }
+        }
+    }
+}
+
+private suspend fun handlePairNearby(
+    call: ApplicationCall,
+    cliPairingService: CliPairingService,
+) {
+    val refresh = call.request.queryParameters["refresh"] == "true"
+    call.respond(cliPairingService.nearbyDevices(refresh))
+}
+
+private suspend fun handlePairInitiate(
+    call: ApplicationCall,
+    cliPairingService: CliPairingService,
+) {
+    val request = call.receive<CliPairInitiateRequest>()
+    if (request.appInstanceId.isBlank()) {
+        call.respond(HttpStatusCode.BadRequest, CliMessageDto("appInstanceId must not be blank."))
+        return
+    }
+    when (val outcome = cliPairingService.initiate(request.appInstanceId)) {
+        is CliPairingService.InitiateOutcome.Started ->
+            call.respond(outcome.session)
+
+        is CliPairingService.InitiateOutcome.DeviceNotFound ->
+            call.respond(HttpStatusCode.NotFound, CliMessageDto(outcome.message))
+
+        is CliPairingService.InitiateOutcome.AlreadyPaired ->
+            call.respond(HttpStatusCode.Conflict, CliMessageDto(outcome.message))
+
+        is CliPairingService.InitiateOutcome.UnsupportedPeer ->
+            call.respond(HttpStatusCode.BadRequest, CliMessageDto(outcome.message))
+
+        is CliPairingService.InitiateOutcome.Unavailable ->
+            call.respond(HttpStatusCode.BadGateway, CliMessageDto(outcome.message))
+    }
+}
+
+private suspend fun handlePairSubmit(
+    call: ApplicationCall,
+    cliPairingService: CliPairingService,
+) {
+    val request = call.receive<CliPairSubmitRequest>()
+    when (val outcome = cliPairingService.submit(request.sessionId, request.code)) {
+        is CliPairingService.SubmitOutcome.Completed ->
+            call.respond(outcome.result)
+
+        CliPairingService.SubmitOutcome.SessionNotFound ->
+            call.respond(
+                HttpStatusCode.NotFound,
+                CliMessageDto("Pairing session not found or expired; start pairing again."),
+            )
+
+        CliPairingService.SubmitOutcome.InvalidCode ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                CliMessageDto("The pairing code must be exactly 6 digits."),
+            )
+    }
+}
+
+private suspend fun handlePairCancel(
+    call: ApplicationCall,
+    cliPairingService: CliPairingService,
+) {
+    val request = call.receive<CliPairCancelRequest>()
+    if (cliPairingService.cancel(request.sessionId)) {
+        call.respond(CliMessageDto("Pairing cancelled."))
+    } else {
+        call.respond(
+            HttpStatusCode.NotFound,
+            CliMessageDto("Pairing session not found or expired."),
+        )
     }
 }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliServer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliServer.kt
@@ -49,6 +49,7 @@ import kotlin.time.Duration.Companion.milliseconds
  */
 class CliServer(
     private val appInfo: AppInfo,
+    private val cliPairingService: CliPairingService,
     private val configManager: DesktopConfigManager,
     private val cliEndpointFile: CliEndpointFile,
     private val pasteboardService: PasteboardService,
@@ -185,6 +186,7 @@ class CliServer(
         routing {
             cliRouting(
                 appInfo = appInfo,
+                cliPairingService = cliPairingService,
                 configManager = configManager,
                 pasteboardService = pasteboardService,
                 pasteDao = pasteDao,

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliDtoContractTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliDtoContractTest.kt
@@ -175,6 +175,78 @@ class CliDtoContractTest {
     }
 
     @Test
+    fun `pair dtos keep their wire fields`() {
+        assertEquals(
+            setOf("appInstanceId", "deviceName", "platform", "appVersion", "pairingVersion", "credentialType"),
+            fieldsOf(
+                json.encodeToString(
+                    CliNearbyDeviceDto.serializer(),
+                    CliNearbyDeviceDto(
+                        appInstanceId = "instance",
+                        deviceName = "device",
+                        platform = "Macos",
+                        appVersion = "2.1.7",
+                        pairingVersion = 2,
+                        credentialType = "SAS_CODE",
+                    ),
+                ),
+            ),
+        )
+        assertEquals(
+            setOf("appInstanceId"),
+            fieldsOf(
+                json.encodeToString(
+                    CliPairInitiateRequest.serializer(),
+                    CliPairInitiateRequest("instance"),
+                ),
+            ),
+        )
+        assertEquals(
+            setOf("sessionId", "appInstanceId", "deviceName", "credentialType", "peerFingerprint", "pinExpiresAt"),
+            fieldsOf(
+                json.encodeToString(
+                    CliPairSessionDto.serializer(),
+                    CliPairSessionDto(
+                        sessionId = "session",
+                        appInstanceId = "instance",
+                        deviceName = "device",
+                        credentialType = "V3_PIN",
+                        peerFingerprint = "AB:CD",
+                        pinExpiresAt = 123L,
+                    ),
+                ),
+            ),
+        )
+        assertEquals(
+            setOf("sessionId", "code"),
+            fieldsOf(
+                json.encodeToString(
+                    CliPairSubmitRequest.serializer(),
+                    CliPairSubmitRequest("session", "123456"),
+                ),
+            ),
+        )
+        assertEquals(
+            setOf("paired", "retryable", "message"),
+            fieldsOf(
+                json.encodeToString(
+                    CliPairSubmitResultDto.serializer(),
+                    CliPairSubmitResultDto(paired = true, retryable = false, message = "ok"),
+                ),
+            ),
+        )
+        assertEquals(
+            setOf("sessionId"),
+            fieldsOf(
+                json.encodeToString(
+                    CliPairCancelRequest.serializer(),
+                    CliPairCancelRequest("session"),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `endpoint file keeps its wire fields`() {
         val encoded =
             json.encodeToString(

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliPairingServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliPairingServiceTest.kt
@@ -26,6 +26,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -331,6 +332,37 @@ class CliPairingServiceTest {
             )
         }
 
+    @Test
+    fun `concurrent initiates for the same device are serialized`() =
+        runTest {
+            val fixture = Fixture()
+            fixture.nearbySyncInfos.value = listOf(syncInfo())
+            every { fixture.syncManager.updateSyncInfo(any()) } answers {
+                fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+            }
+            val enteredCredentialRefresh = CompletableDeferred<Unit>()
+            val releaseCredentialRefresh = CompletableDeferred<Unit>()
+            coEvery { fixture.syncManager.refreshPairingCredentialType(PEER_ID) } coAnswers {
+                enteredCredentialRefresh.complete(Unit)
+                releaseCredentialRefresh.await()
+                PairingCredentialRefreshResult.Resolved(PairingCredentialType.SAS_CODE)
+            }
+
+            val first = async { fixture.service.initiate(PEER_ID) }
+            enteredCredentialRefresh.await()
+            val second = async { fixture.service.initiate(PEER_ID) }
+            yield()
+            assertFalse(second.isCompleted)
+
+            releaseCredentialRefresh.complete(Unit)
+            val firstSession = assertIs<CliPairingService.InitiateOutcome.Started>(first.await()).session
+            assertIs<CliPairingService.InitiateOutcome.Started>(second.await())
+            verify(exactly = 1) { fixture.syncManager.cancelPairing(PEER_ID) }
+            assertIs<CliPairingService.SubmitOutcome.SessionNotFound>(
+                fixture.service.submit(firstSession.sessionId, "123456"),
+            )
+        }
+
     // endregion
 
     // region submit
@@ -460,7 +492,7 @@ class CliPairingServiceTest {
         }
 
     @Test
-    fun `submit v3 remembers a pending commit and retries it on the next submit`() =
+    fun `submit v3 remembers pending recovery and retries commit on the next submit`() =
         runTest {
             val fixture = Fixture(localPairingVersion = 3)
             val session = startedV3Session(fixture)
@@ -497,6 +529,8 @@ class CliPairingServiceTest {
             coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } coAnswers {
                 awaitCancellation()
             }
+            coEvery { fixture.pairingV3UiController.recover("v3-session") } returns
+                PairingV3UiResult.SessionReady("v3-session", 2L, 789L, "")
 
             val outcome = fixture.service.submit(session.sessionId, "123456")
 
@@ -504,6 +538,90 @@ class CliPairingServiceTest {
             assertFalse(completed.result.paired)
             assertTrue(completed.result.retryable)
             assertContains(completed.result.message, "timed out")
+            coVerify(exactly = 1) { fixture.pairingV3UiController.recover("v3-session") }
+        }
+
+    @Test
+    fun `submit v3 retries recovery before using another pin after refresh fails`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("111111")) } returns
+                PairingV3UiResult.Error(PairingV3UiError.INCORRECT_PIN, PairingV3Recovery.REFRESH_OFFER)
+            coEvery { fixture.pairingV3UiController.recover("v3-session") } returns
+                PairingV3UiResult.Error(PairingV3UiError.NETWORK_FAILURE, PairingV3Recovery.REFRESH_OFFER)
+
+            val first =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "111111"),
+                )
+            assertFalse(first.result.paired)
+            assertTrue(first.result.retryable)
+
+            coEvery { fixture.pairingV3UiController.recover("v3-session") } returns
+                PairingV3UiResult.SessionReady("v3-session", 2L, 789L, "")
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } returns
+                PairingV3UiResult.Paired
+
+            val second =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "123456"),
+                )
+            assertTrue(second.result.paired)
+            coVerify(exactly = 2) { fixture.pairingV3UiController.recover("v3-session") }
+        }
+
+    @Test
+    fun `concurrent v3 submits are serialized per session`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            val enteredProtocol = CompletableDeferred<Unit>()
+            val releaseProtocol = CompletableDeferred<Unit>()
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } coAnswers {
+                enteredProtocol.complete(Unit)
+                releaseProtocol.await()
+                PairingV3UiResult.Paired
+            }
+
+            val first = async { fixture.service.submit(session.sessionId, "123456") }
+            enteredProtocol.await()
+            val second = async { fixture.service.submit(session.sessionId, "123456") }
+            yield()
+            assertFalse(second.isCompleted)
+
+            releaseProtocol.complete(Unit)
+            val firstResult = assertIs<CliPairingService.SubmitOutcome.Completed>(first.await())
+            assertTrue(firstResult.result.paired)
+            assertIs<CliPairingService.SubmitOutcome.SessionNotFound>(second.await())
+            coVerify(exactly = 1) {
+                fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456"))
+            }
+        }
+
+    @Test
+    fun `cancelled v3 session is not resurrected by an in-flight submit`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            val enteredProtocol = CompletableDeferred<Unit>()
+            val releaseProtocol = CompletableDeferred<Unit>()
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } coAnswers {
+                enteredProtocol.complete(Unit)
+                releaseProtocol.await()
+                PairingV3UiResult.Error(PairingV3UiError.NETWORK_FAILURE, PairingV3Recovery.REFRESH_OFFER)
+            }
+            every { fixture.pairingV3UiController.cancelDetached("v3-session") } just Runs
+
+            val submit = async { fixture.service.submit(session.sessionId, "123456") }
+            enteredProtocol.await()
+            assertTrue(fixture.service.cancel(session.sessionId))
+            releaseProtocol.complete(Unit)
+
+            assertIs<CliPairingService.SubmitOutcome.SessionNotFound>(submit.await())
+            assertIs<CliPairingService.SubmitOutcome.SessionNotFound>(
+                fixture.service.submit(session.sessionId, "123456"),
+            )
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliPairingServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliPairingServiceTest.kt
@@ -1,0 +1,608 @@
+package com.crosspaste.cli
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.db.sync.SyncRuntimeInfo
+import com.crosspaste.db.sync.SyncState
+import com.crosspaste.dto.sync.EndpointInfo
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.net.PasteBonjourService
+import com.crosspaste.pairing.v3.PairingCapabilityFlag
+import com.crosspaste.platform.Platform
+import com.crosspaste.sync.NearbyDeviceManager
+import com.crosspaste.sync.PairingCredentialRefreshResult
+import com.crosspaste.sync.PairingCredentialType
+import com.crosspaste.sync.SasCode
+import com.crosspaste.sync.SyncManager
+import com.crosspaste.sync.V3Pin
+import com.crosspaste.ui.devices.PairingV3Recovery
+import com.crosspaste.ui.devices.PairingV3UiController
+import com.crosspaste.ui.devices.PairingV3UiError
+import com.crosspaste.ui.devices.PairingV3UiResult
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CliPairingServiceTest {
+
+    private companion object {
+        const val PEER_ID = "peer-1"
+        const val PEER_NAME = "Laptop"
+    }
+
+    private val platform = Platform(name = Platform.MACOS, arch = "arm64", bitMode = 64, version = "15")
+
+    private class Fixture(
+        localPairingVersion: Int = 2,
+    ) {
+        val nearbySyncInfos = MutableStateFlow<List<SyncInfo>>(listOf())
+        val searching = MutableStateFlow(false)
+        val runtimeInfos = MutableStateFlow<List<SyncRuntimeInfo>>(listOf())
+
+        val nearbyDeviceManager =
+            mockk<NearbyDeviceManager> {
+                every { nearbySyncInfos } returns this@Fixture.nearbySyncInfos
+                every { searching } returns this@Fixture.searching
+            }
+        val pairingV3UiController = mockk<PairingV3UiController>()
+        val pasteBonjourService =
+            mockk<PasteBonjourService> {
+                every { refreshAll() } just Runs
+            }
+        val syncManager =
+            mockk<SyncManager> {
+                every { realTimeSyncRuntimeInfos } returns runtimeInfos
+                every { updateSyncInfo(any()) } just Runs
+                every { refresh(any(), any()) } just Runs
+                every { exchangeKeysForPairing(any()) } just Runs
+                every { cancelPairing(any()) } just Runs
+            }
+
+        val service =
+            CliPairingService(
+                nearbyDeviceManager = nearbyDeviceManager,
+                pairingCapabilityFlag = PairingCapabilityFlag(localPairingVersion),
+                pairingV3UiController = pairingV3UiController,
+                pasteBonjourService = pasteBonjourService,
+                syncManager = syncManager,
+            )
+    }
+
+    private fun syncInfo(pairingVersion: Int? = 2): SyncInfo =
+        SyncInfo(
+            appInfo =
+                AppInfo(
+                    appInstanceId = PEER_ID,
+                    appVersion = "2.1.7",
+                    appRevision = "Unknown",
+                    userName = "tester",
+                    pairingVersion = pairingVersion,
+                ),
+            endpointInfo =
+                EndpointInfo(
+                    deviceId = "device-1",
+                    deviceName = PEER_NAME,
+                    platform = platform,
+                    hostInfoList = listOf(HostInfo(24, "192.168.1.10")),
+                    port = 13129,
+                ),
+        )
+
+    private fun runtimeInfo(
+        connectState: Int,
+        connectHostAddress: String? = "192.168.1.10",
+    ): SyncRuntimeInfo =
+        SyncRuntimeInfo(
+            appInstanceId = PEER_ID,
+            appVersion = "2.1.7",
+            userName = "tester",
+            deviceId = "device-1",
+            deviceName = PEER_NAME,
+            platform = platform,
+            port = 13129,
+            connectHostAddress = connectHostAddress,
+            connectState = connectState,
+        )
+
+    // region nearby
+
+    @Test
+    fun `nearby maps sync infos with the negotiated credential type`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 2)
+            fixture.nearbySyncInfos.value =
+                listOf(
+                    syncInfo(pairingVersion = 3),
+                    syncInfo(pairingVersion = null).let {
+                        it.copy(appInfo = it.appInfo.copy(appInstanceId = "legacy-peer"))
+                    },
+                )
+
+            val devices = fixture.service.nearbyDevices(refresh = false)
+
+            assertEquals(2, devices.size)
+            // Local advertises v2, so a v3-capable peer still negotiates SAS
+            assertEquals("SAS_CODE", devices[0].credentialType)
+            assertEquals("QR_BEARER_TOKEN", devices[1].credentialType)
+            verify(exactly = 0) { fixture.pasteBonjourService.refreshAll() }
+        }
+
+    @Test
+    fun `nearby refresh triggers a scan and waits for it to finish`() =
+        runTest {
+            val fixture = Fixture()
+            every { fixture.pasteBonjourService.refreshAll() } answers {
+                fixture.searching.value = true
+            }
+            // Simulates the scan completing while the service waits on it
+            val scanFinisher =
+                launch {
+                    fixture.searching.first { it }
+                    fixture.nearbySyncInfos.value = listOf(syncInfo())
+                    fixture.searching.value = false
+                }
+
+            val devices = fixture.service.nearbyDevices(refresh = true)
+
+            assertEquals(1, devices.size)
+            verify(exactly = 1) { fixture.pasteBonjourService.refreshAll() }
+            scanFinisher.join()
+        }
+
+    // endregion
+
+    // region initiate
+
+    @Test
+    fun `initiate refuses an unknown device`() =
+        runTest {
+            val fixture = Fixture()
+
+            val outcome = fixture.service.initiate("nobody")
+
+            assertIs<CliPairingService.InitiateOutcome.DeviceNotFound>(outcome)
+        }
+
+    @Test
+    fun `initiate refuses an already paired device`() =
+        runTest {
+            val fixture = Fixture()
+            fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.CONNECTED))
+
+            val outcome = fixture.service.initiate(PEER_ID)
+
+            assertIs<CliPairingService.InitiateOutcome.AlreadyPaired>(outcome)
+        }
+
+    @Test
+    fun `initiate v2 persists the device warms up the exchange and starts a session`() =
+        runTest {
+            val fixture = Fixture()
+            fixture.nearbySyncInfos.value = listOf(syncInfo(pairingVersion = 2))
+            every { fixture.syncManager.updateSyncInfo(any()) } answers {
+                fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+            }
+            coEvery { fixture.syncManager.refreshPairingCredentialType(PEER_ID) } returns
+                PairingCredentialRefreshResult.Resolved(PairingCredentialType.SAS_CODE)
+
+            val outcome = fixture.service.initiate(PEER_ID)
+
+            val started = assertIs<CliPairingService.InitiateOutcome.Started>(outcome)
+            assertEquals("SAS_CODE", started.session.credentialType)
+            assertEquals(PEER_NAME, started.session.deviceName)
+            assertNull(started.session.peerFingerprint)
+            verify(exactly = 1) { fixture.syncManager.updateSyncInfo(any()) }
+            verify(exactly = 1) { fixture.syncManager.exchangeKeysForPairing(PEER_ID) }
+        }
+
+    @Test
+    fun `initiate refuses a qr-only peer`() =
+        runTest {
+            val fixture = Fixture()
+            fixture.nearbySyncInfos.value = listOf(syncInfo(pairingVersion = null))
+            every { fixture.syncManager.updateSyncInfo(any()) } answers {
+                fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+            }
+            coEvery { fixture.syncManager.refreshPairingCredentialType(PEER_ID) } returns
+                PairingCredentialRefreshResult.Resolved(PairingCredentialType.QR_BEARER_TOKEN)
+
+            val outcome = fixture.service.initiate(PEER_ID)
+
+            assertIs<CliPairingService.InitiateOutcome.UnsupportedPeer>(outcome)
+        }
+
+    @Test
+    fun `initiate reports an unreachable device after the resolve timeout`() =
+        runTest {
+            val fixture = Fixture()
+            fixture.nearbySyncInfos.value = listOf(syncInfo())
+            // updateSyncInfo never produces a resolvable runtime row
+
+            val outcome = fixture.service.initiate(PEER_ID)
+
+            val unavailable = assertIs<CliPairingService.InitiateOutcome.Unavailable>(outcome)
+            assertContains(unavailable.message, "reachable")
+        }
+
+    @Test
+    fun `initiate keeps waiting through a transient disconnected probe`() =
+        runTest {
+            val fixture = Fixture()
+            fixture.nearbySyncInfos.value = listOf(syncInfo())
+            every { fixture.syncManager.updateSyncInfo(any()) } answers {
+                fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.DISCONNECTED, connectHostAddress = null))
+            }
+            coEvery { fixture.syncManager.refreshPairingCredentialType(PEER_ID) } returns
+                PairingCredentialRefreshResult.Resolved(PairingCredentialType.SAS_CODE)
+
+            // Flip to UNVERIFIED while the service is waiting
+            val outcomeDeferred =
+                async {
+                    fixture.service.initiate(PEER_ID)
+                }
+            yield()
+            fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+            val outcome = outcomeDeferred.await()
+
+            assertIs<CliPairingService.InitiateOutcome.Started>(outcome)
+        }
+
+    @Test
+    fun `initiate v3 returns fingerprint and pin expiry from the controller`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            fixture.nearbySyncInfos.value = listOf(syncInfo(pairingVersion = 3))
+            every { fixture.syncManager.updateSyncInfo(any()) } answers {
+                fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+            }
+            coEvery { fixture.syncManager.refreshPairingCredentialType(PEER_ID) } returns
+                PairingCredentialRefreshResult.Resolved(PairingCredentialType.V3_PIN)
+            coEvery { fixture.pairingV3UiController.startPairing(PEER_ID) } returns
+                PairingV3UiResult.SessionReady(
+                    sessionId = "v3-session",
+                    tokenGeneration = 1L,
+                    pinExpiresAt = 456L,
+                    peerKeyFingerprintDisplay = "AB:CD",
+                )
+
+            val outcome = fixture.service.initiate(PEER_ID)
+
+            val started = assertIs<CliPairingService.InitiateOutcome.Started>(outcome)
+            assertEquals("V3_PIN", started.session.credentialType)
+            assertEquals("AB:CD", started.session.peerFingerprint)
+            assertEquals(456L, started.session.pinExpiresAt)
+            verify(exactly = 0) { fixture.syncManager.exchangeKeysForPairing(any()) }
+        }
+
+    @Test
+    fun `initiate v3 surfaces a closed acceptance window as unavailable`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            fixture.nearbySyncInfos.value = listOf(syncInfo(pairingVersion = 3))
+            every { fixture.syncManager.updateSyncInfo(any()) } answers {
+                fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+            }
+            coEvery { fixture.syncManager.refreshPairingCredentialType(PEER_ID) } returns
+                PairingCredentialRefreshResult.Resolved(PairingCredentialType.V3_PIN)
+            coEvery { fixture.pairingV3UiController.startPairing(PEER_ID) } returns
+                PairingV3UiResult.Error(PairingV3UiError.NOT_ACCEPTING, PairingV3Recovery.RETRY_START)
+
+            val outcome = fixture.service.initiate(PEER_ID)
+
+            val unavailable = assertIs<CliPairingService.InitiateOutcome.Unavailable>(outcome)
+            assertContains(unavailable.message, "not accepting")
+        }
+
+    @Test
+    fun `re-initiating the same device cancels the previous session`() =
+        runTest {
+            val fixture = Fixture()
+            fixture.nearbySyncInfos.value = listOf(syncInfo())
+            every { fixture.syncManager.updateSyncInfo(any()) } answers {
+                fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+            }
+            coEvery { fixture.syncManager.refreshPairingCredentialType(PEER_ID) } returns
+                PairingCredentialRefreshResult.Resolved(PairingCredentialType.SAS_CODE)
+
+            val first = assertIs<CliPairingService.InitiateOutcome.Started>(fixture.service.initiate(PEER_ID))
+            assertIs<CliPairingService.InitiateOutcome.Started>(fixture.service.initiate(PEER_ID))
+
+            verify(exactly = 1) { fixture.syncManager.cancelPairing(PEER_ID) }
+            assertIs<CliPairingService.SubmitOutcome.SessionNotFound>(
+                fixture.service.submit(first.session.sessionId, "123456"),
+            )
+        }
+
+    // endregion
+
+    // region submit
+
+    private suspend fun startedSasSession(fixture: Fixture): CliPairSessionDto {
+        fixture.nearbySyncInfos.value = listOf(syncInfo())
+        every { fixture.syncManager.updateSyncInfo(any()) } answers {
+            fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+        }
+        coEvery { fixture.syncManager.refreshPairingCredentialType(PEER_ID) } returns
+            PairingCredentialRefreshResult.Resolved(PairingCredentialType.SAS_CODE)
+        return assertIs<CliPairingService.InitiateOutcome.Started>(fixture.service.initiate(PEER_ID)).session
+    }
+
+    private suspend fun startedV3Session(fixture: Fixture): CliPairSessionDto {
+        fixture.nearbySyncInfos.value = listOf(syncInfo(pairingVersion = 3))
+        every { fixture.syncManager.updateSyncInfo(any()) } answers {
+            fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+        }
+        coEvery { fixture.syncManager.refreshPairingCredentialType(PEER_ID) } returns
+            PairingCredentialRefreshResult.Resolved(PairingCredentialType.V3_PIN)
+        coEvery { fixture.pairingV3UiController.startPairing(PEER_ID) } returns
+            PairingV3UiResult.SessionReady(
+                sessionId = "v3-session",
+                tokenGeneration = 1L,
+                pinExpiresAt = 456L,
+                peerKeyFingerprintDisplay = "AB:CD",
+            )
+        return assertIs<CliPairingService.InitiateOutcome.Started>(fixture.service.initiate(PEER_ID)).session
+    }
+
+    @Test
+    fun `submit rejects unknown sessions and malformed codes`() =
+        runTest {
+            val fixture = Fixture()
+            assertIs<CliPairingService.SubmitOutcome.SessionNotFound>(
+                fixture.service.submit("nope", "123456"),
+            )
+
+            val session = startedSasSession(fixture)
+            assertIs<CliPairingService.SubmitOutcome.InvalidCode>(
+                fixture.service.submit(session.sessionId, "12345"),
+            )
+            assertIs<CliPairingService.SubmitOutcome.InvalidCode>(
+                fixture.service.submit(session.sessionId, "abc123"),
+            )
+        }
+
+    @Test
+    fun `submit sas pairs and closes the session on a matching code`() =
+        runTest {
+            val fixture = Fixture()
+            val session = startedSasSession(fixture)
+            every { fixture.syncManager.trustBySasCode(PEER_ID, SasCode(123456), any()) } answers {
+                thirdArg<(Boolean) -> Unit>()(true)
+            }
+
+            val outcome = fixture.service.submit(session.sessionId, "123456")
+
+            val completed = assertIs<CliPairingService.SubmitOutcome.Completed>(outcome)
+            assertTrue(completed.result.paired)
+            // Session is consumed
+            assertIs<CliPairingService.SubmitOutcome.SessionNotFound>(
+                fixture.service.submit(session.sessionId, "123456"),
+            )
+        }
+
+    @Test
+    fun `submit sas stays retryable on a mismatch`() =
+        runTest {
+            val fixture = Fixture()
+            val session = startedSasSession(fixture)
+            every { fixture.syncManager.trustBySasCode(PEER_ID, SasCode(111111), any()) } answers {
+                thirdArg<(Boolean) -> Unit>()(false)
+            }
+            every { fixture.syncManager.trustBySasCode(PEER_ID, SasCode(123456), any()) } answers {
+                thirdArg<(Boolean) -> Unit>()(true)
+            }
+
+            val failed =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "111111"),
+                )
+            assertFalse(failed.result.paired)
+            assertTrue(failed.result.retryable)
+
+            val retried =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "123456"),
+                )
+            assertTrue(retried.result.paired)
+        }
+
+    @Test
+    fun `submit sas trusts the observed connected state over a timed-out callback`() =
+        runTest {
+            val fixture = Fixture()
+            val session = startedSasSession(fixture)
+            every { fixture.syncManager.trustBySasCode(PEER_ID, SasCode(123456), any()) } answers {
+                // The background trust "succeeds late": the state flips but the
+                // callback never arrives within the timeout
+                fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.CONNECTED))
+            }
+
+            val outcome = fixture.service.submit(session.sessionId, "123456")
+
+            val completed = assertIs<CliPairingService.SubmitOutcome.Completed>(outcome)
+            assertTrue(completed.result.paired)
+        }
+
+    @Test
+    fun `submit sas treats a false callback for an already connected device as success`() =
+        runTest {
+            val fixture = Fixture()
+            val session = startedSasSession(fixture)
+            every { fixture.syncManager.trustBySasCode(PEER_ID, SasCode(123456), any()) } answers {
+                // The resolver reports false whenever state != UNVERIFIED —
+                // including a retry after the pairing actually completed
+                fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.CONNECTED))
+                thirdArg<(Boolean) -> Unit>()(false)
+            }
+
+            val outcome = fixture.service.submit(session.sessionId, "123456")
+
+            val completed = assertIs<CliPairingService.SubmitOutcome.Completed>(outcome)
+            assertTrue(completed.result.paired)
+        }
+
+    @Test
+    fun `submit v3 remembers a pending commit and retries it on the next submit`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } returns
+                PairingV3UiResult.Error(PairingV3UiError.NETWORK_FAILURE, PairingV3Recovery.RETRY_COMMIT)
+            coEvery { fixture.pairingV3UiController.recover("v3-session") } returns
+                PairingV3UiResult.Error(PairingV3UiError.NETWORK_FAILURE, PairingV3Recovery.RETRY_COMMIT)
+
+            val first =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "123456"),
+                )
+            assertFalse(first.result.paired)
+            assertTrue(first.result.retryable)
+
+            // The commit succeeds on the retry; submitPin must not run again
+            // (it would hit PAIRING_INVALID_STATE against a COMMITTING session)
+            coEvery { fixture.pairingV3UiController.recover("v3-session") } returns
+                PairingV3UiResult.Paired
+
+            val second =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "123456"),
+                )
+            assertTrue(second.result.paired)
+            coVerify(exactly = 1) { fixture.pairingV3UiController.submitPin("v3-session", any()) }
+        }
+
+    @Test
+    fun `submit v3 answers within the trust timeout when a round-trip hangs`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } coAnswers {
+                awaitCancellation()
+            }
+
+            val outcome = fixture.service.submit(session.sessionId, "123456")
+
+            val completed = assertIs<CliPairingService.SubmitOutcome.Completed>(outcome)
+            assertFalse(completed.result.paired)
+            assertTrue(completed.result.retryable)
+            assertContains(completed.result.message, "timed out")
+        }
+
+    @Test
+    fun `submit v3 pairs refreshes the sync state and closes the session`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } returns
+                PairingV3UiResult.Paired
+
+            val outcome = fixture.service.submit(session.sessionId, "123456")
+
+            val completed = assertIs<CliPairingService.SubmitOutcome.Completed>(outcome)
+            assertTrue(completed.result.paired)
+            verify(exactly = 1) { fixture.syncManager.refresh(listOf(PEER_ID), any()) }
+            assertIs<CliPairingService.SubmitOutcome.SessionNotFound>(
+                fixture.service.submit(session.sessionId, "123456"),
+            )
+        }
+
+    @Test
+    fun `submit v3 refreshes the offer and stays retryable on a wrong pin`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("111111")) } returns
+                PairingV3UiResult.Error(PairingV3UiError.INCORRECT_PIN, PairingV3Recovery.REFRESH_OFFER)
+            coEvery { fixture.pairingV3UiController.recover("v3-session") } returns
+                PairingV3UiResult.SessionReady("v3-session", 2L, 789L, "")
+
+            val outcome = fixture.service.submit(session.sessionId, "111111")
+
+            val completed = assertIs<CliPairingService.SubmitOutcome.Completed>(outcome)
+            assertFalse(completed.result.paired)
+            assertTrue(completed.result.retryable)
+            coVerify(exactly = 1) { fixture.pairingV3UiController.recover("v3-session") }
+        }
+
+    @Test
+    fun `submit v3 closes the session when the peer rejects`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } returns
+                PairingV3UiResult.Error(PairingV3UiError.REJECTED)
+
+            val outcome = fixture.service.submit(session.sessionId, "123456")
+
+            val completed = assertIs<CliPairingService.SubmitOutcome.Completed>(outcome)
+            assertFalse(completed.result.paired)
+            assertFalse(completed.result.retryable)
+            assertIs<CliPairingService.SubmitOutcome.SessionNotFound>(
+                fixture.service.submit(session.sessionId, "123456"),
+            )
+        }
+
+    @Test
+    fun `submit v3 finishes a pending commit through recover`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } returns
+                PairingV3UiResult.Error(PairingV3UiError.NETWORK_FAILURE, PairingV3Recovery.RETRY_COMMIT)
+            coEvery { fixture.pairingV3UiController.recover("v3-session") } returns
+                PairingV3UiResult.Paired
+
+            val outcome = fixture.service.submit(session.sessionId, "123456")
+
+            val completed = assertIs<CliPairingService.SubmitOutcome.Completed>(outcome)
+            assertTrue(completed.result.paired)
+        }
+
+    // endregion
+
+    // region cancel
+
+    @Test
+    fun `cancel releases the sas exchange`() =
+        runTest {
+            val fixture = Fixture()
+            val session = startedSasSession(fixture)
+
+            assertTrue(fixture.service.cancel(session.sessionId))
+
+            verify(exactly = 1) { fixture.syncManager.cancelPairing(PEER_ID) }
+            assertFalse(fixture.service.cancel(session.sessionId))
+        }
+
+    @Test
+    fun `cancel forwards a v3 session to the controller`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            every { fixture.pairingV3UiController.cancelDetached("v3-session") } just Runs
+
+            assertTrue(fixture.service.cancel(session.sessionId))
+
+            verify(exactly = 1) { fixture.pairingV3UiController.cancelDetached("v3-session") }
+        }
+
+    // endregion
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -63,6 +63,7 @@ class CliRoutingTest {
         )
 
     private class Fixture {
+        val cliPairingService = mockk<CliPairingService>()
         val configManager = mockk<DesktopConfigManager>()
         val pasteboardService = mockk<PasteboardService>()
         val pasteDao = mockk<PasteDao>()
@@ -107,6 +108,7 @@ class CliRoutingTest {
         routing {
             cliRouting(
                 appInfo = appInfo,
+                cliPairingService = fixture.cliPairingService,
                 configManager = fixture.configManager,
                 pasteboardService = fixture.pasteboardService,
                 pasteDao = fixture.pasteDao,
@@ -558,6 +560,125 @@ class CliRoutingTest {
             assertEquals(HttpStatusCode.OK, client.delete("/cli/paste/42").status)
             assertEquals(HttpStatusCode.NotFound, client.delete("/cli/paste/43").status)
             assertEquals(HttpStatusCode.BadRequest, client.delete("/cli/paste/abc").status)
+        }
+    }
+
+    @Test
+    fun `pair nearby forwards the refresh flag and returns the device list`() {
+        val fixture = Fixture()
+        val device =
+            CliNearbyDeviceDto(
+                appInstanceId = "peer-1",
+                deviceName = "Laptop",
+                platform = "Macos",
+                appVersion = "2.1.7",
+                pairingVersion = 2,
+                credentialType = "SAS_CODE",
+            )
+        coEvery { fixture.cliPairingService.nearbyDevices(refresh = true) } returns listOf(device)
+        coEvery { fixture.cliPairingService.nearbyDevices(refresh = false) } returns listOf()
+
+        withCliRouting(fixture) {
+            val refreshed = client.get("/cli/pair/nearby?refresh=true")
+            assertEquals(HttpStatusCode.OK, refreshed.status)
+            assertContains(refreshed.bodyAsText(), "\"appInstanceId\":\"peer-1\"")
+
+            val cached = client.get("/cli/pair/nearby")
+            assertEquals(HttpStatusCode.OK, cached.status)
+            coVerify(exactly = 1) { fixture.cliPairingService.nearbyDevices(refresh = false) }
+        }
+    }
+
+    @Test
+    fun `pair initiate maps outcomes to status codes`() {
+        val fixture = Fixture()
+        val session =
+            CliPairSessionDto(
+                sessionId = "session-1",
+                appInstanceId = "peer-1",
+                deviceName = "Laptop",
+                credentialType = "SAS_CODE",
+                peerFingerprint = null,
+                pinExpiresAt = null,
+            )
+        coEvery { fixture.cliPairingService.initiate("peer-1") } returns
+            CliPairingService.InitiateOutcome.Started(session)
+        coEvery { fixture.cliPairingService.initiate("missing") } returns
+            CliPairingService.InitiateOutcome.DeviceNotFound("not found")
+        coEvery { fixture.cliPairingService.initiate("paired") } returns
+            CliPairingService.InitiateOutcome.AlreadyPaired("already paired")
+        coEvery { fixture.cliPairingService.initiate("legacy") } returns
+            CliPairingService.InitiateOutcome.UnsupportedPeer("too old")
+        coEvery { fixture.cliPairingService.initiate("busy") } returns
+            CliPairingService.InitiateOutcome.Unavailable("not accepting")
+
+        withCliRouting(fixture) {
+            suspend fun initiate(appInstanceId: String) =
+                client.post("/cli/pair/initiate") {
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"appInstanceId":"$appInstanceId"}""")
+                }
+
+            val started = initiate("peer-1")
+            assertEquals(HttpStatusCode.OK, started.status)
+            assertContains(started.bodyAsText(), "\"sessionId\":\"session-1\"")
+
+            assertEquals(HttpStatusCode.NotFound, initiate("missing").status)
+            assertEquals(HttpStatusCode.Conflict, initiate("paired").status)
+            assertEquals(HttpStatusCode.BadRequest, initiate("legacy").status)
+            assertEquals(HttpStatusCode.BadGateway, initiate("busy").status)
+
+            val blank = initiate("")
+            assertEquals(HttpStatusCode.BadRequest, blank.status)
+            coVerify(exactly = 0) { fixture.cliPairingService.initiate("") }
+        }
+    }
+
+    @Test
+    fun `pair submit maps outcomes to status codes`() {
+        val fixture = Fixture()
+        coEvery { fixture.cliPairingService.submit("session-1", "123456") } returns
+            CliPairingService.SubmitOutcome.Completed(
+                CliPairSubmitResultDto(paired = true, retryable = false, message = "Paired with Laptop."),
+            )
+        coEvery { fixture.cliPairingService.submit("gone", any()) } returns
+            CliPairingService.SubmitOutcome.SessionNotFound
+        coEvery { fixture.cliPairingService.submit("session-1", "12") } returns
+            CliPairingService.SubmitOutcome.InvalidCode
+
+        withCliRouting(fixture) {
+            suspend fun submit(
+                sessionId: String,
+                code: String,
+            ) = client.post("/cli/pair/submit") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"sessionId":"$sessionId","code":"$code"}""")
+            }
+
+            val paired = submit("session-1", "123456")
+            assertEquals(HttpStatusCode.OK, paired.status)
+            assertContains(paired.bodyAsText(), "\"paired\":true")
+
+            assertEquals(HttpStatusCode.NotFound, submit("gone", "123456").status)
+            assertEquals(HttpStatusCode.BadRequest, submit("session-1", "12").status)
+        }
+    }
+
+    @Test
+    fun `pair cancel maps the session lookup to status`() {
+        val fixture = Fixture()
+        every { fixture.cliPairingService.cancel("session-1") } returns true
+        every { fixture.cliPairingService.cancel("gone") } returns false
+
+        withCliRouting(fixture) {
+            suspend fun cancel(sessionId: String) =
+                client.post("/cli/pair/cancel") {
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"sessionId":"$sessionId"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, cancel("session-1").status)
+            assertEquals(HttpStatusCode.NotFound, cancel("gone").status)
         }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliServerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliServerTest.kt
@@ -71,6 +71,7 @@ class CliServerTest {
                         appRevision = "Unknown",
                         userName = "tester",
                     ),
+                cliPairingService = mockk<CliPairingService>(),
                 configManager = configManager,
                 cliEndpointFile = endpointFile,
                 pasteboardService = mockk<PasteboardService>(),

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -89,6 +89,7 @@ kotlin {
         target.compilations.getByName("main") {
             cinterops {
                 val execpath by creating
+                val secretinput by creating
             }
         }
         // Workaround for Clikt duplicate symbol bug in Kotlin/Native

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
@@ -5,6 +5,7 @@ import com.crosspaste.cli.commands.CopyCommand
 import com.crosspaste.cli.commands.DeleteCommand
 import com.crosspaste.cli.commands.DevicesCommand
 import com.crosspaste.cli.commands.HistoryCommand
+import com.crosspaste.cli.commands.PairCommand
 import com.crosspaste.cli.commands.PasteCommand
 import com.crosspaste.cli.commands.SearchCommand
 import com.crosspaste.cli.commands.StatusCommand
@@ -63,6 +64,7 @@ class CrossPasteCommand : CliktCommand(name = cliCommandName) {
             CopyCommand(),
             DeleteCommand(),
             DevicesCommand(),
+            PairCommand(),
             ConfigCommand(),
             TagsCommand(),
             VersionCommand(),

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/api/CliClient.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/api/CliClient.kt
@@ -3,6 +3,7 @@ package com.crosspaste.cli.api
 import com.crosspaste.cli.platform.CliConfigReader
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -16,6 +17,9 @@ import okio.FileSystem
  * on the app side; a mismatch produces a warning, not a failure.
  */
 const val CLI_API_VERSION = 1
+
+/** Default per-request timeout; long-running pair calls override it per call. */
+internal const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 5000L
 
 /**
  * Mirror of the app's CliEndpoint (see design D5): the app atomically writes
@@ -56,7 +60,13 @@ class CliClient(
     private val httpClient =
         HttpClient(CIO) {
             engine {
-                requestTimeout = 5000
+                // Disable the engine-level cap so the HttpTimeout plugin below
+                // is the single authority (some pair calls need more than the
+                // engine default of 15s)
+                requestTimeout = 0
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = DEFAULT_REQUEST_TIMEOUT_MILLIS
             }
         }
 
@@ -81,13 +91,15 @@ class CliClient(
     suspend fun <T> getBody(
         path: String,
         deserializer: DeserializationStrategy<T>,
-    ): T = decode(get(path), deserializer)
+        timeoutMillis: Long? = null,
+    ): T = decode(request(HttpMethod.Get, path, timeoutMillis = timeoutMillis), deserializer)
 
     suspend fun <T> postBody(
         path: String,
         body: String,
         deserializer: DeserializationStrategy<T>,
-    ): T = decode(post(path, body), deserializer)
+        timeoutMillis: Long? = null,
+    ): T = decode(request(HttpMethod.Post, path, body, timeoutMillis), deserializer)
 
     suspend fun <T> putBody(
         path: String,
@@ -118,11 +130,17 @@ class CliClient(
         httpMethod: HttpMethod,
         path: String,
         body: String? = null,
+        timeoutMillis: Long? = null,
     ): HttpResponse =
         try {
             httpClient.request("http://localhost$path") {
                 method = httpMethod
                 unixSocket(endpoint.socketPath)
+                timeoutMillis?.let { millis ->
+                    timeout {
+                        requestTimeoutMillis = millis
+                    }
+                }
                 body?.let {
                     contentType(ContentType.Application.Json)
                     setBody(it)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PairCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PairCommand.kt
@@ -1,0 +1,282 @@
+package com.crosspaste.cli.commands
+
+import com.crosspaste.cli.CliContext
+import com.crosspaste.cli.api.CliClient
+import com.crosspaste.cli.platform.readLineNoEcho
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.core.terminal
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.mordant.rendering.TextColors
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+
+// Mirrors of the app-side pair DTOs (CliApi.kt); parsed with ignoreUnknownKeys.
+@Serializable
+internal data class NearbyDeviceSummary(
+    val appInstanceId: String,
+    val deviceName: String,
+    val platform: String,
+    val appVersion: String,
+    val pairingVersion: Int? = null,
+    val credentialType: String = "",
+)
+
+@Serializable
+internal data class PairInitiateRequest(
+    val appInstanceId: String,
+)
+
+@Serializable
+internal data class PairSessionResponse(
+    val sessionId: String,
+    val appInstanceId: String,
+    val deviceName: String,
+    val credentialType: String,
+    val peerFingerprint: String? = null,
+    val pinExpiresAt: Long? = null,
+)
+
+@Serializable
+internal data class PairSubmitRequest(
+    val sessionId: String,
+    val code: String,
+)
+
+@Serializable
+internal data class PairSubmitResponse(
+    val paired: Boolean,
+    val retryable: Boolean,
+    val message: String,
+)
+
+@Serializable
+internal data class PairCancelRequest(
+    val sessionId: String,
+)
+
+/**
+ * Interactive initiator-side pairing (P6.2, D-P6-2/D-P6-3): this machine picks
+ * a nearby device and types the 6-digit code the target displays. Pairing is a
+ * human confirmation by design, so a non-interactive stdin is a usage error.
+ *
+ * A SIGINT mid-session skips the cancel in the finally block; the peer's own
+ * pairing session TTLs reclaim it (server-side timeout is the second half of
+ * the double insurance).
+ */
+internal class PairCommand(
+    private val secretReader: () -> String? = ::readLineNoEcho,
+    private val lineReader: () -> String? = { readlnOrNull() },
+) : CliktCommand(name = "pair") {
+
+    companion object {
+        // Server-side waits dominate these calls; see CliPairingService
+        private const val NEARBY_TIMEOUT_MILLIS = 20_000L
+        private const val INITIATE_TIMEOUT_MILLIS = 30_000L
+        private const val SUBMIT_TIMEOUT_MILLIS = 60_000L
+
+        private const val MAX_CODE_ATTEMPTS = 5
+
+        private val SIX_DIGITS = Regex("\\d{6}")
+    }
+
+    override fun help(context: Context): String = "Pair with a nearby device by entering the code it displays"
+
+    private val ctx by requireObject<CliContext>()
+
+    private val target by option(
+        "--target",
+        help = "App instance id of the device to pair with (skips the interactive device list)",
+    )
+
+    override fun run() {
+        if (!terminal.terminalInfo.inputInteractive) {
+            throw usageError(
+                "pair requires an interactive terminal: the pairing code shown " +
+                    "on the target device has to be typed in.",
+            )
+        }
+        runCli { client ->
+            val targetId = target ?: selectDevice(client)
+            val session = initiate(client, targetId)
+            var paired = false
+            try {
+                paired = enterCodeLoop(client, session)
+            } finally {
+                if (!paired) {
+                    // Best effort: a terminal failure already closed the session
+                    // server-side, so a 404 here is expected and ignored
+                    runCatching {
+                        client.postBody(
+                            "/cli/pair/cancel",
+                            cliJson.encodeToString(
+                                PairCancelRequest.serializer(),
+                                PairCancelRequest(session.sessionId),
+                            ),
+                            MessageResponse.serializer(),
+                        )
+                    }
+                }
+            }
+            if (!paired) {
+                throw ProgramResult(1)
+            }
+        }
+    }
+
+    private suspend fun selectDevice(client: CliClient): String {
+        echo("Searching for nearby devices...", err = true)
+        val nearby =
+            client.getBody(
+                "/cli/pair/nearby?refresh=true",
+                ListSerializer(NearbyDeviceSummary.serializer()),
+                timeoutMillis = NEARBY_TIMEOUT_MILLIS,
+            )
+        // Devices already known but never trusted (Unverified) are equally
+        // pairable; the nearby list deliberately excludes them
+        val unverified =
+            client
+                .getBody("/cli/devices", ListSerializer(DeviceSummary.serializer()))
+                .filter { it.connectState == 4 }
+                .filter { device -> nearby.none { it.appInstanceId == device.appInstanceId } }
+        val candidates =
+            nearby.map { device ->
+                Candidate(
+                    appInstanceId = device.appInstanceId,
+                    displayName = device.deviceName,
+                    platform = device.platform,
+                    appVersion = device.appVersion,
+                    unsupported = device.credentialType == "QR_BEARER_TOKEN",
+                )
+            } +
+                unverified.map { device ->
+                    Candidate(
+                        appInstanceId = device.appInstanceId,
+                        displayName = device.noteName ?: device.deviceName,
+                        platform = device.platform,
+                        appVersion = device.appVersion,
+                        unsupported = false,
+                    )
+                }
+        if (candidates.isEmpty()) {
+            echo(
+                "Error: No devices available for pairing. Make sure CrossPaste is running " +
+                    "on the other device and both are on the same network.",
+                err = true,
+            )
+            throw ProgramResult(1)
+        }
+        echo("", err = true)
+        candidates.forEachIndexed { index, candidate ->
+            val marker = if (candidate.unsupported) TextColors.red(" (app too old for CLI pairing)") else ""
+            echo(
+                "  ${index + 1}. ${candidate.displayName} " +
+                    "(${candidate.platform} v${candidate.appVersion})$marker",
+                err = true,
+            )
+        }
+        echo("", err = true)
+        while (true) {
+            echo("Select a device [1-${candidates.size}], or q to cancel: ", trailingNewline = false, err = true)
+            val answer = lineReader()?.trim() ?: throw ProgramResult(1)
+            if (answer.equals("q", ignoreCase = true)) {
+                throw ProgramResult(1)
+            }
+            val index = answer.toIntOrNull()
+            if (index != null && index in 1..candidates.size) {
+                return candidates[index - 1].appInstanceId
+            }
+            echo("Please enter a number between 1 and ${candidates.size}.", err = true)
+        }
+    }
+
+    private suspend fun initiate(
+        client: CliClient,
+        appInstanceId: String,
+    ): PairSessionResponse {
+        echo("Contacting the device...", err = true)
+        val session =
+            client.postBody(
+                "/cli/pair/initiate",
+                cliJson.encodeToString(
+                    PairInitiateRequest.serializer(),
+                    PairInitiateRequest(appInstanceId),
+                ),
+                PairSessionResponse.serializer(),
+                timeoutMillis = INITIATE_TIMEOUT_MILLIS,
+            )
+        echo("", err = true)
+        echo(
+            "'${session.deviceName}' now shows a 6-digit ${session.codeLabel()}. " +
+                "Confirm on that device if prompted.",
+            err = true,
+        )
+        session.peerFingerprint
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { echo("Peer key fingerprint: $it", err = true) }
+        return session
+    }
+
+    /** Returns true when pairing completed; false when the user gave up. */
+    private suspend fun enterCodeLoop(
+        client: CliClient,
+        session: PairSessionResponse,
+    ): Boolean {
+        var attempts = 0
+        while (attempts < MAX_CODE_ATTEMPTS) {
+            echo(
+                "Enter the ${session.codeLabel()} (input hidden, q to cancel): ",
+                trailingNewline = false,
+                err = true,
+            )
+            val input = secretReader()?.trim()
+            // Enter is not echoed while echo is off; keep the prompt tidy
+            echo("", err = true)
+            if (input == null || input.equals("q", ignoreCase = true)) {
+                echo("Pairing cancelled.", err = true)
+                return false
+            }
+            if (!SIX_DIGITS.matches(input)) {
+                echo("The ${session.codeLabel()} must be exactly 6 digits.", err = true)
+                continue
+            }
+            attempts++
+            val result =
+                client.postBody(
+                    "/cli/pair/submit",
+                    cliJson.encodeToString(
+                        PairSubmitRequest.serializer(),
+                        PairSubmitRequest(session.sessionId, input),
+                    ),
+                    PairSubmitResponse.serializer(),
+                    timeoutMillis = SUBMIT_TIMEOUT_MILLIS,
+                )
+            if (result.paired) {
+                if (ctx.json) {
+                    echo(cliJson.encodeToString(PairSubmitResponse.serializer(), result))
+                } else {
+                    echo(result.message)
+                }
+                return true
+            }
+            echo(result.message, err = true)
+            if (!result.retryable) {
+                return false
+            }
+        }
+        echo("Error: Too many failed attempts.", err = true)
+        return false
+    }
+
+    private fun PairSessionResponse.codeLabel(): String = if (credentialType == "V3_PIN") "PIN" else "code"
+
+    private data class Candidate(
+        val appInstanceId: String,
+        val displayName: String,
+        val platform: String,
+        val appVersion: String,
+        val unsupported: Boolean,
+    )
+}

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PairCommandTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PairCommandTest.kt
@@ -1,0 +1,30 @@
+package com.crosspaste.cli.commands
+
+import com.crosspaste.cli.CrossPasteCommand
+import com.github.ajalt.clikt.testing.test
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class PairCommandTest {
+
+    // Pairing is a human confirmation (D-P6-3): a non-interactive stdin must
+    // fail fast as a usage error instead of hanging on a code prompt. The
+    // Clikt harness reports UsageError's raw status 1; main() remaps it to 2.
+
+    @Test
+    fun pairRefusesANonInteractiveTerminal() {
+        val result = CrossPasteCommand().test("pair", inputInteractive = false)
+        assertEquals(1, result.statusCode)
+        assertContains(result.stderr, "pair requires an interactive terminal")
+        // The usage error must carry the subcommand's context, not the root's
+        assertContains(result.stderr, " pair [<options>]")
+    }
+
+    @Test
+    fun pairWithTargetStillRequiresAnInteractiveTerminal() {
+        val result = CrossPasteCommand().test("pair --target some-instance", inputInteractive = false)
+        assertEquals(1, result.statusCode)
+        assertContains(result.stderr, "pair requires an interactive terminal")
+    }
+}

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
@@ -4,38 +4,63 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
-import kotlinx.cinterop.value
 import platform.windows.DWORDVar
-import platform.windows.ENABLE_ECHO_INPUT
 import platform.windows.GetConsoleMode
 import platform.windows.GetStdHandle
 import platform.windows.INVALID_HANDLE_VALUE
 import platform.windows.STD_INPUT_HANDLE
-import platform.windows.SetConsoleMode
+import secretinput.read_console_char_no_echo
 
-/**
- * Reads one line from stdin with console echo disabled, for pairing codes
- * (design D-P6-3: the code must not be echoed). When stdin is not a console
- * (pipe, redirection) it falls back to a plain read — that case never echoes
- * anyway.
- */
+/** Reads a line one character at a time without changing shared console mode. */
 @OptIn(ExperimentalForeignApi::class)
 fun readLineNoEcho(): String? =
     memScoped {
         val handle = GetStdHandle(STD_INPUT_HANDLE)
-        if (handle == null || handle == INVALID_HANDLE_VALUE) {
+        val mode = alloc<DWORDVar>()
+        val isConsole =
+            handle != null &&
+                handle != INVALID_HANDLE_VALUE &&
+                GetConsoleMode(handle, mode.ptr) != 0
+        if (!isConsole) {
+            // Piped or redirected stdin (e.g. an MSYS/git-bash pty is a named
+            // pipe, not a console): a pipe read produces no terminal echo, so a
+            // plain read is already echo-free. Only a real console needs the
+            // char-by-char no-echo path below; failing here would make pairing
+            // unusable in those shells for no echo-safety gain.
             return readlnOrNull()
         }
-        val originalMode = alloc<DWORDVar>()
-        if (GetConsoleMode(handle, originalMode.ptr) == 0) {
-            return readlnOrNull()
-        }
-        if (SetConsoleMode(handle, originalMode.value and ENABLE_ECHO_INPUT.toUInt().inv()) == 0) {
-            return readlnOrNull()
-        }
+
+        val chars = CharArray(MAX_INPUT_LENGTH)
+        var length = 0
+        var result: String? = null
+        var finished = false
         try {
-            readlnOrNull()
+            while (!finished) {
+                when (val code = read_console_char_no_echo()) {
+                    CARRIAGE_RETURN -> {
+                        result = chars.concatToString(0, length)
+                        finished = true
+                    }
+                    BACKSPACE -> if (length > 0) length--
+                    EXTENDED_KEY_PREFIX,
+                    EXTENDED_KEY_PREFIX_ALT,
+                    -> read_console_char_no_echo() // Consume and ignore the extended key code.
+                    END_OF_FILE,
+                    WIDE_END_OF_FILE,
+                    -> finished = true
+                    else -> if (length < chars.size) chars[length++] = code.toChar()
+                }
+            }
         } finally {
-            SetConsoleMode(handle, originalMode.value)
+            chars.fill('\u0000')
         }
+        result
     }
+
+private const val CARRIAGE_RETURN = 13
+private const val BACKSPACE = 8
+private const val END_OF_FILE = 26
+private const val WIDE_END_OF_FILE = 0xFFFF
+private const val EXTENDED_KEY_PREFIX = 0
+private const val EXTENDED_KEY_PREFIX_ALT = 0xE0
+private const val MAX_INPUT_LENGTH = 128

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
@@ -1,0 +1,41 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.windows.DWORDVar
+import platform.windows.ENABLE_ECHO_INPUT
+import platform.windows.GetConsoleMode
+import platform.windows.GetStdHandle
+import platform.windows.INVALID_HANDLE_VALUE
+import platform.windows.STD_INPUT_HANDLE
+import platform.windows.SetConsoleMode
+
+/**
+ * Reads one line from stdin with console echo disabled, for pairing codes
+ * (design D-P6-3: the code must not be echoed). When stdin is not a console
+ * (pipe, redirection) it falls back to a plain read — that case never echoes
+ * anyway.
+ */
+@OptIn(ExperimentalForeignApi::class)
+fun readLineNoEcho(): String? =
+    memScoped {
+        val handle = GetStdHandle(STD_INPUT_HANDLE)
+        if (handle == null || handle == INVALID_HANDLE_VALUE) {
+            return readlnOrNull()
+        }
+        val originalMode = alloc<DWORDVar>()
+        if (GetConsoleMode(handle, originalMode.ptr) == 0) {
+            return readlnOrNull()
+        }
+        if (SetConsoleMode(handle, originalMode.value and ENABLE_ECHO_INPUT.toUInt().inv()) == 0) {
+            return readlnOrNull()
+        }
+        try {
+            readlnOrNull()
+        } finally {
+            SetConsoleMode(handle, originalMode.value)
+        }
+    }

--- a/cli/src/nativeInterop/cinterop/secretinput.def
+++ b/cli/src/nativeInterop/cinterop/secretinput.def
@@ -7,7 +7,13 @@
 
 void clear_secret_buffer(char* buffer) {
     if (buffer != NULL) {
-        memset(buffer, 0, strlen(buffer));
+        /* Volatile stores cannot be elided by dead-store elimination the way
+         * a plain memset before free can; keeps the zeroing guaranteed even
+         * if LTO ever inlines this across the cinterop boundary. */
+        volatile char* p = buffer;
+        while (*p != '\0') {
+            *p++ = '\0';
+        }
     }
 }
 

--- a/cli/src/nativeInterop/cinterop/secretinput.def
+++ b/cli/src/nativeInterop/cinterop/secretinput.def
@@ -1,0 +1,20 @@
+---
+#include <string.h>
+
+#if defined(_WIN32)
+#include <conio.h>
+#endif
+
+void clear_secret_buffer(char* buffer) {
+    if (buffer != NULL) {
+        memset(buffer, 0, strlen(buffer));
+    }
+}
+
+int read_console_char_no_echo(void) {
+#if defined(_WIN32)
+    return _getwch();
+#else
+    return -1;
+#endif
+}

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
@@ -1,0 +1,41 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import platform.posix.ECHO
+import platform.posix.STDIN_FILENO
+import platform.posix.TCSAFLUSH
+import platform.posix.tcgetattr
+import platform.posix.tcsetattr
+import platform.posix.termios
+
+/**
+ * Reads one line from stdin with terminal echo disabled, for pairing codes
+ * (design D-P6-3: the code must not be echoed). When stdin is not a
+ * configurable terminal (pipe, closed fd) it falls back to a plain read —
+ * that case never echoes anyway.
+ */
+@OptIn(ExperimentalForeignApi::class)
+fun readLineNoEcho(): String? =
+    memScoped {
+        val original = alloc<termios>()
+        if (tcgetattr(STDIN_FILENO, original.ptr) != 0) {
+            return readlnOrNull()
+        }
+        val modified = alloc<termios>()
+        tcgetattr(STDIN_FILENO, modified.ptr)
+        // tcflag_t is UInt on Linux and ULong on macOS; widen, mask, convert back
+        val flags: ULong = modified.c_lflag.convert()
+        modified.c_lflag = (flags and ECHO.toULong().inv()).convert()
+        if (tcsetattr(STDIN_FILENO, TCSAFLUSH, modified.ptr) != 0) {
+            return readlnOrNull()
+        }
+        try {
+            readlnOrNull()
+        } finally {
+            tcsetattr(STDIN_FILENO, TCSAFLUSH, original.ptr)
+        }
+    }

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
@@ -1,41 +1,21 @@
 package com.crosspaste.cli.platform
 
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.alloc
-import kotlinx.cinterop.convert
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.ptr
-import platform.posix.ECHO
-import platform.posix.STDIN_FILENO
-import platform.posix.TCSAFLUSH
-import platform.posix.tcgetattr
-import platform.posix.tcsetattr
-import platform.posix.termios
+import kotlinx.cinterop.toKString
+import platform.posix.getpass
+import secretinput.clear_secret_buffer
 
 /**
- * Reads one line from stdin with terminal echo disabled, for pairing codes
- * (design D-P6-3: the code must not be echoed). When stdin is not a
- * configurable terminal (pipe, closed fd) it falls back to a plain read —
- * that case never echoes anyway.
+ * Reads a line through libc's terminal password reader. libc owns terminal-mode
+ * restoration across interrupts; a failure is reported instead of falling back
+ * to an echoed read.
  */
 @OptIn(ExperimentalForeignApi::class)
-fun readLineNoEcho(): String? =
-    memScoped {
-        val original = alloc<termios>()
-        if (tcgetattr(STDIN_FILENO, original.ptr) != 0) {
-            return readlnOrNull()
-        }
-        val modified = alloc<termios>()
-        tcgetattr(STDIN_FILENO, modified.ptr)
-        // tcflag_t is UInt on Linux and ULong on macOS; widen, mask, convert back
-        val flags: ULong = modified.c_lflag.convert()
-        modified.c_lflag = (flags and ECHO.toULong().inv()).convert()
-        if (tcsetattr(STDIN_FILENO, TCSAFLUSH, modified.ptr) != 0) {
-            return readlnOrNull()
-        }
-        try {
-            readlnOrNull()
-        } finally {
-            tcsetattr(STDIN_FILENO, TCSAFLUSH, original.ptr)
-        }
+fun readLineNoEcho(): String? {
+    val buffer = getpass("") ?: error("Unable to read the pairing code without terminal echo.")
+    return try {
+        buffer.toKString()
+    } finally {
+        clear_secret_buffer(buffer)
     }
+}

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/SecretInput.kt
@@ -9,6 +9,9 @@ import secretinput.clear_secret_buffer
  * Reads a line through libc's terminal password reader. libc owns terminal-mode
  * restoration across interrupts; a failure is reported instead of falling back
  * to an echoed read.
+ *
+ * getpass uses a static buffer (~128 bytes on macOS): oversized input is
+ * silently truncated, which simply fails the caller's 6-digit validation.
  */
 @OptIn(ExperimentalForeignApi::class)
 fun readLineNoEcho(): String? {


### PR DESCRIPTION
Closes #4785 (P6.2 of the CLI daemon plan).

## What

Adds initiator-side device pairing to the local CLI control plane, so a headless daemon (or the GUI app) can be paired from the terminal.

### Server side (`app/desktopMain`)

- New `CliPairingService` managing short-lived pairing sessions (in-memory, 10 min TTL; re-initiating the same device cancels the previous session first so the peer's pending v2 exchange / v3 session is released instead of leaking until its TTL — keeping the #4684 generation discipline).
  - **v2 SAS** (production path): `updateSyncInfo` → await the resolver reaching `UNVERIFIED` with a resolved host (15s; transient `DISCONNECTED` probes are waited out) → `exchangeKeysForPairing` warm-up (peer displays its SAS) → `trustBySasCode` (30s cap). If the callback reports failure but the device is observed `CONNECTED`, the observed state wins (a slow trust that finished after the timeout must not be reported as a mismatch).
  - **v3 PIN** (same code path, active in dev / after rollout): reuses `DefaultPairingV3UiController` — it has no Compose dependency, so its Koin binding moved from `desktopUiModule` to `desktopNetworkModule`, making it resolvable in headless mode. `startPairing` already drives the peer's `showPairingCode`, which opens its acceptance window the same way a GUI initiator does. A commit that verified the PIN but failed the commit round-trip is remembered per session (`commitPending`) and retried via `recover` instead of a second `submitPin` (which would die with `PAIRING_INVALID_STATE`); the whole submit is capped at 30s symmetrically to the SAS path.
- New routes under `/cli/pair`: `GET nearby` (optional `?refresh=true` runs an active mDNS scan and waits for it), `POST initiate` (negotiates the credential type from the peer's advertised pairingVersion via the existing `selectPairingCredentialType`; QR-only peers are refused with a clear message), `POST submit`, `POST cancel`. Add-only DTOs on both sides, pinned by `CliDtoContractTest`.

### CLI side (`:cli`, Kotlin/Native)

- New `pair` command: interactive TTY only (a non-interactive stdin is a usage error, exit 2 — pairing is a human confirmation); device list merges nearby devices with already-known-but-unverified ones; `--target <appInstanceId>` skips the list; up to 5 code attempts; best-effort `cancel` on abandon (server/peer TTLs are the second line for SIGINT).
- The 6-digit code is read with terminal echo disabled (new `SecretInput.kt`: POSIX termios / Windows console mode, plain-read fallback for non-console stdin) and is never logged on either side.
- `CliClient`: request timeout moved from the CIO engine setting to the `HttpTimeout` plugin (default 5s unchanged) so the long-running pair calls can widen it per request (nearby 20s / initiate 30s / submit 60s — each above its server-side wait budget).

## Tests

- `CliPairingServiceTest` (21): both initiator flows, credential negotiation, resolve waiting/timeouts (virtual time), SAS mismatch retry + observed-state self-heal, v3 wrong-PIN refresh / rejection / pending-commit recovery / hang timeout, session lifecycle and re-initiate cancellation.
- `CliRoutingTest` (+4): route/status-code mapping incl. blank-id guard; `CliDtoContractTest` (+1): pair DTO wire fields; `PairCommandTest` (2): non-TTY refusal with subcommand usage context.
- Full `app:desktopTest` and `:cli` host tests green; `HeadlessStartupResolutionTest` confirms the headless Koin graph still resolves after the binding move; all five CLI targets compile (macos arm64/x64 local, linuxX64/mingwX64 cross).

## Real-device acceptance (v2 SAS)

mac dev headless daemon (`--headless`, fresh data dir) ↔ Parallels Windows 11 VM running production **2.1.7.2461** (advertises pairingVersion=2):

- `crosspaste pair --target …` driven over a real PTY: initiate → the VM displayed its 6-digit SAS → code entered without echo → **Paired**, peer key persisted, device `Connected`.
- Bidirectional sync verified: `crosspaste copy` on the daemon landed in the VM's clipboard; a copy on the VM arrived on the daemon and was fetched with `crosspaste paste --raw`.
- SIGTERM shutdown left no socket/endpoint residue (P6.1 path re-confirmed).

Environment notes from the run (not code defects): Parallels shared networking passes guest→host multicast but not host→guest, so the VM could not discover the daemon via mDNS and its `trustSyncInfo` fail-closed rule (#4506) initially refused the device row — on a real LAN both directions work; the known Parallels D3D black-window issue was worked around with `SKIKO_RENDER_API=SOFTWARE`. The v3 flow on real devices is deferred to P6.3/rollout (it needs a second dev machine; the initiator mapping is covered by unit tests and the existing e2e `PairV3Scenario`).

## Out of scope

Acceptor-side headless pairing (P6.4), CLI headless launch wiring + systemd templates + docs (P6.3), pairing without mDNS (a possible `pair --host <ip>` follow-up).