### PR TITLE
:construction_worker: split the CLI native build into a parallel path-gated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,18 @@ jobs:
 
       # The Kotlin/Native toolchain dependencies (gcc sysroot, llvm, lldb, libffi)
       # are downloaded and extracted into ~/.konan on every run otherwise.
+      # Job-scoped key: app-build and cli-build need different toolchain pieces
+      # (cli cross-compiles linuxArm64/mingwX64), and actions/cache never
+      # re-saves on an exact-key hit — a shared key seeded by one job would
+      # permanently miss the other job's dependencies and re-download them on
+      # every run. The bare konan- fallback bootstraps from pre-split caches.
       - name: Cache Kotlin/Native toolchain
         uses: actions/cache@v5
         with:
           path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+          key: konan-app-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
+            konan-app-${{ runner.os }}-
             konan-${{ runner.os }}-
 
       - name: Install native build dependencies
@@ -143,14 +149,16 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      # The Kotlin/Native toolchain dependencies (gcc sysroot, llvm, lldb, libffi)
-      # are downloaded and extracted into ~/.konan on every run otherwise.
+      # Job-scoped Kotlin/Native toolchain cache — see the app-build comment.
+      # This job's save includes the linuxArm64/mingwX64 cross sysroots and qemu
+      # that the link targets below download on first run.
       - name: Cache Kotlin/Native toolchain
         uses: actions/cache@v5
         with:
           path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+          key: konan-cli-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
+            konan-cli-${{ runner.os }}-
             konan-${{ runner.os }}-
 
       - name: Right-size Gradle for the hosted runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       app: ${{ steps.filter.outputs.app }}
+      cli: ${{ steps.filter.outputs.cli }}
       web: ${{ steps.filter.outputs.web }}
     steps:
       - uses: actions/checkout@v6
@@ -29,7 +30,6 @@ jobs:
               - 'app/**'
               - 'shared/**'
               - 'core/**'
-              - 'cli/**'
               - 'gradle/**'
               - 'gradlew'
               - 'gradlew.bat'
@@ -37,6 +37,18 @@ jobs:
               - 'build.gradle.kts'
               - 'gradle.properties'
               - 'compose-stability.conf'
+              - '.github/workflows/ci.yml'
+            # The cli module has no project dependencies (pure Kotlin/Native HTTP
+            # client), so core/shared changes cannot affect it — only its own
+            # sources and the shared build configuration trigger this gate.
+            cli:
+              - 'cli/**'
+              - 'gradle/**'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - 'settings.gradle.kts'
+              - 'build.gradle.kts'
+              - 'gradle.properties'
               - '.github/workflows/ci.yml'
             web:
               - 'web/**'
@@ -109,11 +121,47 @@ jobs:
       - name: Build common modules and desktop app
         run: ./gradlew :core:build :shared:build :app:build
 
-      # Compile gate for the CLI native binary (host target = linuxX64).
-      # Pure Kotlin since the CLI went all-HTTP; only needs the Kotlin/Native
-      # toolchain already set up above. The release links for linuxArm64 and
-      # mingwX64 guard the cross-compilation path build-release.yml depends on
-      # (its ubuntu job cross-compiles both before Conveyor packaging).
+  # Compile gate for the CLI native binary, split from app-build so the two run
+  # in parallel and app-only PRs skip the ~3 min Kotlin/Native build entirely.
+  # The release links for linuxArm64 and mingwX64 guard the cross-compilation
+  # path build-release.yml depends on (its ubuntu job cross-compiles both
+  # before Conveyor packaging).
+  cli-build:
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          check-latest: true
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      # The Kotlin/Native toolchain dependencies (gcc sysroot, llvm, lldb, libffi)
+      # are downloaded and extracted into ~/.konan on every run otherwise.
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
+
+      - name: Right-size Gradle for the hosted runner
+        run: |
+          {
+            echo ""
+            echo "# CI-only overrides"
+            echo "org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options=-Xmx4g"
+            echo "org.gradle.parallel=true"
+          } >> gradle.properties
+
       - name: Build CLI native binary
         run: >
           ./gradlew :cli:ktlintCheck :cli:cliNativeTest :cli:linkDebugExecutableLinuxX64
@@ -151,7 +199,7 @@ jobs:
         run: npm test
 
   ci:
-    needs: [app-build, web-build]
+    needs: [app-build, cli-build, web-build]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -159,10 +207,12 @@ jobs:
       - name: Verify CI results
         run: |
           app_result="${{ needs.app-build.result }}"
+          cli_result="${{ needs.cli-build.result }}"
           web_result="${{ needs.web-build.result }}"
           echo "app-build: $app_result"
+          echo "cli-build: $cli_result"
           echo "web-build: $web_result"
-          for result in "$app_result" "$web_result"; do
+          for result in "$app_result" "$cli_result" "$web_result"; do
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
               echo "CI failed"
               exit 1


### PR DESCRIPTION
## Change

Implements both optimizations from #4802:

1. **Parallel job**: the CLI native build (`:cli:ktlintCheck :cli:cliNativeTest` + linuxX64/linuxArm64/mingwX64 links) moves out of `app-build` into its own `cli-build` job with its own Konan toolchain cache and CI Gradle overrides, so it runs concurrently with the app build.
2. **Path gating**: a new `cli` filter in the existing `changes` job triggers `cli-build` only for `cli/**` and shared Gradle build configuration. The `cli` module has no project dependencies (pure Kotlin/Native HTTP client), so `core`/`shared`/`app` changes cannot affect it. `cli/**` is likewise removed from the `app` filter, so CLI-only changes no longer rebuild the desktop app.
3. The final `ci` aggregation gate now includes `cli-build` with the same semantics as the other jobs: skipped counts as pass, failure/cancelled fails the gate.

Release workflows are unaffected: `build-release.yml` and `build-beta-linux.yml` keep building and linking the CLI unconditionally.

## Expected effect

| PR touches | Before | After |
|---|---|---|
| app/shared/core only | ~7 min (serial K/N CLI build included) | **~4 min** (cli-build skipped) |
| cli only | ~7 min | **~3 min** (app-build skipped) |
| both | ~7 min | ~4 min wall clock (parallel) |

YAML validated structurally (jobs/needs/outputs/if wiring). This PR itself only touches `.github/workflows/ci.yml`, so this run exercises the `changes` filter fallthrough (both `app` and `cli` trigger on workflow changes) and the parallel execution path.

Fixes #4802.