### PR TITLE
:construction_worker: bump Conveyor CLI in CI packaging workflows from v21.0 to v22.1

### DIFF
--- a/.github/workflows/build-beta-linux.yml
+++ b/.github/workflows/build-beta-linux.yml
@@ -126,7 +126,7 @@ jobs:
           CONF
 
       - name: Conveyor build (Linux deb + tarball)
-        uses: hydraulic-software/conveyor/actions/build@v21.0
+        uses: hydraulic-software/conveyor/actions/build@v22.1
         with:
           command: make site
           extra_flags: -f beta.conveyor.conf

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -273,7 +273,7 @@ jobs:
           echo "${{ secrets.AUTH_KEY }}" | base64 --decode > AuthKey.p8
 
       - name: Conveyor build
-        uses: hydraulic-software/conveyor/actions/build@v21.0
+        uses: hydraulic-software/conveyor/actions/build@v22.1
         with:
           command: make site
           extra_flags: -f build.conveyor.conf


### PR DESCRIPTION
Closes #4834

## Summary

Bump `hydraulic-software/conveyor/actions/build` from `@v21.0` to `@v22.1` (upstream latest, 2026-07-21) in the two CI packaging workflows:

- `.github/workflows/build-release.yml`
- `.github/workflows/build-beta-linux.yml`

Per the audit in #4834, all other Conveyor dependencies (Gradle plugin `dev.hydraulic.conveyor` 2.0, `conveyor-control` 1.1) are already at their latest versions. The 22.x changes relevant to us are the Debian/Ubuntu mirror selection anti-rate-limiting and disk cache eviction improvements (mildly beneficial for CI stability); the rest (DigiCert remote CA fix, Windows ARM64 update-site fix, JDK definition updates) do not apply to our setup.

`conveyor.compatibility-level = 19` in `conveyor.conf` is intentionally left unchanged — it is a behavior pin, and raising it is a separate, deliberate step after reading the migration notes.

## Merge gating

⚠️ **Do not merge until the 2.2.0 release (draft 2.2.0.2502) is published.** #4834 explicitly defers this change so the packaging toolchain stays frozen while the 2.2.0 build is under real-machine verification. If 2.2.0 needs a rebuild, it must still use v21.0.

## Verification

After merge: trigger a beta Linux build (`build-beta-linux.yml`) and check the produced artifacts/site, as specified in #4834.

Reference: https://conveyor.hydraulic.dev/latest/release-notes/