### PR TITLE
:sparkles: dump image bytes and render inline terminal previews from the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ development.properties
 generated.conveyor.conf
 local.properties
 local.conveyor.conf
+local-mac.conveyor.conf
 i18n_key.txt
 package*.json
 selenium-manager

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ development.properties
 generated.conveyor.conf
 local.properties
 local.conveyor.conf
-local-mac.conveyor.conf
 i18n_key.txt
 package*.json
 selenium-manager

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ generated.conveyor.conf
 local.properties
 local.conveyor.conf
 local-mac.conveyor.conf
+local-win.conveyor.conf
 i18n_key.txt
 package*.json
 selenium-manager

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -110,6 +110,7 @@ fun desktopNetworkModule(marketingMode: Boolean): Module =
                 pasteTagDao = get(),
                 searchContentService = get(),
                 syncRuntimeInfoDao = get(),
+                userDataPathProvider = get(),
             )
         }
         // endregion

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
@@ -62,6 +62,12 @@ data class CliPasteDetailDto(
     val content: String?,
     /** Content exactly as stored (HTML/RTF keep their source markup). */
     val rawContent: String?,
+    /**
+     * Absolute paths of the stored payload files (image/file pastes only,
+     * empty otherwise). The CLI runs on the same machine, so it reads the
+     * bytes directly instead of streaming them over the socket.
+     */
+    val filePaths: List<String> = emptyList(),
 )
 
 @Serializable

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -16,8 +16,11 @@ import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.PasteFiles
 import com.crosspaste.paste.item.PasteItemReader
+import com.crosspaste.paste.item.getFilePaths
 import com.crosspaste.paste.plugin.type.DesktopTextTypePlugin
+import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
@@ -48,6 +51,7 @@ fun Routing.cliRouting(
     pasteTagDao: PasteTagDao,
     searchContentService: SearchContentService,
     syncRuntimeInfoDao: SyncRuntimeInfoDao,
+    userDataPathProvider: UserDataPathProvider,
 ) {
     route("/cli") {
         get("/status") {
@@ -55,12 +59,24 @@ fun Routing.cliRouting(
         }
 
         get("/paste/latest") {
-            respondPasteDetail(call, pasteDao.getLatestLoadedPasteData(), pasteTagDao, pasteItemReader)
+            respondPasteDetail(
+                call,
+                pasteDao.getLatestLoadedPasteData(),
+                pasteTagDao,
+                pasteItemReader,
+                userDataPathProvider,
+            )
         }
 
         get("/paste/{id}") {
             val id = call.requireLongParameter("id", "Invalid paste id.") ?: return@get
-            respondPasteDetail(call, pasteDao.getNoDeletePasteData(id), pasteTagDao, pasteItemReader)
+            respondPasteDetail(
+                call,
+                pasteDao.getNoDeletePasteData(id),
+                pasteTagDao,
+                pasteItemReader,
+                userDataPathProvider,
+            )
         }
 
         get("/history") {
@@ -251,6 +267,7 @@ private suspend fun respondPasteDetail(
     pasteData: PasteData?,
     pasteTagDao: PasteTagDao,
     pasteItemReader: PasteItemReader,
+    userDataPathProvider: UserDataPathProvider,
 ) {
     // Raw markup is opt-in (?includeRaw=true): for plain text raw == summary,
     // so sending both unconditionally would ship large pastes twice per
@@ -259,7 +276,7 @@ private suspend fun respondPasteDetail(
     if (pasteData == null) {
         call.respond(HttpStatusCode.NotFound, CliMessageDto("Paste not found."))
     } else {
-        call.respond(pasteData.toDetailDto(pasteTagDao, pasteItemReader, includeRaw))
+        call.respond(pasteData.toDetailDto(pasteTagDao, pasteItemReader, includeRaw, userDataPathProvider))
     }
 }
 
@@ -561,6 +578,7 @@ private suspend fun PasteData.toDetailDto(
     pasteTagDao: PasteTagDao,
     pasteItemReader: PasteItemReader,
     includeRaw: Boolean,
+    userDataPathProvider: UserDataPathProvider,
 ): CliPasteDetailDto =
     CliPasteDetailDto(
         id = id,
@@ -573,6 +591,11 @@ private suspend fun PasteData.toDetailDto(
         hash = hash,
         content = pasteAppearItem?.let { pasteItemReader.getSummary(it) },
         rawContent = if (includeRaw) pasteAppearItem?.let { pasteItemReader.getRaw(it) } else null,
+        filePaths =
+            (pasteAppearItem as? PasteFiles)
+                ?.getFilePaths(userDataPathProvider)
+                ?.map { it.toString() }
+                .orEmpty(),
     )
 
 private fun parseConfigValue(

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliServer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliServer.kt
@@ -11,6 +11,7 @@ import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.item.PasteItemReader
+import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.getAppEnvUtils
 import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -60,6 +61,7 @@ class CliServer(
     private val pasteTagDao: PasteTagDao,
     private val searchContentService: SearchContentService,
     private val syncRuntimeInfoDao: SyncRuntimeInfoDao,
+    private val userDataPathProvider: UserDataPathProvider,
     private val socketBaseDir: Path = Paths.get(System.getProperty("java.io.tmpdir")),
 ) {
 
@@ -196,6 +198,7 @@ class CliServer(
                 pasteTagDao = pasteTagDao,
                 searchContentService = searchContentService,
                 syncRuntimeInfoDao = syncRuntimeInfoDao,
+                userDataPathProvider = userDataPathProvider,
             )
         }
     }

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliDtoContractTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliDtoContractTest.kt
@@ -92,6 +92,7 @@ class CliDtoContractTest {
                     hash = "abc",
                     content = "hello",
                     rawContent = "<b>hello</b>",
+                    filePaths = listOf("/tmp/images/shot.png"),
                 ),
             )
         assertEquals(
@@ -106,6 +107,7 @@ class CliDtoContractTest {
                 "hash",
                 "content",
                 "rawContent",
+                "filePaths",
             ),
             fieldsOf(encoded),
         )

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.cli
 
 import com.crosspaste.app.AppInfo
+import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.config.DesktopAppConfig
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.db.paste.PasteDao
@@ -17,10 +18,14 @@ import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.paste.SearchContentService
 import com.crosspaste.paste.item.CreatePasteItemHelper.createHtmlPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createImagesPasteItem
 import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
 import com.crosspaste.paste.item.DefaultPasteItemReader
 import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.path.PlatformUserDataPathProvider
+import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.platform.Platform
+import com.crosspaste.presist.SingleFileInfoTree
 import com.crosspaste.utils.getJsonUtils
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -42,6 +47,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
+import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -65,6 +71,18 @@ class CliRoutingTest {
     private class Fixture {
         val cliPairingService = mockk<CliPairingService>()
         val configManager = mockk<DesktopConfigManager>()
+
+        // Real provider over a stub platform path: paste items in these tests
+        // carry an explicit basePath, so only relative resolution is exercised
+        val userDataPathProvider =
+            UserDataPathProvider(
+                mockk<CommonConfigManager> {
+                    every { getCurrentConfig() } returns DesktopAppConfig(language = "en")
+                },
+                object : PlatformUserDataPathProvider {
+                    override fun getUserDefaultStoragePath() = "/tmp/cli-routing-test".toPath()
+                },
+            )
         val pasteboardService = mockk<PasteboardService>()
         val pasteDao = mockk<PasteDao>()
         val pasteReleaseService = mockk<PasteReleaseService>()
@@ -118,6 +136,7 @@ class CliRoutingTest {
                 pasteTagDao = fixture.pasteTagDao,
                 searchContentService = fixture.searchContentService,
                 syncRuntimeInfoDao = fixture.syncRuntimeInfoDao,
+                userDataPathProvider = fixture.userDataPathProvider,
             )
         }
     }
@@ -139,6 +158,52 @@ class CliRoutingTest {
             createTime = 123L,
             pasteState = PasteState.LOADED,
         )
+    }
+
+    @Test
+    fun `image paste detail carries absolute file paths`() {
+        val fixture = Fixture()
+        val item =
+            createImagesPasteItem(
+                basePath = "/tmp/images-store",
+                relativePathList = listOf("shot.png"),
+                fileInfoTreeMap = mapOf("shot.png" to SingleFileInfoTree(size = 10L, hash = "img")),
+            )
+        val pasteData =
+            PasteData(
+                id = 7L,
+                appInstanceId = appInfo.appInstanceId,
+                pasteAppearItem = item,
+                pasteCollection = PasteCollection(listOf()),
+                pasteType = PasteType.IMAGE_TYPE.type,
+                source = "Test",
+                size = item.size,
+                hash = item.hash,
+                createTime = 123L,
+                pasteState = PasteState.LOADED,
+            )
+        coEvery { fixture.pasteDao.getLatestLoadedPasteData() } returns pasteData
+        withCliRouting(fixture) {
+            val detail =
+                json.decodeFromString<CliPasteDetailDto>(
+                    client.get("/cli/paste/latest").bodyAsText(),
+                )
+            assertEquals("image", detail.typeName)
+            assertEquals(listOf("/tmp/images-store/shot.png"), detail.filePaths)
+        }
+    }
+
+    @Test
+    fun `text paste detail has no file paths`() {
+        val fixture = Fixture()
+        coEvery { fixture.pasteDao.getLatestLoadedPasteData() } returns textPasteData(42L, "hello")
+        withCliRouting(fixture) {
+            val detail =
+                json.decodeFromString<CliPasteDetailDto>(
+                    client.get("/cli/paste/latest").bodyAsText(),
+                )
+            assertEquals(emptyList(), detail.filePaths)
+        }
     }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliServerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliServerTest.kt
@@ -55,7 +55,8 @@ class CliServerTest {
             object : PlatformUserDataPathProvider {
                 override fun getUserDefaultStoragePath() = userDataDir.toFile().toOkioPath()
             }
-        val endpointFile = CliEndpointFile(UserDataPathProvider(pathConfigManager, platformProvider))
+        val userDataPathProvider = UserDataPathProvider(pathConfigManager, platformProvider)
+        val endpointFile = CliEndpointFile(userDataPathProvider)
 
         val pasteDao = mockk<PasteDao>()
         coEvery { pasteDao.getActiveCount() } returns 3L
@@ -82,6 +83,7 @@ class CliServerTest {
                 pasteTagDao = mockk<PasteTagDao>(),
                 searchContentService = mockk<SearchContentService>(),
                 syncRuntimeInfoDao = syncRuntimeInfoDao,
+                userDataPathProvider = userDataPathProvider,
                 socketBaseDir = socketBaseDir,
             )
         return server to endpointFile

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
@@ -1,14 +1,7 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
-import com.crosspaste.cli.platform.TerminalImageProtocol
-import com.crosspaste.cli.platform.buildItermInlineImage
-import com.crosspaste.cli.platform.buildKittyInlineImage
 import com.crosspaste.cli.platform.detectTerminalImageProtocol
-import com.crosspaste.cli.platform.flushStdout
-import com.crosspaste.cli.platform.isPng
-import com.crosspaste.cli.platform.prepareStdoutForBinary
-import com.crosspaste.cli.platform.writeBytesToStdout
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.ProgramResult
@@ -20,10 +13,6 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.long
 import kotlinx.serialization.Serializable
-import okio.FileSystem
-import okio.Path.Companion.toPath
-import okio.buffer
-import okio.use
 
 @Serializable
 data class PasteDetailResponse(
@@ -138,48 +127,34 @@ class PasteCommand : CliktCommand(name = "paste") {
      * app and CLI share the machine. Text pastes keep the string path.
      */
     private fun printRawImage(detail: PasteDetailResponse) {
-        if (detail.filePaths.isEmpty()) {
-            echo(
-                "Error: the running CrossPaste app does not expose image file paths yet; " +
-                    "update (or restart) the app.",
-                err = true,
-            )
-            throw ProgramResult(1)
-        }
-        if (detail.filePaths.size > 1) {
-            echo(
-                "Error: paste #${detail.id} contains ${detail.filePaths.size} images; " +
-                    "--raw needs a single image. Paths:",
-                err = true,
-            )
-            detail.filePaths.forEach { echo("  $it", err = true) }
-            throw ProgramResult(1)
-        }
-        streamFileToStdout(detail, detail.filePaths.single())
-    }
-
-    private fun streamFileToStdout(
-        detail: PasteDetailResponse,
-        path: String,
-    ) {
-        prepareStdoutForBinary()
-        try {
-            FileSystem.SYSTEM.source(path.toPath()).buffer().use { source ->
-                val buffer = ByteArray(64 * 1024)
-                while (true) {
-                    val read = source.read(buffer, 0, buffer.size)
-                    if (read == -1) break
-                    writeBytesToStdout(buffer, read)
-                }
+        when (val action = resolveRawImageAction(detail.filePaths)) {
+            RawImageAction.MissingPaths -> {
+                echo(
+                    "Error: the running CrossPaste app does not expose image file paths yet; " +
+                        "update (or restart) the app.",
+                    err = true,
+                )
+                throw ProgramResult(1)
             }
-        } catch (e: okio.IOException) {
-            echo(
-                "Error: cannot read the stored image of paste #${detail.id}: ${e.message}",
-                err = true,
-            )
-            throw ProgramResult(1)
-        } finally {
-            flushStdout()
+            is RawImageAction.TooManyImages -> {
+                echo(
+                    "Error: paste #${detail.id} contains ${action.paths.size} images; " +
+                        "--raw needs a single image. Paths:",
+                    err = true,
+                )
+                action.paths.forEach { echo("  $it", err = true) }
+                throw ProgramResult(1)
+            }
+            is RawImageAction.StreamSingle ->
+                try {
+                    ImageByteStreamer().stream(action.path)
+                } catch (e: okio.IOException) {
+                    echo(
+                        "Error: cannot read the stored image of paste #${detail.id}: ${e.message}",
+                        err = true,
+                    )
+                    throw ProgramResult(1)
+                }
         }
     }
 
@@ -209,43 +184,15 @@ class PasteCommand : CliktCommand(name = "paste") {
 
     /**
      * Inline preview in terminals with an image protocol; anywhere else the
-     * absolute paths printed above are the fallback. Uses stdlib print like
-     * [printContentOnly]: Mordant re-renders strings and would mangle the
-     * escape sequences.
+     * absolute paths printed above are the fallback. Escape sequences go
+     * through stdlib print like [printContentOnly]: Mordant re-renders
+     * strings and would mangle them.
      */
     private fun renderInlineImages(detail: PasteDetailResponse) {
-        val protocol = detectTerminalImageProtocol() ?: return
-        for (path in detail.filePaths) {
-            val bytes = readImageForInline(path) ?: continue
-            when (protocol) {
-                TerminalImageProtocol.ITERM -> print(buildItermInlineImage(path.toPath().name, bytes))
-                TerminalImageProtocol.KITTY -> {
-                    // Kitty's f=100 transfer is PNG-only; other formats keep
-                    // the path fallback
-                    if (!isPng(bytes)) continue
-                    print(buildKittyInlineImage(bytes))
-                }
-            }
-            println()
-        }
-    }
-
-    private fun readImageForInline(path: String): ByteArray? {
-        val okioPath = path.toPath()
-        return try {
-            val size = FileSystem.SYSTEM.metadata(okioPath).size ?: return null
-            if (size > MAX_INLINE_IMAGE_BYTES) {
-                echo("  (image too large for inline preview: $path)", err = true)
-                return null
-            }
-            FileSystem.SYSTEM.read(okioPath) { readByteArray() }
-        } catch (_: okio.IOException) {
-            null
-        }
-    }
-
-    companion object {
-        /** Inline preview only; --raw streams without a cap. */
-        private const val MAX_INLINE_IMAGE_BYTES = 20L * 1024 * 1024
+        InlineImageRenderer(
+            protocol = detectTerminalImageProtocol(),
+            emit = { print(it) },
+            note = { echo("  $it") },
+        ).render(detail.filePaths)
     }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
@@ -218,7 +218,7 @@ class PasteCommand : CliktCommand(name = "paste") {
         for (path in detail.filePaths) {
             val bytes = readImageForInline(path) ?: continue
             when (protocol) {
-                TerminalImageProtocol.ITERM -> print(buildItermInlineImage(path.substringAfterLast('/'), bytes))
+                TerminalImageProtocol.ITERM -> print(buildItermInlineImage(path.toPath().name, bytes))
                 TerminalImageProtocol.KITTY -> {
                     // Kitty's f=100 transfer is PNG-only; other formats keep
                     // the path fallback

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
@@ -1,16 +1,29 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
+import com.crosspaste.cli.platform.TerminalImageProtocol
+import com.crosspaste.cli.platform.buildItermInlineImage
+import com.crosspaste.cli.platform.buildKittyInlineImage
+import com.crosspaste.cli.platform.detectTerminalImageProtocol
+import com.crosspaste.cli.platform.flushStdout
+import com.crosspaste.cli.platform.isPng
+import com.crosspaste.cli.platform.prepareStdoutForBinary
+import com.crosspaste.cli.platform.writeBytesToStdout
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.long
 import kotlinx.serialization.Serializable
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import okio.buffer
+import okio.use
 
 @Serializable
 data class PasteDetailResponse(
@@ -26,6 +39,8 @@ data class PasteDetailResponse(
     val content: String?,
     /** Content exactly as stored (HTML/RTF keep their source markup). */
     val rawContent: String? = null,
+    /** Absolute paths of stored payload files (image/file pastes only). */
+    val filePaths: List<String> = emptyList(),
 )
 
 class PasteCommand : CliktCommand(name = "paste") {
@@ -41,7 +56,8 @@ class PasteCommand : CliktCommand(name = "paste") {
         "-r",
         help =
             "Print only the paste content, exactly as stored — HTML/RTF print their source " +
-                "markup (for piping, e.g. `crosspaste paste -r | pbcopy`)",
+                "markup, image pastes dump the image bytes (for piping, e.g. " +
+                "`crosspaste paste -r | pbcopy` or `crosspaste paste -r > shot.png`)",
     ).flag()
 
     private val summary by option(
@@ -70,6 +86,7 @@ class PasteCommand : CliktCommand(name = "paste") {
             val detail = client.getBody(path, PasteDetailResponse.serializer())
 
             when {
+                raw && detail.typeName == "image" -> printRawImage(detail)
                 raw -> printRawContent(detail)
                 summary -> printContentOnly(detail, detail.content)
                 ctx.json -> echo(cliJson.encodeToString(PasteDetailResponse.serializer(), detail))
@@ -115,6 +132,57 @@ class PasteCommand : CliktCommand(name = "paste") {
         }
     }
 
+    /**
+     * `--raw` on an image paste dumps the stored image bytes (for piping:
+     * `crosspaste paste --raw > shot.png`); the file is read directly since
+     * app and CLI share the machine. Text pastes keep the string path.
+     */
+    private fun printRawImage(detail: PasteDetailResponse) {
+        if (detail.filePaths.isEmpty()) {
+            echo(
+                "Error: the running CrossPaste app does not expose image file paths yet; " +
+                    "update (or restart) the app.",
+                err = true,
+            )
+            throw ProgramResult(1)
+        }
+        if (detail.filePaths.size > 1) {
+            echo(
+                "Error: paste #${detail.id} contains ${detail.filePaths.size} images; " +
+                    "--raw needs a single image. Paths:",
+                err = true,
+            )
+            detail.filePaths.forEach { echo("  $it", err = true) }
+            throw ProgramResult(1)
+        }
+        streamFileToStdout(detail, detail.filePaths.single())
+    }
+
+    private fun streamFileToStdout(
+        detail: PasteDetailResponse,
+        path: String,
+    ) {
+        prepareStdoutForBinary()
+        try {
+            FileSystem.SYSTEM.source(path.toPath()).buffer().use { source ->
+                val buffer = ByteArray(64 * 1024)
+                while (true) {
+                    val read = source.read(buffer, 0, buffer.size)
+                    if (read == -1) break
+                    writeBytesToStdout(buffer, read)
+                }
+            }
+        } catch (e: okio.IOException) {
+            echo(
+                "Error: cannot read the stored image of paste #${detail.id}: ${e.message}",
+                err = true,
+            )
+            throw ProgramResult(1)
+        } finally {
+            flushStdout()
+        }
+    }
+
     private fun printDetail(detail: PasteDetailResponse) {
         val fav = if (detail.tagged) " [tagged]" else ""
         val remote = if (detail.remote) " (remote)" else ""
@@ -124,11 +192,60 @@ class PasteCommand : CliktCommand(name = "paste") {
         echo("  Size:    ${formatSize(detail.size)}")
         echo("  Time:    ${formatRelativeTime(detail.createTime)}")
         echo("  Hash:    ${detail.hash}")
-        if (detail.content != null) {
+        if (detail.filePaths.isNotEmpty()) {
+            echo("  Files:")
+            detail.filePaths.forEach { echo("    $it") }
+        }
+        if (detail.content != null && detail.filePaths.isEmpty()) {
             echo("  Content:")
             detail.content.lines().forEach { line ->
                 echo("    $line")
             }
         }
+        if (detail.typeName == "image" && terminal.terminalInfo.outputInteractive) {
+            renderInlineImages(detail)
+        }
+    }
+
+    /**
+     * Inline preview in terminals with an image protocol; anywhere else the
+     * absolute paths printed above are the fallback. Uses stdlib print like
+     * [printContentOnly]: Mordant re-renders strings and would mangle the
+     * escape sequences.
+     */
+    private fun renderInlineImages(detail: PasteDetailResponse) {
+        val protocol = detectTerminalImageProtocol() ?: return
+        for (path in detail.filePaths) {
+            val bytes = readImageForInline(path) ?: continue
+            when (protocol) {
+                TerminalImageProtocol.ITERM -> print(buildItermInlineImage(path.substringAfterLast('/'), bytes))
+                TerminalImageProtocol.KITTY -> {
+                    // Kitty's f=100 transfer is PNG-only; other formats keep
+                    // the path fallback
+                    if (!isPng(bytes)) continue
+                    print(buildKittyInlineImage(bytes))
+                }
+            }
+            println()
+        }
+    }
+
+    private fun readImageForInline(path: String): ByteArray? {
+        val okioPath = path.toPath()
+        return try {
+            val size = FileSystem.SYSTEM.metadata(okioPath).size ?: return null
+            if (size > MAX_INLINE_IMAGE_BYTES) {
+                echo("  (image too large for inline preview: $path)", err = true)
+                return null
+            }
+            FileSystem.SYSTEM.read(okioPath) { readByteArray() }
+        } catch (_: okio.IOException) {
+            null
+        }
+    }
+
+    companion object {
+        /** Inline preview only; --raw streams without a cap. */
+        private const val MAX_INLINE_IMAGE_BYTES = 20L * 1024 * 1024
     }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.cli.commands
 
+import com.crosspaste.cli.platform.PNG_SIGNATURE_SIZE
 import com.crosspaste.cli.platform.TerminalImageProtocol
 import com.crosspaste.cli.platform.flushStdout
 import com.crosspaste.cli.platform.isPng
@@ -65,10 +66,11 @@ internal class ImageByteStreamer(
 
 /**
  * Inline previews with hard resource ceilings: at most [maxImages] images and
- * [maxTotalBytes] bytes read in total per invocation — a file paste may
- * legitimately reference thousands of entries, and previewing must never turn
- * one `paste` into a multi-gigabyte read. Skipped images are summarized in a
- * single note; their paths are already listed in the detail view.
+ * [maxCandidates] inspected paths, with at most [maxTotalBytes] payload bytes
+ * read in total per invocation. A file paste may legitimately reference
+ * thousands of entries, and previewing must never turn one `paste` into a
+ * multi-gigabyte read. Skipped images are summarized in a single note; their
+ * paths are already listed in the detail view.
  */
 internal class InlineImageRenderer(
     private val protocol: TerminalImageProtocol?,
@@ -76,40 +78,44 @@ internal class InlineImageRenderer(
     private val note: (String) -> Unit,
     private val fileSystem: FileSystem = FileSystem.SYSTEM,
     private val maxImages: Int = MAX_PREVIEW_IMAGES,
+    private val maxCandidates: Int = MAX_PREVIEW_CANDIDATES,
     private val maxTotalBytes: Long = MAX_PREVIEW_TOTAL_BYTES,
 ) {
     companion object {
         internal const val MAX_PREVIEW_IMAGES = 4
+        internal const val MAX_PREVIEW_CANDIDATES = 16
         internal const val MAX_PREVIEW_TOTAL_BYTES = 20L * 1024 * 1024
     }
 
     fun render(paths: List<String>) {
         val protocol = protocol ?: return
         var rendered = 0
+        var inspected = 0
         var remainingBudget = maxTotalBytes
         var skipped = 0
-        for (path in paths) {
-            if (rendered >= maxImages) {
-                skipped++
-                continue
+        for ((index, path) in paths.withIndex()) {
+            if (rendered >= maxImages || inspected >= maxCandidates || remainingBudget <= 0) {
+                skipped += paths.size - index
+                break
             }
-            val bytes = readWithinBudget(path, remainingBudget)
+            inspected++
+            val bytes =
+                readWithinBudget(
+                    path = path,
+                    budget = remainingBudget,
+                    requirePng = protocol == TerminalImageProtocol.KITTY,
+                )
             if (bytes == null) {
                 skipped++
                 continue
             }
-            // Kitty's f=100 transfer is PNG-only; other formats keep the path fallback
-            if (protocol == TerminalImageProtocol.KITTY && !isPng(bytes)) {
-                skipped++
-                continue
-            }
+            remainingBudget -= bytes.size
             when (protocol) {
                 TerminalImageProtocol.ITERM -> writeItermInlineImage(path.toPath().name, bytes, emit)
                 TerminalImageProtocol.KITTY -> writeKittyInlineImage(bytes, emit)
             }
             emit("\n")
             rendered++
-            remainingBudget -= bytes.size
         }
         if (skipped > 0) {
             note("($skipped image(s) not previewed; file paths listed above)")
@@ -119,12 +125,26 @@ internal class InlineImageRenderer(
     private fun readWithinBudget(
         path: String,
         budget: Long,
+        requirePng: Boolean,
     ): ByteArray? {
         val okioPath = path.toPath()
         return try {
             val size = fileSystem.metadata(okioPath).size ?: return null
-            if (size > budget) return null
-            fileSystem.read(okioPath) { readByteArray() }
+            if (size <= 0 || size > budget || size > Int.MAX_VALUE) return null
+            fileSystem.source(okioPath).buffer().use { source ->
+                if (requirePng) {
+                    if (!source.request(PNG_SIGNATURE_SIZE.toLong())) return null
+                    val signature = source.peek().readByteArray(PNG_SIGNATURE_SIZE.toLong())
+                    if (!isPng(signature)) return null
+                }
+
+                val bytes = ByteArray(size.toInt())
+                source.readFully(bytes)
+                // Reference-backed files can change after metadata(). Reject a
+                // file that grew instead of reading beyond the declared budget.
+                if (!source.exhausted()) return null
+                bytes
+            }
         } catch (_: IOException) {
             null
         }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
@@ -1,0 +1,132 @@
+package com.crosspaste.cli.commands
+
+import com.crosspaste.cli.platform.TerminalImageProtocol
+import com.crosspaste.cli.platform.flushStdout
+import com.crosspaste.cli.platform.isPng
+import com.crosspaste.cli.platform.prepareStdoutForBinary
+import com.crosspaste.cli.platform.writeBytesToStdout
+import com.crosspaste.cli.platform.writeItermInlineImage
+import com.crosspaste.cli.platform.writeKittyInlineImage
+import okio.FileSystem
+import okio.IOException
+import okio.Path.Companion.toPath
+import okio.buffer
+import okio.use
+
+/** What `paste --raw` should do for an image paste. */
+internal sealed interface RawImageAction {
+    /** The running app predates the filePaths capability. */
+    data object MissingPaths : RawImageAction
+
+    /** Concatenated image bytes are useless; refuse and show the paths. */
+    data class TooManyImages(
+        val paths: List<String>,
+    ) : RawImageAction
+
+    data class StreamSingle(
+        val path: String,
+    ) : RawImageAction
+}
+
+internal fun resolveRawImageAction(filePaths: List<String>): RawImageAction =
+    when {
+        filePaths.isEmpty() -> RawImageAction.MissingPaths
+        filePaths.size > 1 -> RawImageAction.TooManyImages(filePaths)
+        else -> RawImageAction.StreamSingle(filePaths.single())
+    }
+
+/**
+ * Streams a stored image file to stdout in 64 KiB chunks. All effects are
+ * injectable so tests can pin the byte fidelity and the failure paths;
+ * production uses the binary-safe stdout primitives (on Windows the CRT is
+ * switched to binary mode first). Write or flush failures throw and become
+ * exit 1 in runCli — a partial pipe must never look like success.
+ */
+internal class ImageByteStreamer(
+    private val fileSystem: FileSystem = FileSystem.SYSTEM,
+    private val prepareBinary: () -> Unit = ::prepareStdoutForBinary,
+    private val writeChunk: (ByteArray, Int) -> Unit = ::writeBytesToStdout,
+    private val flush: () -> Unit = ::flushStdout,
+) {
+    /** @throws IOException when the stored file cannot be read */
+    fun stream(path: String) {
+        prepareBinary()
+        fileSystem.source(path.toPath()).buffer().use { source ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                val read = source.read(buffer, 0, buffer.size)
+                if (read == -1) break
+                writeChunk(buffer, read)
+            }
+        }
+        flush()
+    }
+}
+
+/**
+ * Inline previews with hard resource ceilings: at most [maxImages] images and
+ * [maxTotalBytes] bytes read in total per invocation — a file paste may
+ * legitimately reference thousands of entries, and previewing must never turn
+ * one `paste` into a multi-gigabyte read. Skipped images are summarized in a
+ * single note; their paths are already listed in the detail view.
+ */
+internal class InlineImageRenderer(
+    private val protocol: TerminalImageProtocol?,
+    private val emit: (String) -> Unit,
+    private val note: (String) -> Unit,
+    private val fileSystem: FileSystem = FileSystem.SYSTEM,
+    private val maxImages: Int = MAX_PREVIEW_IMAGES,
+    private val maxTotalBytes: Long = MAX_PREVIEW_TOTAL_BYTES,
+) {
+    companion object {
+        internal const val MAX_PREVIEW_IMAGES = 4
+        internal const val MAX_PREVIEW_TOTAL_BYTES = 20L * 1024 * 1024
+    }
+
+    fun render(paths: List<String>) {
+        val protocol = protocol ?: return
+        var rendered = 0
+        var remainingBudget = maxTotalBytes
+        var skipped = 0
+        for (path in paths) {
+            if (rendered >= maxImages) {
+                skipped++
+                continue
+            }
+            val bytes = readWithinBudget(path, remainingBudget)
+            if (bytes == null) {
+                skipped++
+                continue
+            }
+            // Kitty's f=100 transfer is PNG-only; other formats keep the path fallback
+            if (protocol == TerminalImageProtocol.KITTY && !isPng(bytes)) {
+                skipped++
+                continue
+            }
+            when (protocol) {
+                TerminalImageProtocol.ITERM -> writeItermInlineImage(path.toPath().name, bytes, emit)
+                TerminalImageProtocol.KITTY -> writeKittyInlineImage(bytes, emit)
+            }
+            emit("\n")
+            rendered++
+            remainingBudget -= bytes.size
+        }
+        if (skipped > 0) {
+            note("($skipped image(s) not previewed; file paths listed above)")
+        }
+    }
+
+    private fun readWithinBudget(
+        path: String,
+        budget: Long,
+    ): ByteArray? {
+        val okioPath = path.toPath()
+        return try {
+            val size = fileSystem.metadata(okioPath).size ?: return null
+            if (size > budget) return null
+            fileSystem.read(okioPath) { readByteArray() }
+        } catch (_: IOException) {
+            null
+        }
+    }
+}

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/Stdout.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/Stdout.kt
@@ -40,7 +40,14 @@ fun writeBytesToStdout(
     }
 }
 
+/**
+ * A failed flush means the tail of the payload never left the CRT buffer
+ * (closed pipe, full disk) — that must surface as an error, not exit 0.
+ */
 @OptIn(ExperimentalForeignApi::class)
 fun flushStdout() {
-    fflush(stdout)
+    if (fflush(stdout) != 0) {
+        val reason = strerror(errno)?.toKString() ?: "errno $errno"
+        throw StdoutWriteException("failed to flush stdout: $reason")
+    }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/Stdout.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/Stdout.kt
@@ -1,0 +1,46 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.errno
+import platform.posix.fflush
+import platform.posix.fwrite
+import platform.posix.stdout
+import platform.posix.strerror
+
+class StdoutWriteException(
+    message: String,
+) : Exception(message)
+
+/**
+ * Writes raw bytes to stdout, bypassing any text-mode translation. Callers
+ * must invoke [prepareStdoutForBinary] once first (on Windows the C runtime
+ * would otherwise expand LF bytes to CRLF, corrupting binary payloads) and
+ * [flushStdout] after the last chunk.
+ */
+@OptIn(ExperimentalForeignApi::class)
+fun writeBytesToStdout(
+    bytes: ByteArray,
+    length: Int = bytes.size,
+) {
+    if (length == 0) return
+    bytes.usePinned { pinned ->
+        var written = 0
+        while (written < length) {
+            val n =
+                fwrite(pinned.addressOf(written), 1uL, (length - written).toULong(), stdout).toInt()
+            if (n <= 0) {
+                val reason = strerror(errno)?.toKString() ?: "errno $errno"
+                throw StdoutWriteException("failed to write to stdout: $reason")
+            }
+            written += n
+        }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+fun flushStdout() {
+    fflush(stdout)
+}

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalImage.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalImage.kt
@@ -46,6 +46,8 @@ internal fun detectTerminalImageProtocol(env: (String) -> String?): TerminalImag
 internal val TERM_ESC: String = 27.toChar().toString()
 internal val TERM_BEL: String = 7.toChar().toString()
 
+internal const val PNG_SIGNATURE_SIZE = 8
+
 private val PNG_MAGIC = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
 
 internal fun isPng(bytes: ByteArray): Boolean =

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalImage.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalImage.kt
@@ -51,14 +51,31 @@ private val PNG_MAGIC = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A,
 internal fun isPng(bytes: ByteArray): Boolean =
     bytes.size >= PNG_MAGIC.size && PNG_MAGIC.indices.all { bytes[it] == PNG_MAGIC[it] }
 
+/**
+ * Base64-encode in slices of 3072 source bytes: a multiple of 3, so chunk
+ * outputs concatenate to exactly the whole-input encoding (no mid-stream
+ * padding), and each chunk is exactly 4096 chars — the Kitty protocol's
+ * per-chunk payload limit. Streaming through [write] keeps only one small
+ * chunk in memory instead of the full base64 plus protocol string.
+ */
+private const val BASE64_CHUNK_SOURCE_BYTES = 3072
+
 /** OSC 1337: ESC ] 1337 ; File = inline=1;... : <base64> BEL */
 @OptIn(ExperimentalEncodingApi::class)
-internal fun buildItermInlineImage(
+internal fun writeItermInlineImage(
     name: String,
     bytes: ByteArray,
-): String {
+    write: (String) -> Unit,
+) {
     val nameB64 = Base64.encode(name.encodeToByteArray())
-    return "$TERM_ESC]1337;File=inline=1;size=${bytes.size};name=$nameB64:${Base64.encode(bytes)}$TERM_BEL"
+    write("$TERM_ESC]1337;File=inline=1;size=${bytes.size};name=$nameB64:")
+    var offset = 0
+    while (offset < bytes.size) {
+        val end = minOf(offset + BASE64_CHUNK_SOURCE_BYTES, bytes.size)
+        write(Base64.encode(bytes, offset, end))
+        offset = end
+    }
+    write(TERM_BEL)
 }
 
 /**
@@ -67,23 +84,25 @@ internal fun buildItermInlineImage(
  * m=1 marks continuation and m=0 the final chunk.
  */
 @OptIn(ExperimentalEncodingApi::class)
-internal fun buildKittyInlineImage(bytes: ByteArray): String {
-    val b64 = Base64.encode(bytes)
-    val sb = StringBuilder()
+internal fun writeKittyInlineImage(
+    bytes: ByteArray,
+    write: (String) -> Unit,
+) {
     var offset = 0
     var first = true
-    while (offset < b64.length) {
-        val end = minOf(offset + 4096, b64.length)
-        val more = if (end < b64.length) 1 else 0
+    while (offset < bytes.size) {
+        val end = minOf(offset + BASE64_CHUNK_SOURCE_BYTES, bytes.size)
+        val more = if (end < bytes.size) 1 else 0
+        val sb = StringBuilder()
         sb.append(TERM_ESC).append("_G")
         if (first) {
             sb.append("a=T,f=100,")
             first = false
         }
-        sb.append("m=$more;")
-        sb.append(b64, offset, end)
-        sb.append(TERM_ESC).append("\\")
+        sb.append("m=").append(more).append(';')
+        sb.append(Base64.encode(bytes, offset, end))
+        sb.append(TERM_ESC).append('\\')
+        write(sb.toString())
         offset = end
     }
-    return sb.toString()
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalImage.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalImage.kt
@@ -1,0 +1,89 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * Inline terminal image rendering (design: the CLI never decodes pixels —
+ * both protocols accept the encoded image file as-is, base64-wrapped in an
+ * escape sequence, and the terminal does the decoding).
+ */
+enum class TerminalImageProtocol {
+    /** iTerm2 OSC 1337 `File=` protocol; accepts any common image format. */
+    ITERM,
+
+    /** Kitty graphics protocol; PNG payloads only (`f=100`). */
+    KITTY,
+}
+
+@OptIn(ExperimentalForeignApi::class)
+fun detectTerminalImageProtocol(): TerminalImageProtocol? = detectTerminalImageProtocol { getenv(it)?.toKString() }
+
+/**
+ * Environment-based detection, injectable for tests. Deliberately
+ * conservative: an unrecognized terminal gets the path fallback rather than
+ * escape garbage.
+ */
+internal fun detectTerminalImageProtocol(env: (String) -> String?): TerminalImageProtocol? {
+    // Inside tmux/screen the sequences would need passthrough wrapping that
+    // the multiplexer may not allow; fall back to printing paths.
+    if (!env("TMUX").isNullOrEmpty()) return null
+    val term = env("TERM").orEmpty()
+    if (term.startsWith("tmux") || term.startsWith("screen")) return null
+    val termProgram = env("TERM_PROGRAM").orEmpty()
+    return when {
+        term.contains("kitty") || !env("KITTY_WINDOW_ID").isNullOrEmpty() -> TerminalImageProtocol.KITTY
+        term.contains("ghostty") || termProgram.equals("ghostty", ignoreCase = true) -> TerminalImageProtocol.KITTY
+        termProgram == "iTerm.app" || termProgram == "WezTerm" || termProgram == "mintty" -> TerminalImageProtocol.ITERM
+        else -> null
+    }
+}
+
+// Spelled out as char codes so the source contains no literal control bytes
+internal val TERM_ESC: String = 27.toChar().toString()
+internal val TERM_BEL: String = 7.toChar().toString()
+
+private val PNG_MAGIC = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+
+internal fun isPng(bytes: ByteArray): Boolean =
+    bytes.size >= PNG_MAGIC.size && PNG_MAGIC.indices.all { bytes[it] == PNG_MAGIC[it] }
+
+/** OSC 1337: ESC ] 1337 ; File = inline=1;... : <base64> BEL */
+@OptIn(ExperimentalEncodingApi::class)
+internal fun buildItermInlineImage(
+    name: String,
+    bytes: ByteArray,
+): String {
+    val nameB64 = Base64.encode(name.encodeToByteArray())
+    return "$TERM_ESC]1337;File=inline=1;size=${bytes.size};name=$nameB64:${Base64.encode(bytes)}$TERM_BEL"
+}
+
+/**
+ * Kitty graphics protocol: APC chunks of at most 4096 base64 chars; control
+ * keys (a=T transmit-and-display, f=100 PNG) go on the first chunk only,
+ * m=1 marks continuation and m=0 the final chunk.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+internal fun buildKittyInlineImage(bytes: ByteArray): String {
+    val b64 = Base64.encode(bytes)
+    val sb = StringBuilder()
+    var offset = 0
+    var first = true
+    while (offset < b64.length) {
+        val end = minOf(offset + 4096, b64.length)
+        val more = if (end < b64.length) 1 else 0
+        sb.append(TERM_ESC).append("_G")
+        if (first) {
+            sb.append("a=T,f=100,")
+            first = false
+        }
+        sb.append("m=$more;")
+        sb.append(b64, offset, end)
+        sb.append(TERM_ESC).append("\\")
+        offset = end
+    }
+    return sb.toString()
+}

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PasteImageOutputTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PasteImageOutputTest.kt
@@ -1,0 +1,172 @@
+package com.crosspaste.cli.commands
+
+import com.crosspaste.cli.platform.StdoutWriteException
+import com.crosspaste.cli.platform.TerminalImageProtocol
+import okio.FileSystem
+import okio.Path
+import okio.SYSTEM
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class PasteImageOutputTest {
+
+    private val fs = FileSystem.SYSTEM
+
+    private fun tempDir(): Path {
+        val dir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "paste-image-test-${Random.nextLong().toULong()}"
+        fs.createDirectories(dir)
+        return dir
+    }
+
+    private val pngMagic = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+
+    private fun writePng(
+        dir: Path,
+        name: String,
+        payloadSize: Int,
+    ): Path {
+        val path = dir / name
+        val bytes = pngMagic + ByteArray(payloadSize) { (it % 251).toByte() }
+        fs.write(path) { write(bytes) }
+        return path
+    }
+
+    // region resolveRawImageAction
+
+    @Test
+    fun rawActionContract() {
+        assertIs<RawImageAction.MissingPaths>(resolveRawImageAction(emptyList()))
+        val tooMany = assertIs<RawImageAction.TooManyImages>(resolveRawImageAction(listOf("/a.png", "/b.png")))
+        assertEquals(listOf("/a.png", "/b.png"), tooMany.paths)
+        assertEquals("/a.png", assertIs<RawImageAction.StreamSingle>(resolveRawImageAction(listOf("/a.png"))).path)
+    }
+
+    // endregion
+
+    // region ImageByteStreamer
+
+    @Test
+    fun streamerReproducesFileBytesExactly() {
+        val dir = tempDir()
+        // Larger than the 64 KiB read buffer to force multiple chunks
+        val path = writePng(dir, "big.png", 150_000)
+        val original = fs.read(path) { readByteArray() }
+
+        val collected = mutableListOf<Byte>()
+        var prepared = false
+        var flushed = false
+        ImageByteStreamer(
+            prepareBinary = { prepared = true },
+            writeChunk = { bytes, length -> repeat(length) { collected.add(bytes[it]) } },
+            flush = { flushed = true },
+        ).stream(path.toString())
+
+        assertTrue(prepared, "binary mode must be prepared before writing")
+        assertTrue(flushed, "stdout must be flushed after the last chunk")
+        assertContentEquals(original, collected.toByteArray())
+    }
+
+    @Test
+    fun streamerPropagatesMissingFile() {
+        assertFailsWith<okio.IOException> {
+            ImageByteStreamer(
+                prepareBinary = {},
+                writeChunk = { _, _ -> },
+                flush = {},
+            ).stream((tempDir() / "missing.png").toString())
+        }
+    }
+
+    @Test
+    fun streamerPropagatesFlushFailure() {
+        val path = writePng(tempDir(), "a.png", 16)
+        assertFailsWith<StdoutWriteException> {
+            ImageByteStreamer(
+                prepareBinary = {},
+                writeChunk = { _, _ -> },
+                flush = { throw StdoutWriteException("flush failed") },
+            ).stream(path.toString())
+        }
+    }
+
+    // endregion
+
+    // region InlineImageRenderer
+
+    private fun renderer(
+        paths: List<String>,
+        protocol: TerminalImageProtocol? = TerminalImageProtocol.ITERM,
+        maxImages: Int = 4,
+        maxTotalBytes: Long = 1_000_000,
+    ): Pair<StringBuilder, MutableList<String>> {
+        val emitted = StringBuilder()
+        val notes = mutableListOf<String>()
+        InlineImageRenderer(
+            protocol = protocol,
+            emit = { emitted.append(it) },
+            note = { notes.add(it) },
+            maxImages = maxImages,
+            maxTotalBytes = maxTotalBytes,
+        ).render(paths)
+        return emitted to notes
+    }
+
+    private fun countItermHeaders(emitted: CharSequence): Int = "File=inline=1".toRegex().findAll(emitted).count()
+
+    @Test
+    fun previewStopsAtTheImageCountCeiling() {
+        val dir = tempDir()
+        val paths = (1..6).map { writePng(dir, "img$it.png", 64).toString() }
+        val (emitted, notes) = renderer(paths, maxImages = 4)
+        assertEquals(4, countItermHeaders(emitted))
+        assertEquals(listOf("(2 image(s) not previewed; file paths listed above)"), notes)
+    }
+
+    @Test
+    fun previewStopsAtTheTotalByteBudget() {
+        val dir = tempDir()
+        val paths = (1..3).map { writePng(dir, "img$it.png", 400).toString() }
+        // Each file is ~408 bytes; a 900-byte budget fits exactly two
+        val (emitted, notes) = renderer(paths, maxTotalBytes = 900)
+        assertEquals(2, countItermHeaders(emitted))
+        assertEquals(listOf("(1 image(s) not previewed; file paths listed above)"), notes)
+    }
+
+    @Test
+    fun unreadableImagesAreSkippedWithANote() {
+        val dir = tempDir()
+        val good = writePng(dir, "good.png", 64).toString()
+        val missing = (dir / "missing.png").toString()
+        val (emitted, notes) = renderer(listOf(missing, good))
+        assertEquals(1, countItermHeaders(emitted))
+        assertEquals(1, notes.size)
+    }
+
+    @Test
+    fun kittyOnlyPreviewsPngPayloads() {
+        val dir = tempDir()
+        val png = writePng(dir, "a.png", 64).toString()
+        val jpegPath = dir / "b.jpg"
+        fs.write(jpegPath) { write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())) }
+        val (emitted, notes) = renderer(listOf(png, jpegPath.toString()), protocol = TerminalImageProtocol.KITTY)
+        assertTrue(emitted.contains("a=T,f=100,"))
+        assertEquals(1, "a=T".toRegex().findAll(emitted).count())
+        assertEquals(1, notes.size)
+    }
+
+    @Test
+    fun noProtocolMeansNoOutputAtAll() {
+        val dir = tempDir()
+        val path = writePng(dir, "a.png", 64).toString()
+        val (emitted, notes) = renderer(listOf(path), protocol = null)
+        assertEquals(0, emitted.length)
+        assertTrue(notes.isEmpty())
+    }
+
+    // endregion
+}

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PasteImageOutputTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PasteImageOutputTest.kt
@@ -2,9 +2,12 @@ package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.platform.StdoutWriteException
 import com.crosspaste.cli.platform.TerminalImageProtocol
+import okio.Buffer
 import okio.FileSystem
+import okio.ForwardingFileSystem
+import okio.ForwardingSource
 import okio.Path
-import okio.SYSTEM
+import okio.Source
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -101,7 +104,9 @@ class PasteImageOutputTest {
     private fun renderer(
         paths: List<String>,
         protocol: TerminalImageProtocol? = TerminalImageProtocol.ITERM,
+        fileSystem: FileSystem = fs,
         maxImages: Int = 4,
+        maxCandidates: Int = 16,
         maxTotalBytes: Long = 1_000_000,
     ): Pair<StringBuilder, MutableList<String>> {
         val emitted = StringBuilder()
@@ -110,7 +115,9 @@ class PasteImageOutputTest {
             protocol = protocol,
             emit = { emitted.append(it) },
             note = { notes.add(it) },
+            fileSystem = fileSystem,
             maxImages = maxImages,
+            maxCandidates = maxCandidates,
             maxTotalBytes = maxTotalBytes,
         ).render(paths)
         return emitted to notes
@@ -157,6 +164,68 @@ class PasteImageOutputTest {
         assertTrue(emitted.contains("a=T,f=100,"))
         assertEquals(1, "a=T".toRegex().findAll(emitted).count())
         assertEquals(1, notes.size)
+    }
+
+    @Test
+    fun unsupportedKittyImagesCountTowardTheCandidateCeiling() {
+        val dir = tempDir()
+        val jpegPaths =
+            (1..4).map { index ->
+                val path = dir / "image$index.jpg"
+                fs.write(path) {
+                    write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()))
+                    write(ByteArray(64 * 1024))
+                }
+                path.toString()
+            }
+        val png = writePng(dir, "later.png", 64).toString()
+
+        val (emitted, notes) =
+            renderer(
+                paths = jpegPaths + png,
+                protocol = TerminalImageProtocol.KITTY,
+                maxCandidates = 4,
+            )
+
+        assertTrue(emitted.isEmpty())
+        assertEquals(listOf("(5 image(s) not previewed; file paths listed above)"), notes)
+    }
+
+    @Test
+    fun kittyRejectsJpegAfterReadingOnlyItsSignatureBuffer() {
+        val dir = tempDir()
+        val jpeg = dir / "large.jpg"
+        val jpegSize = 1024 * 1024
+        fs.write(jpeg) {
+            write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()))
+            write(ByteArray(jpegSize - 3))
+        }
+
+        var bytesRead = 0L
+        val countingFileSystem =
+            object : ForwardingFileSystem(fs) {
+                override fun source(file: Path): Source =
+                    object : ForwardingSource(super.source(file)) {
+                        override fun read(
+                            sink: Buffer,
+                            byteCount: Long,
+                        ): Long =
+                            super.read(sink, byteCount).also { read ->
+                                if (read > 0) bytesRead += read
+                            }
+                    }
+            }
+
+        val (emitted, notes) =
+            renderer(
+                paths = listOf(jpeg.toString()),
+                protocol = TerminalImageProtocol.KITTY,
+                fileSystem = countingFileSystem,
+            )
+
+        assertTrue(emitted.isEmpty())
+        assertEquals(1, notes.size)
+        assertTrue(bytesRead < jpegSize, "unsupported JPEG payload must not be read in full")
     }
 
     @Test

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/TerminalImageTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/TerminalImageTest.kt
@@ -1,0 +1,109 @@
+package com.crosspaste.cli.platform
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalEncodingApi::class)
+class TerminalImageTest {
+
+    private val esc = 27.toChar().toString()
+    private val bel = 7.toChar().toString()
+
+    private fun env(vararg pairs: Pair<String, String>): (String) -> String? = mapOf(*pairs)::get
+
+    @Test
+    fun detectsKnownTerminals() {
+        assertEquals(
+            TerminalImageProtocol.ITERM,
+            detectTerminalImageProtocol(env("TERM_PROGRAM" to "iTerm.app", "TERM" to "xterm-256color")),
+        )
+        assertEquals(
+            TerminalImageProtocol.ITERM,
+            detectTerminalImageProtocol(env("TERM_PROGRAM" to "WezTerm", "TERM" to "xterm-256color")),
+        )
+        assertEquals(
+            TerminalImageProtocol.KITTY,
+            detectTerminalImageProtocol(env("TERM" to "xterm-kitty")),
+        )
+        assertEquals(
+            TerminalImageProtocol.KITTY,
+            detectTerminalImageProtocol(env("KITTY_WINDOW_ID" to "1", "TERM" to "xterm-256color")),
+        )
+        assertEquals(
+            TerminalImageProtocol.KITTY,
+            detectTerminalImageProtocol(env("TERM" to "xterm-ghostty")),
+        )
+    }
+
+    @Test
+    fun unknownTerminalGetsNoProtocol() {
+        assertNull(detectTerminalImageProtocol(env("TERM" to "xterm-256color")))
+        assertNull(detectTerminalImageProtocol(env()))
+    }
+
+    @Test
+    fun multiplexersFallBackEvenInsideASupportedTerminal() {
+        assertNull(
+            detectTerminalImageProtocol(
+                env("TMUX" to "/tmp/tmux-501/default,123,0", "TERM_PROGRAM" to "iTerm.app"),
+            ),
+        )
+        assertNull(
+            detectTerminalImageProtocol(env("TERM" to "screen-256color", "TERM_PROGRAM" to "iTerm.app")),
+        )
+        assertNull(
+            detectTerminalImageProtocol(env("TERM" to "tmux-256color", "KITTY_WINDOW_ID" to "1")),
+        )
+    }
+
+    @Test
+    fun pngMagicIsRecognized() {
+        val png = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3)
+        assertTrue(isPng(png))
+        assertFalse(isPng(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()))) // JPEG
+        assertFalse(isPng(ByteArray(0)))
+    }
+
+    @Test
+    fun itermSequenceWrapsBase64PayloadAndName() {
+        val bytes = byteArrayOf(1, 2, 3, 4)
+        val sequence = buildItermInlineImage("shot.png", bytes)
+        val expectedName = Base64.encode("shot.png".encodeToByteArray())
+        assertEquals(
+            "$esc]1337;File=inline=1;size=4;name=$expectedName:${Base64.encode(bytes)}$bel",
+            sequence,
+        )
+    }
+
+    @Test
+    fun kittySingleChunkCarriesControlKeysAndFinalMarker() {
+        val bytes = byteArrayOf(9, 8, 7)
+        val sequence = buildKittyInlineImage(bytes)
+        assertEquals("${esc}_Ga=T,f=100,m=0;${Base64.encode(bytes)}$esc\\", sequence)
+    }
+
+    @Test
+    fun kittyLargePayloadIsChunkedAndReassembles() {
+        // 9000 bytes -> 12000 base64 chars -> 3 chunks (4096 + 4096 + 3808)
+        val bytes = ByteArray(9000) { (it % 251).toByte() }
+        val sequence = buildKittyInlineImage(bytes)
+        val chunks =
+            sequence
+                .split("$esc\\")
+                .filter { it.isNotEmpty() }
+                .map { it.removePrefix("${esc}_G") }
+        assertEquals(3, chunks.size)
+        assertTrue(chunks[0].startsWith("a=T,f=100,m=1;"))
+        assertTrue(chunks[1].startsWith("m=1;"))
+        assertTrue(chunks[2].startsWith("m=0;"))
+        val payload = chunks.joinToString("") { it.substringAfter(';') }
+        assertEquals(Base64.encode(bytes), payload)
+        // No chunk may exceed the protocol's 4096-char payload limit
+        assertTrue(chunks.all { it.substringAfter(';').length <= 4096 })
+    }
+}

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/TerminalImageTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/TerminalImageTest.kt
@@ -16,6 +16,13 @@ class TerminalImageTest {
 
     private fun env(vararg pairs: Pair<String, String>): (String) -> String? = mapOf(*pairs)::get
 
+    private fun itermSequence(
+        name: String,
+        bytes: ByteArray,
+    ): String = buildString { writeItermInlineImage(name, bytes) { append(it) } }
+
+    private fun kittySequence(bytes: ByteArray): String = buildString { writeKittyInlineImage(bytes) { append(it) } }
+
     @Test
     fun detectsKnownTerminals() {
         assertEquals(
@@ -72,7 +79,7 @@ class TerminalImageTest {
     @Test
     fun itermSequenceWrapsBase64PayloadAndName() {
         val bytes = byteArrayOf(1, 2, 3, 4)
-        val sequence = buildItermInlineImage("shot.png", bytes)
+        val sequence = itermSequence("shot.png", bytes)
         val expectedName = Base64.encode("shot.png".encodeToByteArray())
         assertEquals(
             "$esc]1337;File=inline=1;size=4;name=$expectedName:${Base64.encode(bytes)}$bel",
@@ -81,9 +88,21 @@ class TerminalImageTest {
     }
 
     @Test
+    fun itermChunkedEncodingEqualsWholeInputEncoding() {
+        // Chunking at a multiple of 3 source bytes must concatenate to the
+        // exact whole-input base64 (no mid-stream padding)
+        val bytes = ByteArray(9001) { (it % 251).toByte() }
+        val sequence = itermSequence("a.png", bytes)
+        assertEquals(
+            Base64.encode(bytes),
+            sequence.substringAfter(':').removeSuffix(bel),
+        )
+    }
+
+    @Test
     fun kittySingleChunkCarriesControlKeysAndFinalMarker() {
         val bytes = byteArrayOf(9, 8, 7)
-        val sequence = buildKittyInlineImage(bytes)
+        val sequence = kittySequence(bytes)
         assertEquals("${esc}_Ga=T,f=100,m=0;${Base64.encode(bytes)}$esc\\", sequence)
     }
 
@@ -91,7 +110,7 @@ class TerminalImageTest {
     fun kittyLargePayloadIsChunkedAndReassembles() {
         // 9000 bytes -> 12000 base64 chars -> 3 chunks (4096 + 4096 + 3808)
         val bytes = ByteArray(9000) { (it % 251).toByte() }
-        val sequence = buildKittyInlineImage(bytes)
+        val sequence = kittySequence(bytes)
         val chunks =
             sequence
                 .split("$esc\\")

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/StdoutBinary.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/StdoutBinary.kt
@@ -9,9 +9,12 @@ import platform.posix.stdout
 /**
  * Switches stdout to binary mode so the CRT stops expanding LF to CRLF —
  * mandatory before writing image bytes (`paste --raw` on an image paste).
- * Idempotent; affects only this process's stdout.
+ * Idempotent; affects only this process's stdout. A failure must abort:
+ * writing on in text mode would silently corrupt the payload.
  */
 @OptIn(ExperimentalForeignApi::class)
 fun prepareStdoutForBinary() {
-    _setmode(_fileno(stdout), O_BINARY)
+    if (_setmode(_fileno(stdout), O_BINARY) == -1) {
+        throw StdoutWriteException("failed to switch stdout to binary mode")
+    }
 }

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/StdoutBinary.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/StdoutBinary.kt
@@ -1,0 +1,17 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.O_BINARY
+import platform.posix._fileno
+import platform.posix._setmode
+import platform.posix.stdout
+
+/**
+ * Switches stdout to binary mode so the CRT stops expanding LF to CRLF —
+ * mandatory before writing image bytes (`paste --raw` on an image paste).
+ * Idempotent; affects only this process's stdout.
+ */
+@OptIn(ExperimentalForeignApi::class)
+fun prepareStdoutForBinary() {
+    _setmode(_fileno(stdout), O_BINARY)
+}

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/StdoutBinary.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/StdoutBinary.kt
@@ -1,0 +1,4 @@
+package com.crosspaste.cli.platform
+
+/** No-op: POSIX stdout has no text/binary mode distinction. */
+fun prepareStdoutForBinary() {}

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/StdoutBinary.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/StdoutBinary.kt
@@ -1,4 +1,4 @@
 package com.crosspaste.cli.platform
 
 /** No-op: POSIX stdout has no text/binary mode distinction. */
-fun prepareStdoutForBinary() {}
+fun prepareStdoutForBinary() = Unit

--- a/doc/en/CLI.md
+++ b/doc/en/CLI.md
@@ -72,6 +72,8 @@ crosspaste paste --raw > screenshot.png
 crosspaste paste --raw | magick - -resize 50% small.png
 ```
 
+On Windows, redirect through cmd — `cmd /c "crosspaste-cli paste --raw > shot.png"` — or use PowerShell 7.4+. Windows PowerShell 5.1's `>` re-encodes native command output as UTF-16 text and corrupts binary data.
+
 List and bulk-process history:
 
 ```sh

--- a/doc/en/CLI.md
+++ b/doc/en/CLI.md
@@ -28,7 +28,7 @@ The examples below use `crosspaste`; on Windows substitute `crosspaste-cli`.
 | Command | Description |
 |---|---|
 | `status` | Show whether the app is running, plus version, device and paste counts. Never auto-starts the app. |
-| `paste [id]` | Show the most recent paste, or a specific paste by ID. |
+| `paste [id]` | Show the most recent paste, or a specific paste by ID. Image pastes render inline in terminals that support it (iTerm2, WezTerm, Kitty, Ghostty) and always list their stored file paths. |
 | `history` | List recent paste history (`--limit`, `--type`, `--tag`, `--format`). |
 | `search <query>` | Search paste history (same filters as `history`). |
 | `copy [text]` | Copy text via CrossPaste: stores it in history and syncs it to your devices; the system clipboard is set when the desktop app (not the headless daemon) is running. Reads stdin when piped. |
@@ -63,6 +63,13 @@ Print only the paste content (no decoration), for piping onward. `--raw` reprodu
 crosspaste paste --raw | pbcopy
 crosspaste paste --raw --no-newline > snippet.html
 crosspaste paste --summary            # HTML/RTF converted to plain text
+```
+
+For an image paste, `--raw` dumps the stored image bytes, so a screenshot copied on any device can be piped straight into a file or another tool:
+
+```sh
+crosspaste paste --raw > screenshot.png
+crosspaste paste --raw | magick - -resize 50% small.png
 ```
 
 List and bulk-process history:

--- a/doc/en/CLI.md
+++ b/doc/en/CLI.md
@@ -65,7 +65,7 @@ crosspaste paste --raw --no-newline > snippet.html
 crosspaste paste --summary            # HTML/RTF converted to plain text
 ```
 
-For an image paste, `--raw` dumps the stored image bytes, so a screenshot copied on any device can be piped straight into a file or another tool:
+For an image paste, `--raw` dumps the stored image bytes, so a screenshot copied on any device can be piped straight into a file or another tool. This works for single-image pastes; a paste containing several images fails with the list of stored file paths instead:
 
 ```sh
 crosspaste paste --raw > screenshot.png

--- a/doc/zh/CLI.md
+++ b/doc/zh/CLI.md
@@ -72,6 +72,8 @@ crosspaste paste --raw > screenshot.png
 crosspaste paste --raw | magick - -resize 50% small.png
 ```
 
+Windows 上请经 cmd 重定向——`cmd /c "crosspaste-cli paste --raw > shot.png"`——或使用 PowerShell 7.4+。Windows PowerShell 5.1 的 `>` 会把原生命令输出按 UTF-16 文本重编码,损坏二进制数据。
+
 列表与批量处理：
 
 ```sh

--- a/doc/zh/CLI.md
+++ b/doc/zh/CLI.md
@@ -65,7 +65,7 @@ crosspaste paste --raw --no-newline > snippet.html
 crosspaste paste --summary            # HTML/RTF 转为纯文本
 ```
 
-图片粘贴的 `--raw` 输出的是存储的图片字节，任何设备上复制的截图都能直接导出成文件或接给其他工具：
+图片粘贴的 `--raw` 输出的是存储的图片字节，任何设备上复制的截图都能直接导出成文件或接给其他工具。仅支持单图片粘贴；一条记录含多张图片时会报错并列出各图片的存储路径：
 
 ```sh
 crosspaste paste --raw > screenshot.png

--- a/doc/zh/CLI.md
+++ b/doc/zh/CLI.md
@@ -28,7 +28,7 @@ CLI 二进制随所有桌面安装包一起分发，各平台的差异只在于�
 | 命令 | 说明 |
 |---|---|
 | `status` | 显示应用是否在运行，以及版本、设备数、粘贴条数。永不自动拉起应用。 |
-| `paste [id]` | 显示最近一条粘贴，或按 ID 显示指定一条。 |
+| `paste [id]` | 显示最近一条粘贴，或按 ID 显示指定一条。图片粘贴在支持的终端（iTerm2、WezTerm、Kitty、Ghostty）内联显示，并始终列出存储文件路径。 |
 | `history` | 列出最近粘贴历史（`--limit`、`--type`、`--tag`、`--format`）。 |
 | `search <query>` | 搜索粘贴历史（过滤参数与 `history` 相同）。 |
 | `copy [text]` | 通过 CrossPaste 复制文本：写入历史并同步到其他设备；仅当桌面应用（而非 headless 守护进程）在运行时才会写系统剪贴板。接管道时读取 stdin。 |
@@ -63,6 +63,13 @@ cat notes.md | crosspaste copy
 crosspaste paste --raw | pbcopy
 crosspaste paste --raw --no-newline > snippet.html
 crosspaste paste --summary            # HTML/RTF 转为纯文本
+```
+
+图片粘贴的 `--raw` 输出的是存储的图片字节，任何设备上复制的截图都能直接导出成文件或接给其他工具：
+
+```sh
+crosspaste paste --raw > screenshot.png
+crosspaste paste --raw | magick - -resize 50% small.png
 ```
 
 列表与批量处理：


### PR DESCRIPTION
Closes #4789

## Summary

Image pastes become first-class citizens of the CLI's pipe-first workflow: `paste --raw` dumps the stored image bytes, the default detail view lists the stored file paths and renders the image inline in terminals that support it (iTerm2, WezTerm, Kitty, Ghostty). The CLI never decodes pixels — both terminal protocols accept the encoded image file as-is, base64-wrapped in an escape sequence.

## Changes

### `/cli` API (app side, add-only)

- `CliPasteDetailDto.filePaths`: absolute paths of the stored payload files (image/file pastes; empty otherwise). App and CLI share the machine, so the CLI reads bytes directly — nothing is streamed over the socket. `UserDataPathProvider` is threaded through `CliServer`/`cliRouting` for path resolution.
- Contract stays add-only: old CLIs ignore the field (`ignoreUnknownKeys`), the new CLI degrades with an actionable error against an old app.

### CLI (`cli/`)

- **`paste --raw` on an image paste** streams the stored file to stdout in 64 KiB chunks, binary-safe: POSIX writes through `fwrite`, and on Windows `_setmode(_fileno(stdout), O_BINARY)` stops the CRT from expanding LF to CRLF. Multi-image pastes are rejected with the path list (concatenated image bytes are useless); text pastes keep the existing string path.
- **Detail view**: image/file pastes now list their absolute stored paths (replacing the redundant basename "content"), and when stdout is an interactive terminal with a recognized image protocol the image renders inline below the details.
- **`TerminalImage.kt`**: conservative environment-based protocol detection (`TERM_PROGRAM` iTerm.app/WezTerm/mintty → OSC 1337; kitty/ghostty markers → Kitty graphics protocol; tmux/screen → no inline, path fallback), PNG magic sniffing (Kitty's `f=100` transfer is PNG-only), and the two escape-sequence builders (Kitty chunked at the protocol's 4096-char limit). Inline preview is capped at 20 MiB per image; `--raw` streams without a cap.

## Tests

- `TerminalImageTest` (7): detection matrix incl. multiplexer fallback, PNG magic, exact iTerm sequence, Kitty single-chunk and 3-chunk reassembly with the 4096 limit pinned.
- `CliRoutingTest`: image detail carries absolute paths; text detail has none. `CliDtoContractTest` pins the new field. `CliServerTest`/DI updated for the new dependency.
- Green: `:cli:macosArm64Test`, `app:desktopTest` (cli + headless resolution), Linux x64 test compile, mingw x64 compile (verifies the `_setmode` binary-mode path).

## Real-machine verification (dev app + branch CLI on macOS)

- Copied a PNG to the clipboard, then `paste`: detail shows the absolute stored path under `Files:`.
- `paste --raw > out.png`: `cmp` against the stored file — byte-identical, `file` identifies a valid PNG.
- On a real PTY with `TERM_PROGRAM=iTerm.app`: output contains `ESC ]1337;File=inline=1;size=20536;name=…` terminated by BEL, size matching the stored file. With `TERM=xterm-kitty`: 7 APC chunks (`a=T,f=100,m=1` … `m=0`), exactly ⌈base64/4096⌉ for the payload.