### PR TITLE
:bug: Recover persisted tasks after restart and enforce task-aware shutdown ordering

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncManager.kt
@@ -20,6 +20,7 @@ import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.*
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -37,7 +38,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.seconds
 
 class GeneralSyncManager(
     override val realTimeSyncScope: CoroutineScope = namedScope(ioDispatcher, "GeneralSyncManager"),
@@ -87,6 +90,14 @@ class GeneralSyncManager(
 
     private val started = atomic(false)
 
+    /**
+     * Completed after the first device snapshot from the database has been
+     * turned into sync handlers. [start] waits for it (bounded) so callers —
+     * in particular startup task recovery, which runs right after [start]
+     * returns — never observe an empty handler map for known devices.
+     */
+    private val initialSnapshotLoaded = CompletableDeferred<Unit>()
+
     private var syncRuntimeInfosJob: Job? = null
 
     override suspend fun start() {
@@ -122,6 +133,11 @@ class GeneralSyncManager(
         }
 
         startCollectingSyncRuntimeInfosFlow()
+
+        // Bounded: the first emission is a local DB read that normally lands in
+        // milliseconds; the timeout only guards startup against a stuck flow.
+        withTimeoutOrNull(3.seconds) { initialSnapshotLoaded.await() }
+            ?: logger.warn { "Timed out waiting for the initial device snapshot" }
     }
 
     override suspend fun stop() {
@@ -186,6 +202,8 @@ class GeneralSyncManager(
                             .filter {
                                 it in currentAppInstanceIdSet
                             }.toSet()
+
+                    initialSnapshotLoaded.complete(Unit)
                 }
             }
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
@@ -2,21 +2,28 @@ package com.crosspaste.task
 
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskDao
+import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.TaskUtils
 import com.crosspaste.utils.cpuDispatcher
 import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class TaskExecutor(
     singleTypeTaskExecutors: List<SingleTypeTaskExecutor>,
     private val taskDao: TaskDao,
     maxConcurrentTasks: Int = 10,
+    private val drainTimeout: Duration = 2.seconds,
     private val scope: CoroutineScope = namedScope(cpuDispatcher, "TaskExecutor"),
 ) {
     private val logger = KotlinLogging.logger {}
@@ -27,7 +34,9 @@ class TaskExecutor(
 
     private val semaphore = Semaphore(maxConcurrentTasks)
 
-    init {
+    private val recoveryStarted = atomic(false)
+
+    private val consumerJob =
         scope.launch(CoroutineName("TaskExecutor")) {
             for (taskId in taskChannel) {
                 semaphore.acquire()
@@ -40,7 +49,6 @@ class TaskExecutor(
                 }
             }
         }
-    }
 
     private fun getExecutorImpl(taskType: Int): SingleTypeTaskExecutor =
         singleTypeTaskExecutorMap[taskType] ?: throw IllegalArgumentException("Unknown task type: $taskType")
@@ -61,6 +69,9 @@ class TaskExecutor(
                 })
             }
         }.onFailure { e ->
+            // A cancelled execution must not be recorded as a terminal FAILURE:
+            // the row keeps its persisted status and startup recovery resumes it.
+            if (e is CancellationException) throw e
             logger.error(e) { "execute task error: $taskId" }
             currentTask?.let { task ->
                 taskDao.failureTask(taskId, false, TaskUtils.createFailExtraInfo(task, e))
@@ -68,17 +79,54 @@ class TaskExecutor(
         }
     }
 
+    /**
+     * Re-enqueues tasks a previous process durably recorded but never finished.
+     *
+     * Must be called during startup after all task executors are registered.
+     * [createdBefore] must be captured before any task producer of the current
+     * process starts submitting work: producer tasks then have
+     * createTime >= the bound and are never claimed, so recovery cannot
+     * enqueue them twice. Runs at most once.
+     */
+    suspend fun recoverPersistedTasks(createdBefore: Long = nowEpochMilliseconds()) {
+        if (!recoveryStarted.compareAndSet(expect = false, update = true)) {
+            return
+        }
+        runCatching {
+            val taskIds = taskDao.claimRecoverableTasks(createdBefore)
+            if (taskIds.isEmpty()) {
+                logger.info { "No persisted tasks to recover" }
+            } else {
+                taskIds.forEach { submitTask(it) }
+                logger.info { "Recovered ${taskIds.size} persisted tasks: $taskIds" }
+            }
+        }.onFailure { e ->
+            logger.error(e) { "Failed to recover persisted tasks" }
+        }
+    }
+
     suspend fun submitTask(taskId: Long) {
-        taskChannel.send(taskId)
+        if (taskChannel.trySend(taskId).isFailure) {
+            // Shutdown already closed the channel: the task row stays PREPARING
+            // and is picked up by recoverPersistedTasks on the next start.
+            logger.warn { "Task channel closed, task $taskId deferred to next-start recovery" }
+        }
     }
 
     suspend fun submitTasks(taskIds: List<Long>) {
-        taskIds.forEach { taskChannel.send(it) }
+        taskIds.forEach { submitTask(it) }
     }
 
-    fun shutdown() {
+    /**
+     * Stops accepting new tasks, drains already-queued and in-flight tasks for
+     * up to [drainTimeout], then cancels whatever is still running. Cancelled
+     * tasks keep their persisted status and are resumed by
+     * [recoverPersistedTasks] on the next start.
+     */
+    suspend fun shutdown() {
         taskChannel.close()
+        val drained = withTimeoutOrNull(drainTimeout) { consumerJob.join() } != null
         scope.cancel()
-        logger.info { "TaskExecutor shutdown complete" }
+        logger.info { "TaskExecutor shutdown complete (drained=$drained)" }
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
@@ -2,7 +2,6 @@ package com.crosspaste.task
 
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.TaskDao
-import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.TaskUtils
 import com.crosspaste.utils.cpuDispatcher
 import com.crosspaste.utils.namedScope
@@ -50,16 +49,20 @@ class TaskExecutor(
             }
         }
 
-    private fun getExecutorImpl(taskType: Int): SingleTypeTaskExecutor =
-        singleTypeTaskExecutorMap[taskType] ?: throw IllegalArgumentException("Unknown task type: $taskType")
-
     private suspend fun executeTask(taskId: Long) {
         var currentTask: PasteTask? = null
         runCatching {
             taskDao.getTask(taskId)?.let { task ->
+                val executor = singleTypeTaskExecutorMap[task.taskType]
+                if (executor == null) {
+                    // A downgraded build can see task types persisted by a newer
+                    // version. Leave the row untouched (instead of failing it
+                    // terminally) so a future version can still recover it.
+                    logger.warn { "No executor for task type ${task.taskType}, task $taskId left for future recovery" }
+                    return
+                }
                 currentTask = task
                 taskDao.executingTask(taskId)
-                val executor = getExecutorImpl(task.taskType)
                 executor.executeTask(task, success = {
                     taskDao.successTask(taskId, it)
                 }, fail = { pasteTaskExtraInfo, needRetry ->
@@ -74,7 +77,16 @@ class TaskExecutor(
             if (e is CancellationException) throw e
             logger.error(e) { "execute task error: $taskId" }
             currentTask?.let { task ->
-                taskDao.failureTask(taskId, false, TaskUtils.createFailExtraInfo(task, e))
+                // Failure recording must itself be fault-tolerant: an exception
+                // escaping here (e.g. corrupt extraInfo JSON) would cancel the
+                // consumer coroutine and permanently stop task processing.
+                val failExtraInfo = runCatching { TaskUtils.createFailExtraInfo(task, e) }.getOrNull()
+                runCatching {
+                    taskDao.failureTask(taskId, false, failExtraInfo)
+                }.onFailure { persistError ->
+                    if (persistError is CancellationException) throw persistError
+                    logger.error(persistError) { "record task failure error: $taskId" }
+                }
             }
         }
     }
@@ -83,22 +95,25 @@ class TaskExecutor(
      * Re-enqueues tasks a previous process durably recorded but never finished.
      *
      * Must be called during startup after all task executors are registered.
-     * [createdBefore] must be captured before any task producer of the current
-     * process starts submitting work: producer tasks then have
-     * createTime >= the bound and are never claimed, so recovery cannot
-     * enqueue them twice. Runs at most once.
+     * [maxTaskId] must be captured (via [TaskDao.getMaxTaskId]) before any task
+     * producer of the current process starts submitting work: task ids are
+     * monotonic, so producer tasks always exceed the bound and are never
+     * claimed — recovery cannot enqueue them twice. Runs at most once; the
+     * claim itself is bounded, any overflow is claimed on a later startup.
      */
-    suspend fun recoverPersistedTasks(createdBefore: Long = nowEpochMilliseconds()) {
+    suspend fun recoverPersistedTasks(maxTaskId: Long) {
         if (!recoveryStarted.compareAndSet(expect = false, update = true)) {
             return
         }
         runCatching {
-            val taskIds = taskDao.claimRecoverableTasks(createdBefore)
+            val taskIds = taskDao.claimRecoverableTasks(maxTaskId)
             if (taskIds.isEmpty()) {
                 logger.info { "No persisted tasks to recover" }
             } else {
                 taskIds.forEach { submitTask(it) }
-                logger.info { "Recovered ${taskIds.size} persisted tasks: $taskIds" }
+                logger.info {
+                    "Recovered ${taskIds.size} persisted tasks, first ids: ${taskIds.take(20)}"
+                }
             }
         }.onFailure { e ->
             logger.error(e) { "Failed to recover persisted tasks" }
@@ -125,8 +140,13 @@ class TaskExecutor(
      */
     suspend fun shutdown() {
         taskChannel.close()
-        val drained = withTimeoutOrNull(drainTimeout) { consumerJob.join() } != null
-        scope.cancel()
-        logger.info { "TaskExecutor shutdown complete (drained=$drained)" }
+        try {
+            val drained = withTimeoutOrNull(drainTimeout) { consumerJob.join() } != null
+            logger.info { "TaskExecutor shutdown complete (drained=$drained)" }
+        } finally {
+            // Must run even when an enclosing shutdown timeout cancels the
+            // drain, otherwise task coroutines outlive the closed database.
+            scope.cancel()
+        }
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -30,6 +30,7 @@ import com.crosspaste.cli.CliSymlinkService
 import com.crosspaste.config.AppMetadataRepository
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.db.DriverFactory
+import com.crosspaste.db.task.TaskDao
 import com.crosspaste.listener.GlobalListener
 import com.crosspaste.log.DesktopCrossPasteLogger
 import com.crosspaste.mcp.McpServer
@@ -54,7 +55,6 @@ import com.crosspaste.ui.LocalDesktopAppSizeValueState
 import com.crosspaste.ui.LocalExitApplication
 import com.crosspaste.ui.LocalNavHostController
 import com.crosspaste.ui.theme.DesktopTheme
-import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.DesktopDeviceUtils
 import com.crosspaste.utils.DesktopLocaleUtils
 import com.crosspaste.utils.GlobalCoroutineScope.ioCoroutineDispatcher
@@ -76,6 +76,7 @@ import org.koin.core.KoinApplication
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.named
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.system.exitProcess
 import kotlin.time.Duration.Companion.seconds
 
@@ -209,11 +210,13 @@ class CrossPaste {
                         getManagedService<PasteboardService>(ManagedService.PASTEBOARD)
                     koin.get<QRCodeGenerator>()
                     // Capture the recovery claim bound before any task producer can
-                    // start (SyncManager below launches background sync work): every
-                    // task the current process creates has createTime >= this bound
-                    // and can never be claimed, so recovery cannot double-enqueue a
-                    // task that a live producer just committed and submitted.
-                    val taskRecoveryBound = nowEpochMilliseconds()
+                    // start (SyncManager below launches background sync work): task
+                    // ids are monotonic, so every task the current process creates
+                    // exceeds this bound and can never be claimed — recovery cannot
+                    // double-enqueue a task a live producer just committed.
+                    val taskRecoveryBound = koin.get<TaskDao>().getMaxTaskId()
+                    // start() waits (bounded) for the first device snapshot, so the
+                    // recovered sync/pull tasks below see the known sync handlers.
                     getManagedService<SyncManager>(ManagedService.SYNC_MANAGER).start()
                     koin.get<PastePullService>().init()
                     getManagedService<TaskExecutor>(ManagedService.TASK_EXECUTOR)
@@ -354,149 +357,21 @@ class CrossPaste {
 
         private suspend fun shutdownAllServices() {
             withTimeoutOrNull(5.seconds) {
-                // Phase 1: stop every task producer (pasteboard listener, schedulers,
-                // servers accepting remote work) so no new task IDs get submitted.
-                // Bounded by its own budget so one slow stop (e.g. a Ktor server's
-                // grace period) cannot starve the drain and phase 3 of the shared
-                // 5s window; a producer that outlives the budget can still only
-                // trySend into a closed channel, which defers the task to recovery.
-                withTimeoutOrNull(2.seconds) {
-                    supervisorScope {
-                        val jobs =
-                            buildList {
-                                add(
-                                    async {
-                                        stopManagedService<PasteboardService>(
-                                            ManagedService.PASTEBOARD,
-                                            "PasteboardService",
-                                        ) { it.shutdown() }
-                                    },
-                                )
-                                add(
-                                    async {
-                                        stopManagedService<CleanScheduler>(
-                                            ManagedService.CLEAN_SCHEDULER,
-                                            "CleanPasteScheduler",
-                                        ) { it.stop() }
-                                    },
-                                )
-                                add(
-                                    async {
-                                        stopManagedService<Server>(ManagedService.PASTE_SERVER, "PasteServer") {
-                                            it.stop()
-                                        }
-                                    },
-                                )
-                                add(
-                                    async {
-                                        stopManagedService<CliServer>(ManagedService.CLI_SERVER, "CliServer") {
-                                            it.stop()
-                                        }
-                                    },
-                                )
-                                add(
-                                    async {
-                                        stopManagedService<McpServer>(ManagedService.MCP_SERVER, "McpServer") {
-                                            it.stop()
-                                        }
-                                    },
-                                )
-                                add(
-                                    async {
-                                        stopManagedService<PasteBonjourService>(
-                                            ManagedService.PASTE_BONJOUR,
-                                            "PasteBonjourService",
-                                        ) { it.close() }
-                                    },
-                                )
-                                if (!headless) {
-                                    add(
-                                        async {
-                                            stopManagedService<AppUpdateService>(
-                                                ManagedService.APP_UPDATE,
-                                                "AppUpdateService",
-                                            ) { it.stop() }
-                                        },
-                                    )
-                                    add(
-                                        async {
-                                            stopManagedService<DesktopAppWindowManager>(
-                                                ManagedService.WINDOW_MANAGER,
-                                                "DesktopAppWindowManager",
-                                            ) {
-                                                it.stopWindowService()
-                                            }
-                                        },
-                                    )
-                                    add(
-                                        async {
-                                            stopManagedService<GlobalListener>(
-                                                ManagedService.GLOBAL_LISTENER,
-                                                "GlobalListener",
-                                            ) { it.stop() }
-                                        },
-                                    )
-                                }
-                            }
-
-                        jobs.awaitAll()
-                    }
-                }
-
-                // Phase 2: with producers stopped, drain already-queued tasks so a
-                // normal shutdown completes its work instead of leaving it to
-                // next-start crash recovery.
-                stopManagedService<TaskExecutor>(
-                    ManagedService.TASK_EXECUTOR,
-                    "TaskExecutor",
-                ) { it.shutdown() }
-
-                // Phase 3: stop the services draining tasks may still depend on
-                // (sync push, rendering, HTTP clients).
                 supervisorScope {
-                    val jobs =
-                        buildList {
-                            add(
-                                async {
-                                    stopManagedService<SyncManager>(ManagedService.SYNC_MANAGER, "SyncManager") {
-                                        it.stop()
-                                    }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<RenderingService<String>>(
-                                        service = ManagedService.RENDERING,
-                                        serviceName = "RenderingService",
-                                    ) { it.stop() }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<UserDataPathProvider>(
-                                        ManagedService.USER_DATA_PATH,
-                                        "UserDataPathProvider",
-                                    ) { it.cleanTemp() }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<PasteClient>(ManagedService.PASTE_CLIENT, "PasteClient") {
-                                        it.close()
-                                    }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<ResourcesClient>(
-                                        ManagedService.RESOURCES_CLIENT,
-                                        "ResourcesClient",
-                                    ) { it.close() }
-                                },
-                            )
+                    // Bonjour teardown blocks in its own runBlocking for up to 4s and
+                    // is not a task producer: run it concurrently with all phases so
+                    // it cannot eat the phased budgets below.
+                    val bonjourJob =
+                        async {
+                            stopManagedService<PasteBonjourService>(
+                                ManagedService.PASTE_BONJOUR,
+                                "PasteBonjourService",
+                            ) { it.close() }
                         }
 
-                    jobs.awaitAll()
+                    shutdownPhasedServices()
+
+                    bonjourJob.await()
                 }
             }
 
@@ -504,6 +379,145 @@ class CrossPaste {
                 stopManagedService<DriverFactory>(ManagedService.DRIVER_FACTORY, "DriverFactory") {
                     it.closeDriver()
                 }
+            }
+        }
+
+        private suspend fun shutdownPhasedServices() {
+            // Phase 1: stop every task producer (pasteboard listener, schedulers,
+            // servers accepting remote work) so no new task IDs get submitted.
+            // Bounded by its own budget so one slow stop (e.g. a Ktor server's
+            // grace period) cannot starve the drain and phase 3 of the shared
+            // 5s window; a producer that outlives the budget can still only
+            // trySend into a closed channel, which defers the task to recovery.
+            withTimeoutOrNull(2.seconds) {
+                supervisorScope {
+                    val jobs =
+                        buildList {
+                            add(
+                                async {
+                                    stopManagedService<PasteboardService>(
+                                        ManagedService.PASTEBOARD,
+                                        "PasteboardService",
+                                    ) { it.shutdown() }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<CleanScheduler>(
+                                        ManagedService.CLEAN_SCHEDULER,
+                                        "CleanPasteScheduler",
+                                    ) { it.stop() }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<Server>(ManagedService.PASTE_SERVER, "PasteServer") {
+                                        it.stop()
+                                    }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<CliServer>(ManagedService.CLI_SERVER, "CliServer") {
+                                        it.stop()
+                                    }
+                                },
+                            )
+                            add(
+                                async {
+                                    stopManagedService<McpServer>(ManagedService.MCP_SERVER, "McpServer") {
+                                        it.stop()
+                                    }
+                                },
+                            )
+                            if (!headless) {
+                                add(
+                                    async {
+                                        stopManagedService<AppUpdateService>(
+                                            ManagedService.APP_UPDATE,
+                                            "AppUpdateService",
+                                        ) { it.stop() }
+                                    },
+                                )
+                                add(
+                                    async {
+                                        stopManagedService<DesktopAppWindowManager>(
+                                            ManagedService.WINDOW_MANAGER,
+                                            "DesktopAppWindowManager",
+                                        ) {
+                                            it.stopWindowService()
+                                        }
+                                    },
+                                )
+                                add(
+                                    async {
+                                        stopManagedService<GlobalListener>(
+                                            ManagedService.GLOBAL_LISTENER,
+                                            "GlobalListener",
+                                        ) { it.stop() }
+                                    },
+                                )
+                            }
+                        }
+
+                    jobs.awaitAll()
+                }
+            }
+
+            // Phase 2: with producers stopped, drain already-queued tasks so a
+            // normal shutdown completes its work instead of leaving it to
+            // next-start crash recovery.
+            stopManagedService<TaskExecutor>(
+                ManagedService.TASK_EXECUTOR,
+                "TaskExecutor",
+            ) { it.shutdown() }
+
+            // Phase 3: stop the services draining tasks may still depend on
+            // (sync push, rendering, HTTP clients).
+            supervisorScope {
+                val jobs =
+                    buildList {
+                        add(
+                            async {
+                                stopManagedService<SyncManager>(ManagedService.SYNC_MANAGER, "SyncManager") {
+                                    it.stop()
+                                }
+                            },
+                        )
+                        add(
+                            async {
+                                stopManagedService<RenderingService<String>>(
+                                    service = ManagedService.RENDERING,
+                                    serviceName = "RenderingService",
+                                ) { it.stop() }
+                            },
+                        )
+                        add(
+                            async {
+                                stopManagedService<UserDataPathProvider>(
+                                    ManagedService.USER_DATA_PATH,
+                                    "UserDataPathProvider",
+                                ) { it.cleanTemp() }
+                            },
+                        )
+                        add(
+                            async {
+                                stopManagedService<PasteClient>(ManagedService.PASTE_CLIENT, "PasteClient") {
+                                    it.close()
+                                }
+                            },
+                        )
+                        add(
+                            async {
+                                stopManagedService<ResourcesClient>(
+                                    ManagedService.RESOURCES_CLIENT,
+                                    "ResourcesClient",
+                                ) { it.close() }
+                            },
+                        )
+                    }
+
+                jobs.awaitAll()
             }
         }
 
@@ -531,6 +545,9 @@ class CrossPaste {
             }.onSuccess {
                 logger.info { "$serviceName stop completed" }
             }.onFailure { e ->
+                // Shutdown-timeout cancellation must propagate so an expired
+                // phase budget actually skips ahead instead of being swallowed.
+                if (e is CancellationException) throw e
                 logger.error(e) { "Error stopping $serviceName" }
             }
         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -54,6 +54,7 @@ import com.crosspaste.ui.LocalDesktopAppSizeValueState
 import com.crosspaste.ui.LocalExitApplication
 import com.crosspaste.ui.LocalNavHostController
 import com.crosspaste.ui.theme.DesktopTheme
+import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
 import com.crosspaste.utils.DesktopDeviceUtils
 import com.crosspaste.utils.DesktopLocaleUtils
 import com.crosspaste.utils.GlobalCoroutineScope.ioCoroutineDispatcher
@@ -206,12 +207,20 @@ class CrossPaste {
                     // and shutdown must still perform their ordered cleanup.
                     val pasteboardService =
                         getManagedService<PasteboardService>(ManagedService.PASTEBOARD)
+                    koin.get<QRCodeGenerator>()
+                    // Capture the recovery claim bound before any task producer can
+                    // start (SyncManager below launches background sync work): every
+                    // task the current process creates has createTime >= this bound
+                    // and can never be claimed, so recovery cannot double-enqueue a
+                    // task that a live producer just committed and submitted.
+                    val taskRecoveryBound = nowEpochMilliseconds()
+                    getManagedService<SyncManager>(ManagedService.SYNC_MANAGER).start()
+                    koin.get<PastePullService>().init()
+                    getManagedService<TaskExecutor>(ManagedService.TASK_EXECUTOR)
+                        .recoverPersistedTasks(taskRecoveryBound)
                     if (configManager.getCurrentConfig().enablePasteboardListening) {
                         pasteboardService.start()
                     }
-                    koin.get<QRCodeGenerator>()
-                    getManagedService<SyncManager>(ManagedService.SYNC_MANAGER).start()
-                    koin.get<PastePullService>().init()
                     val pasteServer = getManagedService<Server>(ManagedService.PASTE_SERVER)
                     if (headless) {
                         // A daemon without its sync endpoint is not operational.
@@ -243,12 +252,7 @@ class CrossPaste {
                     }
                     getManagedService<PasteClient>(ManagedService.PASTE_CLIENT)
                     getManagedService<PasteBonjourService>(ManagedService.PASTE_BONJOUR)
-                    val cleanScheduler =
-                        getManagedService<CleanScheduler>(ManagedService.CLEAN_SCHEDULER)
-                    // CleanScheduler resolves TaskExecutor as a dependency. Record the
-                    // existing singleton so its worker scope is closed on shutdown.
-                    getManagedService<TaskExecutor>(ManagedService.TASK_EXECUTOR)
-                    cleanScheduler.start()
+                    getManagedService<CleanScheduler>(ManagedService.CLEAN_SCHEDULER).start()
                     koin.get<DesktopPidFileService>().start()
 
                     if (!headless) {
@@ -350,15 +354,113 @@ class CrossPaste {
 
         private suspend fun shutdownAllServices() {
             withTimeoutOrNull(5.seconds) {
+                // Phase 1: stop every task producer (pasteboard listener, schedulers,
+                // servers accepting remote work) so no new task IDs get submitted.
+                // Bounded by its own budget so one slow stop (e.g. a Ktor server's
+                // grace period) cannot starve the drain and phase 3 of the shared
+                // 5s window; a producer that outlives the budget can still only
+                // trySend into a closed channel, which defers the task to recovery.
+                withTimeoutOrNull(2.seconds) {
+                    supervisorScope {
+                        val jobs =
+                            buildList {
+                                add(
+                                    async {
+                                        stopManagedService<PasteboardService>(
+                                            ManagedService.PASTEBOARD,
+                                            "PasteboardService",
+                                        ) { it.shutdown() }
+                                    },
+                                )
+                                add(
+                                    async {
+                                        stopManagedService<CleanScheduler>(
+                                            ManagedService.CLEAN_SCHEDULER,
+                                            "CleanPasteScheduler",
+                                        ) { it.stop() }
+                                    },
+                                )
+                                add(
+                                    async {
+                                        stopManagedService<Server>(ManagedService.PASTE_SERVER, "PasteServer") {
+                                            it.stop()
+                                        }
+                                    },
+                                )
+                                add(
+                                    async {
+                                        stopManagedService<CliServer>(ManagedService.CLI_SERVER, "CliServer") {
+                                            it.stop()
+                                        }
+                                    },
+                                )
+                                add(
+                                    async {
+                                        stopManagedService<McpServer>(ManagedService.MCP_SERVER, "McpServer") {
+                                            it.stop()
+                                        }
+                                    },
+                                )
+                                add(
+                                    async {
+                                        stopManagedService<PasteBonjourService>(
+                                            ManagedService.PASTE_BONJOUR,
+                                            "PasteBonjourService",
+                                        ) { it.close() }
+                                    },
+                                )
+                                if (!headless) {
+                                    add(
+                                        async {
+                                            stopManagedService<AppUpdateService>(
+                                                ManagedService.APP_UPDATE,
+                                                "AppUpdateService",
+                                            ) { it.stop() }
+                                        },
+                                    )
+                                    add(
+                                        async {
+                                            stopManagedService<DesktopAppWindowManager>(
+                                                ManagedService.WINDOW_MANAGER,
+                                                "DesktopAppWindowManager",
+                                            ) {
+                                                it.stopWindowService()
+                                            }
+                                        },
+                                    )
+                                    add(
+                                        async {
+                                            stopManagedService<GlobalListener>(
+                                                ManagedService.GLOBAL_LISTENER,
+                                                "GlobalListener",
+                                            ) { it.stop() }
+                                        },
+                                    )
+                                }
+                            }
+
+                        jobs.awaitAll()
+                    }
+                }
+
+                // Phase 2: with producers stopped, drain already-queued tasks so a
+                // normal shutdown completes its work instead of leaving it to
+                // next-start crash recovery.
+                stopManagedService<TaskExecutor>(
+                    ManagedService.TASK_EXECUTOR,
+                    "TaskExecutor",
+                ) { it.shutdown() }
+
+                // Phase 3: stop the services draining tasks may still depend on
+                // (sync push, rendering, HTTP clients).
                 supervisorScope {
                     val jobs =
                         buildList {
                             add(
                                 async {
-                                    stopManagedService<TaskExecutor>(
-                                        ManagedService.TASK_EXECUTOR,
-                                        "TaskExecutor",
-                                    ) { it.shutdown() }
+                                    stopManagedService<SyncManager>(ManagedService.SYNC_MANAGER, "SyncManager") {
+                                        it.stop()
+                                    }
                                 },
                             )
                             add(
@@ -369,86 +471,6 @@ class CrossPaste {
                                     ) { it.stop() }
                                 },
                             )
-                            add(
-                                async {
-                                    stopManagedService<PasteboardService>(
-                                        ManagedService.PASTEBOARD,
-                                        "PasteboardService",
-                                    ) { it.shutdown() }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<PasteBonjourService>(
-                                        ManagedService.PASTE_BONJOUR,
-                                        "PasteBonjourService",
-                                    ) { it.close() }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<Server>(ManagedService.PASTE_SERVER, "PasteServer") {
-                                        it.stop()
-                                    }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<CliServer>(ManagedService.CLI_SERVER, "CliServer") {
-                                        it.stop()
-                                    }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<McpServer>(ManagedService.MCP_SERVER, "McpServer") {
-                                        it.stop()
-                                    }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<SyncManager>(ManagedService.SYNC_MANAGER, "SyncManager") {
-                                        it.stop()
-                                    }
-                                },
-                            )
-                            add(
-                                async {
-                                    stopManagedService<CleanScheduler>(
-                                        ManagedService.CLEAN_SCHEDULER,
-                                        "CleanPasteScheduler",
-                                    ) { it.stop() }
-                                },
-                            )
-                            if (!headless) {
-                                add(
-                                    async {
-                                        stopManagedService<AppUpdateService>(
-                                            ManagedService.APP_UPDATE,
-                                            "AppUpdateService",
-                                        ) { it.stop() }
-                                    },
-                                )
-                                add(
-                                    async {
-                                        stopManagedService<DesktopAppWindowManager>(
-                                            ManagedService.WINDOW_MANAGER,
-                                            "DesktopAppWindowManager",
-                                        ) {
-                                            it.stopWindowService()
-                                        }
-                                    },
-                                )
-                                add(
-                                    async {
-                                        stopManagedService<GlobalListener>(
-                                            ManagedService.GLOBAL_LISTENER,
-                                            "GlobalListener",
-                                        ) { it.stop() }
-                                    },
-                                )
-                            }
                             add(
                                 async {
                                     stopManagedService<UserDataPathProvider>(

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/task/TaskDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/task/TaskDaoTest.kt
@@ -264,11 +264,20 @@ class TaskDaoTest {
     // --- Recovery claim ---
 
     @Test
+    fun `getMaxTaskId returns zero on empty table and highest id otherwise`() =
+        runTest {
+            assertEquals(0L, taskDao.getMaxTaskId())
+            taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+            val second = taskDao.createTask(pasteDataId = 2L, taskType = TaskType.SYNC_PASTE_TASK)
+            assertEquals(second, taskDao.getMaxTaskId())
+        }
+
+    @Test
     fun `claimRecoverableTasks returns PREPARING task and keeps its status`() =
         runTest {
             val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
 
-            val claimed = taskDao.claimRecoverableTasks(System.currentTimeMillis() + 10000)
+            val claimed = taskDao.claimRecoverableTasks(taskDao.getMaxTaskId())
 
             assertEquals(listOf(taskId), claimed)
             assertEquals(TaskStatus.PREPARING, taskDao.getTask(taskId)!!.status)
@@ -280,7 +289,7 @@ class TaskDaoTest {
             val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
             taskDao.executingTask(taskId)
 
-            val claimed = taskDao.claimRecoverableTasks(System.currentTimeMillis() + 10000)
+            val claimed = taskDao.claimRecoverableTasks(taskDao.getMaxTaskId())
 
             assertEquals(listOf(taskId), claimed)
             assertEquals(TaskStatus.PREPARING, taskDao.getTask(taskId)!!.status)
@@ -297,7 +306,7 @@ class TaskDaoTest {
             taskDao.executingTask(failureId)
             taskDao.failureTask(failureId, needRetry = false, newExtraInfo = null)
 
-            val claimed = taskDao.claimRecoverableTasks(System.currentTimeMillis() + 10000)
+            val claimed = taskDao.claimRecoverableTasks(taskDao.getMaxTaskId())
 
             assertEquals(emptyList(), claimed)
             assertEquals(TaskStatus.SUCCESS, taskDao.getTask(successId)!!.status)
@@ -305,9 +314,9 @@ class TaskDaoTest {
         }
 
     @Test
-    fun `claimRecoverableTasks ignores tasks created after the bound`() =
+    fun `claimRecoverableTasks ignores tasks above the id bound`() =
         runTest {
-            val bound = System.currentTimeMillis() - 10000
+            val bound = taskDao.getMaxTaskId()
             val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
             taskDao.executingTask(taskId)
 
@@ -324,9 +333,23 @@ class TaskDaoTest {
             val second = taskDao.createTask(pasteDataId = 2L, taskType = TaskType.DELETE_PASTE_TASK)
             taskDao.executingTask(second)
 
-            val claimed = taskDao.claimRecoverableTasks(System.currentTimeMillis() + 10000)
+            val claimed = taskDao.claimRecoverableTasks(taskDao.getMaxTaskId())
 
             assertEquals(listOf(first, second), claimed)
+        }
+
+    @Test
+    fun `claimRecoverableTasks bounds the claim and leaves the overflow intact`() =
+        runTest {
+            val first = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+            val second = taskDao.createTask(pasteDataId = 2L, taskType = TaskType.SYNC_PASTE_TASK)
+            taskDao.executingTask(second)
+
+            val claimed = taskDao.claimRecoverableTasks(taskDao.getMaxTaskId(), limit = 1)
+
+            assertEquals(listOf(first), claimed)
+            // The overflow EXECUTING row keeps its status for a later claim.
+            assertEquals(TaskStatus.EXECUTING, taskDao.getTask(second)!!.status)
         }
 
     // --- Full lifecycle ---

--- a/app/src/desktopTest/kotlin/com/crosspaste/db/task/TaskDaoTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/db/task/TaskDaoTest.kt
@@ -261,6 +261,74 @@ class TaskDaoTest {
             assertNotNull(task)
         }
 
+    // --- Recovery claim ---
+
+    @Test
+    fun `claimRecoverableTasks returns PREPARING task and keeps its status`() =
+        runTest {
+            val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+
+            val claimed = taskDao.claimRecoverableTasks(System.currentTimeMillis() + 10000)
+
+            assertEquals(listOf(taskId), claimed)
+            assertEquals(TaskStatus.PREPARING, taskDao.getTask(taskId)!!.status)
+        }
+
+    @Test
+    fun `claimRecoverableTasks resets EXECUTING task back to PREPARING`() =
+        runTest {
+            val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+            taskDao.executingTask(taskId)
+
+            val claimed = taskDao.claimRecoverableTasks(System.currentTimeMillis() + 10000)
+
+            assertEquals(listOf(taskId), claimed)
+            assertEquals(TaskStatus.PREPARING, taskDao.getTask(taskId)!!.status)
+        }
+
+    @Test
+    fun `claimRecoverableTasks ignores SUCCESS and FAILURE tasks`() =
+        runTest {
+            val successId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+            taskDao.executingTask(successId)
+            taskDao.successTask(successId, newExtraInfo = null)
+
+            val failureId = taskDao.createTask(pasteDataId = 2L, taskType = TaskType.SYNC_PASTE_TASK)
+            taskDao.executingTask(failureId)
+            taskDao.failureTask(failureId, needRetry = false, newExtraInfo = null)
+
+            val claimed = taskDao.claimRecoverableTasks(System.currentTimeMillis() + 10000)
+
+            assertEquals(emptyList(), claimed)
+            assertEquals(TaskStatus.SUCCESS, taskDao.getTask(successId)!!.status)
+            assertEquals(TaskStatus.FAILURE, taskDao.getTask(failureId)!!.status)
+        }
+
+    @Test
+    fun `claimRecoverableTasks ignores tasks created after the bound`() =
+        runTest {
+            val bound = System.currentTimeMillis() - 10000
+            val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+            taskDao.executingTask(taskId)
+
+            val claimed = taskDao.claimRecoverableTasks(bound)
+
+            assertEquals(emptyList(), claimed)
+            assertEquals(TaskStatus.EXECUTING, taskDao.getTask(taskId)!!.status)
+        }
+
+    @Test
+    fun `claimRecoverableTasks returns unfinished tasks in creation order`() =
+        runTest {
+            val first = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.SYNC_PASTE_TASK)
+            val second = taskDao.createTask(pasteDataId = 2L, taskType = TaskType.DELETE_PASTE_TASK)
+            taskDao.executingTask(second)
+
+            val claimed = taskDao.claimRecoverableTasks(System.currentTimeMillis() + 10000)
+
+            assertEquals(listOf(first, second), claimed)
+        }
+
     // --- Full lifecycle ---
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncManagerTest.kt
@@ -22,7 +22,10 @@ import io.mockk.runs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -32,6 +35,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GeneralSyncManagerTest {
@@ -595,5 +599,46 @@ class GeneralSyncManagerTest {
             assertEquals("app-2", handler2.currentSyncRuntimeInfo.appInstanceId)
             assertEquals("device-1", handler1.currentSyncRuntimeInfo.deviceId)
             assertEquals("device-2", handler2.currentSyncRuntimeInfo.deviceId)
+        }
+
+    @Test
+    fun `start waits for the first device snapshot before returning`() =
+        runTest {
+            val mocks = createMocks()
+            val testSyncRuntimeInfo = createTestSyncRuntimeInfo()
+            // No replay: the snapshot only exists once the emitter below fires,
+            // modeling a database flow whose first emission is delayed.
+            val syncInfosFlow = MutableSharedFlow<List<SyncRuntimeInfo>>()
+            every { mocks.syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow() } returns syncInfosFlow
+
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager = createSyncManager(mocks, childScope)
+
+            launch {
+                delay(100.milliseconds)
+                syncInfosFlow.emit(listOf(testSyncRuntimeInfo))
+            }
+
+            syncManager.start()
+
+            // Callers that run right after start() (startup task recovery) must
+            // already see the handler for the persisted device.
+            assertNotNull(syncManager.getSyncHandlers()[testSyncRuntimeInfo.appInstanceId])
+        }
+
+    @Test
+    fun `start returns after a bounded wait when the snapshot flow stalls`() =
+        runTest {
+            val mocks = createMocks()
+            every { mocks.syncRuntimeInfoDao.getAllSyncRuntimeInfosFlow() } returns
+                MutableSharedFlow()
+
+            val childScope = CoroutineScope(coroutineContext + Job())
+            val syncManager = createSyncManager(mocks, childScope)
+
+            // Must not hang startup: the wait is bounded by the internal timeout.
+            syncManager.start()
+
+            assertTrue(syncManager.getSyncHandlers().isEmpty())
         }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/TaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/TaskExecutorTest.kt
@@ -9,11 +9,13 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TaskExecutorTest {
@@ -148,6 +150,106 @@ class TaskExecutorTest {
             coVerify { taskDao.failureTask(1L, false, any()) }
 
             executor.shutdown()
+        }
+
+    @Test
+    fun `recoverPersistedTasks executes claimed tasks`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+            coEvery { taskDao.claimRecoverableTasks(any()) } returns listOf(1L, 2L)
+            coEvery { taskDao.getTask(1L) } returns createMockTask(taskId = 1L)
+            coEvery { taskDao.getTask(2L) } returns createMockTask(taskId = 2L)
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.recoverPersistedTasks()
+            advanceUntilIdle()
+
+            coVerify { taskDao.executingTask(1L) }
+            coVerify { taskDao.executingTask(2L) }
+
+            executor.shutdown()
+        }
+
+    @Test
+    fun `recoverPersistedTasks claims at most once`() =
+        runTest {
+            val taskDao: TaskDao = mockk(relaxed = true)
+            coEvery { taskDao.claimRecoverableTasks(any()) } returns emptyList()
+
+            val executor =
+                TaskExecutor(
+                    emptyList(),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.recoverPersistedTasks()
+            executor.recoverPersistedTasks()
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { taskDao.claimRecoverableTasks(any()) }
+
+            executor.shutdown()
+        }
+
+    @Test
+    fun `submitTask after shutdown neither throws nor touches the task`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.shutdown()
+            executor.submitTask(1L)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { taskDao.executingTask(any()) }
+            coVerify(exactly = 0) { taskDao.failureTask(any(), any(), any()) }
+        }
+
+    @Test
+    fun `shutdown drains queued tasks before cancelling scope`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+            coEvery { singleExecutor.executeTask(any(), any(), any(), any()) } coAnswers {
+                delay(100.milliseconds)
+                @Suppress("UNCHECKED_CAST")
+                val successCallback = it.invocation.args[1] as (suspend (String?) -> Unit)
+                successCallback(null)
+            }
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+            coEvery { taskDao.getTask(1L) } returns createMockTask()
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.submitTask(1L)
+            executor.shutdown()
+
+            coVerify { taskDao.successTask(1L, any()) }
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/TaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/TaskExecutorTest.kt
@@ -159,7 +159,7 @@ class TaskExecutorTest {
             coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
 
             val taskDao: TaskDao = mockk(relaxed = true)
-            coEvery { taskDao.claimRecoverableTasks(any()) } returns listOf(1L, 2L)
+            coEvery { taskDao.claimRecoverableTasks(any(), any()) } returns listOf(1L, 2L)
             coEvery { taskDao.getTask(1L) } returns createMockTask(taskId = 1L)
             coEvery { taskDao.getTask(2L) } returns createMockTask(taskId = 2L)
 
@@ -170,7 +170,7 @@ class TaskExecutorTest {
                     scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
                 )
 
-            executor.recoverPersistedTasks()
+            executor.recoverPersistedTasks(2L)
             advanceUntilIdle()
 
             coVerify { taskDao.executingTask(1L) }
@@ -183,7 +183,7 @@ class TaskExecutorTest {
     fun `recoverPersistedTasks claims at most once`() =
         runTest {
             val taskDao: TaskDao = mockk(relaxed = true)
-            coEvery { taskDao.claimRecoverableTasks(any()) } returns emptyList()
+            coEvery { taskDao.claimRecoverableTasks(any(), any()) } returns emptyList()
 
             val executor =
                 TaskExecutor(
@@ -192,11 +192,11 @@ class TaskExecutorTest {
                     scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
                 )
 
-            executor.recoverPersistedTasks()
-            executor.recoverPersistedTasks()
+            executor.recoverPersistedTasks(10L)
+            executor.recoverPersistedTasks(10L)
             advanceUntilIdle()
 
-            coVerify(exactly = 1) { taskDao.claimRecoverableTasks(any()) }
+            coVerify(exactly = 1) { taskDao.claimRecoverableTasks(any(), any()) }
 
             executor.shutdown()
         }
@@ -250,6 +250,73 @@ class TaskExecutorTest {
             executor.shutdown()
 
             coVerify { taskDao.successTask(1L, any()) }
+        }
+
+    @Test
+    fun `unknown task type is left untouched for future recovery`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+            coEvery { taskDao.getTask(1L) } returns createMockTask(taskType = 999)
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.submitTask(1L)
+            advanceUntilIdle()
+
+            // The row must keep its status: neither EXECUTING nor terminal FAILURE.
+            coVerify(exactly = 0) { taskDao.executingTask(any()) }
+            coVerify(exactly = 0) { taskDao.failureTask(any(), any(), any()) }
+
+            executor.shutdown()
+        }
+
+    @Test
+    fun `corrupt extraInfo does not kill the consumer`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+            coEvery { singleExecutor.executeTask(any(), any(), any(), any()) } coAnswers {
+                val task = it.invocation.args[0] as PasteTask
+                if (task.taskId == 1L) {
+                    throw RuntimeException("boom")
+                }
+                @Suppress("UNCHECKED_CAST")
+                val successCallback = it.invocation.args[1] as (suspend (String?) -> Unit)
+                successCallback(null)
+            }
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+            // Corrupt extraInfo makes createFailExtraInfo throw while recording
+            // the failure; that error must not cancel the consumer coroutine.
+            coEvery { taskDao.getTask(1L) } returns
+                createMockTask(taskId = 1L).copy(extraInfo = "not json")
+            coEvery { taskDao.getTask(2L) } returns createMockTask(taskId = 2L)
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.submitTask(1L)
+            advanceUntilIdle()
+            // Fallback: the failure is still recorded, without the new extraInfo.
+            coVerify { taskDao.failureTask(1L, false, null) }
+
+            executor.submitTask(2L)
+            advanceUntilIdle()
+            coVerify { taskDao.successTask(2L, any()) }
+
+            executor.shutdown()
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/TaskRecoveryTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/TaskRecoveryTest.kt
@@ -36,14 +36,6 @@ class TaskRecoveryTest {
         driverFactory.closeDriver()
     }
 
-    /**
-     * In production the claim bound is captured at next-process startup, long
-     * after the orphaned rows were written; a future bound models that without
-     * relying on the test's task creation and recovery call landing in
-     * different milliseconds.
-     */
-    private fun recoveryBound(): Long = System.currentTimeMillis() + 10000
-
     private class RecordingExecutor : SingleTypeTaskExecutor {
         val executedTaskIds = Channel<Long>(Channel.UNLIMITED)
 
@@ -82,7 +74,7 @@ class TaskRecoveryTest {
             // Simulates a crash between the task commit and the channel submit.
             val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.DELETE_PASTE_TASK)
 
-            executor.recoverPersistedTasks(recoveryBound())
+            executor.recoverPersistedTasks(taskDao.getMaxTaskId())
 
             withContext(Dispatchers.Default) {
                 withTimeout(5.seconds) {
@@ -104,7 +96,7 @@ class TaskRecoveryTest {
             val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.DELETE_PASTE_TASK)
             taskDao.executingTask(taskId)
 
-            executor.recoverPersistedTasks(recoveryBound())
+            executor.recoverPersistedTasks(taskDao.getMaxTaskId())
 
             withContext(Dispatchers.Default) {
                 withTimeout(5.seconds) {

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/TaskRecoveryTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/TaskRecoveryTest.kt
@@ -1,0 +1,134 @@
+package com.crosspaste.task
+
+import com.crosspaste.db.TestDriverFactory
+import com.crosspaste.db.createDatabase
+import com.crosspaste.db.task.PasteTask
+import com.crosspaste.db.task.SqlTaskDao
+import com.crosspaste.db.task.TaskStatus
+import com.crosspaste.db.task.TaskType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Exercises startup recovery against a real [SqlTaskDao]: tasks durably
+ * recorded by a "previous process" (rows written before the executor is
+ * asked to recover) must run to completion in the "next process".
+ */
+class TaskRecoveryTest {
+
+    private val driverFactory = TestDriverFactory()
+    private val database = createDatabase(driverFactory)
+    private val taskDao = SqlTaskDao(database)
+
+    @AfterTest
+    fun tearDown() {
+        driverFactory.closeDriver()
+    }
+
+    /**
+     * In production the claim bound is captured at next-process startup, long
+     * after the orphaned rows were written; a future bound models that without
+     * relying on the test's task creation and recovery call landing in
+     * different milliseconds.
+     */
+    private fun recoveryBound(): Long = System.currentTimeMillis() + 10000
+
+    private class RecordingExecutor : SingleTypeTaskExecutor {
+        val executedTaskIds = Channel<Long>(Channel.UNLIMITED)
+
+        override val taskType: Int = TaskType.DELETE_PASTE_TASK
+
+        override suspend fun doExecuteTask(pasteTask: PasteTask): PasteTaskResult {
+            executedTaskIds.send(pasteTask.taskId)
+            return SuccessPasteTaskResult()
+        }
+    }
+
+    private fun newExecutor(recording: RecordingExecutor): TaskExecutor =
+        TaskExecutor(
+            listOf(recording),
+            taskDao,
+            scope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+        )
+
+    private suspend fun awaitStatus(
+        taskId: Long,
+        status: Int,
+    ) {
+        withTimeout(5.seconds) {
+            while (taskDao.getTask(taskId)?.status != status) {
+                delay(10.milliseconds)
+            }
+        }
+    }
+
+    @Test
+    fun `PREPARING task committed but never submitted executes after recovery`() =
+        runTest {
+            val recording = RecordingExecutor()
+            val executor = newExecutor(recording)
+
+            // Simulates a crash between the task commit and the channel submit.
+            val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.DELETE_PASTE_TASK)
+
+            executor.recoverPersistedTasks(recoveryBound())
+
+            withContext(Dispatchers.Default) {
+                withTimeout(5.seconds) {
+                    assertEquals(taskId, recording.executedTaskIds.receive())
+                }
+                awaitStatus(taskId, TaskStatus.SUCCESS)
+            }
+
+            executor.shutdown()
+        }
+
+    @Test
+    fun `stale EXECUTING task left by an interrupted process is re-executed`() =
+        runTest {
+            val recording = RecordingExecutor()
+            val executor = newExecutor(recording)
+
+            // Simulates a crash while the task was executing.
+            val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.DELETE_PASTE_TASK)
+            taskDao.executingTask(taskId)
+
+            executor.recoverPersistedTasks(recoveryBound())
+
+            withContext(Dispatchers.Default) {
+                withTimeout(5.seconds) {
+                    assertEquals(taskId, recording.executedTaskIds.receive())
+                }
+                awaitStatus(taskId, TaskStatus.SUCCESS)
+            }
+
+            executor.shutdown()
+        }
+
+    @Test
+    fun `task submitted by an in-flight producer after shutdown stays PREPARING`() =
+        runTest {
+            val recording = RecordingExecutor()
+            val executor = newExecutor(recording)
+
+            executor.shutdown()
+
+            // Simulates a producer draining during shutdown: the row was
+            // committed and the submit must not throw or corrupt its status.
+            val taskId = taskDao.createTask(pasteDataId = 1L, taskType = TaskType.DELETE_PASTE_TASK)
+            executor.submitTask(taskId)
+
+            assertEquals(TaskStatus.PREPARING, taskDao.getTask(taskId)?.status)
+        }
+}

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/task/SqlTaskDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/task/SqlTaskDao.kt
@@ -116,6 +116,21 @@ class SqlTaskDao(
             }
         }
 
+    override suspend fun claimRecoverableTasks(createdBefore: Long): List<Long> =
+        withContext(ioDispatcher) {
+            database.transactionWithResult {
+                val taskIds =
+                    pasteTaskDatabaseQueries
+                        .getRecoverableTaskIds(createdBefore)
+                        .executeAsList()
+                pasteTaskDatabaseQueries.resetStaleExecutingTasks(
+                    now = nowEpochMilliseconds(),
+                    createdBefore = createdBefore,
+                )
+                taskIds
+            }
+        }
+
     override suspend fun cleanSuccessTask(time: Long) {
         withContext(ioDispatcher) {
             pasteTaskDatabaseQueries.cleanSuccess(time)

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/task/SqlTaskDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/task/SqlTaskDao.kt
@@ -116,17 +116,27 @@ class SqlTaskDao(
             }
         }
 
-    override suspend fun claimRecoverableTasks(createdBefore: Long): List<Long> =
+    override suspend fun getMaxTaskId(): Long =
+        withContext(ioDispatcher) {
+            pasteTaskDatabaseQueries.getMaxTaskId().executeAsOne()
+        }
+
+    override suspend fun claimRecoverableTasks(
+        maxTaskId: Long,
+        limit: Long,
+    ): List<Long> =
         withContext(ioDispatcher) {
             database.transactionWithResult {
                 val taskIds =
                     pasteTaskDatabaseQueries
-                        .getRecoverableTaskIds(createdBefore)
+                        .getRecoverableTaskIds(maxTaskId, limit)
                         .executeAsList()
-                pasteTaskDatabaseQueries.resetStaleExecutingTasks(
-                    now = nowEpochMilliseconds(),
-                    createdBefore = createdBefore,
-                )
+                if (taskIds.isNotEmpty()) {
+                    pasteTaskDatabaseQueries.resetExecutingTasks(
+                        now = nowEpochMilliseconds(),
+                        taskIds = taskIds,
+                    )
+                }
                 taskIds
             }
         }

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/task/TaskDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/task/TaskDao.kt
@@ -29,20 +29,28 @@ interface TaskDao {
 
     suspend fun getTask(taskId: Long): PasteTask?
 
+    /** The highest persisted task id, or 0 when no tasks exist. */
+    suspend fun getMaxTaskId(): Long
+
     /**
      * Atomically claims tasks a previous process left unfinished so they can be
-     * re-enqueued after startup: returns the ids of PREPARING and EXECUTING
-     * tasks created strictly before [createdBefore], resetting the EXECUTING
-     * ones back to PREPARING in the same transaction.
+     * re-enqueued after startup: returns up to [limit] ids of PREPARING and
+     * EXECUTING tasks with taskId <= [maxTaskId], resetting the claimed
+     * EXECUTING ones back to PREPARING in the same transaction. Rows beyond
+     * [limit] keep their status and are claimed on a later startup.
      *
      * Stale policy: the single-instance app lock guarantees that at startup
-     * every unfinished row older than [createdBefore] belongs to a dead
-     * process, so all of them are recoverable. [createdBefore] must be
-     * captured before any task producer of the current process starts: tasks
-     * that producers create afterwards then have createTime >= the bound and
-     * can never be claimed, so recovery cannot enqueue them twice.
+     * every unfinished row at or below [maxTaskId] belongs to a dead process,
+     * so all of them are recoverable. [maxTaskId] must be captured (via
+     * [getMaxTaskId]) before any task producer of the current process starts:
+     * task ids are monotonic (AUTOINCREMENT), so producer tasks always exceed
+     * the bound and can never be claimed — recovery cannot enqueue them twice,
+     * regardless of wall-clock changes.
      */
-    suspend fun claimRecoverableTasks(createdBefore: Long): List<Long>
+    suspend fun claimRecoverableTasks(
+        maxTaskId: Long,
+        limit: Long = 1000,
+    ): List<Long>
 
     suspend fun cleanSuccessTask(time: Long)
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/db/task/TaskDao.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/db/task/TaskDao.kt
@@ -29,6 +29,21 @@ interface TaskDao {
 
     suspend fun getTask(taskId: Long): PasteTask?
 
+    /**
+     * Atomically claims tasks a previous process left unfinished so they can be
+     * re-enqueued after startup: returns the ids of PREPARING and EXECUTING
+     * tasks created strictly before [createdBefore], resetting the EXECUTING
+     * ones back to PREPARING in the same transaction.
+     *
+     * Stale policy: the single-instance app lock guarantees that at startup
+     * every unfinished row older than [createdBefore] belongs to a dead
+     * process, so all of them are recoverable. [createdBefore] must be
+     * captured before any task producer of the current process starts: tasks
+     * that producers create afterwards then have createTime >= the bound and
+     * can never be claimed, so recovery cannot enqueue them twice.
+     */
+    suspend fun claimRecoverableTasks(createdBefore: Long): List<Long>
+
     suspend fun cleanSuccessTask(time: Long)
 
     suspend fun cleanFailureTask(time: Long)

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteTaskDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteTaskDatabase.sq
@@ -37,14 +37,18 @@ UPDATE PasteTaskEntity SET
   extraInfo = ?
 WHERE taskId = ?;
 
+getMaxTaskId:
+SELECT IFNULL(MAX(taskId), 0) AS maxTaskId FROM PasteTaskEntity;
+
 getRecoverableTaskIds:
 SELECT taskId FROM PasteTaskEntity
-WHERE status IN (0, 1) AND createTime < :createdBefore
-ORDER BY taskId;
+WHERE status IN (0, 1) AND taskId <= :maxTaskId
+ORDER BY taskId
+LIMIT :limit;
 
-resetStaleExecutingTasks:
+resetExecutingTasks:
 UPDATE PasteTaskEntity SET status = 0, modifyTime = :now
-WHERE status = 1 AND createTime < :createdBefore;
+WHERE status = 1 AND taskId IN :taskIds;
 
 cleanSuccess:
 DELETE FROM PasteTaskEntity

--- a/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteTaskDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/crosspaste/db/PasteTaskDatabase.sq
@@ -37,6 +37,15 @@ UPDATE PasteTaskEntity SET
   extraInfo = ?
 WHERE taskId = ?;
 
+getRecoverableTaskIds:
+SELECT taskId FROM PasteTaskEntity
+WHERE status IN (0, 1) AND createTime < :createdBefore
+ORDER BY taskId;
+
+resetStaleExecutingTasks:
+UPDATE PasteTaskEntity SET status = 0, modifyTime = :now
+WHERE status = 1 AND createTime < :createdBefore;
+
 cleanSuccess:
 DELETE FROM PasteTaskEntity
 WHERE status = 2 AND


### PR DESCRIPTION
Fixes #4797

## Problem

`PasteTask` rows are durable, but scheduling only lived in `TaskExecutor`'s in-memory channel. A task became permanently orphaned when:

1. the row was committed but the process died before the ID was submitted to the channel,
2. a producer was still draining during shutdown after the channel had been closed (`send` threw), or
3. execution was cancelled after the status had moved from `PREPARING` to `EXECUTING`.

On the next start nothing queried the database for unfinished work, so those rows sat there forever and the corresponding sync/delete/cleanup never completed.

## Changes

### Startup recovery

- **New DAO queries `getMaxTaskId()` + `claimRecoverableTasks(maxTaskId, limit = 1000)`** (`PasteTaskDatabase.sq`, `TaskDao`, `SqlTaskDao`): one transaction selects up to `limit` IDs of `PREPARING`/`EXECUTING` rows with `taskId <= maxTaskId` and resets the claimed `EXECUTING` ones back to `PREPARING`. Overflow rows keep their status and are claimed on a later startup, keeping recovery bounded.
  - **Stale policy**: the single-instance app lock guarantees that at startup every unfinished row at or below the bound belongs to a dead process, so all of them are recoverable. The bound is a **task-id watermark**, not wall-clock time: ids are monotonic (AUTOINCREMENT), so the guarantee is immune to system clock changes.
- **`TaskExecutor.recoverPersistedTasks(maxTaskId)`**: claims and re-enqueues, guarded to run at most once, logs the recovered count plus a capped id sample (or that there was nothing to recover) and any claim failure.
- **Startup ordering** (`CrossPaste.startApplication`): the watermark is captured **before `SyncManager.start()`**, i.e. before any task producer of the current process is live. Any task a producer creates afterwards has a larger id and can never be claimed, so double-enqueue is impossible by construction rather than by timing. Recovery itself runs right after `SyncManager.start()` / `PastePullService.init()` and before the pasteboard listener, servers, CLI, MCP and `CleanScheduler` start.
- **`GeneralSyncManager.start()` now waits (bounded, 3s) for the first device snapshot** before returning: the DB-flow collector that builds sync handlers is asynchronous, and recovery runs immediately after `start()`. Without the gate, recovered `SYNC_PASTE` tasks would see an empty handler map and complete without syncing, and recovered `PULL_FILE` tasks could burn their retries instantly (retry exhaustion deletes the incomplete paste). The wait is a local DB read (normally milliseconds); the timeout only guards a stuck flow and logs a warning.

### Task-aware shutdown

- **`TaskExecutor.shutdown()`** is now suspend: it closes the channel, drains queued and in-flight tasks for up to 2s, then cancels the scope **in a `finally`** — even when an enclosing shutdown timeout cancels the drain, task coroutines cannot outlive the closed database. Tasks still running after the drain keep their persisted status and are resumed on the next start.
- **`submitTask` uses `trySend`**: a producer racing shutdown no longer gets an exception; the row stays `PREPARING` and is recovered on the next start (with a warning log).
- **`executeTask` rethrows `CancellationException`** instead of recording a cancelled execution as terminal `FAILURE` — the row keeps its status for recovery.
- **`executeTask` failure recording is itself fault-tolerant**: `createFailExtraInfo` parses the persisted extraInfo, and a corrupt row used to throw out of the error path — cancelling the consumer coroutine and permanently stopping all task processing (and recovery would re-feed the row every start). It now falls back to recording the failure without new extraInfo, and any persistence error is logged instead of propagating.
- **Unknown task types are left untouched**: a downgraded build that sees a task type persisted by a newer version logs a warning and leaves the row `PREPARING` (previously it was flipped to `EXECUTING` and then terminal `FAILURE`), so a later upgrade can still recover it.
- **`shutdownAllServices()` is now three-phased** inside the same 5s budget: (1) stop all task producers (pasteboard, scheduler, servers, GUI services) in parallel, (2) drain `TaskExecutor`, (3) stop the services drained tasks still depend on (`SyncManager`, rendering, HTTP clients) in parallel, then close the driver. Phase 1 has its own 2s sub-budget so one slow stop (e.g. a server's grace period) cannot starve the drain and phase 3; a producer that outlives the budget can only `trySend` into a closed channel, which defers its task to recovery. `stopManagedService` rethrows `CancellationException` so an expired phase budget actually skips ahead instead of being swallowed, and the Bonjour teardown (which blocks in its own `runBlocking` for up to 4s and is not a producer) runs concurrently with all phases instead of eating a phase budget.

## Retry-idempotency review of persisted task types (acceptance item 5)

All task types already support retry (`needRetry=true` re-submits), so a restart replay is no stronger than the existing retry path:

- `SYNC_PASTE_TASK`: a restart replay has the same duplicate exposure as the existing retry path (a push whose response was lost is already retried today), and the retry ceiling (3 execution histories) still applies after recovery. The snapshot gate in `GeneralSyncManager.start()` ensures recovered tasks see the known handlers.
- `DELETE_PASTE_TASK` / `CLEAN_PASTE_TASK` / `CLEAN_TASK_TASK` / `PULL_ICON_TASK` / `OPEN_GRAPH_TASK`: idempotent (delete/cleanup of missing rows is a no-op, downloads overwrite).
- `PULL_FILE_TASK`: `PullExtraInfo` tracks progress; re-pull overwrites chunks.
- `SWITCH_LANGUAGE_TASK`: guarded by a current-language check; replay of an outdated switch is skipped.
- `DELAYED_DELETE_PASTE_TASK`: `executeAfter` is an absolute timestamp, so a recovered task re-schedules correctly (immediately if past due). Pre-existing limitation (unchanged): the task marks `SUCCESS` before the in-memory delayed delete fires, so a crash inside that window still loses the delete — tracked as a possible follow-up, not a regression of this PR.

## Acceptance criteria mapping

- Committed-but-never-submitted `PREPARING` task executes after restart → `TaskRecoveryTest`.
- Stale `EXECUTING` task follows the documented policy (reset + re-run) → `TaskRecoveryTest`, `TaskDaoTest`.
- `SUCCESS`/terminal `FAILURE` never replayed → `TaskDaoTest`.
- No double-enqueue during concurrent startup → single-run guard + claim-before-producers ordering (`TaskExecutorTest`).
- Producers stop before `TaskExecutor` on normal shutdown → phased `shutdownAllServices()`.
- Clean shutdown with an in-flight producer → `trySend` path test (`TaskRecoveryTest`, `TaskExecutorTest`).

## Known limitation (documented, unchanged behavior)

The `CancellationException` rethrow in `TaskExecutor.executeTask` protects the framework path (DB writes around execution), but individual `SingleTypeTaskExecutor` implementations that wrap their network calls in `runCatching` still swallow cancellation internally and convert it into their normal fail/retry path. That is pre-existing behavior; tightening every executor is out of scope here.

## Mobile follow-up

`shared` changed (`PasteTaskDatabase.sq` + `TaskDao`/`SqlTaskDao`: `getMaxTaskId`, `claimRecoverableTasks`) and `app/commonMain` changed (`TaskExecutor.shutdown()` is now suspend, new `recoverPersistedTasks`, `GeneralSyncManager.start()` gates on the first snapshot): mobile repos need these when syncing shared code and should wire an equivalent startup recovery call and shutdown ordering.

## Testing

- `./gradlew app:desktopTest` — full fast tier green; new suites stay in the fast tier (in-memory SQLite, virtual time; `TaskRecoveryTest` uses real dispatchers but completes in milliseconds).
- New regression coverage: bounded claim with overflow left intact, id-watermark exclusion, unknown-task-type skip, corrupt-extraInfo consumer survival, drain-then-cancel shutdown, submit-after-shutdown, and `GeneralSyncManager.start()` waiting for a delayed first snapshot (plus its bounded-timeout path).
