### PR TITLE
:sparkles: add a watch command streaming new pastes over an NDJSON feed

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -724,32 +724,43 @@ private suspend fun streamWatchEvents(
         }
     try {
         var tracker: CliWatchTracker? = null
-        pasteDao.getPasteDataFlow(WATCH_WINDOW_LIMIT).collect { rows ->
-            val current = tracker
-            if (current == null) {
-                // The first snapshot is the pre-subscription history baseline
-                tracker = CliWatchTracker(rows, WATCH_WINDOW_LIMIT.toInt())
-                return@collect
-            }
-            val arrived =
-                current.onWindow(rows).filter { row ->
-                    matchesWatchFilters(row, filters, pasteTagDao)
+        // The DAO flow only ever completes after swallowing a transient DB
+        // error (its catch emits an empty snapshot and ends). Resubscribe with
+        // the tracker intact — resetting it would replay the whole window as
+        // fresh arrivals — instead of ending the client's stream over a blip.
+        // The delay keeps a persistently broken DB from turning this into a
+        // busy loop.
+        while (true) {
+            pasteDao.getPasteDataFlow(WATCH_WINDOW_LIMIT).collect { rows ->
+                val current = tracker
+                if (current == null) {
+                    // The first snapshot is the pre-subscription history baseline
+                    tracker = CliWatchTracker(rows, WATCH_WINDOW_LIMIT.toInt())
+                    return@collect
                 }
-            if (arrived.isEmpty()) return@collect
-            writeMutex.withLock {
-                for (row in arrived) {
-                    val dto = row.toSummaryDto(pasteTagDao, pasteDataHelper)
-                    channel.writeStringUtf8(
-                        watchLineJson.encodeToString(CliPasteSummaryDto.serializer(), dto) + "\n",
-                    )
+                val arrived =
+                    current.onWindow(rows).filter { row ->
+                        matchesWatchFilters(row, filters, pasteTagDao)
+                    }
+                if (arrived.isEmpty()) return@collect
+                writeMutex.withLock {
+                    for (row in arrived) {
+                        val dto = row.toSummaryDto(pasteTagDao, pasteDataHelper)
+                        channel.writeStringUtf8(
+                            watchLineJson.encodeToString(CliPasteSummaryDto.serializer(), dto) + "\n",
+                        )
+                    }
+                    channel.flush()
                 }
-                channel.flush()
             }
+            delay(WATCH_RESUBSCRIBE_DELAY)
         }
     } finally {
         heartbeat.cancel()
     }
 }
+
+private val WATCH_RESUBSCRIBE_DELAY = 1.seconds
 
 private suspend fun matchesWatchFilters(
     row: PasteData,

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -29,6 +29,13 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -36,6 +43,7 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.longOrNull
+import kotlin.time.Duration.Companion.seconds
 
 private val configJson = Json { encodeDefaults = true }
 
@@ -106,6 +114,15 @@ fun Routing.cliRouting(
             handleList(
                 call = call,
                 searchContentService = searchContentService,
+                pasteDao = pasteDao,
+                pasteDataHelper = pasteDataHelper,
+                pasteTagDao = pasteTagDao,
+            )
+        }
+
+        get("/watch") {
+            handleWatch(
+                call = call,
                 pasteDao = pasteDao,
                 pasteDataHelper = pasteDataHelper,
                 pasteTagDao = pasteTagDao,
@@ -564,29 +581,7 @@ private suspend fun handleList(
             ?.toIntOrNull()
             ?.coerceIn(1, 1000)
             ?: DEFAULT_LIST_LIMIT
-    // The type parameter repeats for OR-matching: type=text&type=link
-    val pasteTypeList =
-        call.request.queryParameters
-            .getAll("type")
-            .orEmpty()
-            .map { name ->
-                PasteType.TYPES.firstOrNull { it.name.equals(name, ignoreCase = true) }?.type
-                    ?: run {
-                        call.respond(HttpStatusCode.BadRequest, CliMessageDto("Unknown paste type: '$name'."))
-                        return
-                    }
-            }
-    val tagName = call.request.queryParameters["tag"]
-    val tagId =
-        tagName?.let { name ->
-            withContext(ioDispatcher) { pasteTagDao.getAllTagsBlock() }
-                .firstOrNull { it.name.equals(name, ignoreCase = true) }
-                ?.id
-                ?: run {
-                    call.respond(HttpStatusCode.BadRequest, CliMessageDto("Unknown tag: '$name'."))
-                    return
-                }
-        }
+    val filters = parseListFilters(call, pasteTagDao) ?: return
     val sortParam = call.request.queryParameters["sort"]
     val sortNewestFirst =
         when (sortParam?.lowercase()) {
@@ -606,9 +601,9 @@ private suspend fun handleList(
     val results =
         pasteDao.searchPasteData(
             searchTerms = searchTerms,
-            pasteTypeList = pasteTypeList,
+            pasteTypeList = filters.pasteTypeList,
             sort = sortNewestFirst,
-            tag = tagId,
+            tag = filters.tagId,
             limit = limit,
         )
     call.respond(
@@ -624,6 +619,149 @@ private const val SORT_NEWEST = "newest"
 private const val SORT_OLDEST = "oldest"
 
 private const val DEFAULT_LIST_LIMIT = 20
+
+/** Shared ?type=&tag= filters of the list and watch endpoints. */
+private class ListFilters(
+    /** Resolved [PasteType] codes; empty means all types. */
+    val pasteTypeList: List<Int>,
+    /** Resolved tag id; null when no tag filter was given. */
+    val tagId: Long?,
+)
+
+/**
+ * Parses the repeated `type` and single `tag` query parameters. Returns null
+ * after responding 400 when a value does not resolve.
+ */
+private suspend fun parseListFilters(
+    call: ApplicationCall,
+    pasteTagDao: PasteTagDao,
+): ListFilters? {
+    // The type parameter repeats for OR-matching: type=text&type=link
+    val pasteTypeList =
+        call.request.queryParameters
+            .getAll("type")
+            .orEmpty()
+            .map { name ->
+                PasteType.TYPES.firstOrNull { it.name.equals(name, ignoreCase = true) }?.type
+                    ?: run {
+                        call.respond(HttpStatusCode.BadRequest, CliMessageDto("Unknown paste type: '$name'."))
+                        return null
+                    }
+            }
+    val tagName = call.request.queryParameters["tag"]
+    val tagId =
+        tagName?.let { name ->
+            withContext(ioDispatcher) { pasteTagDao.getAllTagsBlock() }
+                .firstOrNull { it.name.equals(name, ignoreCase = true) }
+                ?.id
+                ?: run {
+                    call.respond(HttpStatusCode.BadRequest, CliMessageDto("Unknown tag: '$name'."))
+                    return null
+                }
+        }
+    return ListFilters(pasteTypeList, tagId)
+}
+
+/** How many newest rows the watch diff window covers per snapshot. */
+private const val WATCH_WINDOW_LIMIT = 100L
+
+/**
+ * Keeps idle connections visibly alive: the client treats a long silence as a
+ * broken socket, and the periodic write also keeps the server's idle-connection
+ * reaper away. Must stay well below the CLI's read-silence budget.
+ */
+private val WATCH_HEARTBEAT_INTERVAL = 10.seconds
+
+private val watchLineJson = Json { encodeDefaults = true }
+
+/**
+ * Streams newly arriving pastes (local captures, CLI copies, re-copies, and
+ * entries synced from remote devices) as NDJSON: one [CliPasteSummaryDto] per
+ * line, with a blank line as heartbeat. Existing history is never replayed —
+ * the stream starts at "now". The source of truth is the same SQLDelight
+ * query flow the UI observes, diffed by [CliWatchTracker], so the stream is a
+ * best-effort live feed, not a durable queue: a burst larger than the diff
+ * window between two snapshots can drop events.
+ */
+private suspend fun handleWatch(
+    call: ApplicationCall,
+    pasteDao: PasteDao,
+    pasteDataHelper: PasteDataHelper,
+    pasteTagDao: PasteTagDao,
+) {
+    val filters = parseListFilters(call, pasteTagDao) ?: return
+    call.respondBytesWriter(contentType = ContentType("application", "x-ndjson")) {
+        try {
+            streamWatchEvents(this, filters, pasteDao, pasteDataHelper, pasteTagDao)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // The stream body is writes plus DAO reads that already swallow
+            // their own errors, so a failure here means the client went away;
+            // letting it escape would only make StatusPages try to respond on
+            // a committed response
+        }
+    }
+}
+
+private suspend fun streamWatchEvents(
+    channel: ByteWriteChannel,
+    filters: ListFilters,
+    pasteDao: PasteDao,
+    pasteDataHelper: PasteDataHelper,
+    pasteTagDao: PasteTagDao,
+) = coroutineScope {
+    val writeMutex = Mutex()
+    val heartbeat =
+        launch {
+            while (true) {
+                delay(WATCH_HEARTBEAT_INTERVAL)
+                writeMutex.withLock {
+                    channel.writeStringUtf8("\n")
+                    channel.flush()
+                }
+            }
+        }
+    try {
+        var tracker: CliWatchTracker? = null
+        pasteDao.getPasteDataFlow(WATCH_WINDOW_LIMIT).collect { rows ->
+            val current = tracker
+            if (current == null) {
+                // The first snapshot is the pre-subscription history baseline
+                tracker = CliWatchTracker(rows, WATCH_WINDOW_LIMIT.toInt())
+                return@collect
+            }
+            val arrived =
+                current.onWindow(rows).filter { row ->
+                    matchesWatchFilters(row, filters, pasteTagDao)
+                }
+            if (arrived.isEmpty()) return@collect
+            writeMutex.withLock {
+                for (row in arrived) {
+                    val dto = row.toSummaryDto(pasteTagDao, pasteDataHelper)
+                    channel.writeStringUtf8(
+                        watchLineJson.encodeToString(CliPasteSummaryDto.serializer(), dto) + "\n",
+                    )
+                }
+                channel.flush()
+            }
+        }
+    } finally {
+        heartbeat.cancel()
+    }
+}
+
+private suspend fun matchesWatchFilters(
+    row: PasteData,
+    filters: ListFilters,
+    pasteTagDao: PasteTagDao,
+): Boolean {
+    if (filters.pasteTypeList.isNotEmpty() && row.pasteType !in filters.pasteTypeList) {
+        return false
+    }
+    val tagId = filters.tagId ?: return true
+    return withContext(ioDispatcher) { pasteTagDao.getPasteTagsBlock(row.id) }.contains(tagId)
+}
 
 private suspend fun PasteData.toSummaryDto(
     pasteTagDao: PasteTagDao,

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -24,6 +24,7 @@ import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.getFileUtils
 import com.crosspaste.utils.ioDispatcher
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
@@ -43,6 +44,7 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.longOrNull
+import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
 private val configJson = Json { encodeDefaults = true }
@@ -695,14 +697,22 @@ private suspend fun handleWatch(
             streamWatchEvents(this, filters, pasteDao, pasteDataHelper, pasteTagDao)
         } catch (e: CancellationException) {
             throw e
-        } catch (_: Exception) {
-            // The stream body is writes plus DAO reads that already swallow
-            // their own errors, so a failure here means the client went away;
-            // letting it escape would only make StatusPages try to respond on
-            // a committed response
+        } catch (e: Exception) {
+            // Ending the stream is all that can be done either way — the
+            // response is already committed, so letting the exception escape
+            // would only make StatusPages fail on a second respond. A closed
+            // channel just means the client went away; anything else (tag
+            // lookup, serialization) is a real error and must be visible.
+            if (e is IOException || e is ClosedWriteChannelException) {
+                watchLogger.debug { "CLI watch client disconnected: ${e.message}" }
+            } else {
+                watchLogger.error(e) { "CLI watch stream failed" }
+            }
         }
     }
 }
+
+private val watchLogger = KotlinLogging.logger("com.crosspaste.cli.CliWatch")
 
 private suspend fun streamWatchEvents(
     channel: ByteWriteChannel,
@@ -734,22 +744,29 @@ private suspend fun streamWatchEvents(
             pasteDao.getPasteDataFlow(WATCH_WINDOW_LIMIT).collect { rows ->
                 val current = tracker
                 if (current == null) {
-                    // The first snapshot is the pre-subscription history baseline
+                    // The first snapshot is the pre-subscription history
+                    // baseline. An empty snapshot is ambiguous: it is either a
+                    // genuinely empty history or the DAO flow masking a failed
+                    // query. Building a baseline from the latter would replay
+                    // the whole window as arrivals once the DB recovers, so an
+                    // empty snapshot may only seed the baseline when the count
+                    // confirms the history really is empty.
+                    if (rows.isEmpty() && pasteDao.getActiveCount() > 0L) {
+                        return@collect
+                    }
                     tracker = CliWatchTracker(rows, WATCH_WINDOW_LIMIT.toInt())
                     return@collect
                 }
-                val arrived =
-                    current.onWindow(rows).filter { row ->
-                        matchesWatchFilters(row, filters, pasteTagDao)
+                // Filtering, tag lookups and JSON encoding all happen before
+                // taking the write lock, which exists only to keep event
+                // writes and heartbeats from interleaving
+                val lines =
+                    current.onWindow(rows).mapNotNull { row ->
+                        encodeWatchEvent(row, filters, pasteTagDao, pasteDataHelper)
                     }
-                if (arrived.isEmpty()) return@collect
+                if (lines.isEmpty()) return@collect
                 writeMutex.withLock {
-                    for (row in arrived) {
-                        val dto = row.toSummaryDto(pasteTagDao, pasteDataHelper)
-                        channel.writeStringUtf8(
-                            watchLineJson.encodeToString(CliPasteSummaryDto.serializer(), dto) + "\n",
-                        )
-                    }
+                    lines.forEach { channel.writeStringUtf8(it) }
                     channel.flush()
                 }
             }
@@ -762,20 +779,35 @@ private suspend fun streamWatchEvents(
 
 private val WATCH_RESUBSCRIBE_DELAY = 1.seconds
 
-private suspend fun matchesWatchFilters(
+/** Applies the type/tag filters and returns the NDJSON line, or null when filtered out. */
+private suspend fun encodeWatchEvent(
     row: PasteData,
     filters: ListFilters,
     pasteTagDao: PasteTagDao,
-): Boolean {
+    pasteDataHelper: PasteDataHelper,
+): String? {
     if (filters.pasteTypeList.isNotEmpty() && row.pasteType !in filters.pasteTypeList) {
-        return false
+        return null
     }
-    val tagId = filters.tagId ?: return true
-    return withContext(ioDispatcher) { pasteTagDao.getPasteTagsBlock(row.id) }.contains(tagId)
+    val tagIds = withContext(ioDispatcher) { pasteTagDao.getPasteTagsBlock(row.id) }
+    if (filters.tagId != null && filters.tagId !in tagIds) {
+        return null
+    }
+    val dto = row.toSummaryDto(tagged = tagIds.isNotEmpty(), pasteDataHelper = pasteDataHelper)
+    return watchLineJson.encodeToString(CliPasteSummaryDto.serializer(), dto) + "\n"
 }
 
 private suspend fun PasteData.toSummaryDto(
     pasteTagDao: PasteTagDao,
+    pasteDataHelper: PasteDataHelper,
+): CliPasteSummaryDto =
+    toSummaryDto(
+        tagged = withContext(ioDispatcher) { pasteTagDao.getPasteTagsBlock(id).isNotEmpty() },
+        pasteDataHelper = pasteDataHelper,
+    )
+
+private fun PasteData.toSummaryDto(
+    tagged: Boolean,
     pasteDataHelper: PasteDataHelper,
 ): CliPasteSummaryDto =
     CliPasteSummaryDto(
@@ -783,7 +815,7 @@ private suspend fun PasteData.toSummaryDto(
         typeName = getTypeName(),
         source = source,
         size = size,
-        tagged = withContext(ioDispatcher) { pasteTagDao.getPasteTagsBlock(id).isNotEmpty() },
+        tagged = tagged,
         createTime = createTime,
         preview = pasteDataHelper.getSummary(this, "Loading...", ""),
         remote = remote,

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -732,6 +732,14 @@ private suspend fun streamWatchEvents(
                 }
             }
         }
+    // Sampled BEFORE subscribing so the count and the snapshots cannot
+    // disagree about a paste created in between: with the count at zero here,
+    // anything created afterwards shows up in a snapshot, never behind one.
+    // Sampling inside the collect instead would race — a paste created between
+    // an honestly empty first snapshot and the count query would make the
+    // count read > 0, the empty snapshot look like a masked failure, and the
+    // next snapshot (carrying that first paste) get swallowed as baseline.
+    val activeCountAtConnect = pasteDao.getActiveCount()
     try {
         var tracker: CliWatchTracker? = null
         // The DAO flow only ever completes after swallowing a transient DB
@@ -749,9 +757,13 @@ private suspend fun streamWatchEvents(
                     // genuinely empty history or the DAO flow masking a failed
                     // query. Building a baseline from the latter would replay
                     // the whole window as arrivals once the DB recovers, so an
-                    // empty snapshot may only seed the baseline when the count
-                    // confirms the history really is empty.
-                    if (rows.isEmpty() && pasteDao.getActiveCount() > 0L) {
+                    // empty snapshot may only seed the baseline when the
+                    // connect-time count confirms the history really is empty.
+                    // (Accepted residue: a history that is fully deleted
+                    // between the count and the first snapshot makes the next
+                    // non-empty snapshot seed the baseline silently — a
+                    // one-time swallow in a vanishingly rare sequence.)
+                    if (rows.isEmpty() && activeCountAtConnect > 0L) {
                         return@collect
                     }
                     tracker = CliWatchTracker(rows, WATCH_WINDOW_LIMIT.toInt())

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliWatchTracker.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliWatchTracker.kt
@@ -19,10 +19,14 @@ import com.crosspaste.paste.PasteState
  * still in flight, so they are reported once they finish.
  *
  * The window is a top-N by createTime, so deleting newer rows can slide an
- * old, never-seen row back into view. Such rows carry a createTime at or
- * below the baseline floor and are silently adopted instead of reported.
+ * old, never-seen row back into view. Such rows are silently adopted instead
+ * of reported — recognized by a createTime at or below the baseline floor AND
+ * an id at or below the baseline maximum. The id condition matters because
+ * ids are insertion-ordered while createTime is not trustworthy as an arrival
+ * signal on its own: a paste synced from a device with a lagging clock can
+ * carry an old createTime, but its locally assigned id is always new.
  * Seen-row state is kept for the lifetime of the subscription (a few dozen
- * bytes per distinct row) — pruning would reopen that same hole.
+ * bytes per distinct row) — pruning would reopen the slide-back hole.
  */
 class CliWatchTracker(
     baseline: List<PasteData>,
@@ -44,6 +48,8 @@ class CliWatchTracker(
             baseline.minOf { it.createTime }
         }
 
+    private val baselineMaxId: Long = baseline.maxOfOrNull { it.id } ?: Long.MIN_VALUE
+
     init {
         for (row in baseline) {
             known[row.id] = KnownRow(row.createTime, reported = row.pasteState == PasteState.LOADED)
@@ -62,8 +68,9 @@ class CliWatchTracker(
             when {
                 knownRow == null -> {
                     // Old rows sliding back into the window after deletions
-                    // are pre-subscription history, not arrivals
-                    val preexisting = row.createTime <= baselineFloor
+                    // are pre-subscription history, not arrivals; the id bound
+                    // keeps lagging-clock remote arrivals out of this bucket
+                    val preexisting = row.createTime <= baselineFloor && row.id <= baselineMaxId
                     val report = loaded && !preexisting
                     known[row.id] = KnownRow(row.createTime, reported = report || preexisting)
                     if (report) arrived += row

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliWatchTracker.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliWatchTracker.kt
@@ -1,0 +1,88 @@
+package com.crosspaste.cli
+
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteState
+
+/**
+ * Diffs successive snapshots of the newest-first paste window (as emitted by
+ * `PasteDao.getPasteDataFlow`) into a stream of "newly arrived" rows for the
+ * `/cli/watch` endpoint.
+ *
+ * A row counts as arrived when it becomes LOADED with a createTime the tracker
+ * has not reported yet. That covers all three arrival shapes:
+ * - a fresh capture (local, remote-synced, or CLI copy) entering the window,
+ * - a LOADING row observed earlier finishing its release,
+ * - an existing row re-copied (its createTime is bumped to now).
+ *
+ * Rows already LOADED in the first snapshot are the pre-subscription history
+ * and are never replayed; LOADING rows in the first snapshot are captures
+ * still in flight, so they are reported once they finish.
+ *
+ * The window is a top-N by createTime, so deleting newer rows can slide an
+ * old, never-seen row back into view. Such rows carry a createTime at or
+ * below the baseline floor and are silently adopted instead of reported.
+ * Seen-row state is kept for the lifetime of the subscription (a few dozen
+ * bytes per distinct row) — pruning would reopen that same hole.
+ */
+class CliWatchTracker(
+    baseline: List<PasteData>,
+    windowLimit: Int,
+) {
+    private class KnownRow(
+        var createTime: Long,
+        var reported: Boolean,
+    )
+
+    private val known = mutableMapOf<Long, KnownRow>()
+
+    // With a non-full baseline window every existing row was observed, so any
+    // unknown id is genuinely new regardless of its createTime
+    private val baselineFloor: Long =
+        if (baseline.size < windowLimit) {
+            Long.MIN_VALUE
+        } else {
+            baseline.minOf { it.createTime }
+        }
+
+    init {
+        for (row in baseline) {
+            known[row.id] = KnownRow(row.createTime, reported = row.pasteState == PasteState.LOADED)
+        }
+    }
+
+    /**
+     * Returns the rows that newly arrived in this snapshot, oldest first
+     * (the window itself is newest first).
+     */
+    fun onWindow(rows: List<PasteData>): List<PasteData> {
+        val arrived = mutableListOf<PasteData>()
+        for (row in rows.asReversed()) {
+            val loaded = row.pasteState == PasteState.LOADED
+            val knownRow = known[row.id]
+            when {
+                knownRow == null -> {
+                    // Old rows sliding back into the window after deletions
+                    // are pre-subscription history, not arrivals
+                    val preexisting = row.createTime <= baselineFloor
+                    val report = loaded && !preexisting
+                    known[row.id] = KnownRow(row.createTime, reported = report || preexisting)
+                    if (report) arrived += row
+                }
+
+                row.createTime > knownRow.createTime -> {
+                    // A re-copy bumps createTime: that is new clipboard
+                    // activity even though the row itself is old
+                    knownRow.createTime = row.createTime
+                    knownRow.reported = loaded
+                    if (loaded) arrived += row
+                }
+
+                !knownRow.reported && loaded -> {
+                    knownRow.reported = true
+                    arrived += row
+                }
+            }
+        }
+        return arrived
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -897,6 +897,53 @@ class CliRoutingTest {
     }
 
     @Test
+    fun `watch never builds its baseline from a masked query failure`() {
+        val fixture = Fixture()
+        // The DAO flow masks a failed query as an empty snapshot and completes;
+        // the history itself has rows, so that snapshot must not seed the
+        // baseline — otherwise the recovered window would replay as arrivals
+        coEvery { fixture.pasteDao.getActiveCount() } returns 2L
+        val history =
+            listOf(
+                textPasteData(2L, "history-b", createTime = 200L),
+                textPasteData(1L, "history-a", createTime = 100L),
+            )
+        val arrival = textPasteData(3L, "fresh", createTime = 300L)
+        every { fixture.pasteDao.getPasteDataFlow(any()) } returnsMany
+            listOf(
+                flowOf(listOf()),
+                flowOf(history, listOf(arrival) + history),
+            )
+
+        withCliRouting(fixture) {
+            client.prepareGet("/cli/watch").execute { response ->
+                val channel = response.bodyAsChannel()
+                // Only the post-recovery arrival may appear, never the history
+                val line = readEventLine(channel, timeout = 5.seconds)
+                assertTrue(line != null, "expected the post-recovery arrival")
+                assertEquals(3L, json.decodeFromString<CliPasteSummaryDto>(line).id)
+                assertEquals(null, readEventLine(channel, timeout = 300.milliseconds))
+            }
+        }
+    }
+
+    @Test
+    fun `watch accepts an empty baseline when the history really is empty`() {
+        val fixture = Fixture()
+        val arrival = textPasteData(1L, "first-ever", createTime = 100L)
+        every { fixture.pasteDao.getPasteDataFlow(any()) } returns
+            flowOf(listOf(), listOf(arrival))
+
+        withCliRouting(fixture) {
+            client.prepareGet("/cli/watch").execute { response ->
+                val line = readEventLine(response.bodyAsChannel())
+                assertTrue(line != null, "expected the first-ever paste as an arrival")
+                assertEquals(1L, json.decodeFromString<CliPasteSummaryDto>(line).id)
+            }
+        }
+    }
+
+    @Test
     fun `watch type filter drops non-matching arrivals`() {
         val fixture = Fixture()
         val baseline = listOf(textPasteData(1L, "old", createTime = 100L))

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -39,6 +39,7 @@ import io.ktor.utils.io.*
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -940,6 +941,14 @@ class CliRoutingTest {
                 assertTrue(line != null, "expected the first-ever paste as an arrival")
                 assertEquals(1L, json.decodeFromString<CliPasteSummaryDto>(line).id)
             }
+        }
+        // The count must be sampled BEFORE the snapshot subscription: sampled
+        // inside the collect it would race with a paste created right after an
+        // honestly empty first snapshot (count > 0 → snapshot misread as a
+        // masked failure → that first paste swallowed as the baseline)
+        coVerifyOrder {
+            fixture.pasteDao.getActiveCount()
+            fixture.pasteDao.getPasteDataFlow(any())
         }
     }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -35,6 +35,7 @@ import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
+import io.ktor.utils.io.*
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -44,6 +45,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -53,6 +55,9 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class CliRoutingTest {
 
@@ -845,6 +850,24 @@ class CliRoutingTest {
         }
     }
 
+    /**
+     * Reads the next non-blank (non-heartbeat) event line, or null when
+     * [timeout] elapses first. The watch response never completes on its own
+     * (the handler resubscribes to the DAO flow), so tests read the body
+     * incrementally instead of waiting for it to end.
+     */
+    private suspend fun readEventLine(
+        channel: ByteReadChannel,
+        timeout: Duration = 2.seconds,
+    ): String? =
+        withTimeoutOrNull(timeout) {
+            var line = channel.readLine()
+            while (line != null && line.isEmpty()) {
+                line = channel.readLine()
+            }
+            line
+        }
+
     @Test
     fun `watch streams arrivals after the baseline as ndjson lines`() {
         val fixture = Fixture()
@@ -854,17 +877,22 @@ class CliRoutingTest {
             flowOf(baseline, listOf(arrival) + baseline)
 
         withCliRouting(fixture) {
-            val response = client.get("/cli/watch")
-            assertEquals(HttpStatusCode.OK, response.status)
-            assertEquals(
-                "application/x-ndjson",
-                response.contentType()?.let { "${it.contentType}/${it.contentSubtype}" },
-            )
-            val lines = response.bodyAsText().lines().filter { it.isNotBlank() }
-            assertEquals(1, lines.size)
-            val dto = json.decodeFromString<CliPasteSummaryDto>(lines[0])
-            assertEquals(2L, dto.id)
-            assertEquals("fresh", dto.preview)
+            client.prepareGet("/cli/watch").execute { response ->
+                assertEquals(HttpStatusCode.OK, response.status)
+                assertEquals(
+                    "application/x-ndjson",
+                    response.contentType()?.let { "${it.contentType}/${it.contentSubtype}" },
+                )
+                val channel = response.bodyAsChannel()
+                val line = readEventLine(channel)
+                assertTrue(line != null, "expected an arrival event line")
+                val dto = json.decodeFromString<CliPasteSummaryDto>(line)
+                assertEquals(2L, dto.id)
+                assertEquals("fresh", dto.preview)
+                // The tracker survives DAO flow resubscription, so replaying
+                // the same snapshots must not produce duplicate events
+                assertEquals(null, readEventLine(channel, timeout = 300.milliseconds))
+            }
         }
     }
 
@@ -877,8 +905,9 @@ class CliRoutingTest {
             flowOf(baseline, listOf(arrival) + baseline)
 
         withCliRouting(fixture) {
-            val body = client.get("/cli/watch?type=link").bodyAsText()
-            assertTrue(body.lines().none { it.isNotBlank() })
+            client.prepareGet("/cli/watch?type=link").execute { response ->
+                assertEquals(null, readEventLine(response.bodyAsChannel(), timeout = 300.milliseconds))
+            }
         }
     }
 
@@ -911,14 +940,14 @@ class CliRoutingTest {
         every { fixture.pasteTagDao.getPasteTagsBlock(3L) } returns listOf()
 
         withCliRouting(fixture) {
-            val lines =
-                client
-                    .get("/cli/watch?tag=work")
-                    .bodyAsText()
-                    .lines()
-                    .filter { it.isNotBlank() }
-            assertEquals(1, lines.size)
-            assertEquals(2L, json.decodeFromString<CliPasteSummaryDto>(lines[0]).id)
+            client.prepareGet("/cli/watch?tag=work").execute { response ->
+                val channel = response.bodyAsChannel()
+                val line = readEventLine(channel)
+                assertTrue(line != null, "expected the tagged arrival")
+                assertEquals(2L, json.decodeFromString<CliPasteSummaryDto>(line).id)
+                // The untagged arrival must have been filtered out
+                assertEquals(null, readEventLine(channel, timeout = 300.milliseconds))
+            }
         }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -43,6 +43,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -155,6 +156,7 @@ class CliRoutingTest {
     private fun textPasteData(
         id: Long,
         text: String,
+        createTime: Long = 123L,
     ): PasteData {
         val item = createTextPasteItem(text = text)
         return PasteData(
@@ -166,7 +168,7 @@ class CliRoutingTest {
             source = "Test",
             size = item.size,
             hash = item.hash,
-            createTime = 123L,
+            createTime = createTime,
             pasteState = PasteState.LOADED,
         )
     }
@@ -840,6 +842,83 @@ class CliRoutingTest {
 
             assertEquals(HttpStatusCode.OK, cancel("session-1").status)
             assertEquals(HttpStatusCode.NotFound, cancel("gone").status)
+        }
+    }
+
+    @Test
+    fun `watch streams arrivals after the baseline as ndjson lines`() {
+        val fixture = Fixture()
+        val baseline = listOf(textPasteData(1L, "old", createTime = 100L))
+        val arrival = textPasteData(2L, "fresh", createTime = 200L)
+        every { fixture.pasteDao.getPasteDataFlow(any()) } returns
+            flowOf(baseline, listOf(arrival) + baseline)
+
+        withCliRouting(fixture) {
+            val response = client.get("/cli/watch")
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(
+                "application/x-ndjson",
+                response.contentType()?.let { "${it.contentType}/${it.contentSubtype}" },
+            )
+            val lines = response.bodyAsText().lines().filter { it.isNotBlank() }
+            assertEquals(1, lines.size)
+            val dto = json.decodeFromString<CliPasteSummaryDto>(lines[0])
+            assertEquals(2L, dto.id)
+            assertEquals("fresh", dto.preview)
+        }
+    }
+
+    @Test
+    fun `watch type filter drops non-matching arrivals`() {
+        val fixture = Fixture()
+        val baseline = listOf(textPasteData(1L, "old", createTime = 100L))
+        val arrival = textPasteData(2L, "fresh", createTime = 200L)
+        every { fixture.pasteDao.getPasteDataFlow(any()) } returns
+            flowOf(baseline, listOf(arrival) + baseline)
+
+        withCliRouting(fixture) {
+            val body = client.get("/cli/watch?type=link").bodyAsText()
+            assertTrue(body.lines().none { it.isNotBlank() })
+        }
+    }
+
+    @Test
+    fun `watch rejects unknown type and tag before streaming`() {
+        val fixture = Fixture()
+
+        withCliRouting(fixture) {
+            val badType = client.get("/cli/watch?type=bogus")
+            assertEquals(HttpStatusCode.BadRequest, badType.status)
+            assertContains(badType.bodyAsText(), "Unknown paste type")
+
+            val badTag = client.get("/cli/watch?tag=missing")
+            assertEquals(HttpStatusCode.BadRequest, badTag.status)
+            assertContains(badTag.bodyAsText(), "Unknown tag")
+        }
+    }
+
+    @Test
+    fun `watch tag filter only passes tagged arrivals`() {
+        val fixture = Fixture()
+        val baseline = listOf(textPasteData(1L, "old", createTime = 100L))
+        val tagged = textPasteData(2L, "tagged", createTime = 200L)
+        val untagged = textPasteData(3L, "untagged", createTime = 300L)
+        every { fixture.pasteDao.getPasteDataFlow(any()) } returns
+            flowOf(baseline, listOf(untagged, tagged) + baseline)
+        every { fixture.pasteTagDao.getAllTagsBlock() } returns
+            listOf(PasteTag(id = 9L, name = "work", color = 0L, sortOrder = 0L))
+        every { fixture.pasteTagDao.getPasteTagsBlock(2L) } returns listOf(9L)
+        every { fixture.pasteTagDao.getPasteTagsBlock(3L) } returns listOf()
+
+        withCliRouting(fixture) {
+            val lines =
+                client
+                    .get("/cli/watch?tag=work")
+                    .bodyAsText()
+                    .lines()
+                    .filter { it.isNotBlank() }
+            assertEquals(1, lines.size)
+            assertEquals(2L, json.decodeFromString<CliPasteSummaryDto>(lines[0]).id)
         }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliWatchTrackerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliWatchTrackerTest.kt
@@ -1,0 +1,144 @@
+package com.crosspaste.cli
+
+import com.crosspaste.paste.PasteCollection
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteState
+import com.crosspaste.paste.PasteType
+import com.crosspaste.paste.item.CreatePasteItemHelper.createTextPasteItem
+import com.crosspaste.utils.getJsonUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CliWatchTrackerTest {
+
+    // Guard against PasteItem/JsonUtils circular class initialization
+    private val jsonUtils = getJsonUtils()
+
+    private companion object {
+        const val WINDOW_LIMIT = 3
+    }
+
+    private fun row(
+        id: Long,
+        createTime: Long,
+        pasteState: Int = PasteState.LOADED,
+    ): PasteData {
+        val item = createTextPasteItem(text = "paste-$id")
+        return PasteData(
+            id = id,
+            appInstanceId = "test-instance",
+            pasteAppearItem = item,
+            pasteCollection = PasteCollection(listOf()),
+            pasteType = PasteType.TEXT_TYPE.type,
+            source = "Test",
+            size = item.size,
+            hash = item.hash,
+            createTime = createTime,
+            pasteState = pasteState,
+        )
+    }
+
+    /** Newest-first, as the DAO window query orders. */
+    private fun window(vararg rows: PasteData): List<PasteData> =
+        rows
+            .sortedWith(
+                compareByDescending<PasteData> {
+                    it.createTime
+                }.thenByDescending { it.id },
+            ).take(WINDOW_LIMIT)
+
+    @Test
+    fun `baseline rows are never replayed`() {
+        val baseline = window(row(1, 100), row(2, 200))
+        val tracker = CliWatchTracker(baseline, WINDOW_LIMIT)
+
+        assertTrue(tracker.onWindow(baseline).isEmpty())
+    }
+
+    @Test
+    fun `a new loaded row arrives exactly once`() {
+        val tracker = CliWatchTracker(window(row(1, 100)), WINDOW_LIMIT)
+
+        val snapshot = window(row(1, 100), row(2, 200))
+        assertEquals(listOf(2L), tracker.onWindow(snapshot).map { it.id })
+        assertTrue(tracker.onWindow(snapshot).isEmpty())
+    }
+
+    @Test
+    fun `multiple arrivals come oldest first`() {
+        val tracker = CliWatchTracker(window(row(1, 100)), WINDOW_LIMIT)
+
+        val snapshot = window(row(1, 100), row(2, 200), row(3, 300))
+        assertEquals(listOf(2L, 3L), tracker.onWindow(snapshot).map { it.id })
+    }
+
+    @Test
+    fun `a loading row arrives only when it finishes loading`() {
+        val tracker = CliWatchTracker(window(row(1, 100)), WINDOW_LIMIT)
+
+        val loading = window(row(1, 100), row(2, 200, PasteState.LOADING))
+        assertTrue(tracker.onWindow(loading).isEmpty())
+
+        val loaded = window(row(1, 100), row(2, 200))
+        assertEquals(listOf(2L), tracker.onWindow(loaded).map { it.id })
+    }
+
+    @Test
+    fun `a loading baseline row arrives when it finishes loading`() {
+        val baseline = window(row(1, 100), row(2, 200, PasteState.LOADING))
+        val tracker = CliWatchTracker(baseline, WINDOW_LIMIT)
+
+        val loaded = window(row(1, 100), row(2, 200))
+        assertEquals(listOf(2L), tracker.onWindow(loaded).map { it.id })
+        assertTrue(tracker.onWindow(loaded).isEmpty())
+    }
+
+    @Test
+    fun `a re-copy createTime bump arrives again`() {
+        val tracker = CliWatchTracker(window(row(1, 100), row(2, 200)), WINDOW_LIMIT)
+
+        val snapshot = window(row(1, 300), row(2, 200))
+        assertEquals(listOf(1L), tracker.onWindow(snapshot).map { it.id })
+        assertTrue(tracker.onWindow(snapshot).isEmpty())
+    }
+
+    @Test
+    fun `an old row sliding back into a full window is not an arrival`() {
+        // Full baseline window: rows below its floor exist but are unseen
+        val baseline = window(row(2, 200), row(3, 300), row(4, 400))
+        assertEquals(WINDOW_LIMIT, baseline.size)
+        val tracker = CliWatchTracker(baseline, WINDOW_LIMIT)
+
+        // Deleting row 4 slides pre-subscription row 1 back into view
+        val snapshot = window(row(1, 100), row(2, 200), row(3, 300))
+        assertTrue(tracker.onWindow(snapshot).isEmpty())
+    }
+
+    @Test
+    fun `an unseen row is an arrival when the baseline window was not full`() {
+        // A non-full baseline saw every existing row, so there is no floor
+        val tracker = CliWatchTracker(window(row(5, 500)), WINDOW_LIMIT)
+
+        val snapshot = window(row(1, 100), row(5, 500))
+        assertEquals(listOf(1L), tracker.onWindow(snapshot).map { it.id })
+    }
+
+    @Test
+    fun `a deleted row simply disappears`() {
+        val tracker = CliWatchTracker(window(row(1, 100), row(2, 200)), WINDOW_LIMIT)
+
+        assertTrue(tracker.onWindow(window(row(1, 100))).isEmpty())
+    }
+
+    @Test
+    fun `a re-copied slid-back row does arrive`() {
+        val baseline = window(row(2, 200), row(3, 300), row(4, 400))
+        val tracker = CliWatchTracker(baseline, WINDOW_LIMIT)
+
+        // Row 1 slides back in (adopted silently), then gets re-copied
+        tracker.onWindow(window(row(1, 100), row(2, 200), row(3, 300)))
+        val snapshot = window(row(1, 500), row(2, 200), row(3, 300))
+        assertEquals(listOf(1L), tracker.onWindow(snapshot).map { it.id })
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliWatchTrackerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliWatchTrackerTest.kt
@@ -132,6 +132,18 @@ class CliWatchTrackerTest {
     }
 
     @Test
+    fun `a lagging-clock remote arrival with an old createTime still arrives`() {
+        val baseline = window(row(2, 200), row(3, 300), row(4, 400))
+        val tracker = CliWatchTracker(baseline, WINDOW_LIMIT)
+
+        // Row 4 is deleted and a remote device with a lagging clock syncs a
+        // genuinely new paste: its createTime sits below the baseline floor,
+        // but its locally assigned id is newer than anything in the baseline
+        val snapshot = window(row(9, 150), row(2, 200), row(3, 300))
+        assertEquals(listOf(9L), tracker.onWindow(snapshot).map { it.id })
+    }
+
+    @Test
     fun `a re-copied slid-back row does arrive`() {
         val baseline = window(row(2, 200), row(3, 300), row(4, 400))
         val tracker = CliWatchTracker(baseline, WINDOW_LIMIT)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/CrossPasteCommand.kt
@@ -12,6 +12,7 @@ import com.crosspaste.cli.commands.PickCommand
 import com.crosspaste.cli.commands.StatusCommand
 import com.crosspaste.cli.commands.TagsCommand
 import com.crosspaste.cli.commands.VersionCommand
+import com.crosspaste.cli.commands.WatchCommand
 import com.crosspaste.cli.commands.copyToCrossPaste
 import com.crosspaste.cli.commands.readPipedStdinOrFail
 import com.crosspaste.cli.commands.usageError
@@ -100,6 +101,7 @@ class CrossPasteCommand(
             ConfigCommand(),
             TagsCommand(),
             VersionCommand(),
+            WatchCommand(),
         )
     }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/api/CliClient.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/api/CliClient.kt
@@ -3,10 +3,12 @@ package com.crosspaste.cli.api
 import com.crosspaste.cli.platform.CliConfigReader
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.network.sockets.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.Serializable
@@ -21,6 +23,13 @@ const val CLI_API_VERSION = 1
 
 /** Default per-request timeout; long-running pair calls override it per call. */
 internal const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 5000L
+
+/**
+ * How long a watch stream may stay silent before the connection counts as
+ * broken. The server heartbeats every 10s, so three missed beats end the read
+ * instead of blocking forever on a wedged peer.
+ */
+internal const val STREAM_SILENCE_TIMEOUT_MILLIS = 30_000L
 
 /**
  * Mirror of the app's CliEndpoint (see design D5): the app atomically writes
@@ -122,6 +131,59 @@ class CliClient(
     ): T = decode(delete(path), deserializer)
 
     suspend fun get(path: String): HttpResponse = request(HttpMethod.Get, path)
+
+    /**
+     * Opens a long-lived streaming GET (the /cli/watch NDJSON feed) and hands
+     * each non-blank line to [onLine]; blank lines are server heartbeats.
+     *
+     * This never returns normally: the feed only ends when the app goes away,
+     * so end-of-stream — like a connect failure or a silence past
+     * [STREAM_SILENCE_TIMEOUT_MILLIS] — surfaces as [AppNotRunningException],
+     * which runCli answers with its usual probe-and-retry sequence. An error
+     * status on the initial response is a [CliClientException] as elsewhere.
+     */
+    suspend fun streamLines(
+        path: String,
+        onLine: suspend (String) -> Unit,
+    ) {
+        try {
+            httpClient
+                .prepareRequest("http://localhost$path") {
+                    method = HttpMethod.Get
+                    unixSocket(endpoint.socketPath)
+                    timeout {
+                        requestTimeoutMillis = HttpTimeoutConfig.INFINITE_TIMEOUT_MS
+                        socketTimeoutMillis = STREAM_SILENCE_TIMEOUT_MILLIS
+                    }
+                }.execute { response ->
+                    if (!response.status.isSuccess()) {
+                        val serverMessage = extractMessage(response.bodyAsText())
+                        throw CliClientException(
+                            serverMessage ?: "Request failed with status ${response.status}",
+                            statusCode = response.status.value,
+                            hasServerMessage = serverMessage != null,
+                        )
+                    }
+                    val body = response.bodyAsChannel()
+                    while (true) {
+                        val line = body.readLine() ?: break
+                        if (line.isNotEmpty()) {
+                            onLine(line)
+                        }
+                    }
+                }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: CliClientException) {
+            throw e
+        } catch (e: Exception) {
+            if (isAppUnreachable(e) || e is SocketTimeoutException) {
+                throw AppNotRunningException()
+            }
+            throw CliClientException("Stream failed: ${e.message}", e)
+        }
+        throw AppNotRunningException()
+    }
 
     suspend fun post(
         path: String,

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -22,6 +22,8 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlin.experimental.ExperimentalNativeApi
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 /** Scripts can rely on this exit code to mean "CrossPaste is not running". */
 const val EXIT_CODE_APP_NOT_RUNNING = 3
@@ -51,7 +53,12 @@ val cliJson =
  *
  * If the app goes away mid-command, the connection failure means the request
  * never reached it, so after re-running the liveness sequence the command is
- * retried once.
+ * retried once. The retry budget is time-aware: an attempt that ran for at
+ * least [RETRY_BUDGET_RESET_THRESHOLD] before failing counts as a fresh
+ * failure and earns a new retry. That lets a long-lived stream (`watch`)
+ * survive any number of app restarts spread over hours, while a rapid
+ * crash loop still exhausts the budget after one retry — important with
+ * --start, which would otherwise relaunch a crashing app forever.
  */
 fun CliktCommand.runCli(block: suspend (CliClient) -> Unit) {
     runBlocking {
@@ -62,6 +69,7 @@ fun CliktCommand.runCli(block: suspend (CliClient) -> Unit) {
         var versionWarningShown = false
         while (true) {
             var client: CliClient? = null
+            val attemptStart = TimeSource.Monotonic.markNow()
             try {
                 client = CliClient(configReader)
                 if (!versionWarningShown) {
@@ -72,6 +80,9 @@ fun CliktCommand.runCli(block: suspend (CliClient) -> Unit) {
             } catch (e: ProgramResult) {
                 throw e
             } catch (e: AppNotRunningException) {
+                if (attemptStart.elapsedNow() >= RETRY_BUDGET_RESET_THRESHOLD) {
+                    retriedAfterRestart = false
+                }
                 if (retriedAfterRestart) {
                     echo("Error: ${e.message}", err = true)
                     throw ProgramResult(EXIT_CODE_APP_NOT_RUNNING)
@@ -87,6 +98,12 @@ fun CliktCommand.runCli(block: suspend (CliClient) -> Unit) {
         }
     }
 }
+
+/**
+ * An attempt that survived this long was genuinely connected, not bouncing
+ * off a dead socket; its eventual failure resets the single-retry budget.
+ */
+private val RETRY_BUDGET_RESET_THRESHOLD = 30.seconds
 
 /**
  * D5 unified pre-flight: running → proceed; starting (endpoint file present,

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -53,14 +53,20 @@ val cliJson =
  *
  * If the app goes away mid-command, the connection failure means the request
  * never reached it, so after re-running the liveness sequence the command is
- * retried once. The retry budget is time-aware: an attempt that ran for at
- * least [RETRY_BUDGET_RESET_THRESHOLD] before failing counts as a fresh
- * failure and earns a new retry. That lets a long-lived stream (`watch`)
- * survive any number of app restarts spread over hours, while a rapid
- * crash loop still exhausts the budget after one retry — important with
- * --start, which would otherwise relaunch a crashing app forever.
+ * retried once.
+ *
+ * With [persistentReconnect] (long-lived streaming commands: `watch`) the
+ * retry budget is time-aware instead: an attempt that ran for at least
+ * [RETRY_BUDGET_RESET_THRESHOLD] before failing counts as a fresh failure and
+ * earns a new retry. That lets the stream survive any number of app restarts
+ * spread over hours, while a rapid crash loop still exhausts the budget after
+ * one retry — important with --start, which would otherwise relaunch a
+ * crashing app forever. One-shot commands keep the plain single retry.
  */
-fun CliktCommand.runCli(block: suspend (CliClient) -> Unit) {
+fun CliktCommand.runCli(
+    persistentReconnect: Boolean = false,
+    block: suspend (CliClient) -> Unit,
+) {
     runBlocking {
         val configReader = CliConfigReader(createNativePlatformPathProvider())
         val readinessChecker = AppReadinessChecker(configReader)
@@ -80,7 +86,7 @@ fun CliktCommand.runCli(block: suspend (CliClient) -> Unit) {
             } catch (e: ProgramResult) {
                 throw e
             } catch (e: AppNotRunningException) {
-                if (attemptStart.elapsedNow() >= RETRY_BUDGET_RESET_THRESHOLD) {
+                if (persistentReconnect && attemptStart.elapsedNow() >= RETRY_BUDGET_RESET_THRESHOLD) {
                     retriedAfterRestart = false
                 }
                 if (retriedAfterRestart) {

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/WatchCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/WatchCommand.kt
@@ -92,24 +92,23 @@ class WatchCommand : CliktCommand(name = "watch") {
         line: String,
         format: WatchFormat,
     ) {
-        when (format) {
-            // Pass the server's compact JSON through untouched: kotlinx
-            // escapes control characters inside JSON strings, so the line is
-            // terminal-safe as-is and re-encoding could only lose fidelity
-            WatchFormat.JSON -> println(line)
-            WatchFormat.ID, WatchFormat.LINE -> {
-                val item =
-                    runCatching {
-                        cliJson.decodeFromString(PasteSummaryDto.serializer(), line)
-                    }.getOrElse {
-                        echo("Warning: skipped an unparseable watch event.", err = true)
-                        return
-                    }
-                when (format) {
-                    WatchFormat.ID -> println(item.id)
-                    else -> println(collapsePreviewWhitespace(item.preview))
-                }
+        // Every mode validates the line first, so a final line truncated by a
+        // hard disconnect is warned about and skipped instead of feeding half
+        // a JSON object to the pipe downstream
+        val item =
+            runCatching {
+                cliJson.decodeFromString(PasteSummaryDto.serializer(), line)
+            }.getOrElse {
+                echo("Warning: skipped an unparseable watch event.", err = true)
+                return
             }
+        when (format) {
+            // The validated line is passed through untouched: kotlinx escapes
+            // control characters inside JSON strings, so it is terminal-safe
+            // as-is, and re-encoding would drop fields this CLI predates
+            WatchFormat.JSON -> println(line)
+            WatchFormat.ID -> println(item.id)
+            WatchFormat.LINE -> println(collapsePreviewWhitespace(item.preview))
         }
         // Events must reach a pipe as they happen, not when the CRT buffer
         // fills; stdlib print instead of Mordant keeps non-TTY output verbatim

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/WatchCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/WatchCommand.kt
@@ -1,0 +1,118 @@
+package com.crosspaste.cli.commands
+
+import com.crosspaste.cli.CliContext
+import com.crosspaste.cli.api.CliClientException
+import com.crosspaste.cli.platform.flushStdout
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.choice
+import io.ktor.http.*
+
+enum class WatchFormat { LINE, JSON, ID }
+
+/** An explicit --format wins; the global --json flag implies json; else line. */
+internal fun resolveWatchFormat(
+    explicit: WatchFormat?,
+    json: Boolean,
+): WatchFormat = explicit ?: if (json) WatchFormat.JSON else WatchFormat.LINE
+
+internal fun buildWatchQuery(
+    types: List<String>,
+    tag: String?,
+): String {
+    val params =
+        buildList {
+            types.forEach { add("type=${it.encodeURLParameter()}") }
+            tag?.let { add("tag=${it.encodeURLParameter()}") }
+        }
+    return if (params.isEmpty()) "" else params.joinToString("&", prefix = "?")
+}
+
+class WatchCommand : CliktCommand(name = "watch") {
+
+    override fun help(context: Context): String =
+        "Stream new pastes as they arrive, including entries synced from other devices. " +
+            "Runs until interrupted; existing history is not replayed."
+
+    override fun helpEpilog(context: Context): String =
+        "The default output is one sanitized line per paste (its text content; " +
+            "for links, the URL), ready for pipes: " +
+            "`watch --type link | xargs -n1 open`. Use --format json for the full " +
+            "metadata as one JSON object per line, or --format id with " +
+            "`paste --raw` to fetch exact bytes."
+
+    private val ctx by requireObject<CliContext>()
+
+    private val types by option(
+        "--type",
+        "-t",
+        help = "Only stream these types (text, link, image, file, html, rtf, color); repeat for several",
+    ).multiple()
+
+    private val tag by option("--tag", "-g", help = "Only stream pastes carrying this tag")
+
+    private val format by option(
+        "--format",
+        help =
+            "Output format: line (default, one sanitized content line per paste), " +
+                "json (one JSON object per line), or id (one paste ID per line)",
+    ).choice(
+        "line" to WatchFormat.LINE,
+        "json" to WatchFormat.JSON,
+        "id" to WatchFormat.ID,
+    )
+
+    override fun run() =
+        runCli { client ->
+            val resolvedFormat = resolveWatchFormat(format, ctx.json)
+            try {
+                client.streamLines("/cli/watch${buildWatchQuery(types, tag)}") { line ->
+                    emitEvent(line, resolvedFormat)
+                }
+            } catch (e: CliClientException) {
+                // A 404 with no server message means the route itself is
+                // missing: the running app predates the watch endpoint
+                if (e.statusCode == 404 && !e.hasServerMessage) {
+                    echo(
+                        "Error: the running CrossPaste app does not support 'watch'; " +
+                            "please update the app.",
+                        err = true,
+                    )
+                    throw ProgramResult(1)
+                }
+                throw e
+            }
+        }
+
+    private fun emitEvent(
+        line: String,
+        format: WatchFormat,
+    ) {
+        when (format) {
+            // Pass the server's compact JSON through untouched: kotlinx
+            // escapes control characters inside JSON strings, so the line is
+            // terminal-safe as-is and re-encoding could only lose fidelity
+            WatchFormat.JSON -> println(line)
+            WatchFormat.ID, WatchFormat.LINE -> {
+                val item =
+                    runCatching {
+                        cliJson.decodeFromString(PasteSummaryDto.serializer(), line)
+                    }.getOrElse {
+                        echo("Warning: skipped an unparseable watch event.", err = true)
+                        return
+                    }
+                when (format) {
+                    WatchFormat.ID -> println(item.id)
+                    else -> println(collapsePreviewWhitespace(item.preview))
+                }
+            }
+        }
+        // Events must reach a pipe as they happen, not when the CRT buffer
+        // fills; stdlib print instead of Mordant keeps non-TTY output verbatim
+        flushStdout()
+    }
+}

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/WatchCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/WatchCommand.kt
@@ -67,7 +67,7 @@ class WatchCommand : CliktCommand(name = "watch") {
     )
 
     override fun run() =
-        runCli { client ->
+        runCli(persistentReconnect = true) { client ->
             val resolvedFormat = resolveWatchFormat(format, ctx.json)
             try {
                 client.streamLines("/cli/watch${buildWatchQuery(types, tag)}") { line ->

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/WatchQueryTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/WatchQueryTest.kt
@@ -1,0 +1,43 @@
+package com.crosspaste.cli.commands
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WatchQueryTest {
+
+    @Test
+    fun buildsEmptyQueryWithoutFilters() {
+        assertEquals("", buildWatchQuery(types = listOf(), tag = null))
+    }
+
+    @Test
+    fun repeatsTypeParameterForOrMatching() {
+        assertEquals(
+            "?type=text&type=link",
+            buildWatchQuery(types = listOf("text", "link"), tag = null),
+        )
+    }
+
+    @Test
+    fun encodesTagValues() {
+        assertEquals(
+            "?tag=work%20notes",
+            buildWatchQuery(types = listOf(), tag = "work notes"),
+        )
+    }
+
+    @Test
+    fun explicitFormatWinsOverGlobalJsonFlag() {
+        assertEquals(WatchFormat.ID, resolveWatchFormat(WatchFormat.ID, json = true))
+    }
+
+    @Test
+    fun globalJsonFlagImpliesJsonFormat() {
+        assertEquals(WatchFormat.JSON, resolveWatchFormat(null, json = true))
+    }
+
+    @Test
+    fun defaultFormatIsLine() {
+        assertEquals(WatchFormat.LINE, resolveWatchFormat(null, json = false))
+    }
+}

--- a/doc/en/CLI.md
+++ b/doc/en/CLI.md
@@ -39,6 +39,7 @@ The examples below use `crosspaste`; on Windows substitute `crosspaste-cli`.
 | `config` | View configuration; `config set <key> <value>` changes it. |
 | `tags` | Manage paste tags (`create`, `delete`). |
 | `version` | Show the CLI version. |
+| `watch` | Stream new pastes as they arrive — including entries synced from other devices — one per line, until interrupted. Filters: `--type` (repeat for several), `--tag`; `--format line\|json\|id`. |
 
 The most common commands have single-letter aliases: `c` = `copy`, `p` = `paste`, `h` = `history`.
 
@@ -89,6 +90,21 @@ crosspaste history TODO --type text --sort oldest
 
 # JSON output — combine with jq
 crosspaste history TODO --format json | jq '.items[].preview'
+```
+
+React to new pastes as they arrive — `watch` streams every new entry (a copy on this machine, a `crosspaste copy`, or an entry synced from another device) and runs until interrupted. Existing history is not replayed; the stream starts at "now". The default output is one sanitized line per paste (its text content; for links, the URL). It is a live feed, not a durable queue — events that arrive while the CLI is not running are not delivered later:
+
+```sh
+# Download every video link copied on any of your devices
+crosspaste watch --type link | xargs -n1 yt-dlp
+
+# Full metadata as one JSON object per line
+crosspaste watch --format json | jq '.preview'
+
+# Exact bytes: take IDs from the stream and fetch each paste raw
+crosspaste watch --format id | while read -r id; do
+  crosspaste paste "$id" --raw > "paste-$id.txt"
+done
 ```
 
 ### Exit codes

--- a/doc/zh/CLI.md
+++ b/doc/zh/CLI.md
@@ -39,6 +39,7 @@ CLI 二进制随所有桌面安装包一起分发，各平台的差异只在于�
 | `config` | 查看配置；`config set <key> <value>` 修改配置。 |
 | `tags` | 管理粘贴标签（`create`、`delete`）。 |
 | `version` | 显示 CLI 版本。 |
+| `watch` | 实时流式输出新到达的粘贴（包括从其他设备同步来的条目），每条一行，直到中断。过滤:`--type`（可重复）、`--tag`;`--format line\|json\|id`。 |
 
 最常用的命令有单字母别名：`c` = `copy`、`p` = `paste`、`h` = `history`。
 
@@ -89,6 +90,21 @@ crosspaste history TODO --type text --sort oldest
 
 # JSON 输出——配合 jq
 crosspaste history TODO --format json | jq '.items[].preview'
+```
+
+实时响应新粘贴——`watch` 流式输出每一条新条目（本机复制、`crosspaste copy` 写入、或从其他设备同步来的条目），直到中断。不回放已有历史,流从"现在"开始。默认输出为每条一行的净化文本内容（链接类型即 URL 本体）。它是实时信息流而非持久队列——CLI 未运行期间到达的条目不会补发：
+
+```sh
+# 自动下载任意设备上复制的视频链接
+crosspaste watch --type link | xargs -n1 yt-dlp
+
+# 每行一个 JSON 对象的完整元数据
+crosspaste watch --format json | jq '.preview'
+
+# 需要精确字节时：从流中取 ID,再逐条取原始内容
+crosspaste watch --format id | while read -r id; do
+  crosspaste paste "$id" --raw > "paste-$id.txt"
+done
 ```
 
 ### 退出码


### PR DESCRIPTION
Closes #4823

## Summary

Third and last piece of the CLI advanced-features trio (after `edit` #4815 and `pick` #4822): `crosspaste watch` streams every newly arriving paste — local captures, CLI copies, re-copies, and entries synced from other devices — one per line until interrupted.

### Server (`app`)
- `GET /cli/watch` on the UDS CLI server: long-lived chunked NDJSON response, one `CliPasteSummaryDto` per line plus a blank-line heartbeat every 10s (client liveness + keeps the idle-connection reaper away). NDJSON instead of SSE: same push semantics over a local socket, no new dependency, trivial parsing.
- `CliWatchTracker` diffs successive snapshots of the newest-100 SQLDelight query flow into arrivals: baseline is never replayed; LOADING rows report when they finish releasing; createTime bumps (re-copy) report again; rows sliding back into the window after deletions are adopted silently, recognized by createTime **and** id bounds so a remote device with a lagging clock still gets its new pastes reported (locally assigned ids are insertion-ordered).
- If the DAO flow ends after swallowing a transient DB error, the handler resubscribes with the tracker intact instead of terminating the client's stream.
- `type`/`tag` filter parsing extracted from `/cli/history` into a shared `parseListFilters` (identical validation and errors).

### CLI (`cli`)
- `watch` command: `--type/-t` repeatable, `--tag/-g`, `--format line|json|id`; global `--json` implies `json`. Default `line` = one sanitized content line per paste (links print the URL), so `watch --type link | xargs -n1 yt-dlp` works out of the box. Every event is validated before printing (a line truncated by a hard disconnect is warned and skipped); `json` passes the validated server line through untouched; output is flushed per event and bypasses Mordant for byte-clean pipes.
- `CliClient.streamLines`: infinite request timeout, 30s read-silence budget (3 missed heartbeats); EOF/silence map to the standard app-not-running flow, so an app restart reconnects transparently.
- `runCli`'s single-retry budget is now time-aware: an attempt that ran ≥30s before failing earns a fresh retry, letting a long-lived watch survive any number of app restarts spread over time while a rapid crash loop (relevant with `--start`) still exhausts the budget after one retry.
- Old app without the endpoint (404, no server message) → clear "update the app" error, exit 1.

Known scope decisions: best-effort live feed (bursts larger than the diff window can drop events; no replay while the CLI is not running), full preview in events (same as `/cli/history`).

## Tests

- `CliWatchTrackerTest` (11): baseline no-replay, arrival ordering, LOADING→LOADED, re-copy bumps, slide-back suppression, lagging-clock remote arrival, non-full-window semantics.
- `CliRoutingTest` (+4): NDJSON arrival streaming with no duplicates across DAO-flow resubscription, type filter, tag filter, 400 on unknown type/tag before streaming.
- `WatchQueryTest` (6): query building and format resolution.
- Full fast tier (`app:desktopTest`) and `cli:macosArm64Test` green; linuxX64/linuxArm64/mingwX64 cross-compilation verified.

## Real-machine verification (macOS, dev instance)

- Default line output sees `copy` events as they happen; `--format json` emits one compact object per line; `--format id` emits ids.
- `--type link` passes links (both CLI copies and a Chrome-sourced link re-copy) and drops text.
- Re-copying an existing paste via `POST /cli/paste/{id}/copy` re-emits it.
- 40s idle stream stays alive (heartbeats) and still delivers the next event.
- App stopped: exit code 3 with the standard message; old app without the endpoint: "update the app" error, exit 1.

Remaining for release QA: Windows/mingw real-machine pass (same bucket as the pick raw-mode check).

## Docs

`doc/en/CLI.md` and `doc/zh/CLI.md`: command table entry plus a piping section with yt-dlp / jq / per-id raw-fetch examples.