### PR TITLE
:sparkles: treat piped stdin to bare crosspaste as implicit copy and add c/p/h command aliases

### DIFF
--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
@@ -11,11 +11,16 @@ import com.crosspaste.cli.commands.SearchCommand
 import com.crosspaste.cli.commands.StatusCommand
 import com.crosspaste.cli.commands.TagsCommand
 import com.crosspaste.cli.commands.VersionCommand
+import com.crosspaste.cli.commands.copyToCrossPaste
+import com.crosspaste.cli.commands.readPipedStdinOrFail
+import com.crosspaste.cli.commands.usageError
+import com.crosspaste.cli.platform.readAllStdin
 import com.github.ajalt.clikt.completion.completionOption
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.obj
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.switch
@@ -31,12 +36,29 @@ import kotlin.experimental.ExperimentalNativeApi
 internal val cliCommandName: String =
     if (Platform.osFamily == OsFamily.WINDOWS) "crosspaste-cli" else "crosspaste"
 
-class CrossPasteCommand : CliktCommand(name = cliCommandName) {
+class CrossPasteCommand(
+    /** Injectable so tests of the implicit-copy path never touch real stdin. */
+    private val stdinReader: () -> String = ::readAllStdin,
+) : CliktCommand(name = cliCommandName) {
 
-    override fun help(context: Context): String = "CrossPaste CLI - interact with your local CrossPaste application"
+    /** Lets a bare invocation with piped stdin behave as `copy`. */
+    override val invokeWithoutSubcommand: Boolean get() = true
+
+    override fun aliases(): Map<String, List<String>> =
+        mapOf(
+            "c" to listOf("copy"),
+            "p" to listOf("paste"),
+            "h" to listOf("history"),
+        )
+
+    override fun help(context: Context): String =
+        "CrossPaste CLI - interact with your local CrossPaste application. " +
+            "When input is piped and no command is given, behaves as `copy`: " +
+            "`git log | $cliCommandName` copies the log."
 
     override fun helpEpilog(context: Context): String =
-        "Exit codes: 0 success, 1 error, 2 usage error, 3 CrossPaste not running."
+        "Command aliases: c = copy, p = paste, h = history.\n\n" +
+            "Exit codes: 0 success, 1 error, 2 usage error, 3 CrossPaste not running."
 
     val json by option("--json", help = "Output in JSON format for machine consumption").flag()
 
@@ -51,7 +73,15 @@ class CrossPasteCommand : CliktCommand(name = cliCommandName) {
     )
 
     override fun run() {
-        currentContext.obj = CliContext(json = json, autoStart = autoStart)
+        val cliContext = CliContext(json = json, autoStart = autoStart)
+        currentContext.obj = cliContext
+        if (currentContext.invokedSubcommand != null) return
+        // No subcommand: piped stdin means an implicit `copy`; an interactive
+        // terminal keeps the pre-invokeWithoutSubcommand usage-error behavior
+        if (terminal.terminalInfo.inputInteractive) {
+            throw usageError("missing command (pipe input via stdin to copy it without one)")
+        }
+        copyToCrossPaste(readPipedStdinOrFail(stdinReader), jsonOutput = cliContext.json)
     }
 
     init {

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CopyCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CopyCommand.kt
@@ -38,33 +38,49 @@ class CopyCommand(
 
     override fun run() {
         val content = text ?: readPipedStdin()
-        runCli { client ->
-            val body = cliJson.encodeToString(CopyRequest.serializer(), CopyRequest(content))
-            val response = client.postBody("/cli/copy", body, CopyResponse.serializer())
-            if (ctx?.json == true) {
-                echo(cliJson.encodeToString(CopyResponse.serializer(), response))
-            } else {
-                // "to CrossPaste", not "to clipboard": a headless daemon has no
-                // system clipboard — the paste is stored in history and synced
-                echo("Copied to CrossPaste (id=${response.id}).")
-            }
-        }
+        copyToCrossPaste(content, jsonOutput = ctx?.json == true)
     }
 
     private fun readPipedStdin(): String {
         if (terminal.terminalInfo.inputInteractive) {
             throw usageError("provide text as an argument, or pipe it via stdin")
         }
-        val content =
-            try {
-                stdinReader()
-            } catch (e: StdinException) {
-                echo("Error: ${e.message}", err = true)
-                throw ProgramResult(1)
-            }
-        if (content.isEmpty()) {
-            throw usageError("stdin was empty; nothing to copy")
+        return readPipedStdinOrFail(stdinReader)
+    }
+}
+
+/**
+ * Reads all of piped stdin, mapping read failures to exit code 1 and empty
+ * input to a usage error. Shared between `copy` and the root command's
+ * implicit copy; callers must have checked that stdin is not interactive.
+ */
+internal fun CliktCommand.readPipedStdinOrFail(stdinReader: () -> String): String {
+    val content =
+        try {
+            stdinReader()
+        } catch (e: StdinException) {
+            echo("Error: ${e.message}", err = true)
+            throw ProgramResult(1)
         }
-        return content
+    if (content.isEmpty()) {
+        throw usageError("stdin was empty; nothing to copy")
+    }
+    return content
+}
+
+internal fun CliktCommand.copyToCrossPaste(
+    content: String,
+    jsonOutput: Boolean,
+) {
+    runCli { client ->
+        val body = cliJson.encodeToString(CopyRequest.serializer(), CopyRequest(content))
+        val response = client.postBody("/cli/copy", body, CopyResponse.serializer())
+        if (jsonOutput) {
+            echo(cliJson.encodeToString(CopyResponse.serializer(), response))
+        } else {
+            // "to CrossPaste", not "to clipboard": a headless daemon has no
+            // system clipboard — the paste is stored in history and synced
+            echo("Copied to CrossPaste (id=${response.id}).")
+        }
     }
 }

--- a/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/RootCommandTest.kt
+++ b/cli/src/posixNativeTest/kotlin/com/crosspaste/cli/RootCommandTest.kt
@@ -1,0 +1,107 @@
+package com.crosspaste.cli
+
+import com.github.ajalt.clikt.testing.test
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.FileSystem
+import platform.posix.setenv
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the root command's no-subcommand behavior: piped stdin is an implicit
+ * `copy`, an interactive terminal still gets a usage error (never a blocking
+ * stdin read), and the single-letter aliases route to their commands.
+ * A fake stdin reader keeps tests off the process's real stdin.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class RootCommandTest {
+
+    private fun isolatedHome() {
+        val dir =
+            FileSystem.SYSTEM_TEMPORARY_DIRECTORY
+                .resolve("cli-root-command-test-${Random.nextBits(31)}")
+        FileSystem.SYSTEM.createDirectories(dir)
+        setenv("HOME", dir.toString(), 1)
+    }
+
+    @Test
+    fun pipedStdinWithNoCommandBehavesAsCopy() {
+        isolatedHome()
+        var stdinRead = false
+        val result =
+            CrossPasteCommand(stdinReader = {
+                stdinRead = true
+                "piped text"
+            }).test("", inputInteractive = false)
+        // stdin was consumed, then the (not running) app check failed with 3 —
+        // the same path CopyStdinTest pins for an explicit `copy`
+        assertTrue(stdinRead, "piped stdin must be read as an implicit copy")
+        assertEquals(3, result.statusCode)
+        assertContains(result.stderr, "CrossPaste is not running")
+    }
+
+    @Test
+    fun interactiveTerminalWithNoCommandIsAUsageErrorAndNeverReadsStdin() {
+        isolatedHome()
+        var stdinRead = false
+        val result =
+            CrossPasteCommand(stdinReader = {
+                stdinRead = true
+                "unused"
+            }).test("", inputInteractive = true)
+        assertFalse(stdinRead, "must not block reading an interactive stdin")
+        assertContains(result.stderr, "missing command")
+    }
+
+    @Test
+    fun emptyPipedStdinWithNoCommandIsAUsageError() {
+        isolatedHome()
+        val result = CrossPasteCommand(stdinReader = { "" }).test("", inputInteractive = false)
+        assertContains(result.stderr, "stdin was empty")
+    }
+
+    @Test
+    fun aliasCRoutesToCopy() {
+        isolatedHome()
+        var stdinRead = false
+        val result =
+            CrossPasteCommand(stdinReader = {
+                stdinRead = true
+                "unused"
+            }).test("c \"some text\"", inputInteractive = false)
+        // The argument satisfies copy, so stdin stays untouched and the
+        // command proceeds to the liveness check (app not running → 3)
+        assertFalse(stdinRead)
+        assertEquals(3, result.statusCode)
+        assertContains(result.stderr, "CrossPaste is not running")
+    }
+
+    @Test
+    fun aliasPRoutesToPaste() {
+        isolatedHome()
+        val result = CrossPasteCommand().test("p", inputInteractive = false)
+        assertEquals(3, result.statusCode)
+        assertContains(result.stderr, "CrossPaste is not running")
+    }
+
+    @Test
+    fun aliasHRoutesToHistory() {
+        isolatedHome()
+        val result = CrossPasteCommand().test("h", inputInteractive = false)
+        assertEquals(3, result.statusCode)
+        assertContains(result.stderr, "CrossPaste is not running")
+    }
+
+    @Test
+    fun unknownCommandIsStillAUsageError() {
+        isolatedHome()
+        val result = CrossPasteCommand().test("frobnicate", inputInteractive = false)
+        // Must fail at parse time, not fall through to the implicit copy
+        assertContains(result.stderr, "frobnicate")
+        assertEquals(1, result.statusCode)
+    }
+}

--- a/doc/en/CLI.md
+++ b/doc/en/CLI.md
@@ -39,6 +39,8 @@ The examples below use `crosspaste`; on Windows substitute `crosspaste-cli`.
 | `tags` | Manage paste tags (`create`, `delete`). |
 | `version` | Show the CLI version. |
 
+The most common commands have single-letter aliases: `c` = `copy`, `p` = `paste`, `h` = `history`.
+
 Global options:
 
 - `--json` — machine-readable JSON output for any command.
@@ -50,11 +52,12 @@ Run `crosspaste --help` or `crosspaste <command> --help` for the full reference.
 
 The CLI is built to compose with other tools. Prompts and progress messages go to stderr, so stdout stays clean for pipes.
 
-Copy from a pipe:
+Copy from a pipe — when input is piped and no command is given, the CLI behaves as `copy`, so the command name can be dropped entirely:
 
 ```sh
-git log -1 --format=%H | crosspaste copy
-cat notes.md | crosspaste copy
+git log -1 --format=%H | crosspaste
+cat notes.md | crosspaste
+history | grep test | crosspaste copy   # the explicit form works the same
 ```
 
 Print only the paste content (no decoration), for piping onward. `--raw` reproduces the content exactly as stored — HTML/RTF pastes print their source markup; `--summary` prints the plain-text rendering instead:

--- a/doc/zh/CLI.md
+++ b/doc/zh/CLI.md
@@ -39,6 +39,8 @@ CLI 二进制随所有桌面安装包一起分发，各平台的差异只在于�
 | `tags` | 管理粘贴标签（`create`、`delete`）。 |
 | `version` | 显示 CLI 版本。 |
 
+最常用的命令有单字母别名：`c` = `copy`、`p` = `paste`、`h` = `history`。
+
 全局选项：
 
 - `--json` — 任意命令输出机器可读的 JSON。
@@ -50,11 +52,12 @@ CLI 二进制随所有桌面安装包一起分发，各平台的差异只在于�
 
 CLI 为组合其他工具而设计。询问与进度信息都输出到 stderr，stdout 始终保持纯净、可安全接入管道。
 
-从管道复制：
+从管道复制——当输入来自管道且未指定命令时，CLI 直接按 `copy` 处理，命令名可以完全省略：
 
 ```sh
-git log -1 --format=%H | crosspaste copy
-cat notes.md | crosspaste copy
+git log -1 --format=%H | crosspaste
+cat notes.md | crosspaste
+history | grep test | crosspaste copy   # 显式写法效果相同
 ```
 
 仅输出粘贴内容本体（无任何装饰），供后续管道使用。`--raw` 按存储原样输出——HTML/RTF 输出源码；`--summary` 则输出纯文本摘要：


### PR DESCRIPTION
Closes #4811

## Summary

- A bare `crosspaste` with piped (non-interactive) stdin now behaves as `copy`: `history | grep test | crosspaste` stores the pipeline output. Implemented via Clikt's `invokeWithoutSubcommand`; the root command checks `invokedSubcommand == null` and dispatches to the shared copy path.
- On an interactive terminal a bare `crosspaste` keeps its previous contract: usage error + help, exit code 2, and stdin is never read (no hang).
- Single-letter aliases via Clikt `aliases()`: `c` = `copy`, `p` = `paste`, `h` = `history`; documented in the help epilog and in `doc/{en,zh}/CLI.md`. `s` is intentionally not aliased (`search` vs `status` ambiguity).
- The copy logic (`readPipedStdinOrFail`, `copyToCrossPaste`) is extracted from `CopyCommand` and shared with the root command, so error handling (empty stdin → usage error, read failure → exit 1, size limit) is identical in both entry points.

## Tests

- New `RootCommandTest` (posixNativeTest, injected fake stdin reader, isolated `HOME`): piped stdin routes to copy and proceeds to the liveness check; interactive terminal gets a usage error without reading stdin; empty piped stdin is a usage error; each alias routes to its command; unknown commands still fail at parse time and never fall through to the implicit copy.
- `./gradlew :cli:macosArm64Test` passes (existing `CopyStdinTest` / `CliExitCodeTest` unchanged and green).

## Manual verification (real binary against a running app)

- `echo test | crosspaste-cli.kexe` → `Copied to CrossPaste (id=…)`, exit 0; `p --summary` returned the same content; paste deleted afterwards.
- `crosspaste-cli.kexe </dev/null` → `stdin was empty`, exit 2.
- `crosspaste-cli.kexe frobnicate` → `no such subcommand`, exit 2.
- `--help` shows the implicit-copy description and the alias epilog.