### PR TITLE
:art: downgrade expected heartbeat decrypt-failure logs to warn without stack trace

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -120,10 +120,13 @@ fun Routing.syncRouting(
             }.onSuccess {
                 successResponse(call, syncApi.VERSION)
             }.onFailure { e ->
-                logger.error(e) { "$appInstanceId heartbeat to ${appInfo.appInstanceId} fail" }
                 if (exceptionHandler.isDecryptFail(e)) {
+                    // Key mismatch is an expected protocol state: the peer receives
+                    // DECRYPT_FAIL and falls back to re-pairing.
+                    logger.warn { "$appInstanceId heartbeat to ${appInfo.appInstanceId} fail: decrypt fail" }
                     failResponse(call, StandardErrorCode.DECRYPT_FAIL.toErrorCode())
                 } else {
+                    logger.error(e) { "$appInstanceId heartbeat to ${appInfo.appInstanceId} fail" }
                     failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
                 }
             }

--- a/app/src/commonMain/kotlin/com/crosspaste/secure/SecureMessageProcessor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/secure/SecureMessageProcessor.kt
@@ -47,7 +47,10 @@ class SecureMessageProcessor(
         try {
             return cipher.decryptBlocking(data)
         } catch (e: Throwable) {
-            logger.error(e) { "Decrypt fail" }
+            // Expected when pairing keys have diverged (peer re-paired / restored old
+            // state); the caller maps it to DECRYPT_FAIL and the peer re-pairs, so a
+            // warn without stack trace is enough.
+            logger.warn { "Decrypt fail: ${e.message}" }
             throw PasteException(StandardErrorCode.DECRYPT_FAIL.toErrorCode(), e)
         }
     }


### PR DESCRIPTION
Closes #4837

## Summary

Key mismatch between paired devices (peer re-paired, reinstalled, or restored old state) is an expected protocol condition: the receiver returns `DECRYPT_FAIL` and the sender self-heals by marking the peer `UNMATCHED`, deleting the stale key, and falling back to re-pairing. Yet each failed encrypted heartbeat currently prints two full `BadPaddingException` stack traces at error level, flooding the log at startup.

## Changes

- `SecureMessageProcessor.decrypt`: downgrade to warn with the exception message only; still throws `PasteException(DECRYPT_FAIL)` unchanged.
- `SyncRouting` `/sync/heartbeat/syncInfo` failure handler: when the failure is a decrypt failure, log warn without stack trace; all other (genuinely unexpected) failures keep error with stack trace.

No behavior change — responses and error codes are untouched; only log severity and verbosity change.

## Verification

- `./gradlew ktlintFormat` clean
- `./gradlew app:compileKotlinDesktop` passes