### PR TITLE
:sparkles: let a PATH-installed CLI auto-discover a dev app instance

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -4,6 +4,7 @@ import com.crosspaste.app.AppEnv
 import com.crosspaste.cli.CliEndpointFile
 import com.crosspaste.cli.CliPairingService
 import com.crosspaste.cli.CliServer
+import com.crosspaste.cli.devCliEndpointPointerPath
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.image.DesktopFaviconLoader
 import com.crosspaste.image.FaviconLoader
@@ -89,7 +90,7 @@ fun desktopNetworkModule(
 ): Module =
     module {
         // region CLI
-        single<CliEndpointFile> { CliEndpointFile(get()) }
+        single<CliEndpointFile> { CliEndpointFile(get(), devCliEndpointPointerPath(get())) }
         single<CliPairingService> {
             CliPairingService(
                 nearbyDeviceManager = get(),

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
@@ -12,6 +12,14 @@ const val CLI_API_VERSION = 1
 const val CLI_ENDPOINT_FILE_NAME = "cli-endpoint.json"
 
 /**
+ * Secondary discovery pointer a DEVELOPMENT app (`./gradlew app:run`) writes
+ * into the installed app's default user-data directory, so a PATH-installed
+ * CLI can find the dev instance whose real endpoint file lives in the repo's
+ * dev user dir. Production and test apps never write it.
+ */
+const val CLI_DEV_ENDPOINT_FILE_NAME = "cli-endpoint.dev.json"
+
+/**
  * Wire DTOs for the /cli API.
  *
  * The CLI binary (Kotlin/Native, :cli module) defines its own mirror of these

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliEndpointFile.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliEndpointFile.kt
@@ -1,12 +1,19 @@
 package com.crosspaste.cli
 
 import com.crosspaste.app.AppFileType
+import com.crosspaste.path.LinuxAppPathProvider.Companion.LOCAL
+import com.crosspaste.path.LinuxAppPathProvider.Companion.SHARE
+import com.crosspaste.path.PlatformUserDataPathProvider.Companion.CROSSPASTE_DIR_NAME
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.platform.Platform
+import com.crosspaste.utils.getAppEnvUtils
+import com.crosspaste.utils.getSystemProperty
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.attribute.PosixFilePermissions
@@ -26,8 +33,43 @@ data class CliEndpoint(
     val appInstanceId: String,
 )
 
+/**
+ * Resolves where a DEVELOPMENT app should advertise itself for PATH-installed
+ * CLIs (see [CLI_DEV_ENDPOINT_FILE_NAME]); null in any other environment so
+ * production and test apps never touch the installed app's directory.
+ */
+fun devCliEndpointPointerPath(platform: Platform): Path? =
+    if (getAppEnvUtils().isDevelopment()) {
+        installedAppDefaultUserDataDir(platform, Paths.get(getSystemProperty().get("user.home")))
+            ?.resolve(CLI_DEV_ENDPOINT_FILE_NAME)
+    } else {
+        null
+    }
+
+/**
+ * Pure mirror of the installed app's default user-data locations (the same
+ * table the CLI's NativePlatformPathProvider hardcodes). Deliberately NOT the
+ * production PlatformUserDataPathProvider: its getters have side effects a
+ * dev run must never inflict on the installed app's data — macOS creates the
+ * directory, and Linux performs the real shard→share data migration.
+ */
+internal fun installedAppDefaultUserDataDir(
+    platform: Platform,
+    userHome: Path,
+): Path? =
+    if (platform.isWindows()) {
+        userHome.resolve(CROSSPASTE_DIR_NAME)
+    } else if (platform.isMacos()) {
+        userHome.resolve("Library").resolve("Application Support").resolve("CrossPaste")
+    } else if (platform.isLinux()) {
+        userHome.resolve(LOCAL).resolve(SHARE).resolve(CROSSPASTE_DIR_NAME)
+    } else {
+        null
+    }
+
 class CliEndpointFile(
     private val userDataPathProvider: UserDataPathProvider,
+    private val devPointerPath: Path? = null,
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -39,14 +81,39 @@ class CliEndpointFile(
             .resolve(CLI_ENDPOINT_FILE_NAME, AppFileType.USER)
             .toNioPath()
 
+    fun write(endpoint: CliEndpoint) {
+        writeAtomically(getPath(), endpoint)
+        devPointerPath?.let { pointer ->
+            // Best effort: failing to advertise the dev instance must not
+            // keep the CLI server itself from starting. Creating the default
+            // directory here is accepted even though on Linux a pre-existing
+            // (empty) target makes an installed shard-era app skip its data
+            // migration — that needs data untouched by any release of the
+            // last years, and the old directory stays intact either way.
+            runCatching {
+                Files.createDirectories(pointer.parent)
+                writeAtomically(pointer, endpoint)
+            }.onFailure { e ->
+                logger.warn(e) { "Failed to write dev cli endpoint pointer $pointer" }
+            }
+        }
+    }
+
+    fun delete() {
+        deleteQuietly(getPath())
+        devPointerPath?.let { deleteQuietly(it) }
+    }
+
     /**
      * Atomic write (temp + rename) so the CLI never observes a partial file.
      * The randomly named temp file is created with owner-only permissions
      * BEFORE any content is written (createTempFile applies the mode at
      * open time), so there is no window where other users could read it.
      */
-    fun write(endpoint: CliEndpoint) {
-        val path = getPath()
+    private fun writeAtomically(
+        path: Path,
+        endpoint: CliEndpoint,
+    ) {
         val tempPath = createOwnerOnlyTempFile(path.parent)
         try {
             tempPath.writeText(json.encodeToString(endpoint))
@@ -62,11 +129,11 @@ class CliEndpointFile(
         }
     }
 
-    fun delete() {
+    private fun deleteQuietly(path: Path) {
         runCatching {
-            Files.deleteIfExists(getPath())
+            Files.deleteIfExists(path)
         }.onFailure { e ->
-            logger.warn(e) { "Failed to delete cli endpoint file" }
+            logger.warn(e) { "Failed to delete cli endpoint file $path" }
         }
     }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliEndpointFileTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliEndpointFileTest.kt
@@ -4,6 +4,7 @@ import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.config.DesktopAppConfig
 import com.crosspaste.path.PlatformUserDataPathProvider
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.platform.Platform
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.json.Json
@@ -16,18 +17,22 @@ import kotlin.io.path.readText
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CliEndpointFileTest {
 
-    private fun createEndpointFile(tempDir: java.nio.file.Path): CliEndpointFile {
+    private fun createEndpointFile(
+        tempDir: java.nio.file.Path,
+        devPointerPath: java.nio.file.Path? = null,
+    ): CliEndpointFile {
         val configManager = mockk<CommonConfigManager>()
         every { configManager.getCurrentConfig() } returns DesktopAppConfig(language = "en")
         val platformProvider =
             object : PlatformUserDataPathProvider {
                 override fun getUserDefaultStoragePath() = tempDir.toFile().toOkioPath()
             }
-        return CliEndpointFile(UserDataPathProvider(configManager, platformProvider))
+        return CliEndpointFile(UserDataPathProvider(configManager, platformProvider), devPointerPath)
     }
 
     private val endpoint =
@@ -96,5 +101,57 @@ class CliEndpointFileTest {
 
         // Deleting again must not throw
         endpointFile.delete()
+    }
+
+    @Test
+    fun `write and delete also maintain the dev pointer, creating its directory`() {
+        val tempDir = Files.createTempDirectory("cli-endpoint-test")
+        val pointerDir = Files.createTempDirectory("cli-endpoint-pointer").resolve("not-yet-created")
+        val pointerPath = pointerDir.resolve(CLI_DEV_ENDPOINT_FILE_NAME)
+        val endpointFile = createEndpointFile(tempDir, devPointerPath = pointerPath)
+
+        endpointFile.write(endpoint)
+        assertTrue(endpointFile.getPath().exists())
+        assertEquals(endpoint, Json.decodeFromString<CliEndpoint>(pointerPath.readText()))
+
+        endpointFile.delete()
+        assertFalse(endpointFile.getPath().exists())
+        assertFalse(pointerPath.exists())
+    }
+
+    @Test
+    fun `an unwritable dev pointer does not fail the primary write`() {
+        val tempDir = Files.createTempDirectory("cli-endpoint-test")
+        // A file where the pointer's parent directory should be makes
+        // createDirectories fail; the primary endpoint file must still land
+        val blocker = Files.createTempFile("cli-endpoint-blocker", ".tmp")
+        val pointerPath = blocker.resolve(CLI_DEV_ENDPOINT_FILE_NAME)
+        val endpointFile = createEndpointFile(tempDir, devPointerPath = pointerPath)
+
+        endpointFile.write(endpoint)
+        assertTrue(endpointFile.getPath().exists())
+    }
+
+    @Test
+    fun `installed app default dir mirrors the CLI's per-platform table without side effects`() {
+        val home =
+            java.nio.file.Paths
+                .get("/home/tester")
+
+        fun platform(name: String) = Platform(name = name, arch = "x64", bitMode = 64, version = "1")
+
+        assertEquals(
+            home.resolve(".crosspaste"),
+            installedAppDefaultUserDataDir(platform(Platform.WINDOWS), home),
+        )
+        assertEquals(
+            home.resolve("Library").resolve("Application Support").resolve("CrossPaste"),
+            installedAppDefaultUserDataDir(platform(Platform.MACOS), home),
+        )
+        assertEquals(
+            home.resolve(".local").resolve("share").resolve(".crosspaste"),
+            installedAppDefaultUserDataDir(platform(Platform.LINUX), home),
+        )
+        assertNull(installedAppDefaultUserDataDir(platform(Platform.ANDROID), home))
     }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/CliCommandHelper.kt
@@ -73,7 +73,11 @@ fun CliktCommand.runCli(
         ensureAppRunning(readinessChecker)
         var retriedAfterRestart = false
         var versionWarningShown = false
+        var devNoticeShown = false
         while (true) {
+            if (!devNoticeShown) {
+                devNoticeShown = noteDevEndpointIfActive(configReader)
+            }
             var client: CliClient? = null
             val attemptStart = TimeSource.Monotonic.markNow()
             try {
@@ -220,6 +224,17 @@ private fun CliktCommand.promptStartConfirmation(headless: Boolean): Boolean {
             else -> echo("Please answer y or n.", err = true)
         }
     }
+}
+
+/**
+ * One-line stderr note when the liveness probe fell back to a dev instance
+ * (see AppReadinessChecker), so unexpected-looking output is explainable.
+ * Returns true when the note was emitted, so callers can avoid repeats.
+ */
+internal fun CliktCommand.noteDevEndpointIfActive(configReader: CliConfigReader): Boolean {
+    if (!configReader.devEndpointActive) return false
+    echo("Note: talking to a dev CrossPaste instance (./gradlew app:run).", err = true)
+    return true
 }
 
 /** Returns true when a warning was emitted, so callers can avoid repeats. */

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/StatusCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/StatusCommand.kt
@@ -63,7 +63,10 @@ class StatusCommand : CliktCommand(name = "status") {
             val configReader = CliConfigReader(createNativePlatformPathProvider())
             val readinessChecker = AppReadinessChecker(configReader)
             when (readinessChecker.probe()) {
-                AppLiveness.RUNNING -> printRunning(configReader, readinessChecker)
+                AppLiveness.RUNNING -> {
+                    noteDevEndpointIfActive(configReader)
+                    printRunning(configReader, readinessChecker)
+                }
                 AppLiveness.STARTING -> printNotReady("Starting", "starting")
                 AppLiveness.NOT_RUNNING -> printNotReady("Not running", "not_running")
             }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppReadinessChecker.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/AppReadinessChecker.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okio.FileSystem
+import okio.Path
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -27,6 +28,10 @@ enum class AppLiveness {
  * GET /cli/status over the declared socket whose appInstanceId matches the
  * file means it is running; otherwise the recorded pid disambiguates an app
  * that is still starting up from a stale crash leftover.
+ *
+ * When the installed app is not live, the checker falls back to the dev
+ * pointer file (see [CliConfigReader.CLI_DEV_ENDPOINT_FILE_NAME]) so a
+ * PATH-installed CLI transparently finds a `./gradlew app:run` instance.
  *
  * [socketProber] and [processAlive] are injectable for tests only.
  */
@@ -48,11 +53,16 @@ class AppReadinessChecker(
         }
 
     suspend fun probe(): AppLiveness {
-        val endpoint = readEndpoint() ?: return AppLiveness.NOT_RUNNING
-        if (socketProber(endpoint)) {
+        configReader.devEndpointActive = false
+        val primary = readEndpoint(configReader.primaryEndpointFilePath())
+        if (primary != null && socketProber(primary)) {
             return AppLiveness.RUNNING
         }
-        return if (processAlive(endpoint.pid)) AppLiveness.STARTING else AppLiveness.NOT_RUNNING
+        if (probeDevEndpoint()) {
+            return AppLiveness.RUNNING
+        }
+        if (primary == null) return AppLiveness.NOT_RUNNING
+        return if (processAlive(primary.pid)) AppLiveness.STARTING else AppLiveness.NOT_RUNNING
     }
 
     /**
@@ -70,14 +80,34 @@ class AppReadinessChecker(
         } ?: false
 
     private suspend fun isEndpointReady(): Boolean {
-        val endpoint = readEndpoint() ?: return false
-        return socketProber(endpoint)
+        configReader.devEndpointActive = false
+        val primary = readEndpoint(configReader.primaryEndpointFilePath())
+        if (primary != null && socketProber(primary)) {
+            return true
+        }
+        return probeDevEndpoint()
     }
 
-    private fun readEndpoint(): CliEndpoint? =
+    /**
+     * Fallback for dev instances (`./gradlew app:run`), whose real endpoint
+     * file lives in the repo's dev user dir: they advertise themselves via a
+     * pointer file in the default directory. Only a live, instance-verified
+     * answer counts — the pointer is written when the dev socket is already
+     * up, so a dead socket means a stale leftover, never a starting app.
+     * On success the configReader is switched over so CliClient connects to
+     * the dev instance.
+     */
+    private suspend fun probeDevEndpoint(): Boolean {
+        val dev = readEndpoint(configReader.devEndpointFilePath()) ?: return false
+        if (!socketProber(dev)) return false
+        configReader.devEndpointActive = true
+        return true
+    }
+
+    private fun readEndpoint(path: Path): CliEndpoint? =
         try {
             val content =
-                FileSystem.SYSTEM.read(configReader.resolveEndpointFilePath()) { readUtf8() }
+                FileSystem.SYSTEM.read(path) { readUtf8() }
             json.decodeFromString<CliEndpoint>(content)
         } catch (_: Exception) {
             null

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/CliConfigReader.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/CliConfigReader.kt
@@ -23,7 +23,23 @@ class CliConfigReader(
 
     companion object {
         const val CLI_ENDPOINT_FILE_NAME = "cli-endpoint.json"
+
+        /**
+         * Secondary discovery pointer a dev instance (`./gradlew app:run`)
+         * writes into the installed app's default user-data directory; its
+         * real endpoint file lives in the repo's dev user dir, which this
+         * CLI cannot know. Same record format as the primary file.
+         */
+        const val CLI_DEV_ENDPOINT_FILE_NAME = "cli-endpoint.dev.json"
     }
+
+    /**
+     * When true the CLI targets the dev pointer instead of the installed
+     * app's endpoint file. Set only by AppReadinessChecker after verifying a
+     * live dev instance while no production instance answers; never set on a
+     * release user's machine, where the dev pointer file does not exist.
+     */
+    var devEndpointActive: Boolean = false
 
     private val json =
         Json {
@@ -50,5 +66,14 @@ class CliConfigReader(
         }
     }
 
-    fun resolveEndpointFilePath(): Path = resolveUserDataPath().resolve(CLI_ENDPOINT_FILE_NAME)
+    fun resolveEndpointFilePath(): Path =
+        if (devEndpointActive) {
+            devEndpointFilePath()
+        } else {
+            primaryEndpointFilePath()
+        }
+
+    fun primaryEndpointFilePath(): Path = resolveUserDataPath().resolve(CLI_ENDPOINT_FILE_NAME)
+
+    fun devEndpointFilePath(): Path = platformPathProvider.getDefaultUserDataPath().resolve(CLI_DEV_ENDPOINT_FILE_NAME)
 }

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/AppReadinessCheckerTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/AppReadinessCheckerTest.kt
@@ -35,21 +35,34 @@ class AppReadinessCheckerTest {
         pid: Long = 1234,
         socketPath: String = "/tmp/does-not-matter.sock",
         appInstanceId: String = "instance-a",
+        fileName: String = CliConfigReader.CLI_ENDPOINT_FILE_NAME,
     ) {
-        FileSystem.SYSTEM.write(dir.resolve(CliConfigReader.CLI_ENDPOINT_FILE_NAME)) {
+        FileSystem.SYSTEM.write(dir.resolve(fileName)) {
             writeUtf8(
                 """{"pid":$pid,"socketPath":"$socketPath","apiVersion":1,"appInstanceId":"$appInstanceId"}""",
             )
         }
     }
 
+    private fun writeDevEndpoint(
+        dir: Path,
+        pid: Long = 5678,
+        appInstanceId: String = "dev-instance",
+    ) = writeEndpoint(
+        dir,
+        pid = pid,
+        appInstanceId = appInstanceId,
+        fileName = CliConfigReader.CLI_DEV_ENDPOINT_FILE_NAME,
+    )
+
     private fun checker(
         dir: Path,
         socketProber: suspend (CliEndpoint) -> Boolean = { false },
         processAlive: (Long) -> Boolean = { false },
+        configReader: CliConfigReader = CliConfigReader(FakePathProvider(dir)),
     ): AppReadinessChecker =
         AppReadinessChecker(
-            configReader = CliConfigReader(FakePathProvider(dir)),
+            configReader = configReader,
             socketProber = socketProber,
             processAlive = processAlive,
         )
@@ -98,6 +111,103 @@ class AppReadinessCheckerTest {
                 AppLiveness.NOT_RUNNING,
                 checker(dir, socketProber = { false }, processAlive = { false }).probe(),
             )
+        }
+
+    @Test
+    fun probeFallsBackToLiveDevEndpointWhenPrimaryIsMissing() =
+        runTest {
+            val dir = tempDir()
+            writeDevEndpoint(dir)
+            val configReader = CliConfigReader(FakePathProvider(dir))
+            val liveness =
+                checker(
+                    dir,
+                    socketProber = { it.appInstanceId == "dev-instance" },
+                    configReader = configReader,
+                ).probe()
+            assertEquals(AppLiveness.RUNNING, liveness)
+            assertTrue(configReader.devEndpointActive)
+            assertEquals(configReader.devEndpointFilePath(), configReader.resolveEndpointFilePath())
+        }
+
+    @Test
+    fun probePrefersLivePrimaryOverLiveDevEndpoint() =
+        runTest {
+            val dir = tempDir()
+            writeEndpoint(dir, appInstanceId = "installed-instance")
+            writeDevEndpoint(dir)
+            val configReader = CliConfigReader(FakePathProvider(dir))
+            val liveness =
+                checker(dir, socketProber = { true }, configReader = configReader).probe()
+            assertEquals(AppLiveness.RUNNING, liveness)
+            assertFalse(configReader.devEndpointActive)
+        }
+
+    @Test
+    fun probeFallsBackToDevEndpointOverStartingPrimary() =
+        runTest {
+            val dir = tempDir()
+            writeEndpoint(dir, pid = 4321, appInstanceId = "installed-instance")
+            writeDevEndpoint(dir)
+            val configReader = CliConfigReader(FakePathProvider(dir))
+            val liveness =
+                checker(
+                    dir,
+                    socketProber = { it.appInstanceId == "dev-instance" },
+                    processAlive = { true },
+                    configReader = configReader,
+                ).probe()
+            assertEquals(AppLiveness.RUNNING, liveness)
+            assertTrue(configReader.devEndpointActive)
+        }
+
+    @Test
+    fun probeIgnoresStaleDevEndpoint() =
+        runTest {
+            val dir = tempDir()
+            // The dev pointer is only ever written once the dev socket is
+            // live, so a dead socket means a stale leftover, never STARTING
+            writeDevEndpoint(dir)
+            val configReader = CliConfigReader(FakePathProvider(dir))
+            val liveness =
+                checker(
+                    dir,
+                    socketProber = { false },
+                    processAlive = { true },
+                    configReader = configReader,
+                ).probe()
+            assertEquals(AppLiveness.NOT_RUNNING, liveness)
+            assertFalse(configReader.devEndpointActive)
+        }
+
+    @Test
+    fun probeSwitchesBackToPrimaryWhenItComesAlive() =
+        runTest {
+            val dir = tempDir()
+            writeDevEndpoint(dir)
+            val configReader = CliConfigReader(FakePathProvider(dir))
+            val readiness = checker(dir, socketProber = { true }, configReader = configReader)
+            assertEquals(AppLiveness.RUNNING, readiness.probe())
+            assertTrue(configReader.devEndpointActive)
+
+            writeEndpoint(dir, appInstanceId = "installed-instance")
+            assertEquals(AppLiveness.RUNNING, readiness.probe())
+            assertFalse(configReader.devEndpointActive)
+        }
+
+    @Test
+    fun waitForAppReadyPicksUpDevEndpointAppearingMidWait() =
+        runTest {
+            val dir = tempDir()
+            val configReader = CliConfigReader(FakePathProvider(dir))
+            launch {
+                kotlinx.coroutines.delay(2.seconds)
+                writeDevEndpoint(dir)
+            }
+            assertTrue(
+                checker(dir, socketProber = { true }, configReader = configReader).waitForAppReady(),
+            )
+            assertTrue(configReader.devEndpointActive)
         }
 
     @Test

--- a/doc/en/CLI.md
+++ b/doc/en/CLI.md
@@ -266,6 +266,8 @@ The `:cli:run` task links the host's debug executable and sets `CROSSPASTE_USER_
 CROSSPASTE_USER_DATA_DIR=app/.user cli/build/bin/macosArm64/debugExecutable/crosspaste-cli.kexe history
 ```
 
+A PATH-installed CLI also finds a dev instance on its own: the dev app writes a `cli-endpoint.dev.json` pointer into the installed app's default user-data directory, and the CLI falls back to it whenever the installed app is not live (a one-line note on stderr tells you a dev instance answered). A live installed app always wins; use `CROSSPASTE_USER_DATA_DIR` to force the dev instance while both are running.
+
 Output through Gradle is not a TTY, so the CLI cannot detect your window size and falls back to 79 columns. Pass the width explicitly via `COLUMNS` (the CLI honors it whenever stdout is not interactive):
 
 ```sh

--- a/doc/zh/CLI.md
+++ b/doc/zh/CLI.md
@@ -266,6 +266,8 @@ crosspaste --generate-completion fish > ~/.config/fish/completions/crosspaste.fi
 CROSSPASTE_USER_DATA_DIR=app/.user cli/build/bin/macosArm64/debugExecutable/crosspaste-cli.kexe history
 ```
 
+已加入 PATH 的 CLI 也能自动发现 dev 实例：dev 应用会在已安装应用的默认用户数据目录写入一个 `cli-endpoint.dev.json` 指针文件，当已安装应用不在运行时，CLI 会回退探测它（stderr 会提示当前连接的是 dev 实例）。已安装应用在运行时始终优先；两者同时运行时可用 `CROSSPASTE_USER_DATA_DIR` 强制指向 dev 实例。
+
 经 Gradle 转发的输出不是 TTY，CLI 探测不到窗口宽度，会回退到 79 列。可通过 `COLUMNS` 显式传入宽度（stdout 非交互时 CLI 都会遵循它）：
 
 ```sh


### PR DESCRIPTION
Closes #4842

## Problem

Running the app from source (`./gradlew app:run`) and invoking a PATH-installed `crosspaste-cli` fails with `CrossPaste is not running`: the dev instance writes its `cli-endpoint.json` discovery file into the repo's dev user dir, while the CLI only looks in the installed app's default user-data directory. The `CROSSPASTE_USER_DATA_DIR` override works but must be set manually.

## Solution

**App side**
- A DEVELOPMENT instance additionally advertises itself via a `cli-endpoint.dev.json` pointer (same record format) in the installed app's default user-data directory, written once the CLI socket is live and deleted on exit. Production and test apps never write it.
- The pointer path is a pure per-platform path expression (`installedAppDefaultUserDataDir`) mirroring the CLI's own table — deliberately not the production `PlatformUserDataPathProvider`, whose getters have side effects (macOS dir creation, the Linux shard→share data migration) a dev run must never inflict on the installed app's data.
- The pointer write is best-effort: a failure logs a warning and never blocks the CLI server startup.

**CLI side**
- The D5 liveness sequence gains a fallback: when the installed app's endpoint is not live, the CLI probes the dev pointer with the existing socket + appInstanceId verification and, on success, switches the connection target. A live installed app always wins, so release behavior is unchanged (on release machines the pointer file never exists).
- The dev pointer is written only after the dev socket is up, so a dead socket means a stale leftover and is ignored — it never counts as STARTING.
- A one-line stderr note (`Note: talking to a dev CrossPaste instance`) is emitted by both `runCli`-based commands and `status` (which bypasses `runCli`), keeping stdout pipe-clean including `--json` mode.
- `CROSSPASTE_USER_DATA_DIR` still overrides everything, e.g. to force the dev instance while an installed app is also running.

## Tests

- `CliEndpointFileTest`: dev pointer write/delete, parent-directory creation, best-effort failure isolation, and the pure per-platform path table.
- `AppReadinessCheckerTest`: fallback to a live dev endpoint, precedence of a live primary, stale-dev-pointer rejection, switching back when the installed app comes alive, and mid-wait pickup in `waitForAppReady`.
- Verified end to end on macOS: a rebuilt CLI with no environment overrides discovers a `./gradlew app:run` instance (`status`, `history`, stderr note, `--json` stdout purity), and still reports `Not running` with exit code 3 when no instance is live.

## Docs

`doc/en/CLI.md` and `doc/zh/CLI.md` document the automatic discovery and the precedence rules.