### PR TITLE
:bug: coalesce Windows clipboard bursts into one snapshot via a single-consumer pipeline

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteboardMonitor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteboardMonitor.kt
@@ -7,4 +7,13 @@ interface PasteboardMonitor {
     fun stop()
 
     fun toggle()
+
+    /**
+     * Application-exit variant of [stop]: additionally gives in-flight asynchronous
+     * collection work a bounded chance to finish instead of cancelling it halfway.
+     * Defaults to plain [stop] for implementations without such work.
+     */
+    suspend fun shutdown() {
+        stop()
+    }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -374,7 +374,7 @@ class CrossPaste {
                                     stopManagedService<PasteboardService>(
                                         ManagedService.PASTEBOARD,
                                         "PasteboardService",
-                                    ) { it.stop() }
+                                    ) { it.shutdown() }
                                 },
                             )
                             add(

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/ClipboardEventPipeline.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/ClipboardEventPipeline.kt
@@ -6,9 +6,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -51,6 +53,15 @@ data class ClipboardEvent(
  *   [consume] serially: consume passes never overlap, record order matches event order,
  *   and a slow consume does not delay or conflate the capture of later events.
  *
+ * Snapshots hold full clipboard contents (potentially large images), so the queue is
+ * bounded: when the consumer falls behind, the oldest unconsumed snapshot is dropped in
+ * favor of newer clipboard states and counted in [droppedSnapshotCount].
+ *
+ * Lifecycle: [startCapture] / [stopCapture] toggle snapshot capture at runtime — the
+ * consumer deliberately keeps running across stops so snapshots that were already
+ * captured are persisted in order rather than cancelled halfway through a write.
+ * [close] shuts the whole pipeline down for application exit.
+ *
  * The default windows are initial values; final parameters must be validated on a real
  * machine over 50+ consecutive Snipping Tool captures (#4793).
  */
@@ -58,6 +69,7 @@ class ClipboardEventPipeline<S : Any>(
     private val quietWindow: Duration = DEFAULT_QUIET_WINDOW,
     private val burstQuietWindow: Duration = DEFAULT_BURST_QUIET_WINDOW,
     private val maxQuietWindowRestarts: Int = DEFAULT_MAX_QUIET_WINDOW_RESTARTS,
+    snapshotQueueCapacity: Int = DEFAULT_SNAPSHOT_QUEUE_CAPACITY,
     private val currentSequence: () -> Int,
     private val takeSnapshot: suspend (ClipboardEvent) -> S?,
     private val consume: suspend (snapshot: S, event: ClipboardEvent) -> Unit,
@@ -73,13 +85,34 @@ class ClipboardEventPipeline<S : Any>(
         val DEFAULT_BURST_QUIET_WINDOW = 500.milliseconds
 
         const val DEFAULT_MAX_QUIET_WINDOW_RESTARTS = 4
+
+        // Each entry can hold a full-size image, so the backlog must stay small.
+        const val DEFAULT_SNAPSHOT_QUEUE_CAPACITY = 8
     }
 
     private val logger: KLogger = KotlinLogging.logger {}
 
     private val signal = Channel<Unit>(Channel.CONFLATED)
 
-    private val snapshotQueue = Channel<Pair<S, ClipboardEvent>>(Channel.UNLIMITED)
+    private val discardedCount = AtomicLong(0)
+
+    val discardedSnapshotCount: Long
+        get() = discardedCount.get()
+
+    private val droppedCount = AtomicLong(0)
+
+    val droppedSnapshotCount: Long
+        get() = droppedCount.get()
+
+    private val snapshotQueue =
+        Channel<Pair<S, ClipboardEvent>>(
+            capacity = snapshotQueueCapacity,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            onUndeliveredElement = { (_, event) ->
+                droppedCount.incrementAndGet()
+                logger.warn { "Dropping unconsumed clipboard snapshot at sequence ${event.sequence}" }
+            },
+        )
 
     @Volatile
     private var latestEvent: ClipboardEvent? = null
@@ -87,10 +120,9 @@ class ClipboardEventPipeline<S : Any>(
     // Only read and written by the snapshot worker coroutine.
     private var lastProcessedSequence: Int? = null
 
-    private val discardedCount = AtomicLong(0)
+    private var snapshotterJob: Job? = null
 
-    val discardedSnapshotCount: Long
-        get() = discardedCount.get()
+    private var consumerJob: Job? = null
 
     /**
      * Records a clipboard change and wakes the snapshot worker. Safe to call from any
@@ -105,15 +137,49 @@ class ClipboardEventPipeline<S : Any>(
         signal.trySend(Unit)
     }
 
-    fun launchIn(scope: CoroutineScope): Job =
-        scope.launch(CoroutineName("ClipboardEventPipeline")) {
-            launch(CoroutineName("ClipboardEventPipelineConsumer")) {
-                consumeLoop()
-            }
-            launch(CoroutineName("ClipboardEventPipelineSnapshotter")) {
-                snapshotLoop()
+    @Synchronized
+    fun startCapture(scope: CoroutineScope) {
+        if (consumerJob?.isActive != true) {
+            consumerJob =
+                scope.launch(CoroutineName("ClipboardEventPipelineConsumer")) {
+                    consumeLoop()
+                }
+        }
+        if (snapshotterJob?.isActive != true) {
+            snapshotterJob =
+                scope.launch(CoroutineName("ClipboardEventPipelineSnapshotter")) {
+                    snapshotLoop()
+                }
+        }
+    }
+
+    /**
+     * Stops taking new snapshots. The consumer keeps running so already captured
+     * snapshots are persisted in order instead of being cancelled mid-write.
+     */
+    @Synchronized
+    fun stopCapture() {
+        snapshotterJob?.cancel()
+    }
+
+    /**
+     * Application-exit shutdown: stops capture, then gives the consumer [gracePeriod]
+     * to finish the in-flight consume and drain the queue before cancelling it.
+     * Whatever is still unconsumed afterwards is dropped and counted. The pipeline
+     * cannot be restarted after closing.
+     */
+    suspend fun close(gracePeriod: Duration) {
+        stopCapture()
+        signal.close()
+        snapshotQueue.close()
+        consumerJob?.let { job ->
+            if (withTimeoutOrNull(gracePeriod) { job.join() } == null) {
+                logger.warn { "Clipboard consume did not finish within $gracePeriod, cancelling" }
+                job.cancel()
             }
         }
+        snapshotQueue.cancel()
+    }
 
     private suspend fun snapshotLoop() {
         for (unused in signal) {
@@ -184,6 +250,6 @@ class ClipboardEventPipeline<S : Any>(
         }
 
         lastProcessedSequence = event.sequence
-        snapshotQueue.send(snapshot to event)
+        snapshotQueue.trySend(snapshot to event)
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/ClipboardEventPipeline.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/ClipboardEventPipeline.kt
@@ -30,65 +30,72 @@ data class ClipboardEvent(
  * Apps like Snipping Tool write the clipboard several times per user operation within a
  * short burst, and each eager full snapshot taken in that window competes with the
  * writer's own clipboard access (#4737). This pipeline decouples event delivery from
- * clipboard reading:
+ * clipboard reading, and clipboard reading from record processing:
  *
  * - [onEvent] is cheap and non-blocking: it records the latest event and signals the
- *   worker through a conflated channel. It never touches the clipboard, so the caller
- *   (e.g. a Windows message loop) returns immediately.
- * - The worker waits for the clipboard to stay quiet for [quietWindow] before reading;
- *   every further event restarts the wait (at most [maxQuietWindowRestarts] times), so a
- *   whole burst collapses into one [takeSnapshot] call.
- * - After the snapshot, the sequence is re-validated: if the clipboard changed while the
- *   snapshot was being taken, the snapshot may hold a mixed state, so it is discarded and
- *   retaken — at most [maxRevalidations] times. On exhausting the budget the possibly
- *   intermediate snapshot is accepted, [degradedSnapshotCount] is incremented, and the
- *   newer content is still processed by the next pass (its event has already re-signaled
- *   the channel).
- * - [consume] is awaited by the worker, so consume passes never overlap and record order
- *   matches event order.
+ *   snapshot worker through a conflated channel. It never touches the clipboard, so the
+ *   caller (e.g. a Windows message loop) returns immediately.
+ * - The snapshot worker waits for the clipboard to stay quiet for [quietWindow] before
+ *   reading. Detecting a further write during the wait marks the burst as such and the
+ *   remaining waits use the longer [burstQuietWindow] (at most [maxQuietWindowRestarts]
+ *   restarts), so a whole burst collapses into **one** [takeSnapshot] call.
+ * - After the snapshot, the sequence is re-validated. If the clipboard changed while the
+ *   snapshot was being taken, the snapshot may hold a mixed state and the event carrying
+ *   the new sequence's source has not been seen yet — so the snapshot is **discarded**
+ *   ([discardedSnapshotCount] tracks this) and the sequence is left unprocessed: the new
+ *   write's own event re-enters through a fresh quiet window with its correct source.
+ *   Inheriting the previous event's source here would misattribute the new content and
+ *   could bypass source exclusions; an immediate re-read would recreate the back-to-back
+ *   full snapshots this pipeline exists to avoid.
+ * - Captured snapshots are queued to a separate consume worker that awaits each
+ *   [consume] serially: consume passes never overlap, record order matches event order,
+ *   and a slow consume does not delay or conflate the capture of later events.
  *
  * The default windows are initial values; final parameters must be validated on a real
  * machine over 50+ consecutive Snipping Tool captures (#4793).
  */
 class ClipboardEventPipeline<S : Any>(
     private val quietWindow: Duration = DEFAULT_QUIET_WINDOW,
+    private val burstQuietWindow: Duration = DEFAULT_BURST_QUIET_WINDOW,
     private val maxQuietWindowRestarts: Int = DEFAULT_MAX_QUIET_WINDOW_RESTARTS,
-    private val maxRevalidations: Int = DEFAULT_MAX_REVALIDATIONS,
     private val currentSequence: () -> Int,
     private val takeSnapshot: suspend (ClipboardEvent) -> S?,
     private val consume: suspend (snapshot: S, event: ClipboardEvent) -> Unit,
 ) {
 
     companion object {
-        // Snipping Tool's two writes land 30–90 ms apart, so the quiet window must span
-        // that gap for the burst to collapse into a single snapshot.
+        // A normal single copy only pays this small delay before the snapshot.
         val DEFAULT_QUIET_WINDOW = 100.milliseconds
 
-        // Worst-case added wait ≈ quietWindow * (restarts + 1); Ditto's field experience
-        // suggests ~500 ms is an effective total delay for misbehaving writers.
-        const val DEFAULT_MAX_QUIET_WINDOW_RESTARTS = 4
+        // Snipping Tool's two writes land 30–90 ms apart; once a second write is seen
+        // inside the base window, wait out the longer window that Ditto's field
+        // experience (~500 ms) suggests misbehaving writers need to finish.
+        val DEFAULT_BURST_QUIET_WINDOW = 500.milliseconds
 
-        const val DEFAULT_MAX_REVALIDATIONS = 2
+        const val DEFAULT_MAX_QUIET_WINDOW_RESTARTS = 4
     }
 
     private val logger: KLogger = KotlinLogging.logger {}
 
     private val signal = Channel<Unit>(Channel.CONFLATED)
 
+    private val snapshotQueue = Channel<Pair<S, ClipboardEvent>>(Channel.UNLIMITED)
+
     @Volatile
     private var latestEvent: ClipboardEvent? = null
 
-    // Only read and written by the worker coroutine.
+    // Only read and written by the snapshot worker coroutine.
     private var lastProcessedSequence: Int? = null
 
-    private val degradedCount = AtomicLong(0)
+    private val discardedCount = AtomicLong(0)
 
-    val degradedSnapshotCount: Long
-        get() = degradedCount.get()
+    val discardedSnapshotCount: Long
+        get() = discardedCount.get()
 
     /**
-     * Records a clipboard change and wakes the worker. Safe to call from any thread;
-     * events arriving faster than the worker drains them conflate into the latest one.
+     * Records a clipboard change and wakes the snapshot worker. Safe to call from any
+     * thread; events arriving faster than the worker drains them conflate into the
+     * latest one.
      */
     fun onEvent(
         sequence: Int,
@@ -99,33 +106,57 @@ class ClipboardEventPipeline<S : Any>(
     }
 
     fun launchIn(scope: CoroutineScope): Job =
-        scope.launch(CoroutineName("ClipboardEventPipelineWorker")) {
-            for (unused in signal) {
-                runCatching {
-                    processBurst()
-                }.onFailure { e ->
-                    if (e is CancellationException) {
-                        throw e
-                    }
-                    logger.error(e) { "Failed to process clipboard burst" }
-                }
+        scope.launch(CoroutineName("ClipboardEventPipeline")) {
+            launch(CoroutineName("ClipboardEventPipelineConsumer")) {
+                consumeLoop()
+            }
+            launch(CoroutineName("ClipboardEventPipelineSnapshotter")) {
+                snapshotLoop()
             }
         }
 
-    private suspend fun processBurst() {
+    private suspend fun snapshotLoop() {
+        for (unused in signal) {
+            runCatching {
+                captureBurst()
+            }.onFailure { e ->
+                if (e is CancellationException) {
+                    throw e
+                }
+                logger.error(e) { "Failed to capture clipboard burst" }
+            }
+        }
+    }
+
+    private suspend fun consumeLoop() {
+        for ((snapshot, event) in snapshotQueue) {
+            runCatching {
+                consume(snapshot, event)
+            }.onFailure { e ->
+                if (e is CancellationException) {
+                    throw e
+                }
+                logger.error(e) { "Failed to consume clipboard snapshot at sequence ${event.sequence}" }
+            }
+        }
+    }
+
+    private suspend fun captureBurst() {
         var event = latestEvent ?: return
         if (event.sequence == lastProcessedSequence) {
             return
         }
 
+        var wait = quietWindow
         var restarts = 0
         while (true) {
-            delay(quietWindow)
+            delay(wait)
             val newest = latestEvent ?: event
             if (newest.sequence == event.sequence) {
                 break
             }
             event = newest
+            wait = burstQuietWindow
             restarts++
             if (restarts >= maxQuietWindowRestarts) {
                 logger.warn {
@@ -136,34 +167,23 @@ class ClipboardEventPipeline<S : Any>(
             }
         }
 
-        var snapshot: S?
-        var revalidations = 0
-        while (true) {
-            snapshot = takeSnapshot(event)
-            val sequenceNow = currentSequence()
-            if (sequenceNow == event.sequence) {
-                break
+        val snapshot = takeSnapshot(event)
+        if (snapshot == null) {
+            lastProcessedSequence = event.sequence
+            return
+        }
+
+        val sequenceNow = currentSequence()
+        if (sequenceNow != event.sequence) {
+            discardedCount.incrementAndGet()
+            logger.warn {
+                "Discarding snapshot at sequence ${event.sequence}: clipboard moved to " +
+                    "$sequenceNow during the read; awaiting its own event"
             }
-            if (revalidations >= maxRevalidations) {
-                degradedCount.incrementAndGet()
-                logger.warn {
-                    "Accepting possibly intermediate snapshot at sequence ${event.sequence} " +
-                        "after $revalidations revalidations (clipboard now at $sequenceNow)"
-                }
-                break
-            }
-            revalidations++
-            // Re-bind to the event actually recorded for the new sequence so source
-            // attribution follows the captured content; if its message has not been
-            // recorded yet, keep the previous source rather than re-querying now —
-            // the foreground app may have changed since the write.
-            event = latestEvent?.takeIf { it.sequence == sequenceNow }
-                ?: ClipboardEvent(sequenceNow, event.source)
+            return
         }
 
         lastProcessedSequence = event.sequence
-        snapshot?.let {
-            consume(it, event)
-        }
+        snapshotQueue.send(snapshot to event)
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/ClipboardEventPipeline.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/ClipboardEventPipeline.kt
@@ -1,0 +1,169 @@
+package com.crosspaste.paste
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * A clipboard change event as observed by the platform listener.
+ *
+ * [source] is sampled at event time so it stays bound to [sequence]: by the time the
+ * worker reads the clipboard, the foreground app / clipboard owner may have changed.
+ */
+data class ClipboardEvent(
+    val sequence: Int,
+    val source: String?,
+)
+
+/**
+ * Single-consumer clipboard event pipeline.
+ *
+ * Apps like Snipping Tool write the clipboard several times per user operation within a
+ * short burst, and each eager full snapshot taken in that window competes with the
+ * writer's own clipboard access (#4737). This pipeline decouples event delivery from
+ * clipboard reading:
+ *
+ * - [onEvent] is cheap and non-blocking: it records the latest event and signals the
+ *   worker through a conflated channel. It never touches the clipboard, so the caller
+ *   (e.g. a Windows message loop) returns immediately.
+ * - The worker waits for the clipboard to stay quiet for [quietWindow] before reading;
+ *   every further event restarts the wait (at most [maxQuietWindowRestarts] times), so a
+ *   whole burst collapses into one [takeSnapshot] call.
+ * - After the snapshot, the sequence is re-validated: if the clipboard changed while the
+ *   snapshot was being taken, the snapshot may hold a mixed state, so it is discarded and
+ *   retaken — at most [maxRevalidations] times. On exhausting the budget the possibly
+ *   intermediate snapshot is accepted, [degradedSnapshotCount] is incremented, and the
+ *   newer content is still processed by the next pass (its event has already re-signaled
+ *   the channel).
+ * - [consume] is awaited by the worker, so consume passes never overlap and record order
+ *   matches event order.
+ *
+ * The default windows are initial values; final parameters must be validated on a real
+ * machine over 50+ consecutive Snipping Tool captures (#4793).
+ */
+class ClipboardEventPipeline<S : Any>(
+    private val quietWindow: Duration = DEFAULT_QUIET_WINDOW,
+    private val maxQuietWindowRestarts: Int = DEFAULT_MAX_QUIET_WINDOW_RESTARTS,
+    private val maxRevalidations: Int = DEFAULT_MAX_REVALIDATIONS,
+    private val currentSequence: () -> Int,
+    private val takeSnapshot: suspend (ClipboardEvent) -> S?,
+    private val consume: suspend (snapshot: S, event: ClipboardEvent) -> Unit,
+) {
+
+    companion object {
+        // Snipping Tool's two writes land 30–90 ms apart, so the quiet window must span
+        // that gap for the burst to collapse into a single snapshot.
+        val DEFAULT_QUIET_WINDOW = 100.milliseconds
+
+        // Worst-case added wait ≈ quietWindow * (restarts + 1); Ditto's field experience
+        // suggests ~500 ms is an effective total delay for misbehaving writers.
+        const val DEFAULT_MAX_QUIET_WINDOW_RESTARTS = 4
+
+        const val DEFAULT_MAX_REVALIDATIONS = 2
+    }
+
+    private val logger: KLogger = KotlinLogging.logger {}
+
+    private val signal = Channel<Unit>(Channel.CONFLATED)
+
+    @Volatile
+    private var latestEvent: ClipboardEvent? = null
+
+    // Only read and written by the worker coroutine.
+    private var lastProcessedSequence: Int? = null
+
+    private val degradedCount = AtomicLong(0)
+
+    val degradedSnapshotCount: Long
+        get() = degradedCount.get()
+
+    /**
+     * Records a clipboard change and wakes the worker. Safe to call from any thread;
+     * events arriving faster than the worker drains them conflate into the latest one.
+     */
+    fun onEvent(
+        sequence: Int,
+        source: String?,
+    ) {
+        latestEvent = ClipboardEvent(sequence, source)
+        signal.trySend(Unit)
+    }
+
+    fun launchIn(scope: CoroutineScope): Job =
+        scope.launch(CoroutineName("ClipboardEventPipelineWorker")) {
+            for (unused in signal) {
+                runCatching {
+                    processBurst()
+                }.onFailure { e ->
+                    if (e is CancellationException) {
+                        throw e
+                    }
+                    logger.error(e) { "Failed to process clipboard burst" }
+                }
+            }
+        }
+
+    private suspend fun processBurst() {
+        var event = latestEvent ?: return
+        if (event.sequence == lastProcessedSequence) {
+            return
+        }
+
+        var restarts = 0
+        while (true) {
+            delay(quietWindow)
+            val newest = latestEvent ?: event
+            if (newest.sequence == event.sequence) {
+                break
+            }
+            event = newest
+            restarts++
+            if (restarts >= maxQuietWindowRestarts) {
+                logger.warn {
+                    "Clipboard still changing after $restarts quiet-window restarts, " +
+                        "proceeding at sequence ${event.sequence}"
+                }
+                break
+            }
+        }
+
+        var snapshot: S?
+        var revalidations = 0
+        while (true) {
+            snapshot = takeSnapshot(event)
+            val sequenceNow = currentSequence()
+            if (sequenceNow == event.sequence) {
+                break
+            }
+            if (revalidations >= maxRevalidations) {
+                degradedCount.incrementAndGet()
+                logger.warn {
+                    "Accepting possibly intermediate snapshot at sequence ${event.sequence} " +
+                        "after $revalidations revalidations (clipboard now at $sequenceNow)"
+                }
+                break
+            }
+            revalidations++
+            // Re-bind to the event actually recorded for the new sequence so source
+            // attribution follows the captured content; if its message has not been
+            // recorded yet, keep the previous source rather than re-querying now —
+            // the foreground app may have changed since the write.
+            event = latestEvent?.takeIf { it.sequence == sequenceNow }
+                ?: ClipboardEvent(sequenceNow, event.source)
+        }
+
+        lastProcessedSequence = event.sequence
+        snapshot?.let {
+            consume(it, event)
+        }
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/ClipboardEventPipeline.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/ClipboardEventPipeline.kt
@@ -57,7 +57,11 @@ data class ClipboardEvent(
  * bounded: when the consumer falls behind, the oldest unconsumed snapshot is dropped in
  * favor of newer clipboard states and counted in [droppedSnapshotCount].
  *
- * Lifecycle: [startCapture] / [stopCapture] toggle snapshot capture at runtime — the
+ * Lifecycle: [startCapture] / [stopCapture] toggle snapshot capture at runtime through
+ * a capture-generation gate — both workers are launched once and stay up. A stop
+ * invalidates the current generation, so leftover signals, recorded events, and reads
+ * still in flight from before the stop are discarded instead of being replayed after a
+ * restart, and a stop/start cycle can never run two snapshot readers concurrently. The
  * consumer deliberately keeps running across stops so snapshots that were already
  * captured are persisted in order rather than cancelled halfway through a write.
  * [close] shuts the whole pipeline down for application exit.
@@ -114,8 +118,22 @@ class ClipboardEventPipeline<S : Any>(
             },
         )
 
+    private data class RecordedEvent(
+        val event: ClipboardEvent,
+        val generation: Long,
+    )
+
     @Volatile
-    private var latestEvent: ClipboardEvent? = null
+    private var latestEvent: RecordedEvent? = null
+
+    // 0 = capture disabled. Runtime start/stop only moves this gate; the workers are
+    // launched once and stay up, so a stop/start cycle can never run two snapshotters
+    // concurrently (an in-flight blocking AWT read is not cancellable).
+    @Volatile
+    private var activeGeneration = 0L
+
+    // Guarded by the @Synchronized start/stop methods.
+    private var generationCounter = 0L
 
     // Only read and written by the snapshot worker coroutine.
     private var lastProcessedSequence: Int? = null
@@ -127,13 +145,17 @@ class ClipboardEventPipeline<S : Any>(
     /**
      * Records a clipboard change and wakes the snapshot worker. Safe to call from any
      * thread; events arriving faster than the worker drains them conflate into the
-     * latest one.
+     * latest one. Events arriving while capture is stopped are dropped.
      */
     fun onEvent(
         sequence: Int,
         source: String?,
     ) {
-        latestEvent = ClipboardEvent(sequence, source)
+        val generation = activeGeneration
+        if (generation == 0L) {
+            return
+        }
+        latestEvent = RecordedEvent(ClipboardEvent(sequence, source), generation)
         signal.trySend(Unit)
     }
 
@@ -151,15 +173,21 @@ class ClipboardEventPipeline<S : Any>(
                     snapshotLoop()
                 }
         }
+        if (activeGeneration == 0L) {
+            activeGeneration = ++generationCounter
+        }
     }
 
     /**
-     * Stops taking new snapshots. The consumer keeps running so already captured
-     * snapshots are persisted in order instead of being cancelled mid-write.
+     * Stops taking new snapshots by closing the generation gate: events, pending
+     * signals, and in-flight reads from the closed generation are discarded by the
+     * snapshot worker instead of being replayed after a restart. The consumer keeps
+     * running so already captured snapshots are persisted in order instead of being
+     * cancelled mid-write.
      */
     @Synchronized
     fun stopCapture() {
-        snapshotterJob?.cancel()
+        activeGeneration = 0L
     }
 
     /**
@@ -171,6 +199,7 @@ class ClipboardEventPipeline<S : Any>(
     suspend fun close(gracePeriod: Duration) {
         stopCapture()
         signal.close()
+        snapshotterJob?.cancel()
         snapshotQueue.close()
         consumerJob?.let { job ->
             if (withTimeoutOrNull(gracePeriod) { job.join() } == null) {
@@ -208,7 +237,17 @@ class ClipboardEventPipeline<S : Any>(
     }
 
     private suspend fun captureBurst() {
-        var event = latestEvent ?: return
+        val generation = activeGeneration
+        if (generation == 0L) {
+            return
+        }
+        val recorded = latestEvent ?: return
+        if (recorded.generation != generation) {
+            // A signal left over from a previous capture session; its event must not
+            // leak into this one (e.g. bypassing enableSkipPreLaunchPasteboardContent).
+            return
+        }
+        var event = recorded.event
         if (event.sequence == lastProcessedSequence) {
             return
         }
@@ -217,7 +256,10 @@ class ClipboardEventPipeline<S : Any>(
         var restarts = 0
         while (true) {
             delay(wait)
-            val newest = latestEvent ?: event
+            if (activeGeneration != generation) {
+                return
+            }
+            val newest = latestEvent?.takeIf { it.generation == generation }?.event ?: event
             if (newest.sequence == event.sequence) {
                 break
             }
@@ -234,6 +276,11 @@ class ClipboardEventPipeline<S : Any>(
         }
 
         val snapshot = takeSnapshot(event)
+        if (activeGeneration != generation) {
+            // Capture was stopped while the non-cancellable blocking read was in
+            // flight: discard the result without recording anything.
+            return
+        }
         if (snapshot == null) {
             lastProcessedSequence = event.sequence
             return

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
@@ -10,7 +10,6 @@ import com.crosspaste.platform.Platform
 import com.crosspaste.platform.windows.WindowClipboard
 import com.crosspaste.platform.windows.api.User32
 import com.crosspaste.sound.SoundService
-import com.crosspaste.utils.DesktopControlUtils
 import com.crosspaste.utils.cpuDispatcher
 import com.crosspaste.utils.getControlUtils
 import com.crosspaste.utils.namedScope
@@ -43,13 +42,11 @@ class WindowsPasteboardService(
     User32.WNDPROC {
     override val logger: KLogger = KotlinLogging.logger {}
 
-    private val controlUtils = getControlUtils() as DesktopControlUtils
+    private val controlUtils = getControlUtils()
 
     private val desktopConfigManager = configManager as DesktopConfigManager
 
     @Volatile
-    private var existNew = false
-
     private var changeCount = configManager.getCurrentConfig().lastPasteboardChangeCount
 
     @Volatile
@@ -62,7 +59,40 @@ class WindowsPasteboardService(
 
     private val serviceConsumerScope = namedScope(cpuDispatcher, "WindowsPasteboardService")
 
+    // Single-consumer pipeline (#4793): the message-thread callback only records events;
+    // this worker coalesces bursts, takes one snapshot per burst, and consumes serially.
+    private val pipeline =
+        ClipboardEventPipeline<Transferable>(
+            currentSequence = { User32.INSTANCE.GetClipboardSequenceNumber() },
+            takeSnapshot = { event ->
+                if (sourceExclusionService.isExcluded(event.source)) {
+                    logger.debug { "Ignoring excluded source: ${event.source}" }
+                    null
+                } else {
+                    controlUtils.exponentialBackoffUntilValid(
+                        initTime = 20L,
+                        maxTime = 1000L,
+                        isValidResult = ::isValidContents,
+                    ) {
+                        getPasteboardContentsBySafe()
+                    }
+                }
+            },
+            consume = { contents, event ->
+                if (contents != ownerTransferable) {
+                    ownerTransferable = contents
+                    val pasteTransferable = DesktopReadTransferable(contents)
+                    // in windows, we don't know if the pasteboard is local or remote
+                    pasteConsumer.consume(
+                        pasteTransferable,
+                        PasteSourceContext(source = event.source, remote = false),
+                    )
+                }
+            },
+        )
+
     private var job: Job? = null
+    private var workerJob: Job? = null
     private var viewer: HWND? = null
     private val event =
         Kernel32.INSTANCE.CreateEvent(
@@ -124,8 +154,6 @@ class WindowsPasteboardService(
                     User32.QS_ALLINPUT,
                 )
 
-            existNew = true
-
             if (result == Kernel32.WAIT_OBJECT_0) {
                 User32.INSTANCE.RemoveClipboardFormatListener(viewer)
                 User32.INSTANCE.DestroyWindow(viewer)
@@ -158,6 +186,9 @@ class WindowsPasteboardService(
 
     override fun start() {
         if (job?.isActive != true) {
+            if (workerJob?.isActive != true) {
+                workerJob = pipeline.launchIn(serviceConsumerScope)
+            }
             job =
                 serviceScope.launch(CoroutineName("WindowsPasteboardService")) {
                     val firstChange =
@@ -170,7 +201,10 @@ class WindowsPasteboardService(
                             .getCurrentConfig()
                             .enableSkipPreLaunchPasteboardContent
                     ) {
-                        onChange(true)
+                        pipeline.onEvent(
+                            sequence = User32.INSTANCE.GetClipboardSequenceNumber(),
+                            source = null,
+                        )
                     }
                     run()
                 }
@@ -179,51 +213,9 @@ class WindowsPasteboardService(
 
     override fun stop() {
         Kernel32.INSTANCE.SetEvent(event)
+        workerJob?.cancel()
         job?.cancel()
         configManager.updateConfig("lastPasteboardChangeCount", changeCount)
-    }
-
-    private fun onChange(firstChange: Boolean = false) {
-        runCatching {
-            val source =
-                if (firstChange) {
-                    null
-                } else {
-                    controlUtils.blockEnsureMinExecutionTime(delayTime = 20) {
-                        appWindowManager.getCurrentActiveAppName()
-                    }
-                }
-
-            if (sourceExclusionService.isExcluded(source)) {
-                logger.debug { "Ignoring excluded source: $source" }
-                return
-            }
-
-            val contents =
-                controlUtils.blockExponentialBackoffUntilValid(
-                    initTime = 20L,
-                    maxTime = 1000L,
-                    isValidResult = ::isValidContents,
-                ) {
-                    getPasteboardContentsBySafe()
-                }
-
-            contents?.let {
-                if (it != ownerTransferable) {
-                    ownerTransferable = it
-                    serviceConsumerScope.launch(CoroutineName("WindowsPasteboardConsumer")) {
-                        val pasteTransferable = DesktopReadTransferable(it)
-                        // in windows, we don't know if the pasteboard is local or remote
-                        pasteConsumer.consume(
-                            pasteTransferable,
-                            PasteSourceContext(source = source, remote = false),
-                        )
-                    }
-                }
-            }
-        }.onFailure { e ->
-            logger.error(e) { "Failed to consume transferable" }
-        }
     }
 
     override fun callback(
@@ -233,14 +225,17 @@ class WindowsPasteboardService(
         lParam: LPARAM?,
     ): Int {
         if (uMsg == User32.WM_CLIPBOARDUPDATE) {
-            if (existNew) {
-                existNew = false
-                runCatching {
-                    val clipboardSequenceNumber = User32.INSTANCE.GetClipboardSequenceNumber()
-                    if (changeCount != clipboardSequenceNumber) {
-                        changeCount = clipboardSequenceNumber
-                        onChange()
-                    }
+            runCatching {
+                val clipboardSequenceNumber = User32.INSTANCE.GetClipboardSequenceNumber()
+                if (changeCount != clipboardSequenceNumber) {
+                    changeCount = clipboardSequenceNumber
+                    // Sample the source at event time so it stays bound to this sequence;
+                    // no clipboard read happens on the message thread.
+                    val source =
+                        runCatching {
+                            appWindowManager.getCurrentActiveAppName()
+                        }.getOrNull()
+                    pipeline.onEvent(clipboardSequenceNumber, source)
                 }
             }
             return 0

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
@@ -12,6 +12,7 @@ import com.crosspaste.platform.windows.api.User32
 import com.crosspaste.sound.SoundService
 import com.crosspaste.utils.cpuDispatcher
 import com.crosspaste.utils.getControlUtils
+import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
 import com.sun.jna.platform.win32.Kernel32
 import com.sun.jna.platform.win32.WinDef.HWND
@@ -23,6 +24,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.awt.Toolkit
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.Transferable
@@ -69,12 +71,16 @@ class WindowsPasteboardService(
                     logger.debug { "Ignoring excluded source: ${event.source}" }
                     null
                 } else {
-                    controlUtils.exponentialBackoffUntilValid(
-                        initTime = 20L,
-                        maxTime = 1000L,
-                        isValidResult = ::isValidContents,
-                    ) {
-                        getPasteboardContentsBySafe()
+                    // The AWT snapshot is a blocking native read (retried on failure);
+                    // keep it off the CPU worker pool.
+                    withContext(ioDispatcher) {
+                        controlUtils.exponentialBackoffUntilValid(
+                            initTime = 20L,
+                            maxTime = 1000L,
+                            isValidResult = ::isValidContents,
+                        ) {
+                            getPasteboardContentsBySafe()
+                        }
                     }
                 }
             },

--- a/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/paste/WindowsPasteboardService.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.withContext
 import java.awt.Toolkit
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.Transferable
+import kotlin.time.Duration.Companion.seconds
 
 class WindowsPasteboardService(
     override val appWindowManager: DesktopAppWindowManager,
@@ -98,7 +99,6 @@ class WindowsPasteboardService(
         )
 
     private var job: Job? = null
-    private var workerJob: Job? = null
     private var viewer: HWND? = null
     private val event =
         Kernel32.INSTANCE.CreateEvent(
@@ -192,9 +192,7 @@ class WindowsPasteboardService(
 
     override fun start() {
         if (job?.isActive != true) {
-            if (workerJob?.isActive != true) {
-                workerJob = pipeline.launchIn(serviceConsumerScope)
-            }
+            pipeline.startCapture(serviceConsumerScope)
             job =
                 serviceScope.launch(CoroutineName("WindowsPasteboardService")) {
                     val firstChange =
@@ -219,9 +217,16 @@ class WindowsPasteboardService(
 
     override fun stop() {
         Kernel32.INSTANCE.SetEvent(event)
-        workerJob?.cancel()
+        // Only capture stops here: the pipeline's consumer keeps draining snapshots that
+        // were already taken, so a consume in the middle of persisting is not cancelled.
+        pipeline.stopCapture()
         job?.cancel()
         configManager.updateConfig("lastPasteboardChangeCount", changeCount)
+    }
+
+    override suspend fun shutdown() {
+        stop()
+        pipeline.close(gracePeriod = 3.seconds)
     }
 
     override fun callback(

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/ClipboardEventPipelineTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/ClipboardEventPipelineTest.kt
@@ -323,6 +323,58 @@ class ClipboardEventPipelineTest {
         }
 
     @Test
+    fun `an event queued before stopCapture is not replayed after restart`() =
+        runTest {
+            val harness = Harness()
+            harness.pipeline.startCapture(this)
+
+            // The signal is queued but the quiet window has not elapsed yet.
+            harness.write("AppA")
+            harness.pipeline.stopCapture()
+            harness.pipeline.startCapture(this)
+            advanceUntilIdle()
+
+            assertTrue(harness.snapshots.isEmpty())
+
+            harness.write("AppB")
+            advanceUntilIdle()
+
+            assertEquals(listOf(2), harness.consumed.map { it.second.sequence })
+            harness.pipeline.close(1.seconds)
+        }
+
+    @Test
+    fun `stopCapture during a blocking read discards the result without marking it processed`() =
+        runTest {
+            val harness = Harness()
+            var stopOnce = true
+            harness.onSnapshot = { event ->
+                if (stopOnce) {
+                    stopOnce = false
+                    harness.pipeline.stopCapture()
+                }
+                "snap-${event.sequence}"
+            }
+            harness.pipeline.startCapture(this)
+
+            harness.write("AppA")
+            advanceUntilIdle()
+
+            assertEquals(1, harness.snapshots.size)
+            assertTrue(harness.consumed.isEmpty())
+
+            // After restart the same sequence is still readable: it was never marked
+            // processed by the discarded read.
+            harness.pipeline.startCapture(this)
+            harness.pipeline.onEvent(1, "AppA")
+            advanceUntilIdle()
+
+            assertEquals(2, harness.snapshots.size)
+            assertEquals(listOf(1), harness.consumed.map { it.second.sequence })
+            harness.pipeline.close(1.seconds)
+        }
+
+    @Test
     fun `queue overflow drops the oldest snapshot and keeps the newest states`() =
         runTest {
             val harness = Harness(snapshotQueueCapacity = 2)

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/ClipboardEventPipelineTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/ClipboardEventPipelineTest.kt
@@ -15,8 +15,8 @@ class ClipboardEventPipelineTest {
 
     private class Harness(
         quietWindow: Duration = 100.milliseconds,
+        burstQuietWindow: Duration = 500.milliseconds,
         maxQuietWindowRestarts: Int = ClipboardEventPipeline.DEFAULT_MAX_QUIET_WINDOW_RESTARTS,
-        maxRevalidations: Int = ClipboardEventPipeline.DEFAULT_MAX_REVALIDATIONS,
     ) {
         var sequence = 0
 
@@ -30,8 +30,8 @@ class ClipboardEventPipelineTest {
         val pipeline =
             ClipboardEventPipeline(
                 quietWindow = quietWindow,
+                burstQuietWindow = burstQuietWindow,
                 maxQuietWindowRestarts = maxQuietWindowRestarts,
-                maxRevalidations = maxRevalidations,
                 currentSequence = { sequence },
                 takeSnapshot = { event ->
                     snapshots.add(event)
@@ -61,7 +61,7 @@ class ClipboardEventPipelineTest {
 
             assertEquals(listOf(ClipboardEvent(1, "AppA")), harness.snapshots)
             assertEquals(listOf("snap-1" to ClipboardEvent(1, "AppA")), harness.consumed)
-            assertEquals(0L, harness.pipeline.degradedSnapshotCount)
+            assertEquals(0L, harness.pipeline.discardedSnapshotCount)
             worker.cancel()
         }
 
@@ -78,7 +78,27 @@ class ClipboardEventPipelineTest {
 
             assertEquals(listOf(ClipboardEvent(2, "SnippingTool")), harness.snapshots)
             assertEquals(listOf("snap-2" to ClipboardEvent(2, "SnippingTool")), harness.consumed)
-            assertEquals(0L, harness.pipeline.degradedSnapshotCount)
+            assertEquals(0L, harness.pipeline.discardedSnapshotCount)
+            worker.cancel()
+        }
+
+    @Test
+    fun `detecting a burst extends the wait to the burst quiet window`() =
+        runTest {
+            val harness = Harness()
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("SnippingTool")
+            advanceTimeBy(60.milliseconds)
+            harness.write("SnippingTool")
+
+            // The burst is detected at 100 ms; the snapshot is then deferred by the
+            // 500 ms burst window instead of another base window.
+            advanceTimeBy(500.milliseconds)
+            assertTrue(harness.snapshots.isEmpty())
+
+            advanceUntilIdle()
+            assertEquals(listOf(ClipboardEvent(2, "SnippingTool")), harness.snapshots)
             worker.cancel()
         }
 
@@ -104,7 +124,7 @@ class ClipboardEventPipelineTest {
         }
 
     @Test
-    fun `snapshot is retaken when the sequence changes during the read`() =
+    fun `snapshot is discarded when the sequence changes during the read`() =
         runTest {
             val harness = Harness()
             var firstSnapshot = true
@@ -121,40 +141,51 @@ class ClipboardEventPipelineTest {
             harness.write("AppA")
             advanceUntilIdle()
 
-            assertEquals(2, harness.snapshots.size)
+            // The mixed-state snapshot is dropped; the late event re-enters through its
+            // own quiet window carrying its own source.
+            assertEquals(
+                listOf(ClipboardEvent(1, "AppA"), ClipboardEvent(2, "Late")),
+                harness.snapshots,
+            )
             assertEquals(listOf("snap-2" to ClipboardEvent(2, "Late")), harness.consumed)
-            assertEquals(0L, harness.pipeline.degradedSnapshotCount)
+            assertEquals(1L, harness.pipeline.discardedSnapshotCount)
             worker.cancel()
         }
 
     @Test
-    fun `revalidation is bounded and the latest event is still processed afterwards`() =
+    fun `a write during the read does not inherit the previous source and exclusions hold`() =
         runTest {
-            val harness = Harness(maxRevalidations = 2)
+            val harness = Harness()
             harness.onSnapshot = { event ->
-                if (harness.sequence < 4) {
-                    // The clipboard keeps changing under the reader, and the matching
-                    // change messages have not been recorded yet.
+                if (event.source == "AppA" && harness.sequence == 1) {
+                    // An excluded app writes while AppA's snapshot is being taken; its
+                    // change message has not arrived yet.
                     harness.sequence++
                 }
-                "snap-${event.sequence}"
+                if (event.source == "ExcludedApp") {
+                    null
+                } else {
+                    "snap-${event.sequence}"
+                }
             }
             val worker = harness.pipeline.launchIn(this)
 
             harness.write("AppA")
             advanceUntilIdle()
 
-            assertEquals(3, harness.snapshots.size)
-            assertEquals(1L, harness.pipeline.degradedSnapshotCount)
-            // The degraded snapshot keeps the source of the event it was re-bound from.
-            assertEquals(listOf("snap-3" to ClipboardEvent(3, "AppA")), harness.consumed)
+            // The mixed snapshot was dropped instead of being processed as AppA.
+            assertEquals(1L, harness.pipeline.discardedSnapshotCount)
+            assertTrue(harness.consumed.isEmpty())
 
-            // The change message for the newest write arrives afterwards and is processed.
-            harness.pipeline.onEvent(4, "AppB")
+            // The excluded app's own event arrives and is excluded, not recorded.
+            harness.pipeline.onEvent(2, "ExcludedApp")
             advanceUntilIdle()
 
-            assertEquals(4, harness.snapshots.size)
-            assertEquals("snap-4" to ClipboardEvent(4, "AppB"), harness.consumed.last())
+            assertEquals(
+                listOf(ClipboardEvent(1, "AppA"), ClipboardEvent(2, "ExcludedApp")),
+                harness.snapshots,
+            )
+            assertTrue(harness.consumed.isEmpty())
             worker.cancel()
         }
 
@@ -179,6 +210,26 @@ class ClipboardEventPipelineTest {
 
             assertEquals(listOf(1, 2), harness.consumed.map { it.second.sequence })
             assertEquals(1, maxActive)
+            worker.cancel()
+        }
+
+    @Test
+    fun `a slow consume does not conflate or drop later events`() =
+        runTest {
+            val harness = Harness()
+            harness.onConsume = { _, _ -> delay(10.seconds) }
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("AppA")
+            advanceTimeBy(500.milliseconds)
+            // Both writes land while AppA's consume is still running.
+            harness.write("AppB")
+            advanceTimeBy(1500.milliseconds)
+            harness.write("AppC")
+            advanceUntilIdle()
+
+            assertEquals(listOf(1, 2, 3), harness.snapshots.map { it.sequence })
+            assertEquals(listOf(1, 2, 3), harness.consumed.map { it.second.sequence })
             worker.cancel()
         }
 
@@ -217,10 +268,11 @@ class ClipboardEventPipelineTest {
             advanceUntilIdle()
 
             assertTrue(harness.consumed.isNotEmpty())
-            // The first pass stops extending after two restarts instead of waiting out
-            // the whole write storm.
+            // First wake at 100 ms adopts seq 2, the burst wait of 500 ms wakes at
+            // 600 ms and adopts seq 11, then the restart cap forces the snapshot
+            // instead of waiting out the whole write storm.
             assertEquals(
-                4,
+                11,
                 harness.consumed
                     .first()
                     .second.sequence,

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/ClipboardEventPipelineTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/ClipboardEventPipelineTest.kt
@@ -1,0 +1,230 @@
+package com.crosspaste.paste
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class ClipboardEventPipelineTest {
+
+    private class Harness(
+        quietWindow: Duration = 100.milliseconds,
+        maxQuietWindowRestarts: Int = ClipboardEventPipeline.DEFAULT_MAX_QUIET_WINDOW_RESTARTS,
+        maxRevalidations: Int = ClipboardEventPipeline.DEFAULT_MAX_REVALIDATIONS,
+    ) {
+        var sequence = 0
+
+        var onSnapshot: suspend (ClipboardEvent) -> String? = { event -> "snap-${event.sequence}" }
+
+        var onConsume: suspend (String, ClipboardEvent) -> Unit = { _, _ -> }
+
+        val snapshots = mutableListOf<ClipboardEvent>()
+        val consumed = mutableListOf<Pair<String, ClipboardEvent>>()
+
+        val pipeline =
+            ClipboardEventPipeline(
+                quietWindow = quietWindow,
+                maxQuietWindowRestarts = maxQuietWindowRestarts,
+                maxRevalidations = maxRevalidations,
+                currentSequence = { sequence },
+                takeSnapshot = { event ->
+                    snapshots.add(event)
+                    onSnapshot(event)
+                },
+                consume = { snapshot, event ->
+                    onConsume(snapshot, event)
+                    consumed.add(snapshot to event)
+                },
+            )
+
+        fun write(source: String?): Int {
+            sequence++
+            pipeline.onEvent(sequence, source)
+            return sequence
+        }
+    }
+
+    @Test
+    fun `single event is consumed once with its bound source`() =
+        runTest {
+            val harness = Harness()
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("AppA")
+            advanceUntilIdle()
+
+            assertEquals(listOf(ClipboardEvent(1, "AppA")), harness.snapshots)
+            assertEquals(listOf("snap-1" to ClipboardEvent(1, "AppA")), harness.consumed)
+            assertEquals(0L, harness.pipeline.degradedSnapshotCount)
+            worker.cancel()
+        }
+
+    @Test
+    fun `burst within quiet window collapses to one snapshot attributed to the last event`() =
+        runTest {
+            val harness = Harness()
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("SnippingTool")
+            advanceTimeBy(60.milliseconds)
+            harness.write("SnippingTool")
+            advanceUntilIdle()
+
+            assertEquals(listOf(ClipboardEvent(2, "SnippingTool")), harness.snapshots)
+            assertEquals(listOf("snap-2" to ClipboardEvent(2, "SnippingTool")), harness.consumed)
+            assertEquals(0L, harness.pipeline.degradedSnapshotCount)
+            worker.cancel()
+        }
+
+    @Test
+    fun `events separated by more than the quiet window produce one record each in order`() =
+        runTest {
+            val harness = Harness()
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("AppA")
+            advanceTimeBy(500.milliseconds)
+            harness.write("AppB")
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(
+                    "snap-1" to ClipboardEvent(1, "AppA"),
+                    "snap-2" to ClipboardEvent(2, "AppB"),
+                ),
+                harness.consumed,
+            )
+            worker.cancel()
+        }
+
+    @Test
+    fun `snapshot is retaken when the sequence changes during the read`() =
+        runTest {
+            val harness = Harness()
+            var firstSnapshot = true
+            harness.onSnapshot = { event ->
+                if (firstSnapshot) {
+                    firstSnapshot = false
+                    // A second write lands while the first snapshot is being taken.
+                    harness.write("Late")
+                }
+                "snap-${event.sequence}"
+            }
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("AppA")
+            advanceUntilIdle()
+
+            assertEquals(2, harness.snapshots.size)
+            assertEquals(listOf("snap-2" to ClipboardEvent(2, "Late")), harness.consumed)
+            assertEquals(0L, harness.pipeline.degradedSnapshotCount)
+            worker.cancel()
+        }
+
+    @Test
+    fun `revalidation is bounded and the latest event is still processed afterwards`() =
+        runTest {
+            val harness = Harness(maxRevalidations = 2)
+            harness.onSnapshot = { event ->
+                if (harness.sequence < 4) {
+                    // The clipboard keeps changing under the reader, and the matching
+                    // change messages have not been recorded yet.
+                    harness.sequence++
+                }
+                "snap-${event.sequence}"
+            }
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("AppA")
+            advanceUntilIdle()
+
+            assertEquals(3, harness.snapshots.size)
+            assertEquals(1L, harness.pipeline.degradedSnapshotCount)
+            // The degraded snapshot keeps the source of the event it was re-bound from.
+            assertEquals(listOf("snap-3" to ClipboardEvent(3, "AppA")), harness.consumed)
+
+            // The change message for the newest write arrives afterwards and is processed.
+            harness.pipeline.onEvent(4, "AppB")
+            advanceUntilIdle()
+
+            assertEquals(4, harness.snapshots.size)
+            assertEquals("snap-4" to ClipboardEvent(4, "AppB"), harness.consumed.last())
+            worker.cancel()
+        }
+
+    @Test
+    fun `consume passes never overlap and record order matches event order`() =
+        runTest {
+            val harness = Harness()
+            var active = 0
+            var maxActive = 0
+            harness.onConsume = { _, _ ->
+                active++
+                maxActive = maxOf(maxActive, active)
+                delay(1.seconds)
+                active--
+            }
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("AppA")
+            advanceTimeBy(150.milliseconds)
+            harness.write("AppB")
+            advanceUntilIdle()
+
+            assertEquals(listOf(1, 2), harness.consumed.map { it.second.sequence })
+            assertEquals(1, maxActive)
+            worker.cancel()
+        }
+
+    @Test
+    fun `null snapshot consumes nothing and still marks the sequence processed`() =
+        runTest {
+            val harness = Harness()
+            harness.onSnapshot = { null }
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("Excluded")
+            advanceUntilIdle()
+
+            assertEquals(1, harness.snapshots.size)
+            assertTrue(harness.consumed.isEmpty())
+
+            // A duplicate signal for an already processed sequence does not re-read.
+            harness.pipeline.onEvent(1, "Excluded")
+            advanceUntilIdle()
+
+            assertEquals(1, harness.snapshots.size)
+            worker.cancel()
+        }
+
+    @Test
+    fun `quiet window restarts are bounded when the clipboard never settles`() =
+        runTest {
+            val harness = Harness(maxQuietWindowRestarts = 2)
+            val worker = harness.pipeline.launchIn(this)
+
+            harness.write("AppA")
+            repeat(10) {
+                advanceTimeBy(60.milliseconds)
+                harness.write("AppA")
+            }
+            advanceUntilIdle()
+
+            assertTrue(harness.consumed.isNotEmpty())
+            // The first pass stops extending after two restarts instead of waiting out
+            // the whole write storm.
+            assertEquals(
+                4,
+                harness.consumed
+                    .first()
+                    .second.sequence,
+            )
+            worker.cancel()
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/ClipboardEventPipelineTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/ClipboardEventPipelineTest.kt
@@ -17,6 +17,7 @@ class ClipboardEventPipelineTest {
         quietWindow: Duration = 100.milliseconds,
         burstQuietWindow: Duration = 500.milliseconds,
         maxQuietWindowRestarts: Int = ClipboardEventPipeline.DEFAULT_MAX_QUIET_WINDOW_RESTARTS,
+        snapshotQueueCapacity: Int = ClipboardEventPipeline.DEFAULT_SNAPSHOT_QUEUE_CAPACITY,
     ) {
         var sequence = 0
 
@@ -32,6 +33,7 @@ class ClipboardEventPipelineTest {
                 quietWindow = quietWindow,
                 burstQuietWindow = burstQuietWindow,
                 maxQuietWindowRestarts = maxQuietWindowRestarts,
+                snapshotQueueCapacity = snapshotQueueCapacity,
                 currentSequence = { sequence },
                 takeSnapshot = { event ->
                     snapshots.add(event)
@@ -54,7 +56,7 @@ class ClipboardEventPipelineTest {
     fun `single event is consumed once with its bound source`() =
         runTest {
             val harness = Harness()
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("AppA")
             advanceUntilIdle()
@@ -62,14 +64,14 @@ class ClipboardEventPipelineTest {
             assertEquals(listOf(ClipboardEvent(1, "AppA")), harness.snapshots)
             assertEquals(listOf("snap-1" to ClipboardEvent(1, "AppA")), harness.consumed)
             assertEquals(0L, harness.pipeline.discardedSnapshotCount)
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
         }
 
     @Test
     fun `burst within quiet window collapses to one snapshot attributed to the last event`() =
         runTest {
             val harness = Harness()
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("SnippingTool")
             advanceTimeBy(60.milliseconds)
@@ -79,14 +81,14 @@ class ClipboardEventPipelineTest {
             assertEquals(listOf(ClipboardEvent(2, "SnippingTool")), harness.snapshots)
             assertEquals(listOf("snap-2" to ClipboardEvent(2, "SnippingTool")), harness.consumed)
             assertEquals(0L, harness.pipeline.discardedSnapshotCount)
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
         }
 
     @Test
     fun `detecting a burst extends the wait to the burst quiet window`() =
         runTest {
             val harness = Harness()
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("SnippingTool")
             advanceTimeBy(60.milliseconds)
@@ -99,14 +101,14 @@ class ClipboardEventPipelineTest {
 
             advanceUntilIdle()
             assertEquals(listOf(ClipboardEvent(2, "SnippingTool")), harness.snapshots)
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
         }
 
     @Test
     fun `events separated by more than the quiet window produce one record each in order`() =
         runTest {
             val harness = Harness()
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("AppA")
             advanceTimeBy(500.milliseconds)
@@ -120,7 +122,7 @@ class ClipboardEventPipelineTest {
                 ),
                 harness.consumed,
             )
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
         }
 
     @Test
@@ -136,7 +138,7 @@ class ClipboardEventPipelineTest {
                 }
                 "snap-${event.sequence}"
             }
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("AppA")
             advanceUntilIdle()
@@ -149,7 +151,7 @@ class ClipboardEventPipelineTest {
             )
             assertEquals(listOf("snap-2" to ClipboardEvent(2, "Late")), harness.consumed)
             assertEquals(1L, harness.pipeline.discardedSnapshotCount)
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
         }
 
     @Test
@@ -168,7 +170,7 @@ class ClipboardEventPipelineTest {
                     "snap-${event.sequence}"
                 }
             }
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("AppA")
             advanceUntilIdle()
@@ -186,7 +188,7 @@ class ClipboardEventPipelineTest {
                 harness.snapshots,
             )
             assertTrue(harness.consumed.isEmpty())
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
         }
 
     @Test
@@ -201,7 +203,7 @@ class ClipboardEventPipelineTest {
                 delay(1.seconds)
                 active--
             }
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("AppA")
             advanceTimeBy(150.milliseconds)
@@ -210,7 +212,7 @@ class ClipboardEventPipelineTest {
 
             assertEquals(listOf(1, 2), harness.consumed.map { it.second.sequence })
             assertEquals(1, maxActive)
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
         }
 
     @Test
@@ -218,7 +220,7 @@ class ClipboardEventPipelineTest {
         runTest {
             val harness = Harness()
             harness.onConsume = { _, _ -> delay(10.seconds) }
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("AppA")
             advanceTimeBy(500.milliseconds)
@@ -230,7 +232,7 @@ class ClipboardEventPipelineTest {
 
             assertEquals(listOf(1, 2, 3), harness.snapshots.map { it.sequence })
             assertEquals(listOf(1, 2, 3), harness.consumed.map { it.second.sequence })
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
         }
 
     @Test
@@ -238,7 +240,7 @@ class ClipboardEventPipelineTest {
         runTest {
             val harness = Harness()
             harness.onSnapshot = { null }
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("Excluded")
             advanceUntilIdle()
@@ -251,14 +253,14 @@ class ClipboardEventPipelineTest {
             advanceUntilIdle()
 
             assertEquals(1, harness.snapshots.size)
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
         }
 
     @Test
     fun `quiet window restarts are bounded when the clipboard never settles`() =
         runTest {
             val harness = Harness(maxQuietWindowRestarts = 2)
-            val worker = harness.pipeline.launchIn(this)
+            harness.pipeline.startCapture(this)
 
             harness.write("AppA")
             repeat(10) {
@@ -277,6 +279,107 @@ class ClipboardEventPipelineTest {
                     .first()
                     .second.sequence,
             )
-            worker.cancel()
+            harness.pipeline.close(1.seconds)
+        }
+
+    @Test
+    fun `stopCapture stops new snapshots but already captured ones are still consumed`() =
+        runTest {
+            val harness = Harness()
+            harness.onConsume = { _, _ -> delay(10.seconds) }
+            harness.pipeline.startCapture(this)
+
+            harness.write("AppA")
+            advanceTimeBy(200.milliseconds)
+            harness.write("AppB")
+            advanceTimeBy(200.milliseconds)
+
+            // AppA is mid-consume and AppB's snapshot sits in the queue.
+            harness.pipeline.stopCapture()
+            harness.write("AppC")
+            advanceUntilIdle()
+
+            assertEquals(listOf(1, 2), harness.snapshots.map { it.sequence })
+            assertEquals(listOf(1, 2), harness.consumed.map { it.second.sequence })
+            harness.pipeline.close(1.seconds)
+        }
+
+    @Test
+    fun `startCapture after stopCapture resumes capturing`() =
+        runTest {
+            val harness = Harness()
+            harness.pipeline.startCapture(this)
+
+            harness.write("AppA")
+            advanceUntilIdle()
+            harness.pipeline.stopCapture()
+
+            harness.pipeline.startCapture(this)
+            harness.write("AppB")
+            advanceUntilIdle()
+
+            assertEquals(listOf(1, 2), harness.consumed.map { it.second.sequence })
+            harness.pipeline.close(1.seconds)
+        }
+
+    @Test
+    fun `queue overflow drops the oldest snapshot and keeps the newest states`() =
+        runTest {
+            val harness = Harness(snapshotQueueCapacity = 2)
+            harness.onConsume = { _, _ -> delay(100.seconds) }
+            harness.pipeline.startCapture(this)
+
+            harness.write("AppA")
+            advanceTimeBy(200.milliseconds)
+            harness.write("AppB")
+            advanceTimeBy(400.milliseconds)
+            harness.write("AppC")
+            advanceTimeBy(400.milliseconds)
+            // AppA is mid-consume; the queue holds AppB and AppC, so AppD evicts AppB.
+            harness.write("AppD")
+            advanceUntilIdle()
+
+            assertEquals(listOf(1, 2, 3, 4), harness.snapshots.map { it.sequence })
+            assertEquals(listOf(1, 3, 4), harness.consumed.map { it.second.sequence })
+            assertEquals(1L, harness.pipeline.droppedSnapshotCount)
+            harness.pipeline.close(1.seconds)
+        }
+
+    @Test
+    fun `close drains the queue within the grace period`() =
+        runTest {
+            val harness = Harness()
+            harness.onConsume = { _, _ -> delay(1.seconds) }
+            harness.pipeline.startCapture(this)
+
+            harness.write("AppA")
+            advanceTimeBy(150.milliseconds)
+            harness.write("AppB")
+            advanceTimeBy(150.milliseconds)
+
+            // AppA is mid-consume, AppB is queued; both finish inside the grace period.
+            harness.pipeline.close(10.seconds)
+
+            assertEquals(listOf(1, 2), harness.consumed.map { it.second.sequence })
+            assertEquals(0L, harness.pipeline.droppedSnapshotCount)
+        }
+
+    @Test
+    fun `close cancels a consume exceeding the grace period and drops leftovers`() =
+        runTest {
+            val harness = Harness()
+            harness.onConsume = { _, _ -> delay(100.seconds) }
+            harness.pipeline.startCapture(this)
+
+            harness.write("AppA")
+            advanceTimeBy(200.milliseconds)
+            harness.write("AppB")
+            advanceTimeBy(200.milliseconds)
+
+            // AppA's consume outlives the grace period; queued AppB is dropped.
+            harness.pipeline.close(1.seconds)
+
+            assertTrue(harness.consumed.isEmpty())
+            assertEquals(1L, harness.pipeline.droppedSnapshotCount)
         }
 }


### PR DESCRIPTION
## Summary

Rework the Windows clipboard collection entry into a single-consumer event pipeline, per the design in #4793. Snipping Tool writes the clipboard twice per capture 30–90 ms apart, and each `WM_CLIPBOARDUPDATE` used to trigger an eager full AWT snapshot on the message thread (with backoff re-snapshots), landing exactly in the window where Snipping Tool's fragile save pipeline needs clipboard access (#4737).

### New `ClipboardEventPipeline`

- The message-thread callback now only records `(sequence, source)` — sampling the source app **at event time** so attribution stays bound to the sequence — and signals a `Channel.CONFLATED`. No clipboard read happens on the message thread.
- A snapshot worker waits for the clipboard to stay quiet for 100 ms before reading. Detecting a second write inside the window marks the burst and switches the remaining waits to a 500 ms burst window (Ditto's field experience; bounded to 4 restarts), so a whole burst collapses into **one** `getContents()` snapshot while a normal single copy only pays the 100 ms base delay. The blocking AWT read runs on the IO dispatcher.
- After the snapshot the sequence is re-validated. If the clipboard changed mid-read, the snapshot may hold a mixed state and the event carrying the new sequence's source has not been seen yet — so the snapshot is **discarded** (tracked by `discardedSnapshotCount`) and the sequence is left unprocessed: the new write's own event re-enters through a fresh quiet window with its correct source. Inheriting the previous event's source would misattribute the new content and could bypass `sourceExclusions`; an immediate re-read would recreate the back-to-back full snapshots this pipeline exists to avoid. (This replaces the bounded-retry-then-accept scheme sketched in #4793 — retrying inline cannot attribute a source the pipeline has not observed.)
- Captured snapshots are handed to a separate serial consume worker through a **bounded** FIFO queue (capacity 8): consume passes never overlap, record order matches event order, and a slow consume (e.g. large image encoding) no longer conflates or drops events that arrive while it runs. Because each entry can hold a full-size clipboard image, overflow drops the **oldest** unconsumed snapshot in favor of newer clipboard states and counts it in `droppedSnapshotCount` — unbounded buffering of full snapshots would grow without limit whenever capture outpaces persistence.

### Lifecycle

- Both workers are launched once and stay up; runtime `stop()` / `start()` toggle capture through a **capture-generation gate**. A stop invalidates the current generation, so leftover conflated signals, recorded events, and a blocking AWT read still in flight from before the stop are all discarded by generation checks (at burst entry, after each wait, and after the read) instead of being replayed after a restart — a stale pre-stop event can no longer bypass `enableSkipPreLaunchPasteboardContent`, and a stop/start cycle can never run two snapshot readers concurrently. Events arriving while capture is stopped are dropped at the door.
- The consumer deliberately keeps running across stops so snapshots that were already captured are persisted in order — cancelling it mid-consume could strand a LOADING row or partial image files (`DesktopTransferableConsumer.consume()` swallows the `CancellationException`). This matches the old behavior where started collections outlived `stop()`. There is no stale-queue replay: the queue keeps draining across stops and overflow-dropped snapshots are gone for good.
- Application exit goes through a new `PasteboardMonitor.shutdown()` (default: plain `stop()`, so other platforms and mobile are unaffected). The Windows implementation stops capture and then gives the consumer a 3 s grace period to finish the in-flight consume and drain the queue before cancelling; leftovers are dropped and counted. Wired into `shutdownAllServices()` in place of `stop()`.

### Preserved semantics

- `firstChange` / `enableSkipPreLaunchPasteboardContent`: the pre-launch clipboard is fed through the pipeline as a source-less event.
- `ownerTransferable` self-write skip and `sourceExclusions` checks (exclusion still short-circuits before any clipboard read).
- `lastPasteboardChangeCount` persistence on stop.
- The `existNew` gate in the message loop is removed: it existed to throttle the expensive in-callback read, and would now drop the source binding of the second write in a burst.

### Notes

- The quiet-window/burst-window/restart/queue-capacity parameters are initial values; per the acceptance criteria they must be validated on a real machine over **50+ consecutive Snipping Tool captures** (single runs are meaningless for a race). Short-window dedup fallback is tracked separately in #4791.
- Unit tests (17) cover burst coalescing, the extended burst wait, final-event source attribution, mid-read discard with correct-source reprocessing, the exclusion-bypass scenario, serial consume ordering, slow-consume non-conflation, exclusion, dedup, the coalescing cap, stop/restart lifecycle (including stale-signal non-replay and stop-during-read discard), queue overflow accounting, and graceful-close drain/timeout.

Addresses #4793. Addresses #4737.

## Test plan

- [x] `./gradlew app:desktopTest --tests "com.crosspaste.paste.ClipboardEventPipelineTest"` (17 tests)
- [x] Full `./gradlew app:desktopTest`
- [x] `./gradlew ktlintFormat` clean
- [ ] Real-machine validation: 50+ consecutive Snipping Tool captures with CrossPaste running (tracked in #4793)
