### PR TITLE
:bug: survive mordant's native-Windows raw-mode timeout and restore console modes on exit

### DIFF
--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
@@ -10,6 +10,7 @@ import com.crosspaste.cli.commands.readImageWithinBudget
 import com.crosspaste.cli.platform.TerminalImageProtocol
 import com.crosspaste.cli.platform.detectTerminalImageProtocol
 import com.crosspaste.cli.platform.fitImageCellBox
+import com.crosspaste.cli.platform.isRawModeReadTimeout
 import com.crosspaste.cli.platform.kittyDeleteImages
 import com.crosspaste.cli.platform.parsePngDimensions
 import com.crosspaste.cli.platform.restoreConsoleModes
@@ -234,15 +235,15 @@ internal class PickTui(
             // RuntimeException("Timeout reading from console input") when the
             // wait expires instead of returning null like the other platforms
             // (readKeyOrNull only swallows TimeoutException), so every idle
-            // poll tick would crash the picker. Treat any read failure as "no
-            // key this tick": a transient error costs one poll interval, and
-            // a genuinely dead console still exits via the TerminalGuard
-            // console-control handler.
+            // poll tick would crash the picker. Only that known signature is
+            // treated as "no key this tick" (isRawModeReadTimeout is
+            // platform-split: always false on POSIX); real console errors
+            // still propagate and end the picker.
             val event =
                 try {
                     raw.readKeyOrNull(KEY_POLL_INTERVAL)
-                } catch (_: RuntimeException) {
-                    null
+                } catch (e: RuntimeException) {
+                    if (isRawModeReadTimeout(e)) null else throw e
                 } ?: return null
             val action = toPickAction(event, state.query.isEmpty()) ?: return null
             val selectedBefore = state.selectedItem?.id

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
@@ -12,6 +12,7 @@ import com.crosspaste.cli.platform.detectTerminalImageProtocol
 import com.crosspaste.cli.platform.fitImageCellBox
 import com.crosspaste.cli.platform.kittyDeleteImages
 import com.crosspaste.cli.platform.parsePngDimensions
+import com.crosspaste.cli.platform.restoreConsoleModes
 import com.crosspaste.cli.platform.writeItermInlineImage
 import com.crosspaste.cli.platform.writeKittyInlineImage
 import com.github.ajalt.mordant.input.RawModeScope
@@ -163,6 +164,11 @@ internal class PickTui(
                 fetchScope.cancel()
                 session.deleteDrawnKittyImage()
                 terminal.rawPrint(CURSOR_SHOW + ALT_SCREEN_EXIT)
+                // Undo Mordant's broken native-Windows raw-mode restore (it
+                // writes console mode 0 instead of the saved value); no-op on
+                // POSIX. Runs on every exit from the loop, so the Ctrl-E
+                // editor hop also gets a sane console back.
+                restoreConsoleModes()
             }
         }
 
@@ -224,7 +230,20 @@ internal class PickTui(
          * non-null return is the picker's final outcome.
          */
         suspend fun readAndHandleKey(raw: RawModeScope): PickOutcome? {
-            val event = raw.readKeyOrNull(KEY_POLL_INTERVAL) ?: return null
+            // Mordant 3.0.2's native-Windows readRawEvent throws a plain
+            // RuntimeException("Timeout reading from console input") when the
+            // wait expires instead of returning null like the other platforms
+            // (readKeyOrNull only swallows TimeoutException), so every idle
+            // poll tick would crash the picker. Treat any read failure as "no
+            // key this tick": a transient error costs one poll interval, and
+            // a genuinely dead console still exits via the TerminalGuard
+            // console-control handler.
+            val event =
+                try {
+                    raw.readKeyOrNull(KEY_POLL_INTERVAL)
+                } catch (_: RuntimeException) {
+                    null
+                } ?: return null
             val action = toPickAction(event, state.query.isEmpty()) ?: return null
             val selectedBefore = state.selectedItem?.id
             applyEffect(state.handle(action, pageSize()))?.let { return it }

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/RawModeErrors.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/RawModeErrors.kt
@@ -1,0 +1,13 @@
+package com.crosspaste.cli.platform
+
+/**
+ * Mordant 3.0.2's native-Windows readRawEvent throws a plain
+ * RuntimeException with exactly this message when the key-poll wait expires,
+ * instead of returning null like every other platform (its common wrapper
+ * only swallows TimeoutException). Only this known signature may be treated
+ * as "no key this tick"; anything else is a real console error and must
+ * propagate.
+ */
+private const val MORDANT_WINDOWS_TIMEOUT_MESSAGE = "Timeout reading from console input"
+
+fun isRawModeReadTimeout(e: RuntimeException): Boolean = e.message == MORDANT_WINDOWS_TIMEOUT_MESSAGE

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/TerminalGuard.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/TerminalGuard.kt
@@ -62,6 +62,20 @@ fun installTerminalGuard() {
     )
 }
 
+/**
+ * Puts the console modes saved by [installTerminalGuard] back. Called after
+ * leaving raw mode because Mordant 3.0.2's native-Windows setStdinConsoleMode
+ * ignores its argument and always writes 0, so its own raw-mode "restore"
+ * leaves the console with echo and line input disabled.
+ */
+@OptIn(ExperimentalForeignApi::class)
+fun restoreConsoleModes() {
+    if (modesSaved) {
+        SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), savedStdinMode)
+        SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), savedStdoutMode)
+    }
+}
+
 /** Cursor show + alternate-screen exit, written straight to the console. */
 @OptIn(ExperimentalForeignApi::class)
 private fun writeRestoreSequence() {

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/RawModeErrors.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/RawModeErrors.kt
@@ -1,0 +1,10 @@
+package com.crosspaste.cli.platform
+
+/**
+ * POSIX Mordant honors the readKeyOrNull null-on-timeout contract, so no
+ * RuntimeException from the key poll is ever a timeout here — every one is a
+ * real error and must propagate (see the mingw actual for the Windows bug).
+ */
+fun isRawModeReadTimeout(
+    @Suppress("UNUSED_PARAMETER") e: RuntimeException,
+): Boolean = false

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/TerminalGuard.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/TerminalGuard.kt
@@ -43,7 +43,7 @@ private var restoreLength = 0
  * correctly here. Only the native-Windows implementation needs the explicit
  * console-mode restore (see the mingw TerminalGuard).
  */
-fun restoreConsoleModes() {}
+fun restoreConsoleModes() = Unit
 
 /**
  * Restores the terminal when the process is killed from OUTSIDE while a

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/TerminalGuard.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/TerminalGuard.kt
@@ -39,6 +39,13 @@ private var restoreBuffer: CPointer<ByteVar>? = null
 private var restoreLength = 0
 
 /**
+ * No-op on POSIX: Mordant's raw-mode exit restores the saved termios
+ * correctly here. Only the native-Windows implementation needs the explicit
+ * console-mode restore (see the mingw TerminalGuard).
+ */
+fun restoreConsoleModes() {}
+
+/**
  * Restores the terminal when the process is killed from OUTSIDE while a
  * full-screen TUI owns it: in raw mode Ctrl-C arrives as a key event, but an
  * external SIGINT/SIGTERM/SIGHUP would otherwise leave the shell stuck in


### PR DESCRIPTION
Closes #4825

## Summary

First real-machine run of `pick` on Windows (native mingwX64 binary) crashed immediately with `Error: Timeout reading from console input`. Two Mordant 3.0.2 native-Windows bugs are involved; both are worked around on our side:

1. **Idle key poll crashes the picker.** `readKeyOrNull(33ms)`'s contract is null-on-timeout, but Mordant's `TerminalInterfaceNativeWindows.readRawEvent` throws a plain `RuntimeException("Timeout reading from console input")` when `WaitForSingleObject` expires, and the common wrapper only catches `TimeoutException`. The JVM (JNA) Windows path is unaffected, which is why mac/linux and all prior testing never hit it. Fix: the pick event loop treats any `RuntimeException` from the poll as "no key this tick" — a transient error costs one 33ms interval, and a genuinely dead console still exits via the TerminalGuard console-control handler.
2. **Raw-mode exit leaves the console broken.** Mordant's `setStdinConsoleMode(dwMode)` on native Windows ignores its argument and always writes mode 0, so its own raw-mode restore disables echo and line input for the shell that ran `pick`. Fix: new `restoreConsoleModes()` puts back the console modes saved by `installTerminalGuard`, invoked on every picker exit path (including the Ctrl-E editor hop); no-op on POSIX, where Mordant's termios restore is correct.

## Verification

- Reproduced on Windows 11 (Parallels, PowerShell under Windows Terminal): unfixed binary crashes on the first idle tick; fixed binary runs the picker (interactive session confirmed working on the VM).
- `cli:macosArm64Test` green; macosArm64 + mingwX64 release builds cross-compile.
- POSIX behavior unchanged (wrapper only converts exceptions that never occur there; `restoreConsoleModes()` is a no-op).