### PR TITLE
:bug: apply sqlite pragmas via connection properties so busy_timeout takes effect

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/db/DesktopDriverFactory.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/db/DesktopDriverFactory.kt
@@ -32,7 +32,14 @@ class DesktopDriverFactory(
                 isAutoCommit = true
                 poolName = "CrossPastePool"
 
-                connectionInitSql = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA busy_timeout=10000;"
+                // Pragmas must go through connection properties (sqlite-jdbc's
+                // SQLiteConfig): a multi-statement connectionInitSql silently
+                // executes only its first statement, leaving synchronous=FULL
+                // and busy_timeout at the driver default (3 s) — which surfaced
+                // as SQLITE_BUSY under concurrent clipboard-burst writes.
+                addDataSourceProperty("journal_mode", "WAL")
+                addDataSourceProperty("synchronous", "NORMAL")
+                addDataSourceProperty("busy_timeout", "10000")
             }
 
         val hikariDataSource = HikariDataSource(config)

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/DesktopDriverFactoryTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/DesktopDriverFactoryTest.kt
@@ -1,0 +1,58 @@
+package com.crosspaste.db
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import com.crosspaste.app.AppFileType
+import com.crosspaste.path.UserDataPathProvider
+import io.mockk.every
+import io.mockk.mockk
+import okio.Path.Companion.toOkioPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopDriverFactoryTest {
+
+    private fun querySingle(
+        driver: SqlDriver,
+        sql: String,
+    ): String? =
+        driver
+            .executeQuery(
+                null,
+                sql,
+                { cursor ->
+                    cursor.next()
+                    QueryResult.Value(cursor.getString(0))
+                },
+                0,
+                null,
+            ).value
+
+    // Guards against regressing to a multi-statement connectionInitSql: sqlite-jdbc
+    // silently executes only the first statement of such a string, leaving
+    // synchronous=FULL and busy_timeout at the driver default (3 s), which surfaces
+    // as SQLITE_BUSY under concurrent writes.
+    @Test
+    fun `sqlite pragmas are applied on pooled connections`() {
+        val tempDb =
+            Files
+                .createTempDirectory("crosspaste-driver-test")
+                .resolve("crosspaste.db")
+        val userDataPathProvider = mockk<UserDataPathProvider>()
+        every {
+            userDataPathProvider.resolve("crosspaste.db", AppFileType.DATA)
+        } returns tempDb.toOkioPath()
+
+        val factory = DesktopDriverFactory(userDataPathProvider)
+        val driver = factory.createDriver()
+        try {
+            assertEquals("wal", querySingle(driver, "PRAGMA journal_mode"))
+            // 1 = NORMAL
+            assertEquals("1", querySingle(driver, "PRAGMA synchronous"))
+            assertEquals("10000", querySingle(driver, "PRAGMA busy_timeout"))
+        } finally {
+            factory.closeDriver()
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A `SQLITE_BUSY` (`database is locked`) exception was observed in `SqlPasteDao.createPasteData` during real-machine clipboard testing. Concurrent write pressure during clipboard bursts has grown (the keep-first image dedup from #4798 schedules a delete task per discarded duplicate, whose hard delete runs concurrently with the next collection's pre-record insert), which exposed a latent driver configuration bug.

`DesktopDriverFactory` configured SQLite through a multi-statement HikariCP `connectionInitSql`:

```
PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA busy_timeout=10000;
```

Verified empirically against sqlite-jdbc 3.51.3.0: a multi-statement string passed to `Statement.execute` silently executes **only the first statement**. Production connections have therefore been running with `journal_mode=WAL` but `synchronous=FULL` (full fsync on every commit, slow commits) and `busy_timeout=3000` (the sqlite-jdbc default) instead of the intended `NORMAL` / `10000`. Under concurrent writes, a writer waiting more than 3 s throws `SQLITE_BUSY` instead of waiting out the intended 10 s window.

## Fix

Pass the pragmas as Hikari data source properties, which sqlite-jdbc's `SQLiteConfig` applies to every pooled connection at creation:

```kotlin
addDataSourceProperty("journal_mode", "WAL")
addDataSourceProperty("synchronous", "NORMAL")
addDataSourceProperty("busy_timeout", "10000")
```

Verified empirically that all three take effect through this path (`journal_mode=wal`, `synchronous=1`, `busy_timeout=10000`).

## Tests

`DesktopDriverFactoryTest` creates a driver against a temp database and asserts the three effective pragma values on a pooled connection, guarding against regressing to an init-SQL string. Full app:desktopTest suite green.