### PR TITLE
:bug: discard duplicate local image records via short-window keep-first dedup

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -131,6 +131,10 @@ class PasteReleaseService(
             val hash = firstItem.hash
             val pasteType = firstItem.getPasteType()
 
+            if (discardDuplicateLocalImage(pasteData, firstItem, remainingItems, size, hash, pasteType, id)) {
+                return@let
+            }
+
             val change =
                 database.transactionWithResult {
                     database.pasteDatabaseQueries.updatePasteDataToLoaded(
@@ -171,6 +175,63 @@ class PasteReleaseService(
                 }
             }
         }
+    }
+
+    /**
+     * Keep-first dedup for locally collected non-ref images: a single clipboard
+     * operation can fire multiple clipboard events (Windows Snipping Tool writes
+     * twice per capture), each collected into an identical record. Non-ref images
+     * intentionally bypass [markDeleteSameHash] (the #2693 resource-lifecycle
+     * guard), so an identical local image released within
+     * [com.crosspaste.db.paste.SqlPasteDao.RECENT_SAME_HASH_WINDOW] identifies
+     * this record as that duplicate: keep the first record, discard this one.
+     *
+     * The final items (with the real file paths) must be persisted before the row
+     * is marked deleted — at this point the row still holds the pre-collect
+     * placeholder, and deleting it as-is would orphan the just-written files.
+     * Only a delete task is created, never sync or rendering tasks, so the
+     * discarded record never has in-flight consumers and clearing its files
+     * cannot race anything — which is what keeps the #2693 guard intact.
+     *
+     * Returns true when the record was discarded as a duplicate.
+     */
+    private suspend fun discardDuplicateLocalImage(
+        pasteData: PasteData,
+        firstItem: PasteItem,
+        remainingItems: List<PasteItem>,
+        size: Long,
+        hash: String,
+        pasteType: PasteType,
+        id: Long,
+    ): Boolean {
+        if (pasteData.remote ||
+            !pasteType.isImage() ||
+            firstItem !is PasteFiles ||
+            firstItem.isRefFiles() ||
+            hash.isEmpty()
+        ) {
+            return false
+        }
+
+        val keptId = pasteDao.getRecentSameHashLocalPasteId(hash, pasteType.type, id) ?: return false
+
+        logger.info { "Discarding duplicate local image paste id=$id, keeping recent record id=$keptId" }
+        taskSubmitter.submit {
+            database.transaction {
+                database.pasteDatabaseQueries.updatePasteDataToLoaded(
+                    pasteAppearItem = firstItem.toStoredJson(),
+                    pasteCollection = PasteCollection(remainingItems).toStoredJson(),
+                    pasteType = pasteType.type.toLong(),
+                    pasteSearchContent = null,
+                    size = size,
+                    hash = hash,
+                    id = id,
+                )
+                database.pasteDatabaseQueries.markDeletePasteData(listOf(id))
+                addDeletePasteTasks(listOf(id))
+            }
+        }
+        return true
     }
 
     /**

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -21,6 +21,7 @@ import com.crosspaste.sync.FilePullService
 import com.crosspaste.sync.PastePullCursorManager
 import com.crosspaste.task.TaskBuilder
 import com.crosspaste.task.TaskSubmitter
+import com.crosspaste.utils.StripedMutex
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -30,6 +31,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
 data class PushPrepareResult(
@@ -60,9 +62,17 @@ class PasteReleaseService(
         private val fileUtils = getFileUtils()
         private const val DISCARD_PUSH_PREPARED_ATTEMPTS = 3
         private val DISCARD_PUSH_PREPARED_RETRY_DELAY = 50.milliseconds
+
+        // Keep-first image dedup window, measured between record createTimes.
+        // Wide enough to cover a duplicate write from a single clipboard operation
+        // (Snipping Tool writes twice, 30–90 ms apart) plus collection latency,
+        // short enough to rarely collapse intentional re-copies.
+        val IMAGE_DEDUP_WINDOW = 5.seconds
     }
 
     private val logger = KotlinLogging.logger {}
+
+    private val imageDedupMutex = StripedMutex()
 
     @OptIn(ExperimentalTime::class)
     private fun TaskBuilder.markDeleteSameHash(
@@ -131,26 +141,19 @@ class PasteReleaseService(
             val hash = firstItem.hash
             val pasteType = firstItem.getPasteType()
 
-            if (discardDuplicateLocalImage(pasteData, firstItem, remainingItems, size, hash, pasteType, id)) {
-                return@let
-            }
+            val isLocalNonRefImage =
+                !pasteData.remote &&
+                    pasteType.isImage() &&
+                    firstItem is PasteFiles &&
+                    !firstItem.isRefFiles() &&
+                    hash.isNotEmpty()
 
             val change =
-                database.transactionWithResult {
-                    database.pasteDatabaseQueries.updatePasteDataToLoaded(
-                        pasteAppearItem = firstItem.toStoredJson(),
-                        pasteCollection = PasteCollection(remainingItems).toStoredJson(),
-                        pasteType = pasteType.type.toLong(),
-                        pasteSearchContent =
-                            searchContentService.createSearchContent(
-                                pasteData.source,
-                                pasteItemReader.getSearchContent(firstItem),
-                            ),
-                        size = size,
-                        hash = hash,
-                        id = id,
-                    )
-                    database.pasteDatabaseQueries.change().executeAsOne() > 0
+                if (isLocalNonRefImage) {
+                    releaseLocalImageDeduped(pasteData, firstItem, remainingItems, size, hash, pasteType, id)
+                        ?: return@let
+                } else {
+                    persistLoaded(pasteData, firstItem, remainingItems, size, hash, pasteType, id)
                 }
 
             if (change) {
@@ -177,25 +180,7 @@ class PasteReleaseService(
         }
     }
 
-    /**
-     * Keep-first dedup for locally collected non-ref images: a single clipboard
-     * operation can fire multiple clipboard events (Windows Snipping Tool writes
-     * twice per capture), each collected into an identical record. Non-ref images
-     * intentionally bypass [markDeleteSameHash] (the #2693 resource-lifecycle
-     * guard), so an identical local image released within
-     * [com.crosspaste.db.paste.SqlPasteDao.RECENT_SAME_HASH_WINDOW] identifies
-     * this record as that duplicate: keep the first record, discard this one.
-     *
-     * The final items (with the real file paths) must be persisted before the row
-     * is marked deleted — at this point the row still holds the pre-collect
-     * placeholder, and deleting it as-is would orphan the just-written files.
-     * Only a delete task is created, never sync or rendering tasks, so the
-     * discarded record never has in-flight consumers and clearing its files
-     * cannot race anything — which is what keeps the #2693 guard intact.
-     *
-     * Returns true when the record was discarded as a duplicate.
-     */
-    private suspend fun discardDuplicateLocalImage(
+    private fun persistLoaded(
         pasteData: PasteData,
         firstItem: PasteItem,
         remainingItems: List<PasteItem>,
@@ -203,36 +188,92 @@ class PasteReleaseService(
         hash: String,
         pasteType: PasteType,
         id: Long,
-    ): Boolean {
-        if (pasteData.remote ||
-            !pasteType.isImage() ||
-            firstItem !is PasteFiles ||
-            firstItem.isRefFiles() ||
-            hash.isEmpty()
-        ) {
-            return false
+    ): Boolean =
+        database.transactionWithResult {
+            database.pasteDatabaseQueries.updatePasteDataToLoaded(
+                pasteAppearItem = firstItem.toStoredJson(),
+                pasteCollection = PasteCollection(remainingItems).toStoredJson(),
+                pasteType = pasteType.type.toLong(),
+                pasteSearchContent =
+                    searchContentService.createSearchContent(
+                        pasteData.source,
+                        pasteItemReader.getSearchContent(firstItem),
+                    ),
+                size = size,
+                hash = hash,
+                id = id,
+            )
+            database.pasteDatabaseQueries.change().executeAsOne() > 0
         }
 
-        val keptId = pasteDao.getRecentSameHashLocalPasteId(hash, pasteType.type, id) ?: return false
-
-        logger.info { "Discarding duplicate local image paste id=$id, keeping recent record id=$keptId" }
-        taskSubmitter.submit {
-            database.transaction {
-                database.pasteDatabaseQueries.updatePasteDataToLoaded(
-                    pasteAppearItem = firstItem.toStoredJson(),
-                    pasteCollection = PasteCollection(remainingItems).toStoredJson(),
-                    pasteType = pasteType.type.toLong(),
-                    pasteSearchContent = null,
-                    size = size,
+    /**
+     * Keep-first dedup for locally collected non-ref images: a single clipboard
+     * operation can fire multiple clipboard events (Windows Snipping Tool writes
+     * twice per capture), each collected into an identical record. Non-ref images
+     * intentionally bypass [markDeleteSameHash] (the #2693 resource-lifecycle
+     * guard), so an identical local image whose record was created within
+     * [IMAGE_DEDUP_WINDOW] of this one identifies this record as that duplicate:
+     * keep the first record, discard this one. The window compares record
+     * createTimes (event proximity), so slow image processing before release
+     * cannot shrink it.
+     *
+     * The duplicate probe and the row's final state commit run under a per-hash
+     * striped lock: without it, two concurrent releases of the same image could
+     * each miss the other's not-yet-committed record and both survive (macOS and
+     * Linux launch a consumer per clipboard change; only the Windows pipeline
+     * serializes consumes).
+     *
+     * When discarding, the final items (with the real file paths) must be
+     * persisted before the row is marked deleted — at this point the row still
+     * holds the pre-collect placeholder, and deleting it as-is would orphan the
+     * just-written files. Only a delete task is created, never sync or rendering
+     * tasks, so the discarded record never has in-flight consumers and clearing
+     * its files cannot race anything — which is what keeps the #2693 guard
+     * intact.
+     *
+     * Returns null when the record was discarded as a duplicate, otherwise the
+     * result of persisting the record as LOADED.
+     */
+    private suspend fun releaseLocalImageDeduped(
+        pasteData: PasteData,
+        firstItem: PasteItem,
+        remainingItems: List<PasteItem>,
+        size: Long,
+        hash: String,
+        pasteType: PasteType,
+        id: Long,
+    ): Boolean? =
+        imageDedupMutex.withLock("${pasteType.type}:$hash") {
+            val keptId =
+                pasteDao.getRecentSameHashLocalPasteId(
                     hash = hash,
-                    id = id,
+                    pasteType = pasteType.type,
+                    minCreateTime = pasteData.createTime - IMAGE_DEDUP_WINDOW.inWholeMilliseconds,
+                    excludeId = id,
                 )
-                database.pasteDatabaseQueries.markDeletePasteData(listOf(id))
-                addDeletePasteTasks(listOf(id))
+
+            if (keptId == null) {
+                persistLoaded(pasteData, firstItem, remainingItems, size, hash, pasteType, id)
+            } else {
+                logger.info { "Discarding duplicate local image paste id=$id, keeping recent record id=$keptId" }
+                taskSubmitter.submit {
+                    database.transaction {
+                        database.pasteDatabaseQueries.updatePasteDataToLoaded(
+                            pasteAppearItem = firstItem.toStoredJson(),
+                            pasteCollection = PasteCollection(remainingItems).toStoredJson(),
+                            pasteType = pasteType.type.toLong(),
+                            pasteSearchContent = null,
+                            size = size,
+                            hash = hash,
+                            id = id,
+                        )
+                        database.pasteDatabaseQueries.markDeletePasteData(listOf(id))
+                        addDeletePasteTasks(listOf(id))
+                    }
+                }
+                null
             }
         }
-        return true
-    }
 
     /**
      * Shared file-paste landing pad for both directions of remote receive:

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -180,6 +180,31 @@ class PasteReleaseService(
         }
     }
 
+    /**
+     * Single writer of the updatePasteDataToLoaded statement so the normal
+     * release and the duplicate-discard transaction cannot drift apart when
+     * fields are added. Must be called inside a transaction.
+     */
+    private fun writeLoadedRow(
+        firstItem: PasteItem,
+        remainingItems: List<PasteItem>,
+        size: Long,
+        hash: String,
+        pasteType: PasteType,
+        id: Long,
+        pasteSearchContent: String?,
+    ) {
+        database.pasteDatabaseQueries.updatePasteDataToLoaded(
+            pasteAppearItem = firstItem.toStoredJson(),
+            pasteCollection = PasteCollection(remainingItems).toStoredJson(),
+            pasteType = pasteType.type.toLong(),
+            pasteSearchContent = pasteSearchContent,
+            size = size,
+            hash = hash,
+            id = id,
+        )
+    }
+
     private fun persistLoaded(
         pasteData: PasteData,
         firstItem: PasteItem,
@@ -190,18 +215,18 @@ class PasteReleaseService(
         id: Long,
     ): Boolean =
         database.transactionWithResult {
-            database.pasteDatabaseQueries.updatePasteDataToLoaded(
-                pasteAppearItem = firstItem.toStoredJson(),
-                pasteCollection = PasteCollection(remainingItems).toStoredJson(),
-                pasteType = pasteType.type.toLong(),
+            writeLoadedRow(
+                firstItem = firstItem,
+                remainingItems = remainingItems,
+                size = size,
+                hash = hash,
+                pasteType = pasteType,
+                id = id,
                 pasteSearchContent =
                     searchContentService.createSearchContent(
                         pasteData.source,
                         pasteItemReader.getSearchContent(firstItem),
                     ),
-                size = size,
-                hash = hash,
-                id = id,
             )
             database.pasteDatabaseQueries.change().executeAsOne() > 0
         }
@@ -244,11 +269,13 @@ class PasteReleaseService(
         id: Long,
     ): Boolean? =
         imageDedupMutex.withLock("${pasteType.type}:$hash") {
+            val windowMillis = IMAGE_DEDUP_WINDOW.inWholeMilliseconds
             val keptId =
                 pasteDao.getRecentSameHashLocalPasteId(
                     hash = hash,
                     pasteType = pasteType.type,
-                    minCreateTime = pasteData.createTime - IMAGE_DEDUP_WINDOW.inWholeMilliseconds,
+                    minCreateTime = pasteData.createTime - windowMillis,
+                    maxCreateTime = pasteData.createTime + windowMillis,
                     excludeId = id,
                 )
 
@@ -258,14 +285,14 @@ class PasteReleaseService(
                 logger.info { "Discarding duplicate local image paste id=$id, keeping recent record id=$keptId" }
                 taskSubmitter.submit {
                     database.transaction {
-                        database.pasteDatabaseQueries.updatePasteDataToLoaded(
-                            pasteAppearItem = firstItem.toStoredJson(),
-                            pasteCollection = PasteCollection(remainingItems).toStoredJson(),
-                            pasteType = pasteType.type.toLong(),
-                            pasteSearchContent = null,
+                        writeLoadedRow(
+                            firstItem = firstItem,
+                            remainingItems = remainingItems,
                             size = size,
                             hash = hash,
+                            pasteType = pasteType,
                             id = id,
+                            pasteSearchContent = null,
                         )
                         database.pasteDatabaseQueries.markDeletePasteData(listOf(id))
                         addDeletePasteTasks(listOf(id))

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceImageDedupTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceImageDedupTest.kt
@@ -1,0 +1,312 @@
+package com.crosspaste.paste
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.db.TestDriverFactory
+import com.crosspaste.db.createDatabase
+import com.crosspaste.db.paste.SqlPasteDao
+import com.crosspaste.paste.item.CreatePasteItemHelper.createImagesPasteItem
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.paste.item.DefaultPasteItemReader
+import com.crosspaste.paste.item.ImagesPasteItem
+import com.crosspaste.paste.item.PasteItem
+import com.crosspaste.presist.SingleFileInfoTree
+import com.crosspaste.task.TaskBuilder
+import com.crosspaste.task.TaskSubmitter
+import com.crosspaste.utils.DateUtils
+import com.crosspaste.utils.getJsonUtils
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PasteReleaseServiceImageDedupTest {
+
+    // Eagerly initialize JsonUtils to avoid circular class initialization between
+    // PasteItem.Companion (which calls getJsonUtils()) and paste item classes
+    @Suppress("unused")
+    private val jsonUtils = getJsonUtils()
+
+    private val appInfo =
+        AppInfo(
+            appInstanceId = "test-instance",
+            appVersion = "1.0.0",
+            appRevision = "abc",
+            userName = "testUser",
+        )
+
+    private val searchContentService =
+        object : SearchContentService {
+            override fun createSearchContent(
+                source: String?,
+                searchContentList: List<String>,
+            ): String =
+                (
+                    listOfNotNull(source?.lowercase()) +
+                        searchContentList.map { it.lowercase() }
+                ).joinToString(" ")
+
+            override fun createSearchTerms(queryString: String): List<String> =
+                queryString.trim().split("\\s+".toRegex()).filter {
+                    it.isNotBlank()
+                }
+        }
+
+    private class RecordingTaskBuilder : TaskBuilder {
+        val deleteIds = mutableListOf<Long>()
+        var syncTaskCount = 0
+        var renderingTaskCount = 0
+
+        override fun addDelayedDeletePasteTask(
+            id: Long,
+            delayMillis: Long,
+        ): TaskBuilder = this
+
+        override fun addDeletePasteTasks(ids: List<Long>): TaskBuilder {
+            deleteIds.addAll(ids)
+            return this
+        }
+
+        override fun addPullFileTask(
+            id: Long,
+            remotePasteDataId: Long,
+        ): TaskBuilder = this
+
+        override fun addSyncTask(
+            id: Long,
+            fileSize: Long,
+            appInstanceId: String,
+            targetAppInstanceIds: Set<String>?,
+        ): TaskBuilder {
+            syncTaskCount++
+            return this
+        }
+
+        override fun addRelaySyncTask(
+            id: Long,
+            appInstanceId: String,
+        ): TaskBuilder = this
+
+        override fun addPullIconTask(
+            id: Long,
+            existIconFile: Boolean,
+        ): TaskBuilder = this
+
+        override fun addRenderingTask(
+            id: Long,
+            pasteType: PasteType,
+        ): TaskBuilder {
+            renderingTaskCount++
+            return this
+        }
+    }
+
+    private class ImmediateTaskSubmitter : TaskSubmitter {
+        val builder = RecordingTaskBuilder()
+
+        override suspend fun submit(block: suspend TaskBuilder.() -> Unit) {
+            builder.block()
+        }
+    }
+
+    private class Fixture {
+        val taskSubmitter = ImmediateTaskSubmitter()
+        val currentPaste = mockk<CurrentPaste>(relaxed = true)
+        val database = createDatabase(TestDriverFactory())
+        private val pasteItemReader = DefaultPasteItemReader()
+
+        lateinit var pasteDao: SqlPasteDao
+        lateinit var service: PasteReleaseService
+
+        fun init(
+            appInfo: AppInfo,
+            searchContentService: SearchContentService,
+        ) {
+            pasteDao =
+                SqlPasteDao(
+                    appInfo = appInfo,
+                    database = database,
+                    pasteItemReader = pasteItemReader,
+                    searchContentService = searchContentService,
+                    taskSubmitter = taskSubmitter,
+                    userDataPathProvider = mockk(relaxed = true),
+                )
+            service =
+                PasteReleaseService(
+                    commonConfigManager = mockk(relaxed = true),
+                    currentPaste = currentPaste,
+                    database = database,
+                    notificationManager = mockk(relaxed = true),
+                    pasteDao = pasteDao,
+                    pasteItemReader = pasteItemReader,
+                    pasteProcessPlugins = emptyList(),
+                    pastePullCursorManager = mockk(relaxed = true),
+                    searchContentService = searchContentService,
+                    syncRuntimeInfoDao = mockk(relaxed = true),
+                    taskSubmitter = taskSubmitter,
+                    userDataPathProvider = mockk(relaxed = true),
+                )
+        }
+    }
+
+    private fun newFixture(): Fixture = Fixture().apply { init(appInfo, searchContentService) }
+
+    private fun imageItem(fileHash: String = "file-hash"): ImagesPasteItem =
+        createImagesPasteItem(
+            identifiers = listOf("image/png"),
+            relativePathList = listOf("img/a.png"),
+            fileInfoTreeMap = mapOf("a.png" to SingleFileInfoTree(size = 10L, hash = fileHash)),
+        )
+
+    private suspend fun Fixture.createLoadedRecord(
+        item: PasteItem,
+        pasteType: PasteType,
+        createTime: Long,
+        remote: Boolean = false,
+    ): Long =
+        pasteDao.createPasteData(
+            PasteData(
+                appInstanceId = if (remote) "remote-device" else appInfo.appInstanceId,
+                pasteAppearItem = item,
+                pasteCollection = PasteCollection(emptyList()),
+                pasteType = pasteType.type,
+                size = item.size,
+                hash = item.hash,
+                createTime = createTime,
+                pasteState = PasteState.LOADED,
+                remote = remote,
+            ),
+        )
+
+    private suspend fun Fixture.createLoadingRecord(): Long =
+        pasteDao.createPasteData(
+            PasteData(
+                appInstanceId = appInfo.appInstanceId,
+                pasteCollection = PasteCollection(emptyList()),
+                pasteType = PasteType.INVALID_TYPE.type,
+                size = 0L,
+                hash = "",
+                pasteState = PasteState.LOADING,
+            ),
+        )
+
+    @Test
+    fun `duplicate local image within window is discarded keeping first record`() =
+        runTest {
+            val fixture = newFixture()
+            val item = imageItem()
+            val keptId =
+                fixture.createLoadedRecord(item, PasteType.IMAGE_TYPE, DateUtils.nowEpochMilliseconds())
+            val loadingId = fixture.createLoadingRecord()
+
+            fixture.service.releaseLocalPasteData(loadingId, listOf(imageItem()), null)
+
+            // Second record is marked deleted with the final item persisted, so the
+            // delete task can reclaim the just-written image files.
+            val discarded = fixture.pasteDao.getDeletePasteData(loadingId)
+            assertNotNull(discarded)
+            val discardedItem = discarded.pasteAppearItem as ImagesPasteItem
+            assertContentEquals(listOf("img/a.png"), discardedItem.relativePathList)
+            assertEquals(item.hash, discarded.hash)
+
+            // Only a delete task for the discarded record — never sync or rendering.
+            assertContentEquals(listOf(loadingId), fixture.taskSubmitter.builder.deleteIds)
+            assertEquals(0, fixture.taskSubmitter.builder.syncTaskCount)
+            assertEquals(0, fixture.taskSubmitter.builder.renderingTaskCount)
+            coVerify(exactly = 0) { fixture.currentPaste.setPasteId(any()) }
+
+            // First record is untouched.
+            assertNotNull(fixture.pasteDao.getNoDeletePasteDataBlock(keptId))
+        }
+
+    @Test
+    fun `identical image outside dedup window is kept`() =
+        runTest {
+            val fixture = newFixture()
+            val outsideWindow =
+                DateUtils.nowEpochMilliseconds() -
+                    SqlPasteDao.RECENT_SAME_HASH_WINDOW.inWholeMilliseconds - 1000L
+            fixture.createLoadedRecord(imageItem(), PasteType.IMAGE_TYPE, outsideWindow)
+            val loadingId = fixture.createLoadingRecord()
+
+            fixture.service.releaseLocalPasteData(loadingId, listOf(imageItem()), null)
+
+            val released = fixture.pasteDao.getNoDeletePasteDataBlock(loadingId)
+            assertNotNull(released)
+            assertEquals(PasteState.LOADED, released.pasteState)
+            assertTrue(
+                fixture.taskSubmitter.builder.deleteIds
+                    .isEmpty(),
+            )
+            assertEquals(1, fixture.taskSubmitter.builder.syncTaskCount)
+            assertEquals(1, fixture.taskSubmitter.builder.renderingTaskCount)
+        }
+
+    @Test
+    fun `remote record with same hash does not trigger dedup`() =
+        runTest {
+            val fixture = newFixture()
+            fixture.createLoadedRecord(
+                imageItem(),
+                PasteType.IMAGE_TYPE,
+                DateUtils.nowEpochMilliseconds(),
+                remote = true,
+            )
+            val loadingId = fixture.createLoadingRecord()
+
+            fixture.service.releaseLocalPasteData(loadingId, listOf(imageItem()), null)
+
+            val released = fixture.pasteDao.getNoDeletePasteDataBlock(loadingId)
+            assertNotNull(released)
+            assertEquals(PasteState.LOADED, released.pasteState)
+            assertTrue(
+                fixture.taskSubmitter.builder.deleteIds
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `text pastes keep existing same-hash cleanup semantics`() =
+        runTest {
+            val fixture = newFixture()
+            val textItem = createTextPasteItem(text = "hello")
+            val oldId =
+                fixture.createLoadedRecord(textItem, PasteType.TEXT_TYPE, DateUtils.nowEpochMilliseconds())
+            val loadingId = fixture.createLoadingRecord()
+
+            fixture.service.releaseLocalPasteData(loadingId, listOf(createTextPasteItem(text = "hello")), null)
+
+            // Existing behavior: the new record is kept and the old same-hash
+            // record is removed (keep-new), untouched by image keep-first dedup.
+            val released = fixture.pasteDao.getNoDeletePasteDataBlock(loadingId)
+            assertNotNull(released)
+            assertEquals(PasteState.LOADED, released.pasteState)
+            assertContentEquals(listOf(oldId), fixture.taskSubmitter.builder.deleteIds)
+        }
+
+    @Test
+    fun `dedup query ignores deleted records`() =
+        runTest {
+            val fixture = newFixture()
+            val item = imageItem()
+            fixture.pasteDao.createPasteData(
+                PasteData(
+                    appInstanceId = appInfo.appInstanceId,
+                    pasteAppearItem = item,
+                    pasteCollection = PasteCollection(emptyList()),
+                    pasteType = PasteType.IMAGE_TYPE.type,
+                    size = item.size,
+                    hash = item.hash,
+                    pasteState = PasteState.DELETED,
+                ),
+            )
+
+            assertNull(
+                fixture.pasteDao.getRecentSameHashLocalPasteId(item.hash, PasteType.IMAGE_TYPE.type, -1L),
+            )
+        }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceImageDedupTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceImageDedupTest.kt
@@ -16,7 +16,12 @@ import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.getJsonUtils
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -56,10 +61,11 @@ class PasteReleaseServiceImageDedupTest {
                 }
         }
 
+    // Thread-safe: the concurrent-release test records from parallel coroutines.
     private class RecordingTaskBuilder : TaskBuilder {
-        val deleteIds = mutableListOf<Long>()
-        var syncTaskCount = 0
-        var renderingTaskCount = 0
+        val deleteIds = CopyOnWriteArrayList<Long>()
+        val syncTaskCount = AtomicInteger(0)
+        val renderingTaskCount = AtomicInteger(0)
 
         override fun addDelayedDeletePasteTask(
             id: Long,
@@ -82,7 +88,7 @@ class PasteReleaseServiceImageDedupTest {
             appInstanceId: String,
             targetAppInstanceIds: Set<String>?,
         ): TaskBuilder {
-            syncTaskCount++
+            syncTaskCount.incrementAndGet()
             return this
         }
 
@@ -100,7 +106,7 @@ class PasteReleaseServiceImageDedupTest {
             id: Long,
             pasteType: PasteType,
         ): TaskBuilder {
-            renderingTaskCount++
+            renderingTaskCount.incrementAndGet()
             return this
         }
     }
@@ -182,7 +188,7 @@ class PasteReleaseServiceImageDedupTest {
             ),
         )
 
-    private suspend fun Fixture.createLoadingRecord(): Long =
+    private suspend fun Fixture.createLoadingRecord(createTime: Long = DateUtils.nowEpochMilliseconds()): Long =
         pasteDao.createPasteData(
             PasteData(
                 appInstanceId = appInfo.appInstanceId,
@@ -190,6 +196,7 @@ class PasteReleaseServiceImageDedupTest {
                 pasteType = PasteType.INVALID_TYPE.type,
                 size = 0L,
                 hash = "",
+                createTime = createTime,
                 pasteState = PasteState.LOADING,
             ),
         )
@@ -215,8 +222,16 @@ class PasteReleaseServiceImageDedupTest {
 
             // Only a delete task for the discarded record — never sync or rendering.
             assertContentEquals(listOf(loadingId), fixture.taskSubmitter.builder.deleteIds)
-            assertEquals(0, fixture.taskSubmitter.builder.syncTaskCount)
-            assertEquals(0, fixture.taskSubmitter.builder.renderingTaskCount)
+            assertEquals(
+                0,
+                fixture.taskSubmitter.builder.syncTaskCount
+                    .get(),
+            )
+            assertEquals(
+                0,
+                fixture.taskSubmitter.builder.renderingTaskCount
+                    .get(),
+            )
             coVerify(exactly = 0) { fixture.currentPaste.setPasteId(any()) }
 
             // First record is untouched.
@@ -229,7 +244,7 @@ class PasteReleaseServiceImageDedupTest {
             val fixture = newFixture()
             val outsideWindow =
                 DateUtils.nowEpochMilliseconds() -
-                    SqlPasteDao.RECENT_SAME_HASH_WINDOW.inWholeMilliseconds - 1000L
+                    PasteReleaseService.IMAGE_DEDUP_WINDOW.inWholeMilliseconds - 1000L
             fixture.createLoadedRecord(imageItem(), PasteType.IMAGE_TYPE, outsideWindow)
             val loadingId = fixture.createLoadingRecord()
 
@@ -242,8 +257,16 @@ class PasteReleaseServiceImageDedupTest {
                 fixture.taskSubmitter.builder.deleteIds
                     .isEmpty(),
             )
-            assertEquals(1, fixture.taskSubmitter.builder.syncTaskCount)
-            assertEquals(1, fixture.taskSubmitter.builder.renderingTaskCount)
+            assertEquals(
+                1,
+                fixture.taskSubmitter.builder.syncTaskCount
+                    .get(),
+            )
+            assertEquals(
+                1,
+                fixture.taskSubmitter.builder.renderingTaskCount
+                    .get(),
+            )
         }
 
     @Test
@@ -306,7 +329,73 @@ class PasteReleaseServiceImageDedupTest {
             )
 
             assertNull(
-                fixture.pasteDao.getRecentSameHashLocalPasteId(item.hash, PasteType.IMAGE_TYPE.type, -1L),
+                fixture.pasteDao.getRecentSameHashLocalPasteId(item.hash, PasteType.IMAGE_TYPE.type, 0L, -1L),
             )
+        }
+
+    @Test
+    fun `loading row with same hash is not a kept candidate`() =
+        runTest {
+            val fixture = newFixture()
+            val item = imageItem()
+            // A LOADING row that (contrary to the current convention of an empty
+            // placeholder hash) already carries the final hash must still not be
+            // treated as a kept candidate: it is not fully released yet.
+            fixture.pasteDao.createPasteData(
+                PasteData(
+                    appInstanceId = appInfo.appInstanceId,
+                    pasteAppearItem = item,
+                    pasteCollection = PasteCollection(emptyList()),
+                    pasteType = PasteType.IMAGE_TYPE.type,
+                    size = item.size,
+                    hash = item.hash,
+                    pasteState = PasteState.LOADING,
+                ),
+            )
+
+            assertNull(
+                fixture.pasteDao.getRecentSameHashLocalPasteId(item.hash, PasteType.IMAGE_TYPE.type, 0L, -1L),
+            )
+        }
+
+    @Test
+    fun `dedup window compares record create times not release time`() =
+        runTest {
+            val fixture = newFixture()
+            val now = DateUtils.nowEpochMilliseconds()
+            // Both records were created ~8s ago, only 50ms apart — slow image
+            // processing delayed the release, but they are still duplicates of a
+            // single clipboard operation and must be deduped.
+            fixture.createLoadedRecord(imageItem(), PasteType.IMAGE_TYPE, now - 8000L)
+            val loadingId = fixture.createLoadingRecord(createTime = now - 7950L)
+
+            fixture.service.releaseLocalPasteData(loadingId, listOf(imageItem()), null)
+
+            assertNotNull(fixture.pasteDao.getDeletePasteData(loadingId))
+            assertContentEquals(listOf(loadingId), fixture.taskSubmitter.builder.deleteIds)
+        }
+
+    @Test
+    fun `concurrent duplicate releases keep exactly one record`() =
+        runTest {
+            val fixture = newFixture()
+            val firstId = fixture.createLoadingRecord()
+            val secondId = fixture.createLoadingRecord()
+
+            listOf(firstId, secondId)
+                .map { id ->
+                    async(Dispatchers.Default) {
+                        fixture.service.releaseLocalPasteData(id, listOf(imageItem()), null)
+                    }
+                }.awaitAll()
+
+            val loadedIds =
+                listOf(firstId, secondId).filter {
+                    fixture.pasteDao.getNoDeletePasteDataBlock(it) != null
+                }
+            assertEquals(1, loadedIds.size)
+            val discardedId = (listOf(firstId, secondId) - loadedIds.toSet()).single()
+            assertNotNull(fixture.pasteDao.getDeletePasteData(discardedId))
+            assertContentEquals(listOf(discardedId), fixture.taskSubmitter.builder.deleteIds)
         }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceImageDedupTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/paste/PasteReleaseServiceImageDedupTest.kt
@@ -329,7 +329,13 @@ class PasteReleaseServiceImageDedupTest {
             )
 
             assertNull(
-                fixture.pasteDao.getRecentSameHashLocalPasteId(item.hash, PasteType.IMAGE_TYPE.type, 0L, -1L),
+                fixture.pasteDao.getRecentSameHashLocalPasteId(
+                    item.hash,
+                    PasteType.IMAGE_TYPE.type,
+                    0L,
+                    Long.MAX_VALUE,
+                    -1L,
+                ),
             )
         }
 
@@ -354,7 +360,13 @@ class PasteReleaseServiceImageDedupTest {
             )
 
             assertNull(
-                fixture.pasteDao.getRecentSameHashLocalPasteId(item.hash, PasteType.IMAGE_TYPE.type, 0L, -1L),
+                fixture.pasteDao.getRecentSameHashLocalPasteId(
+                    item.hash,
+                    PasteType.IMAGE_TYPE.type,
+                    0L,
+                    Long.MAX_VALUE,
+                    -1L,
+                ),
             )
         }
 
@@ -373,6 +385,28 @@ class PasteReleaseServiceImageDedupTest {
 
             assertNotNull(fixture.pasteDao.getDeletePasteData(loadingId))
             assertContentEquals(listOf(loadingId), fixture.taskSubmitter.builder.deleteIds)
+        }
+
+    @Test
+    fun `loaded candidate newer than the window does not trigger dedup`() =
+        runTest {
+            val fixture = newFixture()
+            val now = DateUtils.nowEpochMilliseconds()
+            // The same image was copied again 10s after this record's event and
+            // finished releasing first (out of order); the delayed old record is a
+            // separate operation and must not discard itself against it.
+            fixture.createLoadedRecord(imageItem(), PasteType.IMAGE_TYPE, now)
+            val loadingId = fixture.createLoadingRecord(createTime = now - 10_000L)
+
+            fixture.service.releaseLocalPasteData(loadingId, listOf(imageItem()), null)
+
+            val released = fixture.pasteDao.getNoDeletePasteDataBlock(loadingId)
+            assertNotNull(released)
+            assertEquals(PasteState.LOADED, released.pasteState)
+            assertTrue(
+                fixture.taskSubmitter.builder.deleteIds
+                    .isEmpty(),
+            )
         }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -50,14 +50,16 @@ interface PasteDao : SearchPasteData {
     ): List<Long>
 
     /**
-     * Returns the id of a non-deleted, locally collected record with the same
-     * hash and paste type created within the recent dedup window, or null.
-     * Used for keep-first dedup of duplicate records produced by a single
-     * clipboard operation (e.g. Windows Snipping Tool writes twice per capture).
+     * Returns the id of a LOADED, locally collected record with the same hash
+     * and paste type created after [minCreateTime], or null. Used for keep-first
+     * dedup of duplicate records produced by a single clipboard operation
+     * (e.g. Windows Snipping Tool writes twice per capture); the caller owns the
+     * dedup window policy and passes it as an explicit [minCreateTime].
      */
     fun getRecentSameHashLocalPasteId(
         hash: String,
         pasteType: Int,
+        minCreateTime: Long,
         excludeId: Long,
     ): Long?
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -51,15 +51,17 @@ interface PasteDao : SearchPasteData {
 
     /**
      * Returns the id of a LOADED, locally collected record with the same hash
-     * and paste type created after [minCreateTime], or null. Used for keep-first
-     * dedup of duplicate records produced by a single clipboard operation
-     * (e.g. Windows Snipping Tool writes twice per capture); the caller owns the
-     * dedup window policy and passes it as an explicit [minCreateTime].
+     * and paste type created inside ([minCreateTime], [maxCreateTime]), or null.
+     * Used for keep-first dedup of duplicate records produced by a single
+     * clipboard operation (e.g. Windows Snipping Tool writes twice per capture);
+     * the caller owns the dedup window policy and passes it as an explicit
+     * createTime range.
      */
     fun getRecentSameHashLocalPasteId(
         hash: String,
         pasteType: Int,
         minCreateTime: Long,
+        maxCreateTime: Long,
         excludeId: Long,
     ): Long?
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/PasteDao.kt
@@ -49,6 +49,18 @@ interface PasteDao : SearchPasteData {
         excludeId: Long,
     ): List<Long>
 
+    /**
+     * Returns the id of a non-deleted, locally collected record with the same
+     * hash and paste type created within the recent dedup window, or null.
+     * Used for keep-first dedup of duplicate records produced by a single
+     * clipboard operation (e.g. Windows Snipping Tool writes twice per capture).
+     */
+    fun getRecentSameHashLocalPasteId(
+        hash: String,
+        pasteType: Int,
+        excludeId: Long,
+    ): Long?
+
     suspend fun markDeleteByCleanTime(
         cleanTime: Long,
         pasteType: Int? = null,

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import kotlin.time.Duration.Companion.seconds
 
 class SqlPasteDao(
     private val appInfo: AppInfo,
@@ -32,6 +33,13 @@ class SqlPasteDao(
     private val taskSubmitter: TaskSubmitter,
     private val userDataPathProvider: UserDataPathProvider,
 ) : PasteDao {
+
+    companion object {
+        // Wide enough to cover a duplicate write from a single clipboard operation
+        // (Snipping Tool writes twice, 30–90 ms apart) plus collection latency,
+        // short enough to rarely collapse intentional re-copies.
+        val RECENT_SAME_HASH_WINDOW = 5.seconds
+    }
 
     private val logger = KotlinLogging.logger {}
 
@@ -240,6 +248,19 @@ class SqlPasteDao(
                 DateUtils.getOffsetDay(days = -1),
                 excludeId,
             ).executeAsList()
+
+    override fun getRecentSameHashLocalPasteId(
+        hash: String,
+        pasteType: Int,
+        excludeId: Long,
+    ): Long? =
+        pasteDatabaseQueries
+            .getRecentSameHashLocalPasteId(
+                hash,
+                pasteType.toLong(),
+                DateUtils.nowEpochMilliseconds() - RECENT_SAME_HASH_WINDOW.inWholeMilliseconds,
+                excludeId,
+            ).executeAsOneOrNull()
 
     override suspend fun markDeleteByCleanTime(
         cleanTime: Long,

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlin.time.Duration.Companion.seconds
 
 class SqlPasteDao(
     private val appInfo: AppInfo,
@@ -33,13 +32,6 @@ class SqlPasteDao(
     private val taskSubmitter: TaskSubmitter,
     private val userDataPathProvider: UserDataPathProvider,
 ) : PasteDao {
-
-    companion object {
-        // Wide enough to cover a duplicate write from a single clipboard operation
-        // (Snipping Tool writes twice, 30–90 ms apart) plus collection latency,
-        // short enough to rarely collapse intentional re-copies.
-        val RECENT_SAME_HASH_WINDOW = 5.seconds
-    }
 
     private val logger = KotlinLogging.logger {}
 
@@ -252,13 +244,14 @@ class SqlPasteDao(
     override fun getRecentSameHashLocalPasteId(
         hash: String,
         pasteType: Int,
+        minCreateTime: Long,
         excludeId: Long,
     ): Long? =
         pasteDatabaseQueries
             .getRecentSameHashLocalPasteId(
                 hash,
                 pasteType.toLong(),
-                DateUtils.nowEpochMilliseconds() - RECENT_SAME_HASH_WINDOW.inWholeMilliseconds,
+                minCreateTime,
                 excludeId,
             ).executeAsOneOrNull()
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/paste/SqlPasteDao.kt
@@ -245,6 +245,7 @@ class SqlPasteDao(
         hash: String,
         pasteType: Int,
         minCreateTime: Long,
+        maxCreateTime: Long,
         excludeId: Long,
     ): Long? =
         pasteDatabaseQueries
@@ -252,6 +253,7 @@ class SqlPasteDao(
                 hash,
                 pasteType.toLong(),
                 minCreateTime,
+                maxCreateTime,
                 excludeId,
             ).executeAsOneOrNull()
 

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
@@ -166,6 +166,20 @@ WHERE hash = :hash AND
         WHERE PasteTagEntity.pasteId = PasteDataEntity.id
     );
 
+-- Keep-first dedup probe: a matching row means the paste being released is a
+-- duplicate of a record collected moments ago (e.g. Windows Snipping Tool writes
+-- the clipboard twice per capture) and should be discarded instead of kept.
+-- LOADING rows cannot match because their hash is still the empty placeholder.
+getRecentSameHashLocalPasteId:
+SELECT id FROM PasteDataEntity
+WHERE hash = :hash AND
+    pasteType = :pasteType AND
+    pasteState != -1 AND
+    remote = 0 AND
+    createTime > :minCreateTime AND
+    id != :id
+LIMIT 1;
+
 -- pasteType filter: filterByPasteType=TRUE means no type filter (return all types);
 -- filterByPasteType=FALSE applies the IN clause to match any of the given types.
 -- This supports mobile clients that need to query multiple paste types in one request.

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
@@ -170,7 +170,9 @@ WHERE hash = :hash AND
 -- duplicate of a record collected moments ago (e.g. Windows Snipping Tool writes
 -- the clipboard twice per capture) and should be discarded instead of kept.
 -- Only LOADED rows qualify: the kept candidate must be fully released with
--- complete resource information.
+-- complete resource information. The createTime range is bounded on both sides:
+-- an identical image copied again long after this record's event (and released
+-- first, out of order) is a separate operation, not a duplicate.
 getRecentSameHashLocalPasteId:
 SELECT id FROM PasteDataEntity
 WHERE hash = :hash AND
@@ -178,6 +180,7 @@ WHERE hash = :hash AND
     pasteState = 1 AND
     remote = 0 AND
     createTime > :minCreateTime AND
+    createTime < :maxCreateTime AND
     id != :id
 LIMIT 1;
 

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteDatabase.sq
@@ -169,12 +169,13 @@ WHERE hash = :hash AND
 -- Keep-first dedup probe: a matching row means the paste being released is a
 -- duplicate of a record collected moments ago (e.g. Windows Snipping Tool writes
 -- the clipboard twice per capture) and should be discarded instead of kept.
--- LOADING rows cannot match because their hash is still the empty placeholder.
+-- Only LOADED rows qualify: the kept candidate must be fully released with
+-- complete resource information.
 getRecentSameHashLocalPasteId:
 SELECT id FROM PasteDataEntity
 WHERE hash = :hash AND
     pasteType = :pasteType AND
-    pasteState != -1 AND
+    pasteState = 1 AND
     remote = 0 AND
     createTime > :minCreateTime AND
     id != :id


### PR DESCRIPTION
## Background

On Windows, Snipping Tool writes the clipboard twice per capture (30–90 ms apart, #4737). Real-machine validation after the single-consumer event pipeline (#4793) confirmed duplicate image records still occur, so this implements the keep-first fallback designed in #4791.

Non-ref image records intentionally bypass the generic `markDeleteSameHash` cleanup (the #2693 resource-lifecycle guard), so these duplicates persist. That guard is left fully intact.

## Change

- New `getRecentSameHashLocalPasteId` query/DAO method (shared): probes for a LOADED, locally collected (`remote = 0`) record with the same hash and paste type inside an explicit `(minCreateTime, maxCreateTime)` range. The dedup window policy lives in `PasteReleaseService` (`IMAGE_DEDUP_WINDOW`, 5s), not in the DAO.
- `PasteReleaseService.releaseLocalPasteData`: locally collected non-ref image releases go through `releaseLocalImageDeduped`, which runs the duplicate probe and the row's final state commit (LOADED or DELETED) under a per-hash `StripedMutex` — without it, two concurrent releases of the same image could each miss the other's not-yet-committed record and both survive (macOS/Linux launch a consumer per clipboard change; only the Windows pipeline serializes consumes). Image IO and hashing happen earlier in collection and are never under the lock; non-image types don't touch the mutex.
- The window compares record createTimes (event proximity), bounded on both sides (`createTime ± window`): slow image processing before release cannot shrink it, and out-of-order completion cannot make a delayed release discard itself against an identical image copied long after its own event.
- Discarding the duplicate (keep-first; keep-newest was rejected in #4791 because the first record's sync task may already be reading its files):
  1. The final items (with the real file paths) are persisted into the row first — at this point the row still holds the pre-collect placeholder, and deleting it as-is would orphan the just-written PNGs. `writeLoadedRow` is the single writer of that statement, shared with the normal release path so the two branches cannot drift.
  2. The row is marked deleted in the same transaction.
  3. Only a `DELETE_PASTE_TASK` is created — never sync or rendering tasks — so the discarded record never has in-flight consumers and clearing its files cannot race anything.

No additional hashing is introduced: the content hash is already computed unconditionally during collection (`DesktopImageTypePlugin` → `getFileInfoTree` → streaming MurmurHash3), off the UI thread. The dedup adds one indexed query.

If the two writes of a capture ever produce different bytes, the hashes differ and the dedup is a no-op — fail-safe, no false deletions.

## Tests

`PasteReleaseServiceImageDedupTest` (real in-memory database + real `SqlPasteDao`), 9 cases:
- duplicate local image within the window is discarded, final paths persisted, only a delete task created, first record untouched, `currentPaste` not updated
- identical image outside the window is kept and released normally
- the window is measured between record createTimes, not release time (release delayed ~8s, records 50 ms apart → still deduped)
- a LOADED candidate newer than the window does not trigger dedup (out-of-order completion)
- two concurrent releases of the same image keep exactly one record
- a remote record with the same hash does not trigger dedup
- a LOADING row carrying the final hash is not a kept candidate
- the dedup query ignores deleted records
- text pastes keep the existing keep-new same-hash cleanup semantics

Note for mobile follow-up: `shared` changes (`PasteDatabase.sq` + `PasteDao`/`SqlPasteDao`).

Addresses #4791. Addresses #4737.