### PR TITLE
:bug: Harden TaskExecutor error and shutdown paths

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/TaskExecutor.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
+import kotlin.coroutines.cancellation.CancellationException
 
 class TaskExecutor(
     singleTypeTaskExecutors: List<SingleTypeTaskExecutor>,
@@ -61,19 +62,36 @@ class TaskExecutor(
                 })
             }
         }.onFailure { e ->
+            // A cancelled execution (shutdown) must not be recorded as a
+            // terminal FAILURE: rethrow so the row keeps its persisted status.
+            if (e is CancellationException) throw e
             logger.error(e) { "execute task error: $taskId" }
             currentTask?.let { task ->
-                taskDao.failureTask(taskId, false, TaskUtils.createFailExtraInfo(task, e))
+                // Failure recording must itself be fault-tolerant: an exception
+                // escaping here (e.g. corrupt extraInfo JSON in
+                // createFailExtraInfo) would cancel the consumer coroutine and
+                // permanently stop task processing for the whole session.
+                val failExtraInfo = runCatching { TaskUtils.createFailExtraInfo(task, e) }.getOrNull()
+                runCatching {
+                    taskDao.failureTask(taskId, false, failExtraInfo)
+                }.onFailure { persistError ->
+                    if (persistError is CancellationException) throw persistError
+                    logger.error(persistError) { "record task failure error: $taskId" }
+                }
             }
         }
     }
 
     suspend fun submitTask(taskId: Long) {
-        taskChannel.send(taskId)
+        if (taskChannel.trySend(taskId).isFailure) {
+            // The channel is only closed during shutdown; a producer racing it
+            // must not crash — the unfinished row just stays persisted.
+            logger.warn { "Task channel closed, dropping submission of task $taskId" }
+        }
     }
 
     suspend fun submitTasks(taskIds: List<Long>) {
-        taskIds.forEach { taskChannel.send(it) }
+        taskIds.forEach { submitTask(it) }
     }
 
     fun shutdown() {

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/TaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/TaskExecutorTest.kt
@@ -9,11 +9,13 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TaskExecutorTest {
@@ -148,6 +150,97 @@ class TaskExecutorTest {
             coVerify { taskDao.failureTask(1L, false, any()) }
 
             executor.shutdown()
+        }
+
+    @Test
+    fun `corrupt extraInfo does not kill the consumer`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+            coEvery { singleExecutor.executeTask(any(), any(), any(), any()) } coAnswers {
+                val task = it.invocation.args[0] as PasteTask
+                if (task.taskId == 1L) {
+                    throw RuntimeException("boom")
+                }
+                @Suppress("UNCHECKED_CAST")
+                val successCallback = it.invocation.args[1] as (suspend (String?) -> Unit)
+                successCallback(null)
+            }
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+            // Corrupt extraInfo makes createFailExtraInfo throw while recording
+            // the failure; that error must not cancel the consumer coroutine.
+            coEvery { taskDao.getTask(1L) } returns
+                createMockTask(taskId = 1L).copy(extraInfo = "not json")
+            coEvery { taskDao.getTask(2L) } returns createMockTask(taskId = 2L)
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.submitTask(1L)
+            advanceUntilIdle()
+            // Fallback: the failure is still recorded, without the new extraInfo.
+            coVerify { taskDao.failureTask(1L, false, null) }
+
+            executor.submitTask(2L)
+            advanceUntilIdle()
+            coVerify { taskDao.successTask(2L, any()) }
+
+            executor.shutdown()
+        }
+
+    @Test
+    fun `cancelled in-flight task is not recorded as terminal failure`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+            coEvery { singleExecutor.executeTask(any(), any(), any(), any()) } coAnswers {
+                delay(1.seconds)
+            }
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+            coEvery { taskDao.getTask(1L) } returns createMockTask()
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.submitTask(1L)
+            // Shutdown cancels the execution mid-delay.
+            executor.shutdown()
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { taskDao.failureTask(any(), any(), any()) }
+        }
+
+    @Test
+    fun `submitTask after shutdown neither throws nor touches the task`() =
+        runTest {
+            val singleExecutor: SingleTypeTaskExecutor = mockk(relaxed = true)
+            coEvery { singleExecutor.taskType } returns TaskType.DELETE_PASTE_TASK
+
+            val taskDao: TaskDao = mockk(relaxed = true)
+
+            val executor =
+                TaskExecutor(
+                    listOf(singleExecutor),
+                    taskDao,
+                    scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + SupervisorJob()),
+                )
+
+            executor.shutdown()
+            executor.submitTask(1L)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { taskDao.executingTask(any()) }
+            coVerify(exactly = 0) { taskDao.failureTask(any(), any(), any()) }
         }
 
     @Test


### PR DESCRIPTION
Fixes #4805

Three small, independent robustness fixes in `TaskExecutor` (app/commonMain), extracted from the rejected recovery PR #4804:

1. **Fault-tolerant failure recording.** `createFailExtraInfo` force-parses the persisted `extraInfo`; a corrupt row used to throw out of the error path, cancel the channel-consumer coroutine (the per-task `launch` is its structured child, so the scope's `SupervisorJob` does not protect it), and silently halt all task processing for the rest of the session. It now falls back to recording the failure with `null` extraInfo (terminal `FAILURE`, original extraInfo preserved), and any persistence error is logged instead of propagating.

2. **Cancellation is not a failure.** `executeTask` rethrows `CancellationException` instead of recording a shutdown-cancelled execution as terminal `FAILURE` — the row keeps its persisted status.

3. **No-throw submit during shutdown.** `submitTask`/`submitTasks` use `trySend`: a producer racing `shutdown()` no longer gets a `ClosedSendChannelException`; the dropped submission is logged as a warning.

No DAO/schema, startup-ordering, or shutdown-orchestration changes (deliberately — see #4804's closing comment). `app/commonMain` change only; mobile picks it up when syncing shared code, no API signature changes.

## Testing

- `./gradlew app:desktopTest` green.
- New regression tests: a corrupt-extraInfo task records a fallback failure and the next task still executes; a task cancelled mid-execution by `shutdown()` is never marked `FAILURE`; a submit after `shutdown()` neither throws nor touches the row.