### PR TITLE
:sparkles: launch the headless daemon from the CLI and document daemon deployment

### DIFF
--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -20,6 +20,7 @@ import com.github.ajalt.clikt.core.terminal
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import kotlin.experimental.ExperimentalNativeApi
 
 /** Scripts can rely on this exit code to mean "CrossPaste is not running". */
 const val EXIT_CODE_APP_NOT_RUNNING = 3
@@ -115,14 +116,21 @@ private suspend fun CliktCommand.ensureAppRunning(readinessChecker: AppReadiness
  * forced no, or (the default) a TTY prompt. A non-interactive caller is never
  * blocked on input: it fails fast with [EXIT_CODE_APP_NOT_RUNNING].
  */
+@OptIn(ExperimentalNativeApi::class)
 private suspend fun CliktCommand.startApp(readinessChecker: AppReadinessChecker) {
     // No graphical session (Linux server without DISPLAY/WAYLAND_DISPLAY):
     // the same app is launched as a headless daemon instead of the GUI.
-    val headless = !isGuiEnvironment()
+    // createAppLauncher owns that decision; headless here only picks the prompt.
+    val guiEnvironment = isGuiEnvironment()
+    val headless = !guiEnvironment
     if (!consentToStart(headless)) {
         throw ProgramResult(EXIT_CODE_APP_NOT_RUNNING)
     }
-    val starter = AppAutoStarter(createAppLauncher(CliAppPathProvider(), headless), readinessChecker)
+    val starter =
+        AppAutoStarter(
+            createAppLauncher(CliAppPathProvider(), guiEnvironment = guiEnvironment),
+            readinessChecker,
+        )
     val started = starter.startAndWait { message -> echo(message, err = true) }
     if (!started) {
         throw ProgramResult(1)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -116,26 +116,20 @@ private suspend fun CliktCommand.ensureAppRunning(readinessChecker: AppReadiness
  * blocked on input: it fails fast with [EXIT_CODE_APP_NOT_RUNNING].
  */
 private suspend fun CliktCommand.startApp(readinessChecker: AppReadinessChecker) {
-    if (!isGuiEnvironment()) {
-        echo(
-            "Error: CrossPaste is not running, and this looks like a headless environment " +
-                "(no DISPLAY or WAYLAND_DISPLAY), so the desktop application cannot be " +
-                "started here. Headless daemon support is not available yet.",
-            err = true,
-        )
+    // No graphical session (Linux server without DISPLAY/WAYLAND_DISPLAY):
+    // the same app is launched as a headless daemon instead of the GUI.
+    val headless = !isGuiEnvironment()
+    if (!consentToStart(headless)) {
         throw ProgramResult(EXIT_CODE_APP_NOT_RUNNING)
     }
-    if (!consentToStart()) {
-        throw ProgramResult(EXIT_CODE_APP_NOT_RUNNING)
-    }
-    val starter = AppAutoStarter(createAppLauncher(CliAppPathProvider()), readinessChecker)
+    val starter = AppAutoStarter(createAppLauncher(CliAppPathProvider(), headless), readinessChecker)
     val started = starter.startAndWait { message -> echo(message, err = true) }
     if (!started) {
         throw ProgramResult(1)
     }
 }
 
-private fun CliktCommand.consentToStart(): Boolean =
+private fun CliktCommand.consentToStart(headless: Boolean): Boolean =
     when (currentContext.findObject<CliContext>()?.autoStart) {
         true -> true
         false -> {
@@ -144,7 +138,7 @@ private fun CliktCommand.consentToStart(): Boolean =
         }
         null -> {
             if (terminal.terminalInfo.inputInteractive) {
-                val confirmed = promptStartConfirmation()
+                val confirmed = promptStartConfirmation(headless)
                 if (!confirmed) {
                     echo("Error: CrossPaste is not running.", err = true)
                 }
@@ -165,9 +159,15 @@ private fun CliktCommand.consentToStart(): Boolean =
  * stdout must stay pipe-clean even when stdin is a TTY but stdout is
  * redirected (e.g. `crosspaste --json paste > out`).
  */
-private fun CliktCommand.promptStartConfirmation(): Boolean {
+private fun CliktCommand.promptStartConfirmation(headless: Boolean): Boolean {
+    val prompt =
+        if (headless) {
+            "CrossPaste is not running. Start the headless daemon now? [Y/n]: "
+        } else {
+            "CrossPaste is not running. Start it now? [Y/n]: "
+        }
     while (true) {
-        echo("CrossPaste is not running. Start it now? [Y/n]: ", trailingNewline = false, err = true)
+        echo(prompt, trailingNewline = false, err = true)
         val answer = readlnOrNull()?.trim()?.lowercase() ?: return false
         when (answer) {
             "", "y", "yes" -> return true

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CopyCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CopyCommand.kt
@@ -27,7 +27,8 @@ class CopyCommand(
     private val stdinReader: () -> String = ::readAllStdin,
 ) : CliktCommand(name = "copy") {
 
-    override fun help(context: Context): String = "Copy text to the clipboard via CrossPaste (reads stdin when piped)"
+    override fun help(context: Context): String =
+        "Copy text via CrossPaste: stores it in history and syncs it to your devices (reads stdin when piped)"
 
     // findObject instead of requireObject: tests run this command standalone
     private val ctx: CliContext? by findObject()
@@ -43,7 +44,9 @@ class CopyCommand(
             if (ctx?.json == true) {
                 echo(cliJson.encodeToString(CopyResponse.serializer(), response))
             } else {
-                echo("Copied to clipboard (id=${response.id}).")
+                // "to CrossPaste", not "to clipboard": a headless daemon has no
+                // system clipboard — the paste is stored in history and synced
+                echo("Copied to CrossPaste (id=${response.id}).")
             }
         }
     }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppLauncher.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppLauncher.kt
@@ -25,12 +25,20 @@ interface AppLauncher {
  */
 private fun launchTargetExists(target: Path): Boolean = FileSystem.SYSTEM.exists(target)
 
+/**
+ * The environment → launch-mode decision lives here (not at the call site) so
+ * tests can pin the whole wiring: no graphical session on Linux must produce
+ * a launcher that starts the headless daemon. [os] is injectable for tests
+ * only — macOS and Windows always have a GUI session (see isGuiEnvironment),
+ * so their launchers ignore the flag.
+ */
 @OptIn(ExperimentalNativeApi::class)
 fun createAppLauncher(
     appPathProvider: CliAppPathProvider,
-    headless: Boolean = false,
+    guiEnvironment: Boolean = true,
+    os: OsFamily = Platform.osFamily,
 ): AppLauncher {
-    val os = Platform.osFamily
+    val headless = !guiEnvironment
     return when (os) {
         OsFamily.MACOSX -> MacosAppLauncher(appPathProvider)
         OsFamily.LINUX -> LinuxAppLauncher(appPathProvider, headless)
@@ -55,7 +63,7 @@ class MacosAppLauncher(
 @OptIn(ExperimentalForeignApi::class)
 class LinuxAppLauncher(
     private val appPathProvider: CliAppPathProvider,
-    private val headless: Boolean = false,
+    internal val headless: Boolean = false,
 ) : AppLauncher {
 
     override fun launch(): Boolean {

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppLauncher.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppLauncher.kt
@@ -26,11 +26,14 @@ interface AppLauncher {
 private fun launchTargetExists(target: Path): Boolean = FileSystem.SYSTEM.exists(target)
 
 @OptIn(ExperimentalNativeApi::class)
-fun createAppLauncher(appPathProvider: CliAppPathProvider): AppLauncher {
+fun createAppLauncher(
+    appPathProvider: CliAppPathProvider,
+    headless: Boolean = false,
+): AppLauncher {
     val os = Platform.osFamily
     return when (os) {
         OsFamily.MACOSX -> MacosAppLauncher(appPathProvider)
-        OsFamily.LINUX -> LinuxAppLauncher(appPathProvider)
+        OsFamily.LINUX -> LinuxAppLauncher(appPathProvider, headless)
         OsFamily.WINDOWS -> WindowsAppLauncher(appPathProvider)
         else -> throw IllegalStateException("Unsupported platform: $os")
     }
@@ -52,14 +55,27 @@ class MacosAppLauncher(
 @OptIn(ExperimentalForeignApi::class)
 class LinuxAppLauncher(
     private val appPathProvider: CliAppPathProvider,
+    private val headless: Boolean = false,
 ) : AppLauncher {
 
     override fun launch(): Boolean {
         val launcher = appPathProvider.resolveGuiLaunchTarget()
         if (!launchTargetExists(launcher)) return false
-        val exitCode = system("nohup \"$launcher\" > /dev/null 2>&1 &")
+        val exitCode = system(buildLinuxLaunchCommand(launcher, headless))
         return exitCode == 0
     }
+}
+
+/**
+ * The app would auto-detect a missing DISPLAY anyway, but passing --headless
+ * makes the daemon intent explicit rather than relying on AWT detection.
+ */
+internal fun buildLinuxLaunchCommand(
+    launcher: Path,
+    headless: Boolean,
+): String {
+    val headlessArg = if (headless) " --headless" else ""
+    return "nohup \"$launcher\"$headlessArg > /dev/null 2>&1 &"
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/GuiEnvironment.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/GuiEnvironment.kt
@@ -7,9 +7,9 @@ import kotlin.experimental.ExperimentalNativeApi
 
 /**
  * macOS and Windows always have a graphical session the desktop app can
- * attach to; on Linux the CLI may be running on a headless server where
- * launching the desktop app is impossible (headless daemon support is a
- * separate future deliverable, design P6).
+ * attach to; on Linux the CLI may be running on a headless server, in which
+ * case the app is launched as a headless daemon (`--headless`) instead of
+ * the desktop GUI.
  */
 @OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
 fun isGuiEnvironment(): Boolean =

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/AppLauncherTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/AppLauncherTest.kt
@@ -1,0 +1,20 @@
+package com.crosspaste.cli.platform
+
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppLauncherTest {
+
+    @Test
+    fun linuxGuiLaunchCommandHasNoHeadlessFlag() {
+        val command = buildLinuxLaunchCommand("/opt/crosspaste/bin/crosspaste".toPath(), headless = false)
+        assertEquals("nohup \"/opt/crosspaste/bin/crosspaste\" > /dev/null 2>&1 &", command)
+    }
+
+    @Test
+    fun linuxHeadlessLaunchCommandPassesHeadlessFlag() {
+        val command = buildLinuxLaunchCommand("/opt/crosspaste/bin/crosspaste".toPath(), headless = true)
+        assertEquals("nohup \"/opt/crosspaste/bin/crosspaste\" --headless > /dev/null 2>&1 &", command)
+    }
+}

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/AppLauncherTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/AppLauncherTest.kt
@@ -1,10 +1,30 @@
 package com.crosspaste.cli.platform
 
 import okio.Path.Companion.toPath
+import kotlin.experimental.ExperimentalNativeApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
+@OptIn(ExperimentalNativeApi::class)
 class AppLauncherTest {
+
+    // Environment → launch-mode wiring (headless is decided inside
+    // createAppLauncher, so these pin the whole decision, not just the string)
+
+    @Test
+    fun headlessEnvironmentOnLinuxProducesAHeadlessLauncher() {
+        val launcher = createAppLauncher(CliAppPathProvider(), guiEnvironment = false, os = OsFamily.LINUX)
+        assertTrue(assertIs<LinuxAppLauncher>(launcher).headless)
+    }
+
+    @Test
+    fun guiEnvironmentOnLinuxProducesAGuiLauncher() {
+        val launcher = createAppLauncher(CliAppPathProvider(), guiEnvironment = true, os = OsFamily.LINUX)
+        assertFalse(assertIs<LinuxAppLauncher>(launcher).headless)
+    }
 
     @Test
     fun linuxGuiLaunchCommandHasNoHeadlessFlag() {

--- a/doc/en/CLI.md
+++ b/doc/en/CLI.md
@@ -31,7 +31,7 @@ The examples below use `crosspaste`; on Windows substitute `crosspaste-cli`.
 | `paste [id]` | Show the most recent paste, or a specific paste by ID. |
 | `history` | List recent paste history (`--limit`, `--type`, `--tag`, `--format`). |
 | `search <query>` | Search paste history (same filters as `history`). |
-| `copy [text]` | Copy text to the clipboard via CrossPaste. Reads stdin when piped. |
+| `copy [text]` | Copy text via CrossPaste: stores it in history and syncs it to your devices; the system clipboard is set when the desktop app (not the headless daemon) is running. Reads stdin when piped. |
 | `delete <id>` | Delete a paste by ID. |
 | `devices` | List paired devices and their connection state. |
 | `pair` | Pair with a nearby device by entering the code it displays (see [Pairing from the terminal](#pairing-from-the-terminal)). |
@@ -102,7 +102,7 @@ fi
 2. The target device (desktop or mobile — anything with a screen) displays a 6-digit code. Confirm on that device if it asks.
 3. Type the code in the terminal (input is hidden). On success the two devices trust each other and start syncing.
 
-Pairing is a human confirmation by design, so `pair` requires an interactive terminal — piping input into it is a usage error. You get up to 5 code attempts per session, and an in-progress session is cancelled when the command exits.
+Pairing is a human confirmation by design, so `pair` requires an interactive terminal — piping input into it is a usage error. You get up to 5 code attempts per session; on normal exit the CLI cancels an in-progress session, and a session orphaned by an interrupt (Ctrl-C) is reclaimed by a server-side timeout.
 
 If the device list comes up empty, make sure CrossPaste is running on the other device, both machines are on the same network, and multicast/mDNS traffic is not blocked by a firewall.
 
@@ -114,7 +114,9 @@ Headless mode is auto-detected: on a machine with no `DISPLAY`/`WAYLAND_DISPLAY`
 
 ### Getting started
 
-Install the deb (or unpack the tarball) as described in [Installation](#installation). Then run any CLI command:
+There are two mutually exclusive ways to run the daemon: let the CLI launch it on demand (this section), or have systemd supervise it ([next section](#running-as-a-systemd-user-service)). Pick one — if you want the daemon supervised and started at boot, skip the CLI launch and set up the systemd unit directly.
+
+For the on-demand path: install the deb (or unpack the tarball) as described in [Installation](#installation), then run any command that needs the daemon (`status` is the one exception — it never auto-starts):
 
 ```sh
 crosspaste history
@@ -130,7 +132,13 @@ The GUI and the daemon are one peer: they share the same data directory and sing
 
 ### Running as a systemd user service
 
-The CLI launch above is a convenience; for a server you want the daemon supervised and started at boot. The daemon is per-user (its data and socket live in your home directory), so use a systemd **user** unit, not a system one.
+For a server you want the daemon supervised and started at boot. The daemon is per-user (its data and socket live in your home directory), so use a systemd **user** unit, not a system one.
+
+If a CLI-launched (unmanaged) daemon is already running, stop it **before** enabling the unit — the two are the same single-instance daemon, so each systemd start attempt would otherwise die against the instance lock and `Restart=on-failure` would keep retrying:
+
+```sh
+kill "$(cat ~/.local/share/.crosspaste/crosspaste.pid)"   # graceful shutdown (SIGTERM)
+```
 
 Create `~/.config/systemd/user/crosspaste.service`:
 
@@ -156,6 +164,8 @@ sudo loginctl enable-linger "$USER"   # start at boot, keep running after logout
 ```
 
 There is deliberately no `daemon start/stop` CLI subcommand: `systemctl --user stop crosspaste` (or plain SIGTERM) shuts the daemon down gracefully, and `crosspaste status` reports whether it is running.
+
+Once systemd owns the daemon, keep it that way: if the unit is stopped and a CLI command offers to start CrossPaste, decline (or run with `--no-start`) and use `systemctl --user start crosspaste` instead, so the daemon stays supervised.
 
 ### macOS (launchd)
 
@@ -184,7 +194,7 @@ Then `launchctl load ~/Library/LaunchAgents/com.crosspaste.daemon.plist`.
 
 - `crosspaste status` shows whether the daemon is up; exit code 3 means not running.
 - Logs are written to `~/.local/share/.crosspaste/logs/` (on macOS: `~/Library/Application Support/CrossPaste/logs/`).
-- A second instance refuses to start with an error on stderr and a non-zero exit — that includes trying to start the daemon while the desktop app is running (one peer per machine).
+- A second instance refuses to start with an error on stderr and a non-zero exit — that includes trying to start the daemon while the desktop app is running (the GUI and the daemon are one peer per user).
 - Device discovery needs mDNS/multicast on the local network; if `crosspaste pair` finds nothing, check the firewall and that both machines share a network segment.
 
 ## Shell completion

--- a/doc/en/CLI.md
+++ b/doc/en/CLI.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Command-Line Interface
 
-CrossPaste ships with a command-line client that talks to the desktop application running on the same machine. Use it to copy, paste, search, and manage your pasteboard history from the terminal and from shell scripts.
+CrossPaste ships with a command-line client that talks to the CrossPaste application running on the same machine — the desktop app, or the [headless daemon](#headless-daemon-linux-servers) on a server without a graphical session. Use it to copy, paste, search, and manage your pasteboard history from the terminal and from shell scripts.
 
 The CLI is a thin client: every command goes through the local CrossPaste application (over a Unix domain socket), so the terminal always sees the same history, tags, and devices as the UI, and text copied from the CLI syncs to your other devices like any other paste.
 
@@ -34,6 +34,7 @@ The examples below use `crosspaste`; on Windows substitute `crosspaste-cli`.
 | `copy [text]` | Copy text to the clipboard via CrossPaste. Reads stdin when piped. |
 | `delete <id>` | Delete a paste by ID. |
 | `devices` | List paired devices and their connection state. |
+| `pair` | Pair with a nearby device by entering the code it displays (see [Pairing from the terminal](#pairing-from-the-terminal)). |
 | `config` | View configuration; `config set <key> <value>` changes it. |
 | `tags` | Manage paste tags (`create`, `delete`). |
 | `version` | Show the CLI version. |
@@ -92,6 +93,99 @@ if ! crosspaste status > /dev/null; then
   echo "CrossPaste is not ready"
 fi
 ```
+
+## Pairing from the terminal
+
+`crosspaste pair` pairs this machine with another CrossPaste device without touching the UI — the flow every other sync feature builds on:
+
+1. The command lists nearby unpaired devices discovered on the local network (plus devices that are already known but not yet trusted). Pick one by number, or skip the list with `--target <app-instance-id>`.
+2. The target device (desktop or mobile — anything with a screen) displays a 6-digit code. Confirm on that device if it asks.
+3. Type the code in the terminal (input is hidden). On success the two devices trust each other and start syncing.
+
+Pairing is a human confirmation by design, so `pair` requires an interactive terminal — piping input into it is a usage error. You get up to 5 code attempts per session, and an in-progress session is cancelled when the command exits.
+
+If the device list comes up empty, make sure CrossPaste is running on the other device, both machines are on the same network, and multicast/mDNS traffic is not blocked by a firewall.
+
+## Headless daemon (Linux servers)
+
+CrossPaste also runs on machines without a graphical session — a Linux server over SSH, for example. It is the same application started in headless mode (`--headless`): full sync engine, paste history database, and CLI endpoint, but no window and no system-clipboard access. `crosspaste copy` on such a machine adds the content straight to history and syncs it to your paired devices; `crosspaste paste --raw` fetches what you copied elsewhere.
+
+Headless mode is auto-detected: on a machine with no `DISPLAY`/`WAYLAND_DISPLAY` the app enters it even without the flag.
+
+### Getting started
+
+Install the deb (or unpack the tarball) as described in [Installation](#installation). Then run any CLI command:
+
+```sh
+crosspaste history
+```
+
+When the daemon is not running, the CLI offers to start it (or use `--start` to skip the question; scripts get exit code 3 instead of a prompt). Then pair with your other devices:
+
+```sh
+crosspaste pair
+```
+
+The GUI and the daemon are one peer: they share the same data directory and single-instance lock, so exactly one of them runs per user at a time.
+
+### Running as a systemd user service
+
+The CLI launch above is a convenience; for a server you want the daemon supervised and started at boot. The daemon is per-user (its data and socket live in your home directory), so use a systemd **user** unit, not a system one.
+
+Create `~/.config/systemd/user/crosspaste.service`:
+
+```ini
+[Unit]
+Description=CrossPaste headless daemon
+
+[Service]
+# deb install path; for a tarball use <install-dir>/bin/crosspaste
+ExecStart=/usr/lib/crosspaste/bin/crosspaste --headless
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+Enable it, and allow it to run while you are not logged in:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now crosspaste
+sudo loginctl enable-linger "$USER"   # start at boot, keep running after logout
+```
+
+There is deliberately no `daemon start/stop` CLI subcommand: `systemctl --user stop crosspaste` (or plain SIGTERM) shuts the daemon down gracefully, and `crosspaste status` reports whether it is running.
+
+### macOS (launchd)
+
+A headless macOS machine is rare, but the equivalent is a LaunchAgent. Only use this on a Mac where the desktop app never runs: the app and the daemon are one peer sharing a single-instance lock, so with the GUI running launchd would keep restarting the daemon into that lock. Create `~/Library/LaunchAgents/com.crosspaste.daemon.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.crosspaste.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Applications/CrossPaste.app/Contents/MacOS/CrossPaste</string>
+    <string>--headless</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+</dict>
+</plist>
+```
+
+Then `launchctl load ~/Library/LaunchAgents/com.crosspaste.daemon.plist`.
+
+### Troubleshooting
+
+- `crosspaste status` shows whether the daemon is up; exit code 3 means not running.
+- Logs are written to `~/.local/share/.crosspaste/logs/` (on macOS: `~/Library/Application Support/CrossPaste/logs/`).
+- A second instance refuses to start with an error on stderr and a non-zero exit — that includes trying to start the daemon while the desktop app is running (one peer per machine).
+- Device discovery needs mDNS/multicast on the local network; if `crosspaste pair` finds nothing, check the firewall and that both machines share a network segment.
 
 ## Shell completion
 

--- a/doc/zh/CLI.md
+++ b/doc/zh/CLI.md
@@ -4,7 +4,7 @@ outline: deep
 
 # 命令行工具
 
-CrossPaste 自带一个命令行客户端，与同一台机器上运行的桌面应用通信。你可以在终端和 shell 脚本里复制、粘贴、搜索和管理粘贴板历史。
+CrossPaste 自带一个命令行客户端，与同一台机器上运行的 CrossPaste 应用通信——桌面应用，或无图形会话服务器上的 [headless 守护进程](#headless-守护进程linux-服务器)。你可以在终端和 shell 脚本里复制、粘贴、搜索和管理粘贴板历史。
 
 CLI 是一个薄客户端：所有命令都经由本机的 CrossPaste 应用完成（通过 Unix domain socket），因此终端看到的历史、标签、设备与 UI 完全一致；从 CLI 复制的文本也会像普通粘贴一样同步到你的其他设备。
 
@@ -34,6 +34,7 @@ CLI 二进制随所有桌面安装包一起分发，各平台的差异只在于�
 | `copy [text]` | 通过 CrossPaste 复制文本到剪贴板；接管道时读取 stdin。 |
 | `delete <id>` | 按 ID 删除一条粘贴。 |
 | `devices` | 列出已配对设备及连接状态。 |
+| `pair` | 与附近设备配对：输入对方屏幕上显示的配对码（见[在终端里配对](#在终端里配对)）。 |
 | `config` | 查看配置；`config set <key> <value>` 修改配置。 |
 | `tags` | 管理粘贴标签（`create`、`delete`）。 |
 | `version` | 显示 CLI 版本。 |
@@ -92,6 +93,99 @@ if ! crosspaste status > /dev/null; then
   echo "CrossPaste 尚未就绪"
 fi
 ```
+
+## 在终端里配对
+
+`crosspaste pair` 让这台机器不经任何 UI 就能与另一台 CrossPaste 设备配对——这是所有同步功能的前提：
+
+1. 命令列出局域网内发现的附近未配对设备（以及已知但尚未信任的设备）。按序号选择，或用 `--target <app-instance-id>` 跳过列表。
+2. 目标设备（桌面或移动端，任何有屏幕的设备）会显示一个 6 位配对码；如有弹窗请在该设备上确认。
+3. 在终端输入配对码（输入不回显）。成功后两台设备互相信任并开始同步。
+
+配对本质是一次人工确认，因此 `pair` 要求交互式终端——向它管道输入会被视为参数错误。每个会话最多允许输入 5 次配对码；命令退出时会取消进行中的会话。
+
+如果设备列表为空，请确认对方设备上的 CrossPaste 正在运行、两台机器在同一网络，且防火墙没有拦截 multicast/mDNS 流量。
+
+## headless 守护进程（Linux 服务器）
+
+CrossPaste 也能在没有图形会话的机器上运行——例如通过 SSH 访问的 Linux 服务器。它就是同一个应用以 headless 模式（`--headless`）启动：完整的同步引擎、粘贴历史数据库和 CLI 端点，只是没有窗口、不接触系统剪贴板。在这样的机器上，`crosspaste copy` 直接把内容写入历史并同步到已配对设备；`crosspaste paste --raw` 取回你在其他设备上复制的内容。
+
+headless 模式是自动检测的：机器上没有 `DISPLAY`/`WAYLAND_DISPLAY` 时，即使不带参数也会进入 headless 模式。
+
+### 快速开始
+
+按[安装](#安装)一节装好 deb（或解压 tarball），然后运行任意 CLI 命令：
+
+```sh
+crosspaste history
+```
+
+守护进程未运行时，CLI 会询问是否拉起（也可用 `--start` 免询问；脚本场景不会弹询问，直接返回退出码 3）。然后与其他设备配对：
+
+```sh
+crosspaste pair
+```
+
+图形应用与守护进程是同一个 peer：它们共享同一数据目录和单实例锁，同一用户同一时刻只会运行其中一个。
+
+### 用 systemd 用户服务常驻
+
+CLI 拉起只是便捷方式；服务器上应该让守护进程被托管、开机自启。守护进程是按用户隔离的（数据与 socket 都在用户主目录下），所以要用 systemd **用户** 单元，而不是系统单元。
+
+创建 `~/.config/systemd/user/crosspaste.service`：
+
+```ini
+[Unit]
+Description=CrossPaste headless daemon
+
+[Service]
+# deb 安装路径；tarball 用 <安装目录>/bin/crosspaste
+ExecStart=/usr/lib/crosspaste/bin/crosspaste --headless
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+启用它，并允许在未登录时运行：
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now crosspaste
+sudo loginctl enable-linger "$USER"   # 开机自启，注销后继续运行
+```
+
+CLI 刻意不提供 `daemon start/stop` 子命令：`systemctl --user stop crosspaste`（或直接 SIGTERM）即可优雅停机，`crosspaste status` 查看是否在运行。
+
+### macOS（launchd）
+
+headless 的 macOS 机器很少见，等价方式是 LaunchAgent。只在桌面应用从不运行的 Mac 上使用：应用与守护进程是共享单实例锁的同一个 peer，图形应用在跑时 launchd 会不断把守护进程重启到锁上。创建 `~/Library/LaunchAgents/com.crosspaste.daemon.plist`：
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.crosspaste.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Applications/CrossPaste.app/Contents/MacOS/CrossPaste</string>
+    <string>--headless</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+</dict>
+</plist>
+```
+
+然后执行 `launchctl load ~/Library/LaunchAgents/com.crosspaste.daemon.plist`。
+
+### 排障
+
+- `crosspaste status` 查看守护进程是否在运行；退出码 3 表示未运行。
+- 日志写入 `~/.local/share/.crosspaste/logs/`（macOS 为 `~/Library/Application Support/CrossPaste/logs/`）。
+- 第二个实例会拒绝启动（stderr 报错 + 非零退出码）——包括桌面应用运行时再启动守护进程（每台机器只有一个 peer）。
+- 设备发现依赖局域网 mDNS/multicast；`crosspaste pair` 找不到设备时，请检查防火墙以及两台机器是否在同一网段。
 
 ## Shell 补全
 

--- a/doc/zh/CLI.md
+++ b/doc/zh/CLI.md
@@ -31,7 +31,7 @@ CLI 二进制随所有桌面安装包一起分发，各平台的差异只在于�
 | `paste [id]` | 显示最近一条粘贴，或按 ID 显示指定一条。 |
 | `history` | 列出最近粘贴历史（`--limit`、`--type`、`--tag`、`--format`）。 |
 | `search <query>` | 搜索粘贴历史（过滤参数与 `history` 相同）。 |
-| `copy [text]` | 通过 CrossPaste 复制文本到剪贴板；接管道时读取 stdin。 |
+| `copy [text]` | 通过 CrossPaste 复制文本：写入历史并同步到其他设备；仅当桌面应用（而非 headless 守护进程）在运行时才会写系统剪贴板。接管道时读取 stdin。 |
 | `delete <id>` | 按 ID 删除一条粘贴。 |
 | `devices` | 列出已配对设备及连接状态。 |
 | `pair` | 与附近设备配对：输入对方屏幕上显示的配对码（见[在终端里配对](#在终端里配对)）。 |
@@ -102,7 +102,7 @@ fi
 2. 目标设备（桌面或移动端，任何有屏幕的设备）会显示一个 6 位配对码；如有弹窗请在该设备上确认。
 3. 在终端输入配对码（输入不回显）。成功后两台设备互相信任并开始同步。
 
-配对本质是一次人工确认，因此 `pair` 要求交互式终端——向它管道输入会被视为参数错误。每个会话最多允许输入 5 次配对码；命令退出时会取消进行中的会话。
+配对本质是一次人工确认，因此 `pair` 要求交互式终端——向它管道输入会被视为参数错误。每个会话最多允许输入 5 次配对码；命令正常退出时会取消进行中的会话，被中断（Ctrl-C）遗留的会话则由服务端超时兜底回收。
 
 如果设备列表为空，请确认对方设备上的 CrossPaste 正在运行、两台机器在同一网络，且防火墙没有拦截 multicast/mDNS 流量。
 
@@ -114,7 +114,9 @@ headless 模式是自动检测的：机器上没有 `DISPLAY`/`WAYLAND_DISPLAY` 
 
 ### 快速开始
 
-按[安装](#安装)一节装好 deb（或解压 tarball），然后运行任意 CLI 命令：
+运行守护进程有两条互斥的路径：让 CLI 按需拉起（本节），或交给 systemd 托管（[下一节](#用-systemd-用户服务常驻)）。二选一——如果你想要守护进程被托管、开机自启，请跳过 CLI 拉起，直接配置 systemd 单元。
+
+按需拉起路径：按[安装](#安装)一节装好 deb（或解压 tarball），然后运行任意需要守护进程的命令（唯一例外是 `status`，它刻意永不自动拉起）：
 
 ```sh
 crosspaste history
@@ -130,7 +132,13 @@ crosspaste pair
 
 ### 用 systemd 用户服务常驻
 
-CLI 拉起只是便捷方式；服务器上应该让守护进程被托管、开机自启。守护进程是按用户隔离的（数据与 socket 都在用户主目录下），所以要用 systemd **用户** 单元，而不是系统单元。
+服务器上应该让守护进程被托管、开机自启。守护进程是按用户隔离的（数据与 socket 都在用户主目录下），所以要用 systemd **用户** 单元，而不是系统单元。
+
+如果已经有一个 CLI 拉起的（非托管）守护进程在跑，**先停掉它再启用单元**——两者是同一个单实例守护进程，否则 systemd 每次启动都会撞单实例锁退出，`Restart=on-failure` 会不停重试：
+
+```sh
+kill "$(cat ~/.local/share/.crosspaste/crosspaste.pid)"   # 优雅停机（SIGTERM）
+```
 
 创建 `~/.config/systemd/user/crosspaste.service`：
 
@@ -156,6 +164,8 @@ sudo loginctl enable-linger "$USER"   # 开机自启，注销后继续运行
 ```
 
 CLI 刻意不提供 `daemon start/stop` 子命令：`systemctl --user stop crosspaste`（或直接 SIGTERM）即可优雅停机，`crosspaste status` 查看是否在运行。
+
+一旦交给 systemd 托管，就保持托管：单元停止时如果某个 CLI 命令询问是否拉起 CrossPaste，请拒绝（或用 `--no-start`），改用 `systemctl --user start crosspaste`，让守护进程始终处于被托管状态。
 
 ### macOS（launchd）
 
@@ -184,7 +194,7 @@ headless 的 macOS 机器很少见，等价方式是 LaunchAgent。只在桌面�
 
 - `crosspaste status` 查看守护进程是否在运行；退出码 3 表示未运行。
 - 日志写入 `~/.local/share/.crosspaste/logs/`（macOS 为 `~/Library/Application Support/CrossPaste/logs/`）。
-- 第二个实例会拒绝启动（stderr 报错 + 非零退出码）——包括桌面应用运行时再启动守护进程（每台机器只有一个 peer）。
+- 第二个实例会拒绝启动（stderr 报错 + 非零退出码）——包括桌面应用运行时再启动守护进程（图形应用与守护进程是同一用户下的同一个 peer）。
 - 设备发现依赖局域网 mDNS/multicast；`crosspaste pair` 找不到设备时，请检查防火墙以及两台机器是否在同一网段。
 
 ## Shell 补全


### PR DESCRIPTION
Closes #4787

## Summary

P6.3 of the CLI daemon plan: the last mile for Linux servers. On a headless machine the CLI no longer refuses with *"Headless daemon support is not available yet"* — it offers to start the app as a headless daemon, and the CLI guide now documents terminal pairing and persistent daemon deployment.

## Changes

### CLI launch wiring (`cli/`)

- `CliCommandHelper.startApp`: the headless environment check no longer fails fast. Instead `headless = !isGuiEnvironment()` flows through the existing consent tri-state (`--start` / `--no-start` / TTY prompt) and the 30s readiness wait; the interactive prompt says "Start the headless daemon now?" so the user knows a background daemon (not a window) is coming. Non-interactive behavior is unchanged: never blocks on input, exit code 3.
- `LinuxAppLauncher`: launches `nohup bin/crosspaste --headless` when headless. The app would auto-detect a missing DISPLAY anyway; passing the flag makes the intent explicit rather than relying on AWT detection. `headless` can only be true on Linux (`isGuiEnvironment()` is constant-true on macOS/Windows), and the command construction is extracted as `buildLinuxLaunchCommand` for testing.

### Documentation (`doc/en/CLI.md`, `doc/zh/CLI.md`)

- New **Pairing from the terminal** section for `crosspaste pair` (added in #4786 but not yet documented): device selection, code entry, `--target`, interactivity requirement, empty-list troubleshooting.
- New **Headless daemon (Linux servers)** section: what headless mode is (same app, full sync engine, no clipboard), getting started (deb/tarball → any CLI command offers to start the daemon → `pair`), a systemd **user** unit template with `loginctl enable-linger` for boot persistence, a launchd LaunchAgent example for the rare headless mac (with a warning about the single-instance lock when the GUI also runs), and troubleshooting (status/exit codes, log locations, one-peer-per-machine, mDNS requirements).
- No `daemon start/stop` subcommand by design: systemd/SIGTERM own stop semantics, `crosspaste status` reports liveness.

## Tests

- New `AppLauncherTest` pins the Linux launch command with and without `--headless`.
- `:cli:macosArm64Test` green; `:cli:compileTestKotlinLinuxX64` compiles.

## Validation on real Linux

End-to-end in a Docker Linux (arm64) container with the real cross-compiled CLI binary, a stub `bin/crosspaste` recording its argv, and a fake daemon that publishes `cli-endpoint.json` only after its unix socket is live (matching the real app's semantics). 13/13 assertions passed across 4 cases:

1. non-TTY without `--start` → exit 3, `--start` hint, launcher never invoked
2. TTY prompt answered with Enter → "Start the headless daemon now?" wording, launcher invoked with `--headless`, readiness wait, command output
3. `--start` non-interactive → auto-launch without any prompt
4. TTY prompt answered `n` → exit 3, launcher never invoked

An independent strict review found no blocking issues; its two documentation findings (ineffective `After=network-online.target` in a user unit, launchd `KeepAlive` vs. the single-instance lock) are addressed in this PR.