### PR TITLE
:sparkles: add raw RGBA transcode endpoint for CLI image previews

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
@@ -4,10 +4,14 @@ import kotlinx.serialization.Serializable
 
 /**
  * Version of the local /cli HTTP API served over the Unix domain socket.
- * Bump when the wire contract changes in a way the CLI must know about
- * (no bump needed while the CLI has never shipped in a release).
+ * Bump when the wire contract changes in a way the CLI must know about.
+ * 2: GET /cli/paste/{id}/image raw-RGBA transcode endpoint (sixel support).
  */
-const val CLI_API_VERSION = 1
+const val CLI_API_VERSION = 2
+
+/** Response headers carrying the exact dimensions of a transcoded image. */
+const val CLI_IMAGE_WIDTH_HEADER = "X-Image-Width"
+const val CLI_IMAGE_HEIGHT_HEADER = "X-Image-Height"
 
 const val CLI_ENDPOINT_FILE_NAME = "cli-endpoint.json"
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliImageTranscoder.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliImageTranscoder.kt
@@ -1,0 +1,103 @@
+package com.crosspaste.cli
+
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorInfo
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.SamplingMode
+import org.jetbrains.skia.Surface
+
+/**
+ * Decoded pixels for the CLI's sixel rendering (design:
+ * ai/design/cli-sixel-support.md, issue #4846). The CLI never decodes image
+ * files itself; this transcoder is where stored images become raw pixels.
+ */
+class CliRawImage(
+    val width: Int,
+    val height: Int,
+    /** Straight-alpha RGBA8888, row-major, exactly width * height * 4 bytes. */
+    val rgba: ByteArray,
+)
+
+object CliImageTranscoder {
+
+    /** Server-side ceiling for the requested display box, per axis. */
+    const val MAX_BOX_PX = 1000
+
+    /**
+     * Refuses decompression bombs: dimensions are known from the encoded
+     * header before any pixel decoding, and 64M pixels (~8k x 8k) already
+     * means a ~256 MB internal decode.
+     */
+    const val MAX_SOURCE_PIXELS = 64_000_000L
+
+    /**
+     * Decodes any Skia-supported format (PNG/JPEG/WebP/GIF/BMP; animated
+     * images yield their first frame) and aspect-fit scales it into
+     * [maxWidth] x [maxHeight], never upscaling. Returns straight-alpha
+     * RGBA8888 at the exact returned dimensions, or null when [bytes] is not
+     * a decodable image or exceeds [MAX_SOURCE_PIXELS].
+     */
+    fun transcode(
+        bytes: ByteArray,
+        maxWidth: Int,
+        maxHeight: Int,
+    ): CliRawImage? {
+        val boxWidth = maxWidth.coerceIn(1, MAX_BOX_PX)
+        val boxHeight = maxHeight.coerceIn(1, MAX_BOX_PX)
+        val image =
+            try {
+                Image.makeFromEncoded(bytes)
+            } catch (_: Exception) {
+                // Undecodable bytes are an expected input (arbitrary stored
+                // files), not an error condition
+                return null
+            }
+        image.use { source ->
+            if (source.width <= 0 || source.height <= 0) return null
+            if (source.width.toLong() * source.height > MAX_SOURCE_PIXELS) return null
+            val scale =
+                minOf(
+                    boxWidth.toFloat() / source.width,
+                    boxHeight.toFloat() / source.height,
+                    1f,
+                )
+            val outWidth = (source.width * scale).toInt().coerceAtLeast(1)
+            val outHeight = (source.height * scale).toInt().coerceAtLeast(1)
+            // Draw on a premul surface (Skia cannot render onto unpremul),
+            // then let readPixels convert to the straight alpha the sixel
+            // encoder expects
+            Surface.makeRasterN32Premul(outWidth, outHeight).use { surface ->
+                surface.canvas.drawImageRect(
+                    source,
+                    Rect.makeWH(source.width.toFloat(), source.height.toFloat()),
+                    Rect.makeWH(outWidth.toFloat(), outHeight.toFloat()),
+                    SamplingMode.LINEAR,
+                    null,
+                    true,
+                )
+                surface.makeImageSnapshot().use { snapshot ->
+                    val bitmap = Bitmap()
+                    try {
+                        val info =
+                            ImageInfo(
+                                ColorInfo(ColorType.RGBA_8888, ColorAlphaType.UNPREMUL, null),
+                                outWidth,
+                                outHeight,
+                            )
+                        if (!bitmap.allocPixels(info)) return null
+                        if (!snapshot.readPixels(bitmap)) return null
+                        val rgba = bitmap.readPixels() ?: return null
+                        if (rgba.size != outWidth * outHeight * 4) return null
+                        return CliRawImage(outWidth, outHeight, rgba)
+                    } finally {
+                        bitmap.close()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -105,6 +105,11 @@ fun Routing.cliRouting(
             )
         }
 
+        get("/paste/{id}/image") {
+            val id = call.requireLongParameter("id", "Invalid paste id.") ?: return@get
+            handlePasteImage(call, id, pasteDao, userDataPathProvider)
+        }
+
         post("/paste/{id}/copy") {
             if (!supportsPasteCopy) {
                 call.respond(
@@ -328,6 +333,71 @@ private suspend fun respondPasteDetail(
     } else {
         call.respond(pasteData.toDetailDto(pasteTagDao, pasteItemReader, includeRaw, userDataPathProvider))
     }
+}
+
+/** Input-file ceiling for CLI image transcoding; larger files are refused. */
+private const val CLI_IMAGE_MAX_SOURCE_BYTES = 64L * 1024 * 1024
+
+/**
+ * Serves decoded pixels for the CLI's sixel rendering: the stored image at
+ * `index` of the paste's file list, decoded and aspect-fit scaled by
+ * [CliImageTranscoder] into the requested `maxWidth` x `maxHeight` box (both
+ * clamped to [CliImageTranscoder.MAX_BOX_PX], defaulting to it), returned as
+ * straight-alpha RGBA8888 with the exact dimensions in X-Image-Width /
+ * X-Image-Height headers. Every not-servable case — unknown id, no file at
+ * the index, unreadable/oversized file, undecodable bytes — is a 404 with a
+ * message; the CLI falls back to printing paths on any non-200.
+ */
+private suspend fun handlePasteImage(
+    call: ApplicationCall,
+    id: Long,
+    pasteDao: PasteDao,
+    userDataPathProvider: UserDataPathProvider,
+) {
+    val index = call.request.queryParameters["index"]?.toIntOrNull() ?: 0
+    val maxWidth =
+        call.request.queryParameters["maxWidth"]?.toIntOrNull()
+            ?: CliImageTranscoder.MAX_BOX_PX
+    val maxHeight =
+        call.request.queryParameters["maxHeight"]?.toIntOrNull()
+            ?: CliImageTranscoder.MAX_BOX_PX
+    val pasteData =
+        pasteDao.getNoDeletePasteData(id) ?: run {
+            call.respond(HttpStatusCode.NotFound, CliMessageDto("Paste #$id not found."))
+            return
+        }
+    val path =
+        (pasteData.pasteAppearItem as? PasteFiles)
+            ?.getFilePaths(userDataPathProvider)
+            ?.getOrNull(index)
+            ?: run {
+                call.respond(
+                    HttpStatusCode.NotFound,
+                    CliMessageDto("Paste #$id has no stored file at index $index."),
+                )
+                return
+            }
+    val raw =
+        withContext(ioDispatcher) {
+            runCatching {
+                val file = path.toFile()
+                if (file.length() in 1..CLI_IMAGE_MAX_SOURCE_BYTES) {
+                    CliImageTranscoder.transcode(file.readBytes(), maxWidth, maxHeight)
+                } else {
+                    null
+                }
+            }.getOrNull()
+        }
+    if (raw == null) {
+        call.respond(
+            HttpStatusCode.NotFound,
+            CliMessageDto("Paste #$id file at index $index is not a decodable image."),
+        )
+        return
+    }
+    call.response.header(CLI_IMAGE_WIDTH_HEADER, raw.width)
+    call.response.header(CLI_IMAGE_HEIGHT_HEADER, raw.height)
+    call.respondBytes(raw.rgba, ContentType.Application.OctetStream)
 }
 
 private suspend fun handleDevices(

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -40,7 +40,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -48,6 +50,7 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.longOrNull
+import java.io.File
 import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
@@ -339,6 +342,34 @@ private suspend fun respondPasteDetail(
 private const val CLI_IMAGE_MAX_SOURCE_BYTES = 64L * 1024 * 1024
 
 /**
+ * Serializes CLI image transcodes process-wide: one decode can hold hundreds
+ * of MiB of intermediate pixels (up to 64 MiB input + ~256 MiB decoded), and
+ * concurrent CLI requests must never multiply that against the desktop app's
+ * heap. Previews are bursty, not throughput-bound, so one permit is enough.
+ */
+private val cliImageTranscodeSemaphore = Semaphore(permits = 1)
+
+/**
+ * Reads at most [limit] bytes through a stream with a hard cap — the cap
+ * holds even when the file grows or is swapped between any size check and the
+ * read (reference-backed paste files can change underneath us). Returns null
+ * for an empty, oversized, or unreadable file. Only I/O failures are caught:
+ * JVM resource errors must surface, not masquerade as a 404.
+ */
+private fun readImageBytesBounded(
+    file: File,
+    limit: Long,
+): ByteArray? =
+    try {
+        file.inputStream().use { input ->
+            val bytes = input.readNBytes(limit.toInt() + 1)
+            if (bytes.isEmpty() || bytes.size > limit) null else bytes
+        }
+    } catch (_: IOException) {
+        null
+    }
+
+/**
  * Serves decoded pixels for the CLI's sixel rendering: the stored image at
  * `index` of the paste's file list, decoded and aspect-fit scaled by
  * [CliImageTranscoder] into the requested `maxWidth` x `maxHeight` box (both
@@ -379,14 +410,10 @@ private suspend fun handlePasteImage(
             }
     val raw =
         withContext(ioDispatcher) {
-            runCatching {
-                val file = path.toFile()
-                if (file.length() in 1..CLI_IMAGE_MAX_SOURCE_BYTES) {
-                    CliImageTranscoder.transcode(file.readBytes(), maxWidth, maxHeight)
-                } else {
-                    null
-                }
-            }.getOrNull()
+            cliImageTranscodeSemaphore.withPermit {
+                readImageBytesBounded(path.toFile(), CLI_IMAGE_MAX_SOURCE_BYTES)
+                    ?.let { CliImageTranscoder.transcode(it, maxWidth, maxHeight) }
+            }
         }
     if (raw == null) {
         call.respond(

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliImageTranscoderTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliImageTranscoderTest.kt
@@ -1,0 +1,80 @@
+package com.crosspaste.cli
+
+import org.jetbrains.skia.Surface
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CliImageTranscoderTest {
+
+    /** Encodes a solid-[argb]-filled PNG of the given size via Skia. */
+    private fun pngBytes(
+        width: Int,
+        height: Int,
+        argb: Int,
+    ): ByteArray =
+        Surface.makeRasterN32Premul(width, height).use { surface ->
+            surface.canvas.clear(argb)
+            surface.makeImageSnapshot().encodeToData()!!.bytes
+        }
+
+    @Test
+    fun decodesAtOriginalSizeWhenItFitsTheBox() {
+        val raw = CliImageTranscoder.transcode(pngBytes(4, 2, 0xFFFF0000.toInt()), 100, 100)
+        assertNotNull(raw)
+        assertEquals(4, raw.width)
+        assertEquals(2, raw.height)
+        assertEquals(4 * 2 * 4, raw.rgba.size)
+        // Straight-alpha RGBA byte order: opaque red
+        assertEquals(0xFF.toByte(), raw.rgba[0])
+        assertEquals(0x00.toByte(), raw.rgba[1])
+        assertEquals(0x00.toByte(), raw.rgba[2])
+        assertEquals(0xFF.toByte(), raw.rgba[3])
+    }
+
+    @Test
+    fun downscalesToFitPreservingAspectRatio() {
+        val raw = CliImageTranscoder.transcode(pngBytes(100, 50, 0xFF00FF00.toInt()), 10, 10)
+        assertNotNull(raw)
+        assertEquals(10, raw.width)
+        assertEquals(5, raw.height)
+        assertEquals(10 * 5 * 4, raw.rgba.size)
+    }
+
+    @Test
+    fun neverUpscalesASmallImage() {
+        val raw = CliImageTranscoder.transcode(pngBytes(4, 2, 0xFF0000FF.toInt()), 1000, 1000)
+        assertNotNull(raw)
+        assertEquals(4, raw.width)
+        assertEquals(2, raw.height)
+    }
+
+    @Test
+    fun returnsStraightAlphaNotPremultiplied() {
+        // Half-transparent red: premultiplied storage would read back r=128,
+        // straight alpha must restore r=255 (allow rounding wiggle)
+        val raw = CliImageTranscoder.transcode(pngBytes(2, 2, 0x80FF0000.toInt()), 100, 100)
+        assertNotNull(raw)
+        val r = raw.rgba[0].toInt() and 0xFF
+        val a = raw.rgba[3].toInt() and 0xFF
+        assertTrue(abs(a - 0x80) <= 1, "alpha should stay ~0x80, was $a")
+        assertTrue(r >= 0xFD, "red should be un-premultiplied back to ~0xFF, was $r")
+    }
+
+    @Test
+    fun rejectsUndecodableBytes() {
+        assertNull(CliImageTranscoder.transcode("not an image".encodeToByteArray(), 100, 100))
+        assertNull(CliImageTranscoder.transcode(ByteArray(0), 100, 100))
+    }
+
+    @Test
+    fun clampsDegenerateBoxToOnePixel() {
+        val raw = CliImageTranscoder.transcode(pngBytes(4, 2, 0xFFFF0000.toInt()), 0, -5)
+        assertNotNull(raw)
+        assertEquals(1, raw.width)
+        assertEquals(1, raw.height)
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliImageTranscoderTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliImageTranscoderTest.kt
@@ -64,6 +64,82 @@ class CliImageTranscoderTest {
         assertTrue(r >= 0xFD, "red should be un-premultiplied back to ~0xFF, was $r")
     }
 
+    /**
+     * Hand-built 1x1 two-frame animated GIF89a: global palette [red, blue],
+     * frame 1 pixel = color 0 (red), frame 2 pixel = color 1 (blue).
+     */
+    private fun animatedGifBytes(): ByteArray {
+        fun frame(lzwPixelBytes: ByteArray): ByteArray =
+            byteArrayOf(
+                // Graphic Control Extension: 0.1s delay, no transparency
+                0x21,
+                0xF9.toByte(),
+                0x04,
+                0x00,
+                0x0A,
+                0x00,
+                0x00,
+                0x00,
+                // Image descriptor: full 1x1 frame, no local palette
+                0x2C,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0x00,
+                0x00,
+            ) + lzwPixelBytes
+        return byteArrayOf(
+            0x47,
+            0x49,
+            0x46,
+            0x38,
+            0x39,
+            0x61, // "GIF89a"
+            0x01,
+            0x00,
+            0x01,
+            0x00, // logical screen 1x1
+            0x80.toByte(),
+            0x00,
+            0x00, // 2-entry global palette, bg 0
+            0xFF.toByte(),
+            0x00,
+            0x00, // color 0: red
+            0x00,
+            0x00,
+            0xFF.toByte(), // color 1: blue
+        ) +
+            frame(byteArrayOf(0x02, 0x02, 0x44, 0x01, 0x00)) + // clear, 0, end
+            frame(byteArrayOf(0x02, 0x02, 0x4C, 0x01, 0x00)) + // clear, 1, end
+            byteArrayOf(0x3B) // trailer
+    }
+
+    @Test
+    fun animatedGifDecodesToItsFirstFrame() {
+        val raw = CliImageTranscoder.transcode(animatedGifBytes(), 100, 100)
+        assertNotNull(raw)
+        assertEquals(1, raw.width)
+        assertEquals(1, raw.height)
+        // The first frame paints palette color 0 (red); blue would mean a
+        // later frame leaked through
+        assertEquals(0xFF.toByte(), raw.rgba[0])
+        assertEquals(0x00.toByte(), raw.rgba[1])
+        assertEquals(0x00.toByte(), raw.rgba[2])
+        assertEquals(0xFF.toByte(), raw.rgba[3])
+    }
+
+    @Test
+    fun clampsOversizedBoxToServerCeiling() {
+        val raw = CliImageTranscoder.transcode(pngBytes(2000, 100, 0xFF00FF00.toInt()), 999_999, 999_999)
+        assertNotNull(raw)
+        assertEquals(CliImageTranscoder.MAX_BOX_PX, raw.width)
+        assertEquals(50, raw.height)
+    }
+
     @Test
     fun rejectsUndecodableBytes() {
         assertNull(CliImageTranscoder.transcode("not an image".encodeToByteArray(), 100, 100))

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -63,6 +63,9 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import okio.Path.Companion.toPath
+import org.jetbrains.skia.Surface
+import java.io.File
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -249,6 +252,121 @@ class CliRoutingTest {
                     client.get("/cli/paste/latest").bodyAsText(),
                 )
             assertEquals(emptyList(), detail.filePaths)
+        }
+    }
+
+    /** Builds an image paste whose stored file holds [bytes] on real disk. */
+    private fun imagePasteDataOnDisk(
+        id: Long,
+        bytes: ByteArray,
+        fileName: String = "shot.png",
+    ): PasteData {
+        val dir = Files.createTempDirectory("cli-image-route").toFile()
+        File(dir, fileName).writeBytes(bytes)
+        val item =
+            createImagesPasteItem(
+                basePath = dir.absolutePath,
+                relativePathList = listOf(fileName),
+                fileInfoTreeMap =
+                    mapOf(fileName to SingleFileInfoTree(size = bytes.size.toLong(), hash = "img")),
+            )
+        return PasteData(
+            id = id,
+            appInstanceId = appInfo.appInstanceId,
+            pasteAppearItem = item,
+            pasteCollection = PasteCollection(listOf()),
+            pasteType = PasteType.IMAGE_TYPE.type,
+            source = "Test",
+            size = item.size,
+            hash = item.hash,
+            createTime = 123L,
+            pasteState = PasteState.LOADED,
+        )
+    }
+
+    /** Encodes a solid-[argb] PNG of the given size via Skia. */
+    private fun pngBytes(
+        width: Int,
+        height: Int,
+        argb: Int,
+    ): ByteArray =
+        Surface.makeRasterN32Premul(width, height).use { surface ->
+            surface.canvas.clear(argb)
+            surface.makeImageSnapshot().encodeToData()!!.bytes
+        }
+
+    @Test
+    fun `image endpoint serves raw rgba with dimension headers`() {
+        val fixture = Fixture()
+        coEvery { fixture.pasteDao.getNoDeletePasteData(7L) } returns
+            imagePasteDataOnDisk(7L, pngBytes(4, 2, 0xFFFF0000.toInt()))
+        withCliRouting(fixture) {
+            val response = client.get("/cli/paste/7/image?maxWidth=100&maxHeight=100")
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("4", response.headers[CLI_IMAGE_WIDTH_HEADER])
+            assertEquals("2", response.headers[CLI_IMAGE_HEIGHT_HEADER])
+            val body = response.readRawBytes()
+            assertEquals(4 * 2 * 4, body.size, "payload must be width * height * 4")
+            // Straight-alpha RGBA byte order: opaque red
+            assertEquals(0xFF.toByte(), body[0])
+            assertEquals(0x00.toByte(), body[1])
+            assertEquals(0x00.toByte(), body[2])
+            assertEquals(0xFF.toByte(), body[3])
+        }
+    }
+
+    @Test
+    fun `image endpoint downscales into the requested box`() {
+        val fixture = Fixture()
+        coEvery { fixture.pasteDao.getNoDeletePasteData(8L) } returns
+            imagePasteDataOnDisk(8L, pngBytes(100, 50, 0xFF00FF00.toInt()))
+        withCliRouting(fixture) {
+            val response = client.get("/cli/paste/8/image?maxWidth=10&maxHeight=10")
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("10", response.headers[CLI_IMAGE_WIDTH_HEADER])
+            assertEquals("5", response.headers[CLI_IMAGE_HEIGHT_HEADER])
+            assertEquals(10 * 5 * 4, response.readRawBytes().size)
+        }
+    }
+
+    @Test
+    fun `image endpoint returns 404 for an unknown paste`() {
+        val fixture = Fixture()
+        coEvery { fixture.pasteDao.getNoDeletePasteData(99L) } returns null
+        withCliRouting(fixture) {
+            val response = client.get("/cli/paste/99/image")
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+    }
+
+    @Test
+    fun `image endpoint returns 404 when the index has no file`() {
+        val fixture = Fixture()
+        coEvery { fixture.pasteDao.getNoDeletePasteData(7L) } returns
+            imagePasteDataOnDisk(7L, pngBytes(4, 2, 0xFFFF0000.toInt()))
+        coEvery { fixture.pasteDao.getNoDeletePasteData(42L) } returns textPasteData(42L, "hello")
+        withCliRouting(fixture) {
+            assertEquals(
+                HttpStatusCode.NotFound,
+                client.get("/cli/paste/7/image?index=5").status,
+            )
+            // A text paste has no stored files at all
+            assertEquals(
+                HttpStatusCode.NotFound,
+                client.get("/cli/paste/42/image").status,
+            )
+        }
+    }
+
+    @Test
+    fun `image endpoint returns 404 for an undecodable stored file`() {
+        val fixture = Fixture()
+        coEvery { fixture.pasteDao.getNoDeletePasteData(7L) } returns
+            imagePasteDataOnDisk(7L, "definitely not an image".encodeToByteArray())
+        withCliRouting(fixture) {
+            val response = client.get("/cli/paste/7/image")
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertContains(response.bodyAsText(), "not a decodable image")
         }
     }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -65,6 +65,7 @@ import kotlinx.serialization.json.put
 import okio.Path.Companion.toPath
 import org.jetbrains.skia.Surface
 import java.io.File
+import java.io.RandomAccessFile
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -326,6 +327,38 @@ class CliRoutingTest {
             assertEquals("10", response.headers[CLI_IMAGE_WIDTH_HEADER])
             assertEquals("5", response.headers[CLI_IMAGE_HEIGHT_HEADER])
             assertEquals(10 * 5 * 4, response.readRawBytes().size)
+        }
+    }
+
+    @Test
+    fun `image endpoint clamps oversized box parameters server side`() {
+        val fixture = Fixture()
+        coEvery { fixture.pasteDao.getNoDeletePasteData(9L) } returns
+            imagePasteDataOnDisk(9L, pngBytes(2000, 100, 0xFF00FF00.toInt()))
+        withCliRouting(fixture) {
+            val response = client.get("/cli/paste/9/image?maxWidth=999999&maxHeight=999999")
+            assertEquals(HttpStatusCode.OK, response.status)
+            // Without the 1000 px clamp this would come back at 2000x100
+            assertEquals("1000", response.headers[CLI_IMAGE_WIDTH_HEADER])
+            assertEquals("50", response.headers[CLI_IMAGE_HEIGHT_HEADER])
+        }
+    }
+
+    @Test
+    fun `image endpoint refuses a file over the source byte budget`() {
+        val fixture = Fixture()
+        val pasteData = imagePasteDataOnDisk(11L, pngBytes(4, 2, 0xFFFF0000.toInt()))
+        // Grow the stored file past 64 MiB AFTER creation — the bounded read
+        // must reject it at read time, size checks alone are racy
+        val storedFile =
+            File(
+                (pasteData.pasteAppearItem as com.crosspaste.paste.item.PasteFiles).basePath!!,
+                "shot.png",
+            )
+        RandomAccessFile(storedFile, "rw").use { it.setLength(64L * 1024 * 1024 + 1) }
+        coEvery { fixture.pasteDao.getNoDeletePasteData(11L) } returns pasteData
+        withCliRouting(fixture) {
+            assertEquals(HttpStatusCode.NotFound, client.get("/cli/paste/11/image").status)
         }
     }
 

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/api/CliClient.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/api/CliClient.kt
@@ -18,8 +18,27 @@ import okio.FileSystem
 /**
  * Version of the local /cli API this binary speaks. Mirrors CLI_API_VERSION
  * on the app side; a mismatch produces a warning, not a failure.
+ * 2: GET /cli/paste/{id}/image raw-RGBA transcode endpoint (sixel support).
  */
-const val CLI_API_VERSION = 1
+const val CLI_API_VERSION = 2
+
+/** Response headers carrying the exact dimensions of a transcoded image. */
+internal const val CLI_IMAGE_WIDTH_HEADER = "X-Image-Width"
+internal const val CLI_IMAGE_HEIGHT_HEADER = "X-Image-Height"
+
+/** Mirror of the app-side request box clamp; requests never exceed it. */
+internal const val CLI_IMAGE_MAX_BOX_PX = 1000
+
+/**
+ * Straight-alpha RGBA8888 pixels at exact display size, served by the app's
+ * transcode endpoint. The CLI never decodes image files (design:
+ * ai/design/cli-sixel-support.md); the sixel path renders from this.
+ */
+class CliRawImage(
+    val width: Int,
+    val height: Int,
+    val rgba: ByteArray,
+)
 
 /** Default per-request timeout; long-running pair calls override it per call. */
 internal const val DEFAULT_REQUEST_TIMEOUT_MILLIS = 5000L
@@ -131,6 +150,53 @@ class CliClient(
     ): T = decode(delete(path), deserializer)
 
     suspend fun get(path: String): HttpResponse = request(HttpMethod.Get, path)
+
+    /**
+     * Fetches the stored image at [index] of paste [id] as raw pixels, scaled
+     * by the app to fit [maxWidth] x [maxHeight] (clamped to
+     * [CLI_IMAGE_MAX_BOX_PX]). Any non-200 — including 404 from an app that
+     * predates the endpoint — surfaces as [CliClientException]; callers fall
+     * back to printing file paths. A 200 whose headers or body do not describe
+     * a consistent image is also an error, never a partial result.
+     */
+    suspend fun getRawImage(
+        id: Long,
+        index: Int,
+        maxWidth: Int,
+        maxHeight: Int,
+    ): CliRawImage {
+        val boxWidth = maxWidth.coerceIn(1, CLI_IMAGE_MAX_BOX_PX)
+        val boxHeight = maxHeight.coerceIn(1, CLI_IMAGE_MAX_BOX_PX)
+        val response =
+            request(
+                HttpMethod.Get,
+                "/cli/paste/$id/image?index=$index&maxWidth=$boxWidth&maxHeight=$boxHeight",
+            )
+        if (!response.status.isSuccess()) {
+            val serverMessage = extractMessage(response.bodyAsText())
+            throw CliClientException(
+                serverMessage ?: "Request failed with status ${response.status}",
+                statusCode = response.status.value,
+                hasServerMessage = serverMessage != null,
+            )
+        }
+        val width = response.headers[CLI_IMAGE_WIDTH_HEADER]?.toIntOrNull()
+        val height = response.headers[CLI_IMAGE_HEIGHT_HEADER]?.toIntOrNull()
+        if (width == null ||
+            height == null ||
+            width !in 1..CLI_IMAGE_MAX_BOX_PX ||
+            height !in 1..CLI_IMAGE_MAX_BOX_PX
+        ) {
+            throw CliClientException("Unexpected image dimensions from CrossPaste: $width x $height")
+        }
+        val rgba = response.readRawBytes()
+        if (rgba.size != width * height * 4) {
+            throw CliClientException(
+                "Image payload size ${rgba.size} does not match $width x $height RGBA.",
+            )
+        }
+        return CliRawImage(width, height, rgba)
+    }
 
     /**
      * Opens a long-lived streaming GET (the /cli/watch NDJSON feed) and hands


### PR DESCRIPTION
Closes #4846. Phase 2 of #4844 (sixel graphics support for Windows Terminal). Independent of the P1 encoder (#4849); the two meet in the P4 wiring (#4848).

## Summary

Adds `GET /cli/paste/{id}/image?index=&maxWidth=&maxHeight=` so the CLI can obtain decoded pixels for sixel rendering without ever decoding image files itself. The app decodes and aspect-fit scales the stored image with its existing Skia stack and returns straight-alpha RGBA8888 with the exact dimensions in `X-Image-Width` / `X-Image-Height` headers. Everything is desktopMain-only — no commonMain changes, no mobile impact.

## Implementation

- **`CliImageTranscoder`** (new, desktopMain): decodes any Skia-supported format (animated images yield their first frame), aspect-fit scales into the requested box without ever upscaling, and reads pixels back as UNPREMUL RGBA_8888 — rendering happens on a premul surface (Skia cannot draw onto unpremul) and the conversion to straight alpha happens in `readPixels`. Undecodable bytes return null (expected input, not an error). Decompression-bomb guard: dimensions are known from the encoded header before pixel decoding, and anything over 64M source pixels is refused.
- **Route** in `CliRouting.kt`: resolves the stored file by paste id + index through `PasteFiles.getFilePaths` (no path parameter — no arbitrary-file-read surface on the CLI socket), caps the input file at 64 MiB, clamps the box to 1000 px per axis (also the default), and answers 404 with a message for every not-servable case: unknown id, no file at the index, unreadable/oversized file, undecodable bytes. The CLI falls back to printing paths on any non-200.
- **`CLI_API_VERSION` 1 → 2** on both sides. A new CLI against an old app degrades gracefully: the route 404s without a server message, which `CliClientException.hasServerMessage` already distinguishes.
- **`CliClient.getRawImage(id, index, maxWidth, maxHeight)`** (CLI side): clamps the requested box, validates the response headers (dimensions in 1..1000) and that the payload is exactly `width * height * 4` bytes — a truncated body is an error, never a partial image.

## Tests

- `CliImageTranscoderTest` (new): original-size passthrough, aspect-fit downscale (100x50 → 10x5), never-upscale, straight-alpha round-trip (half-transparent red must read back r≈0xFF/a≈0x80, catching accidental premul output), undecodable rejection, degenerate box clamp.
- `CliRoutingTest`: 200 with dimension headers and pixel-level payload check against a real PNG on disk, downscale via query params, 404 for unknown paste / out-of-range index / text paste / undecodable stored file.

`./gradlew app:desktopTest` (full fast tier), `cli:macosArm64Test`, and `ktlintCheck` pass.