### PR TITLE
:construction_worker: tier the test suite so PRs run fast tests and releases run integration suites

### DIFF
--- a/.github/workflows/build-beta-linux.yml
+++ b/.github/workflows/build-beta-linux.yml
@@ -96,7 +96,7 @@ jobs:
           key: jbr-${{ hashFiles('**/jbr.yaml') }}
 
       - name: Build with Gradle
-        run: ./gradlew app:build
+        run: ./gradlew app:build -PintegrationTests
 
       - name: Cache Kotlin/Native toolchain
         uses: actions/cache@v5

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -212,7 +212,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Build with Gradle
-        run: ./gradlew app:build
+        run: ./gradlew app:build -PintegrationTests
 
       - name: Cache Kotlin/Native toolchain
         uses: actions/cache@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,22 @@ SQLDelight manages database schema in `.sq` files:
 - Platform-specific test utilities in `desktopTest/`
 - System property `appEnv=TEST` is set automatically during test runs
 
+#### Test Tiers
+
+The desktop suite is split into two tiers via the JUnit 5 tag `integration`. Every new test class MUST be assigned to the correct tier:
+
+- **Fast tier (default, untagged)** — runs on every PR (`./gradlew app:desktopTest`) and must stay fast. A fast-tier test uses mocks/fakes, in-memory SQLite (`TestDriverFactory`), and virtual time (`runTest`); a whole class should finish in well under a second.
+- **Integration tier (`@com.crosspaste.test.IntegrationTest` on the class)** — excluded from PRs; runs with `-PintegrationTests`, which the release and beta build workflows pass, so published artifacts are always gated by the full suite.
+
+Tag a class `@IntegrationTest` if it does ANY of the following:
+- spawns real child processes (e.g. headless daemon launch tests)
+- performs full cryptographic pairing/sync handshakes end to end
+- opens real sockets/servers and exchanges real network traffic beyond a trivial request
+- sleeps or waits on wall-clock time (real `delay`/timeouts not under `runTest` virtual time)
+- takes more than ~1 second for the class in total
+
+Everything else stays untagged in the fast tier. Do not "fix" a slow test by tagging it if it could instead be rewritten against virtual time or mocks — tagging is for tests whose value comes from exercising the real thing. Never delete or weaken a test to make the fast tier faster; move it to the integration tier instead.
+
 ## Code Style and Conventions
 
 - **Commit messages**: Use emoji prefixes (see `doc/en/CommitMessage.md`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,13 @@ CrossPaste is a Kotlin Multiplatform application using Gradle. Key commands:
 
 - **Run the application**: `./gradlew app:run`
 - **Build**: `./gradlew build`
-- **Run tests**: `./gradlew test`
+- **Run tests (fast tier)**: `./gradlew app:desktopTest` — the default; suites annotated `@IntegrationTest` (real processes, full pairing handshakes, wall-clock timing) are excluded
+- **Run all tests including integration tier**: `./gradlew app:desktopTest -PintegrationTests` — release/beta CI builds run this; PR CI runs only the fast tier
 - **Code formatting**: `./gradlew ktlintFormat`
 - **Code style check**: `./gradlew ktlintCheck`
-- **Run single test**: `./gradlew test --tests "ClassName.testMethodName"`
+- **Run single test**: `./gradlew test --tests "ClassName.testMethodName"` (add `-PintegrationTests` if the class is `@IntegrationTest`-tagged)
+
+When adding a test suite that spawns processes, performs real pairing/sync handshakes, or sleeps on wall-clock time (roughly: anything adding multiple seconds), tag the class with `@com.crosspaste.test.IntegrationTest` so it lands in the integration tier instead of slowing every PR.
 
 First startup downloads JBR (JetBrains Runtime) and gradle dependencies automatically.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -589,7 +589,14 @@ compose.desktop {
 }
 
 tasks.withType<Test> {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        // Fast tier by default: suites tagged @IntegrationTest (real processes,
+        // full handshakes, wall-clock timing) only run with -PintegrationTests,
+        // which release/beta CI builds pass. See com.crosspaste.test.IntegrationTest.
+        if (!providers.gradleProperty("integrationTests").isPresent) {
+            excludeTags("integration")
+        }
+    }
     systemProperty("appEnv", "TEST")
     systemProperty("project.root", rootProject.rootDir.absolutePath)
     testLogging {

--- a/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessDaemonProcessTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/headless/HeadlessDaemonProcessTest.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.headless
 
+import com.crosspaste.test.IntegrationTest
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
@@ -22,6 +23,7 @@ import kotlin.test.assertTrue
  * POSIX-only: `Process.destroy()` must deliver SIGTERM so that JVM shutdown
  * hooks run; on Windows it terminates the process without running hooks.
  */
+@IntegrationTest
 class HeadlessDaemonProcessTest {
 
     private fun isPosix(): Boolean =

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
@@ -28,6 +28,7 @@ import com.crosspaste.pairing.v3.PakeSession
 import com.crosspaste.pairing.v3.Spake2PakeProvider
 import com.crosspaste.pairing.v3.TestPakeProvider
 import com.crosspaste.pairing.v3.pairingV3ErrorCodeOf
+import com.crosspaste.test.IntegrationTest
 import com.crosspaste.utils.CryptographyUtils
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
@@ -50,6 +51,7 @@ import kotlin.test.fail
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
+@IntegrationTest
 class PairingV3IntegrationTest {
 
     private val instances = mutableListOf<TestInstance>()

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
@@ -9,6 +9,7 @@ import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.sync.SyncHandler
+import com.crosspaste.test.IntegrationTest
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import io.ktor.client.call.body
@@ -27,6 +28,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
+@IntegrationTest
 class SyncIntegrationTest {
 
     private val instances = mutableListOf<TestInstance>()

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
@@ -29,6 +29,7 @@ import com.crosspaste.secure.GeneralSecureStore
 import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.PendingKeyExchangeStore
+import com.crosspaste.test.IntegrationTest
 import com.crosspaste.utils.CryptographyUtils.generateSecureKeyPair
 import com.crosspaste.utils.DesktopDeviceUtils
 import com.crosspaste.utils.DeviceUtils
@@ -54,6 +55,7 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
+@IntegrationTest
 class SyncTest : KoinTest {
 
     private val appTokenApi by inject<AppTokenApi>()

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsAuthenticationIntegrationTest.kt
@@ -11,6 +11,7 @@ import com.crosspaste.net.routing.wsRouting
 import com.crosspaste.secure.GeneralSecureStore
 import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureStore
+import com.crosspaste.test.IntegrationTest
 import com.crosspaste.utils.CryptographyUtils
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -34,6 +35,7 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
+@IntegrationTest
 class WsAuthenticationIntegrationTest {
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncPollingManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncPollingManagerTest.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.sync
 
+import com.crosspaste.test.IntegrationTest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -18,6 +19,7 @@ import kotlin.time.Duration.Companion.seconds
  * so these tests use runBlocking with real-time delays instead of runTest with virtual time.
  * The fail() backoff starts at 1500ms (500 + 500*2^1), keeping test times reasonable.
  */
+@IntegrationTest
 class SyncPollingManagerTest {
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/test/IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/test/IntegrationTest.kt
@@ -1,0 +1,17 @@
+package com.crosspaste.test
+
+import org.junit.jupiter.api.Tag
+
+/**
+ * Marks slow integration-style suites (real child processes, full pairing
+ * handshakes, real sockets and wall-clock timing) that dominate suite runtime.
+ *
+ * Tagged suites are excluded from the default fast tier that runs on every PR
+ * (`./gradlew app:desktopTest`); they run when `-PintegrationTests` is passed,
+ * which release and beta builds do. Run the full suite locally with:
+ * `./gradlew app:desktopTest -PintegrationTests`.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Tag("integration")
+annotation class IntegrationTest


### PR DESCRIPTION
## Change

Implements the two-tier test strategy from #4800.

- New `@com.crosspaste.test.IntegrationTest` class annotation (meta-annotated with JUnit 5 `@Tag("integration")`).
- `app/build.gradle.kts`: the JUnit platform excludes the `integration` tag unless `-PintegrationTests` is passed.
- Tagged the 6 suites that account for ~90% of suite runtime: `PairingV3IntegrationTest`, `SyncIntegrationTest`, `HeadlessDaemonProcessTest`, `SyncPollingManagerTest`, `WsAuthenticationIntegrationTest`, `SyncTest`.
- `build-release.yml` and `build-beta-linux.yml` pass `-PintegrationTests`, so every published artifact is still gated by the full suite. PR CI (`ci.yml`) is untouched and automatically runs the fast tier.
- CLAUDE.md documents both commands and the rule for tagging future slow suites.

## Measured effect

| Tier | Tests | Wall clock (local, warm) |
|---|---|---|
| Fast (default, PR CI) | 1547 | ~29 s |
| Full (`-PintegrationTests`, release/beta CI) | 1607 | ~3 min |

Both tiers verified green; the fast tier run contains none of the tagged suites, the full run contains all 60 of their tests, 0 failures.

No test is deleted or weakened — the integration tier runs unchanged on every release/beta build and on demand locally.

Fixes #4800.