### PR TITLE
:sparkles: support targeting a dev app instance via CROSSPASTE_USER_DATA_DIR and a :cli:run task

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -168,6 +168,57 @@ tasks.register("cliNativeTest") {
     hostTestTaskName?.let { dependsOn(it) }
 }
 
+// Runs the debug CLI for the host target against the dev app instance
+// (`./gradlew app:run`, whose user-data dir is app/.user) without packaging
+// a release build. Usage: ./gradlew :cli:run --args="history -n 5"
+// An explicit CROSSPASTE_USER_DATA_DIR in the caller's environment wins over
+// the app/.user default, so the task can also target other instances.
+abstract class CliRunTask : Exec() {
+    @get:Input
+    @get:org.gradle.api.tasks.options.Option(
+        option = "args",
+        description = "Arguments passed to the CLI (whitespace-separated)",
+    )
+    abstract val cliArgs: Property<String>
+
+    init {
+        cliArgs.convention("")
+    }
+}
+
+kotlin.targets
+    .withType<KotlinNativeTarget>()
+    .firstOrNull { it.konanTarget == HostManager.host }
+    ?.let { hostTarget ->
+        val debugExecutable = hostTarget.binaries.getExecutable(NativeBuildType.DEBUG)
+        tasks.register<CliRunTask>("run") {
+            group = "application"
+            description = "Runs the debug CLI against the dev app started with ./gradlew app:run."
+            dependsOn(debugExecutable.linkTaskProvider)
+            executable(debugExecutable.outputFile.absolutePath)
+            standardInput = System.`in`
+            // The CLI uses non-zero exits as part of its contract (3 = app not
+            // running, 2 = usage); don't turn those into Gradle build failures.
+            isIgnoreExitValue = true
+            if (System.getenv("CROSSPASTE_USER_DATA_DIR") == null) {
+                environment(
+                    "CROSSPASTE_USER_DATA_DIR",
+                    rootProject.layout.projectDirectory
+                        .dir("app/.user")
+                        .asFile.absolutePath,
+                )
+            }
+            doFirst {
+                args(
+                    cliArgs
+                        .get()
+                        .split(Regex("\\s+"))
+                        .filter { it.isNotEmpty() },
+                )
+            }
+        }
+    }
+
 // Collects release executables under cli/dist/<target>/crosspaste-cli(.exe),
 // the layout the packaging pipeline (Conveyor + release workflow) consumes.
 kotlin.targets.withType<KotlinNativeTarget>().forEach { target ->

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -177,12 +177,48 @@ abstract class CliRunTask : Exec() {
     @get:Input
     @get:org.gradle.api.tasks.options.Option(
         option = "args",
-        description = "Arguments passed to the CLI (whitespace-separated)",
+        description = "Arguments passed to the CLI (whitespace-separated; quote to group)",
     )
     abstract val cliArgs: Property<String>
 
     init {
         cliArgs.convention("")
+    }
+
+    companion object {
+        // Quote-aware whitespace tokenizer matching Gradle's own
+        // JavaExec.setArgsString() semantics (ArgumentsSplitter): single or
+        // double quotes group text (including embedded mid-token quoting like
+        // foo"bar baz"); an unterminated quote runs to the end of the string.
+        fun splitArgs(argsString: String): List<String> {
+            val tokens = mutableListOf<String>()
+            val current = StringBuilder()
+            var quote: Char? = null
+            var inToken = false
+            for (c in argsString) {
+                when {
+                    quote != null ->
+                        if (c == quote) quote = null else current.append(c)
+                    c == '"' || c == '\'' -> {
+                        quote = c
+                        inToken = true
+                    }
+                    c.isWhitespace() -> {
+                        if (inToken) {
+                            tokens.add(current.toString())
+                            current.setLength(0)
+                            inToken = false
+                        }
+                    }
+                    else -> {
+                        current.append(c)
+                        inToken = true
+                    }
+                }
+            }
+            if (inToken) tokens.add(current.toString())
+            return tokens
+        }
     }
 }
 
@@ -199,8 +235,10 @@ kotlin.targets
             standardInput = System.`in`
             // The CLI uses non-zero exits as part of its contract (3 = app not
             // running, 2 = usage); don't turn those into Gradle build failures.
+            // Anything else (internal error, crash, signal) still fails the
+            // build — checked in doLast below.
             isIgnoreExitValue = true
-            if (System.getenv("CROSSPASTE_USER_DATA_DIR") == null) {
+            if (System.getenv("CROSSPASTE_USER_DATA_DIR").isNullOrBlank()) {
                 environment(
                     "CROSSPASTE_USER_DATA_DIR",
                     rootProject.layout.projectDirectory
@@ -209,12 +247,13 @@ kotlin.targets
                 )
             }
             doFirst {
-                args(
-                    cliArgs
-                        .get()
-                        .split(Regex("\\s+"))
-                        .filter { it.isNotEmpty() },
-                )
+                args(CliRunTask.splitArgs(cliArgs.get()))
+            }
+            doLast {
+                val exitValue = executionResult.get().exitValue
+                if (exitValue !in setOf(0, 2, 3)) {
+                    throw GradleException("CLI exited with unexpected exit code $exitValue")
+                }
             }
         }
     }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -9,13 +9,14 @@ import com.crosspaste.cli.platform.AppLiveness
 import com.crosspaste.cli.platform.AppReadinessChecker
 import com.crosspaste.cli.platform.CliAppPathProvider
 import com.crosspaste.cli.platform.CliConfigReader
+import com.crosspaste.cli.platform.NativePlatformPathProvider
 import com.crosspaste.cli.platform.createAppLauncher
 import com.crosspaste.cli.platform.createNativePlatformPathProvider
 import com.crosspaste.cli.platform.isGuiEnvironment
+import com.crosspaste.cli.platform.userDataDirOverride
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.UsageError
-import com.github.ajalt.clikt.core.findObject
 import com.github.ajalt.clikt.core.terminal
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.runBlocking
@@ -118,6 +119,19 @@ private suspend fun CliktCommand.ensureAppRunning(readinessChecker: AppReadiness
  */
 @OptIn(ExperimentalNativeApi::class)
 private suspend fun CliktCommand.startApp(readinessChecker: AppReadinessChecker) {
+    // With the user-data dir overridden, auto-launch would start the
+    // installed app, which writes its endpoint file to the production path —
+    // the CLI would then wait forever on the overridden path. The target
+    // (usually a dev instance via `./gradlew app:run`) must be started by hand.
+    userDataDirOverride()?.let { override ->
+        echo(
+            "Error: CrossPaste is not running at $override " +
+                "(set via ${NativePlatformPathProvider.USER_DATA_DIR_ENV}). " +
+                "Start that instance yourself, e.g. './gradlew app:run' for a dev build.",
+            err = true,
+        )
+        throw ProgramResult(EXIT_CODE_APP_NOT_RUNNING)
+    }
     // No graphical session (Linux server without DISPLAY/WAYLAND_DISPLAY):
     // the same app is launched as a headless daemon instead of the GUI.
     // createAppLauncher owns that decision; headless here only picks the prompt.

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/NativePlatformPathProvider.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/NativePlatformPathProvider.kt
@@ -17,15 +17,30 @@ interface NativePlatformPathProvider {
 
     companion object {
         const val CROSSPASTE_DIR_NAME = ".crosspaste"
+
+        /**
+         * Overrides the app user-data directory the CLI targets. Meant for
+         * development: point it at a dev instance's storage (e.g. `app/.user`
+         * for `./gradlew app:run`) so the CLI finds that instance's
+         * cli-endpoint.json instead of the installed app's.
+         */
+        const val USER_DATA_DIR_ENV = "CROSSPASTE_USER_DATA_DIR"
     }
 
     fun getDefaultUserDataPath(): Path
 }
 
+fun userDataDirOverride(): String? = getEnv(NativePlatformPathProvider.USER_DATA_DIR_ENV)?.takeIf { it.isNotBlank() }
+
 @OptIn(ExperimentalNativeApi::class)
 fun createNativePlatformPathProvider(): NativePlatformPathProvider {
-    val os = Platform.osFamily
-    return when (os) {
+    userDataDirOverride()?.let { override ->
+        val path = override.toPath(normalize = true)
+        return object : NativePlatformPathProvider {
+            override fun getDefaultUserDataPath(): Path = path
+        }
+    }
+    return when (val os = Platform.osFamily) {
         OsFamily.MACOSX -> MacosNativePlatformPathProvider()
         OsFamily.LINUX -> LinuxNativePlatformPathProvider()
         OsFamily.WINDOWS -> WindowsNativePlatformPathProvider()

--- a/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/platform/UserDataDirOverrideTest.kt
+++ b/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/platform/UserDataDirOverrideTest.kt
@@ -1,0 +1,55 @@
+package com.crosspaste.cli.platform
+
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class UserDataDirOverrideTest {
+
+    private val env = NativePlatformPathProvider.USER_DATA_DIR_ENV
+
+    private fun withEnv(
+        value: String?,
+        block: () -> Unit,
+    ) {
+        if (value == null) {
+            platform.posix.unsetenv(env)
+        } else {
+            platform.posix.setenv(env, value, 1)
+        }
+        try {
+            block()
+        } finally {
+            platform.posix.unsetenv(env)
+        }
+    }
+
+    @Test
+    fun envOverrideReplacesThePlatformDefault() {
+        withEnv("/tmp/crosspaste-dev-user") {
+            assertEquals(
+                "/tmp/crosspaste-dev-user".toPath(),
+                createNativePlatformPathProvider().getDefaultUserDataPath(),
+            )
+        }
+    }
+
+    @Test
+    fun blankOverrideIsIgnored() {
+        withEnv("  ") {
+            assertNotEquals(
+                "  ".toPath(),
+                createNativePlatformPathProvider().getDefaultUserDataPath(),
+            )
+        }
+    }
+
+    @Test
+    fun withoutTheEnvThePlatformDefaultIsUsed() {
+        withEnv(null) {
+            val path = createNativePlatformPathProvider().getDefaultUserDataPath().toString()
+            assertEquals(true, path.contains("CrossPaste") || path.contains(".crosspaste"))
+        }
+    }
+}

--- a/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/platform/UserDataDirOverrideTest.kt
+++ b/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/platform/UserDataDirOverrideTest.kt
@@ -1,5 +1,7 @@
 package com.crosspaste.cli.platform
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
 import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,10 +11,12 @@ class UserDataDirOverrideTest {
 
     private val env = NativePlatformPathProvider.USER_DATA_DIR_ENV
 
+    @OptIn(ExperimentalForeignApi::class)
     private fun withEnv(
         value: String?,
         block: () -> Unit,
     ) {
+        val original = platform.posix.getenv(env)?.toKString()
         if (value == null) {
             platform.posix.unsetenv(env)
         } else {
@@ -21,7 +25,11 @@ class UserDataDirOverrideTest {
         try {
             block()
         } finally {
-            platform.posix.unsetenv(env)
+            if (original == null) {
+                platform.posix.unsetenv(env)
+            } else {
+                platform.posix.setenv(env, original, 1)
+            }
         }
     }
 

--- a/doc/en/CLI.md
+++ b/doc/en/CLI.md
@@ -224,3 +224,29 @@ crosspaste --generate-completion fish > ~/.config/fish/completions/crosspaste.fi
 ## Colors
 
 Human-readable output uses a few colors (paste types, device states, app status). Colors are automatically disabled when output is not a terminal, and the [`NO_COLOR`](https://no-color.org) environment variable is respected.
+
+## Development
+
+To test the CLI against a development app instance without packaging a release build:
+
+```sh
+# Terminal 1: start the dev app (its user-data dir is app/.user)
+./gradlew app:run
+
+# Terminal 2: run the debug CLI against it
+./gradlew :cli:run --args="history -n 5"
+```
+
+The `:cli:run` task links the host's debug executable and sets `CROSSPASTE_USER_DATA_DIR` to `app/.user`, so the CLI discovers the dev instance's `cli-endpoint.json` instead of the installed app's. An explicit `CROSSPASTE_USER_DATA_DIR` in your environment wins over the default, and the same variable also works when invoking a built CLI binary directly — useful for testing with a real TTY (colors, full terminal width):
+
+```sh
+CROSSPASTE_USER_DATA_DIR=app/.user cli/build/bin/macosArm64/debugExecutable/crosspaste-cli.kexe history
+```
+
+Output through Gradle is not a TTY, so the CLI cannot detect your window size and falls back to 79 columns. Pass the width explicitly via `COLUMNS` (the CLI honors it whenever stdout is not interactive):
+
+```sh
+COLUMNS=$(tput cols) ./gradlew :cli:run --args="history"
+```
+
+When the override is set, the CLI never offers to auto-launch the app (that would start the installed one); start the target instance yourself.

--- a/doc/zh/CLI.md
+++ b/doc/zh/CLI.md
@@ -224,3 +224,29 @@ crosspaste --generate-completion fish > ~/.config/fish/completions/crosspaste.fi
 ## 颜色
 
 人类可读输出使用少量颜色（粘贴类型、设备状态、应用状态）。输出不是终端时自动关闭颜色，并遵循 [`NO_COLOR`](https://no-color.org) 环境变量。
+
+## 开发
+
+无需打包发行版即可让 CLI 连上开发模式的应用实例：
+
+```sh
+# 终端 1：启动 dev 应用（其用户数据目录为 app/.user）
+./gradlew app:run
+
+# 终端 2：用 debug CLI 连接它
+./gradlew :cli:run --args="history -n 5"
+```
+
+`:cli:run` 任务会链接宿主平台的 debug 可执行文件，并把 `CROSSPASTE_USER_DATA_DIR` 指向 `app/.user`，因此 CLI 会发现 dev 实例的 `cli-endpoint.json` 而不是已安装应用的。环境中显式设置的 `CROSSPASTE_USER_DATA_DIR` 优先于默认值；该变量同样适用于直接运行已构建的 CLI 二进制——适合在真实 TTY 下测试（颜色、完整终端宽度）：
+
+```sh
+CROSSPASTE_USER_DATA_DIR=app/.user cli/build/bin/macosArm64/debugExecutable/crosspaste-cli.kexe history
+```
+
+经 Gradle 转发的输出不是 TTY，CLI 探测不到窗口宽度，会回退到 79 列。可通过 `COLUMNS` 显式传入宽度（stdout 非交互时 CLI 都会遵循它）：
+
+```sh
+COLUMNS=$(tput cols) ./gradlew :cli:run --args="history"
+```
+
+设置了该覆盖变量后，CLI 不会再提示自动启动应用（那会启动已安装的正式版）；请自行启动目标实例。


### PR DESCRIPTION
Closes #4808

## Summary

- New `CROSSPASTE_USER_DATA_DIR` environment variable overrides the app user-data directory the CLI targets, so it can discover a dev instance's `cli-endpoint.json` (e.g. `app/.user` for `./gradlew app:run`). The existing `appConfig.json` `storagePath` redirection keeps working relative to the overridden directory; a blank value is ignored.
- New `./gradlew :cli:run --args="history -n 5"` task links the host target's debug executable and runs it with the override preset to `app/.user`; an explicit `CROSSPASTE_USER_DATA_DIR` in the caller's environment wins over that default. The CLI's contractual non-zero exits (3 = not running, 2 = usage) are not turned into Gradle build failures.
- With the override set and the target not running, the CLI fails fast (exit 3) instead of offering to auto-launch the installed app — that app would publish its endpoint to the production path while the CLI waits forever on the overridden one.
- `doc/en/CLI.md` / `doc/zh/CLI.md` gain a Development section, including the `COLUMNS=$(tput cols)` tip for Gradle-forwarded output (the `COLUMNS` fallback itself ships in #4809).

## Test plan

- New `UserDataDirOverrideTest`: override replaces the platform default, blank override ignored, platform default used without the variable.
- `./gradlew :cli:macosArm64Test` green; mingwX64 compile clean.
- End-to-end on a real dev instance: `./gradlew app:run` + `:cli:run --args="status"` / `--args="history -n 5"` return live data; with the app stopped, the guard fails fast with the expected message; `storagePath` redirection followed correctly on a config that stores data outside the user-data dir.