### PR TITLE
:sparkles: add pure-Kotlin sixel encoder with median-cut quantization

### DIFF
--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/SixelImage.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/SixelImage.kt
@@ -1,0 +1,343 @@
+package com.crosspaste.cli.platform
+
+/**
+ * Sixel encoding (design: ai/design/cli-sixel-support.md, issue #4845).
+ *
+ * Unlike the iTerm/kitty writers in TerminalImage.kt — which pass the stored
+ * image file through for the terminal to decode — sixel requires the sender
+ * to hold decoded pixels. The CLI receives exact-display-size straight-alpha
+ * RGBA8888 from the app's transcode endpoint and only quantizes + encodes
+ * here: pure math over raw pixels, still no image-format decoding in the CLI.
+ */
+
+internal const val SIXEL_MAX_COLORS = 256
+
+/** Pixels below this alpha are left unpainted (DCS P2=1 keeps background). */
+internal const val SIXEL_OPAQUE_ALPHA_THRESHOLD = 128
+
+internal class QuantizedSixelImage(
+    val width: Int,
+    val height: Int,
+    /** Palette index per pixel in row-major order, or -1 for transparent. */
+    val indices: IntArray,
+    /** Packed 0xRRGGBB palette colors, at most [SIXEL_MAX_COLORS] entries. */
+    val palette: IntArray,
+)
+
+/**
+ * Quantizes straight-alpha RGBA8888 to a sixel-ready indexed image. Images
+ * with at most [SIXEL_MAX_COLORS] distinct opaque colors keep them exactly,
+ * in first-seen order (deterministic output for tests); larger color counts
+ * go through median-cut.
+ */
+internal fun quantizeForSixel(
+    rgba: ByteArray,
+    width: Int,
+    height: Int,
+): QuantizedSixelImage {
+    val pixelCount = width * height
+    require(rgba.size >= pixelCount * 4) {
+        "rgba buffer holds ${rgba.size} bytes, need ${pixelCount * 4} for ${width}x$height"
+    }
+    val packed = IntArray(pixelCount)
+    val colorToIndex = HashMap<Int, Int>()
+    val distinct = ArrayList<Int>()
+    for (i in 0 until pixelCount) {
+        val o = i * 4
+        val alpha = rgba[o + 3].toInt() and 0xFF
+        if (alpha < SIXEL_OPAQUE_ALPHA_THRESHOLD) {
+            packed[i] = -1
+            continue
+        }
+        val color =
+            ((rgba[o].toInt() and 0xFF) shl 16) or
+                ((rgba[o + 1].toInt() and 0xFF) shl 8) or
+                (rgba[o + 2].toInt() and 0xFF)
+        packed[i] = color
+        if (colorToIndex[color] == null) {
+            colorToIndex[color] = distinct.size
+            distinct.add(color)
+        }
+    }
+    val palette: IntArray
+    val mapping: HashMap<Int, Int>
+    if (distinct.size <= SIXEL_MAX_COLORS) {
+        palette = distinct.toIntArray()
+        mapping = colorToIndex
+    } else {
+        val counts = IntArray(distinct.size)
+        for (i in 0 until pixelCount) {
+            val color = packed[i]
+            if (color >= 0) counts[colorToIndex.getValue(color)]++
+        }
+        val cut = medianCutPalette(distinct.toIntArray(), counts)
+        palette = cut.palette
+        mapping = cut.colorToIndex
+    }
+    val indices = IntArray(pixelCount)
+    for (i in 0 until pixelCount) {
+        val color = packed[i]
+        indices[i] = if (color < 0) -1 else mapping.getValue(color)
+    }
+    return QuantizedSixelImage(width, height, indices, palette)
+}
+
+/**
+ * Encodes RGBA8888 pixels as a sixel escape sequence. The pixels must already
+ * be at final display size — the CLI never scales (the app endpoint returns
+ * exact dimensions). Output is streamed through [write] one band at a time so
+ * the full escape string is never held in memory.
+ */
+internal fun writeSixelInlineImage(
+    rgba: ByteArray,
+    width: Int,
+    height: Int,
+    write: (String) -> Unit,
+) {
+    if (width <= 0 || height <= 0) return
+    writeSixel(quantizeForSixel(rgba, width, height), write)
+}
+
+internal fun writeSixel(
+    image: QuantizedSixelImage,
+    write: (String) -> Unit,
+) {
+    val width = image.width
+    val sb = StringBuilder()
+    // DCS q with P2=1: unpainted pixels keep the terminal background, which
+    // is how alpha-transparent regions stay transparent.
+    sb.append(TERM_ESC).append("P0;1;0q")
+    // Raster attributes: 1:1 pixel aspect plus the image size hint
+    sb
+        .append('"')
+        .append("1;1;")
+        .append(width)
+        .append(';')
+        .append(image.height)
+    for ((i, color) in image.palette.withIndex()) {
+        sb
+            .append('#')
+            .append(i)
+            .append(";2;")
+            .append(sixelChannel(color shr 16))
+            .append(';')
+            .append(sixelChannel(color shr 8))
+            .append(';')
+            .append(sixelChannel(color))
+    }
+    write(sb.toString())
+    sb.setLength(0)
+
+    if (image.palette.isNotEmpty()) {
+        // Per-band column bitmasks, one row of [width] slots per palette
+        // color; only slots of colors seen in the band are written and reset.
+        val masks = IntArray(image.palette.size * width)
+        val inBand = BooleanArray(image.palette.size)
+        val bandColors = ArrayList<Int>()
+        var bandTop = 0
+        while (bandTop < image.height) {
+            val bandRows = minOf(6, image.height - bandTop)
+            for (r in 0 until bandRows) {
+                val bit = 1 shl r
+                val rowBase = (bandTop + r) * width
+                for (x in 0 until width) {
+                    val ci = image.indices[rowBase + x]
+                    if (ci < 0) continue
+                    val slot = ci * width + x
+                    masks[slot] = masks[slot] or bit
+                    if (!inBand[ci]) {
+                        inBand[ci] = true
+                        bandColors.add(ci)
+                    }
+                }
+            }
+            bandColors.sort()
+            for ((k, ci) in bandColors.withIndex()) {
+                // '$' returns to the band's first column for the next plane
+                if (k > 0) sb.append('$')
+                sb.append('#').append(ci)
+                appendSixelRuns(sb, masks, ci * width, width)
+            }
+            bandTop += 6
+            if (bandTop < image.height) sb.append('-')
+            if (sb.isNotEmpty()) {
+                write(sb.toString())
+                sb.setLength(0)
+            }
+            for (ci in bandColors) {
+                masks.fill(0, ci * width, ci * width + width)
+                inBand[ci] = false
+            }
+            bandColors.clear()
+        }
+    }
+    write("$TERM_ESC\\")
+}
+
+/** Sixel palette channels use a 0–100 scale. */
+private fun sixelChannel(value: Int): Int = ((value and 0xFF) * 100 + 127) / 255
+
+/**
+ * Emits one color plane: 6-bit column masks as chars 63..126, run-length
+ * encoded with `!n` for runs of 4+ (shorter runs are cheaper spelled out).
+ * Trailing empty columns are trimmed — the terminal treats them as unpainted.
+ */
+private fun appendSixelRuns(
+    sb: StringBuilder,
+    masks: IntArray,
+    offset: Int,
+    width: Int,
+) {
+    var last = width - 1
+    while (last >= 0 && masks[offset + last] == 0) last--
+    var x = 0
+    while (x <= last) {
+        val mask = masks[offset + x]
+        var run = 1
+        while (x + run <= last && masks[offset + x + run] == mask) run++
+        val ch = (63 + mask).toChar()
+        if (run >= 4) {
+            sb.append('!').append(run).append(ch)
+        } else {
+            repeat(run) { sb.append(ch) }
+        }
+        x += run
+    }
+}
+
+internal class MedianCutResult(
+    val palette: IntArray,
+    val colorToIndex: HashMap<Int, Int>,
+)
+
+/**
+ * Entry layout (Long): bits 0..23 packed RGB color, bits 24..47 saturated
+ * pixel count, bits 48..55 the current split channel value. Sorting a segment
+ * after stamping bits 48..55 orders it by that channel; ties resolve by count
+ * then color, so the result is deterministic without a stable sort.
+ */
+private const val ENTRY_COLOR_MASK = 0xFFFFFFL
+private const val ENTRY_COUNT_SHIFT = 24
+private const val ENTRY_COUNT_MAX = 0xFFFFFF
+private const val ENTRY_KEY_SHIFT = 48
+private const val ENTRY_LOW_MASK = 0xFFFFFFFFFFFFL
+
+private fun entryColor(entry: Long): Int = (entry and ENTRY_COLOR_MASK).toInt()
+
+private fun entryCount(entry: Long): Long = (entry ushr ENTRY_COUNT_SHIFT) and ENTRY_COLOR_MASK
+
+private class SixelColorBox(
+    val start: Int,
+    val end: Int,
+    val total: Long,
+    val widestChannelShift: Int,
+    val splittable: Boolean,
+)
+
+private fun makeBox(
+    entries: LongArray,
+    start: Int,
+    end: Int,
+): SixelColorBox {
+    var total = 0L
+    var rMin = 255
+    var rMax = 0
+    var gMin = 255
+    var gMax = 0
+    var bMin = 255
+    var bMax = 0
+    for (i in start until end) {
+        val color = entryColor(entries[i])
+        total += entryCount(entries[i])
+        val r = (color shr 16) and 0xFF
+        val g = (color shr 8) and 0xFF
+        val b = color and 0xFF
+        if (r < rMin) rMin = r
+        if (r > rMax) rMax = r
+        if (g < gMin) gMin = g
+        if (g > gMax) gMax = g
+        if (b < bMin) bMin = b
+        if (b > bMax) bMax = b
+    }
+    val rRange = rMax - rMin
+    val gRange = gMax - gMin
+    val bRange = bMax - bMin
+    val shift =
+        when {
+            rRange >= gRange && rRange >= bRange -> 16
+            gRange >= bRange -> 8
+            else -> 0
+        }
+    return SixelColorBox(start, end, total, shift, end - start > 1)
+}
+
+/**
+ * Median-cut quantization: repeatedly splits the most populous splittable box
+ * along its widest RGB axis at the count-weighted median, until [maxColors]
+ * boxes exist. Each box's representative is its count-weighted average color.
+ * [maxColors] is a parameter only for tests; production always passes 256.
+ */
+internal fun medianCutPalette(
+    distinctColors: IntArray,
+    counts: IntArray,
+    maxColors: Int = SIXEL_MAX_COLORS,
+): MedianCutResult {
+    val n = distinctColors.size
+    val entries = LongArray(n)
+    for (i in 0 until n) {
+        val count = minOf(counts[i], ENTRY_COUNT_MAX)
+        entries[i] = (count.toLong() shl ENTRY_COUNT_SHIFT) or distinctColors[i].toLong()
+    }
+    val boxes = ArrayList<SixelColorBox>()
+    boxes.add(makeBox(entries, 0, n))
+    while (boxes.size < maxColors) {
+        var pick = -1
+        var pickTotal = -1L
+        for ((i, box) in boxes.withIndex()) {
+            if (box.splittable && box.total > pickTotal) {
+                pick = i
+                pickTotal = box.total
+            }
+        }
+        if (pick < 0) break
+        val box = boxes[pick]
+        for (i in box.start until box.end) {
+            val channel = ((entryColor(entries[i]) shr box.widestChannelShift) and 0xFF).toLong()
+            entries[i] = (entries[i] and ENTRY_LOW_MASK) or (channel shl ENTRY_KEY_SHIFT)
+        }
+        entries.sort(box.start, box.end)
+        val half = box.total / 2
+        var acc = 0L
+        var cut = box.start
+        while (cut < box.end - 1) {
+            acc += entryCount(entries[cut])
+            cut++
+            if (acc >= half) break
+        }
+        boxes[pick] = makeBox(entries, box.start, cut)
+        boxes.add(makeBox(entries, cut, box.end))
+    }
+    val palette = IntArray(boxes.size)
+    val colorToIndex = HashMap<Int, Int>(n * 2)
+    for ((boxIndex, box) in boxes.withIndex()) {
+        var rSum = 0L
+        var gSum = 0L
+        var bSum = 0L
+        var count = 0L
+        for (i in box.start until box.end) {
+            val entry = entries[i]
+            val color = entryColor(entry)
+            val weight = entryCount(entry)
+            rSum += weight * ((color shr 16) and 0xFF)
+            gSum += weight * ((color shr 8) and 0xFF)
+            bSum += weight * (color and 0xFF)
+            count += weight
+            colorToIndex[color] = boxIndex
+        }
+        val r = ((rSum + count / 2) / count).toInt()
+        val g = ((gSum + count / 2) / count).toInt()
+        val b = ((bSum + count / 2) / count).toInt()
+        palette[boxIndex] = (r shl 16) or (g shl 8) or b
+    }
+    return MedianCutResult(palette, colorToIndex)
+}

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/SixelImageTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/SixelImageTest.kt
@@ -1,0 +1,209 @@
+package com.crosspaste.cli.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class SixelImageTest {
+
+    private val esc = 27.toChar().toString()
+
+    private val red = 0xFF0000
+    private val green = 0x00FF00
+    private val blue = 0x0000FF
+
+    /** Builds RGBA8888 from a per-pixel packed 0xRRGGBB color, or null for transparent. */
+    private fun rgba(
+        width: Int,
+        height: Int,
+        pixel: (x: Int, y: Int) -> Int?,
+    ): ByteArray {
+        val bytes = ByteArray(width * height * 4)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val o = (y * width + x) * 4
+                val color = pixel(x, y)
+                if (color == null) {
+                    bytes[o + 3] = 0
+                } else {
+                    bytes[o] = (color shr 16).toByte()
+                    bytes[o + 1] = (color shr 8).toByte()
+                    bytes[o + 2] = color.toByte()
+                    bytes[o + 3] = 0xFF.toByte()
+                }
+            }
+        }
+        return bytes
+    }
+
+    private fun sixelSequence(
+        bytes: ByteArray,
+        width: Int,
+        height: Int,
+    ): String = buildString { writeSixelInlineImage(bytes, width, height, write = { append(it) }) }
+
+    @Test
+    fun goldenSingleColorColumnTrimsTrailingTransparency() {
+        // 2x6: left column red, right column transparent. All six band rows
+        // set -> mask 63 -> char '~'; the empty right column is trimmed.
+        val bytes = rgba(2, 6) { x, _ -> if (x == 0) red else null }
+        assertEquals(
+            "${esc}P0;1;0q\"1;1;2;6#0;2;100;0;0#0~$esc\\",
+            sixelSequence(bytes, 2, 6),
+        )
+    }
+
+    @Test
+    fun goldenRunLengthEncodesRunsOfFourOrMore() {
+        // 8x3 solid blue: rows 0..2 -> mask 7 -> char 'F', run of 8 -> !8F
+        val bytes = rgba(8, 3) { _, _ -> blue }
+        assertEquals(
+            "${esc}P0;1;0q\"1;1;8;3#0;2;0;0;100#0!8F$esc\\",
+            sixelSequence(bytes, 8, 3),
+        )
+    }
+
+    @Test
+    fun goldenShortRunsStaySpelledOut() {
+        // Runs of 3 are cheaper literal than as !3<ch>
+        val bytes = rgba(3, 6) { _, _ -> red }
+        assertEquals(
+            "${esc}P0;1;0q\"1;1;3;6#0;2;100;0;0#0~~~$esc\\",
+            sixelSequence(bytes, 3, 6),
+        )
+    }
+
+    @Test
+    fun goldenTwoColorPlanesSeparatedByCarriageReturn() {
+        // 2x6 red|blue: plane #0 paints column 0 ('~', column 1 trimmed),
+        // '$' returns to the band start, plane #1 skips column 0 ('?')
+        val bytes = rgba(2, 6) { x, _ -> if (x == 0) red else blue }
+        assertEquals(
+            "${esc}P0;1;0q\"1;1;2;6#0;2;100;0;0#1;2;0;0;100#0~$#1?~$esc\\",
+            sixelSequence(bytes, 2, 6),
+        )
+    }
+
+    @Test
+    fun goldenMultipleBandsSeparatedByNewline() {
+        // 1x8 red: full first band ('~'), then a partial band of two rows
+        // (mask 3 -> 'B') after the '-' separator
+        val bytes = rgba(1, 8) { _, _ -> red }
+        assertEquals(
+            "${esc}P0;1;0q\"1;1;1;8#0;2;100;0;0#0~-#0B$esc\\",
+            sixelSequence(bytes, 1, 8),
+        )
+    }
+
+    @Test
+    fun fullyTransparentBandStillEmitsItsSeparator() {
+        // 1x12 with rows 0..5 transparent, rows 6..11 red: the empty first
+        // band must still advance the cursor with '-'
+        val bytes = rgba(1, 12) { _, y -> if (y < 6) null else red }
+        assertEquals(
+            "${esc}P0;1;0q\"1;1;1;12#0;2;100;0;0-#0~$esc\\",
+            sixelSequence(bytes, 1, 12),
+        )
+    }
+
+    @Test
+    fun fullyTransparentImageEmitsHeaderOnly() {
+        val bytes = rgba(2, 2) { _, _ -> null }
+        assertEquals(
+            "${esc}P0;1;0q\"1;1;2;2$esc\\",
+            sixelSequence(bytes, 2, 2),
+        )
+    }
+
+    @Test
+    fun alphaBelowThresholdIsTransparentAtThresholdIsOpaque() {
+        val bytes = rgba(2, 1) { _, _ -> red }
+        bytes[3] = (SIXEL_OPAQUE_ALPHA_THRESHOLD - 1).toByte()
+        bytes[7] = SIXEL_OPAQUE_ALPHA_THRESHOLD.toByte()
+        val quantized = quantizeForSixel(bytes, 2, 1)
+        assertEquals(-1, quantized.indices[0])
+        assertEquals(0, quantized.indices[1])
+    }
+
+    @Test
+    fun paletteKeepsFirstSeenOrderWhenColorsFit() {
+        val bytes =
+            rgba(3, 1) { x, _ ->
+                when (x) {
+                    0 -> green
+                    1 -> red
+                    else -> blue
+                }
+            }
+        val quantized = quantizeForSixel(bytes, 3, 1)
+        assertEquals(listOf(green, red, blue), quantized.palette.toList())
+        assertEquals(listOf(0, 1, 2), quantized.indices.toList())
+    }
+
+    @Test
+    fun manyDistinctColorsQuantizeToAtMost256() {
+        // 32x32 with 1024 distinct colors forces the median-cut path
+        val bytes =
+            rgba(32, 32) { x, y ->
+                val i = y * 32 + x
+                (i shl 12) or i
+            }
+        val quantized = quantizeForSixel(bytes, 32, 32)
+        assertEquals(SIXEL_MAX_COLORS, quantized.palette.size)
+        assertTrue(quantized.indices.all { it in 0 until SIXEL_MAX_COLORS })
+        assertTrue(quantized.palette.all { it in 0..0xFFFFFF })
+    }
+
+    @Test
+    fun medianCutSplitsAlongWidestAxisAndAveragesByWeight() {
+        // Two near-black colors vs a heavy red cluster; with two boxes the
+        // split must isolate red (widest axis), and the dark box's average
+        // rounds to 0x000001 with equal weights
+        val result =
+            medianCutPalette(
+                distinctColors = intArrayOf(0x000000, 0x000001, 0xFF0000),
+                counts = intArrayOf(1, 1, 100),
+                maxColors = 2,
+            )
+        assertEquals(listOf(0x000001, 0xFF0000), result.palette.toList())
+        assertEquals(0, result.colorToIndex.getValue(0x000000))
+        assertEquals(0, result.colorToIndex.getValue(0x000001))
+        assertEquals(1, result.colorToIndex.getValue(0xFF0000))
+    }
+
+    @Test
+    fun medianCutWithEnoughBoxesKeepsColorsExact() {
+        val colors = intArrayOf(red, green, blue)
+        val result = medianCutPalette(colors, intArrayOf(5, 3, 1), maxColors = 8)
+        assertEquals(colors.toSet(), result.palette.toSet())
+        for (color in colors) {
+            assertEquals(color, result.palette[result.colorToIndex.getValue(color)])
+        }
+    }
+
+    @Test
+    fun zeroSizeImageWritesNothing() {
+        assertEquals("", sixelSequence(ByteArray(0), 0, 0))
+    }
+
+    @Test
+    fun undersizedBufferIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            quantizeForSixel(ByteArray(7), 2, 1)
+        }
+    }
+
+    @Test
+    fun outputContainsNoLiteralControlBytesBesidesEscapes() {
+        // Every byte between DCS and ST must be printable ASCII — a mask can
+        // never exceed 63, so chars stay in 63..126
+        val bytes =
+            rgba(16, 16) { x, y ->
+                if ((x + y) % 3 == 0) null else ((x * 16 + y) shl 8) or 0x40
+            }
+        val sequence = sixelSequence(bytes, 16, 16)
+        val inner = sequence.removePrefix("${esc}P").removeSuffix("$esc\\")
+        assertTrue(inner.all { it.code in 32..126 }, "unexpected control byte in sixel payload")
+    }
+}


### PR DESCRIPTION
Closes #4845. Phase 1 of #4844 (sixel graphics support for Windows Terminal).

## Summary

Adds `SixelImage.kt` to the CLI: a pure-function sixel encoder that turns straight-alpha RGBA8888 pixels into a sixel escape sequence. Nothing is wired into commands yet — `paste`/`pick` integration lands in #4848 after the app transcode endpoint (#4846) and the terminal capability probe (#4847).

Per the design (`ai/design/cli-sixel-support.md`), the CLI still never decodes image files: pixels will arrive pre-decoded and pre-scaled from the app, and this module only does palette math and escape emission.

## Implementation

- **Quantization**: images with <= 256 distinct opaque colors keep them exactly, in first-seen order (deterministic goldens). Larger counts go through median-cut: split the most populous splittable box along its widest RGB axis at the count-weighted median until 256 boxes; representatives are count-weighted averages. Entries pack color + saturated count + sort-channel into one `Long` so segment sorts need no comparator and stay deterministic.
- **Transparency**: alpha < 128 leaves the pixel unpainted; the DCS header uses `P2=1` so unpainted pixels keep the terminal background.
- **Emission**: DCS `0;1;0q`, raster attributes `"1;1;W;H`, palette in the 0–100 scale, then 6-row bands per color plane with `!n` RLE (runs of 4+), `$` between planes, `-` between bands (including fully transparent bands, which must still advance the cursor), `ST` terminator. Output streams through the `write` callback one band at a time; the full escape string is never held in memory. Control bytes are spelled as char codes per the existing `TerminalImage.kt` convention.

## Tests

14 fast-tier tests: golden escape strings (single color, RLE threshold at 4, two planes with `$`, multi-band `-`, empty leading band, fully transparent image), alpha threshold boundary, first-seen palette order, >256-color median-cut path, weighted-median split behavior, exact-color preservation with enough boxes, zero-size/undersized-buffer guards, and a no-control-bytes sweep over the payload.

`./gradlew cli:macosArm64Test` and `ktlintCheck` pass.