### PR TITLE
:sparkles: add sixel terminal capability probe with DA1 confirmation

### DIFF
--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
@@ -88,7 +88,9 @@ internal class InlineImageRenderer(
     }
 
     fun render(paths: List<String>) {
-        val protocol = protocol ?: return
+        // SIXEL renders from app-transcoded pixels, not stored files; it is
+        // wired into this renderer in #4848 and never selected until then
+        val protocol = protocol?.takeIf { it != TerminalImageProtocol.SIXEL } ?: return
         var rendered = 0
         var inspected = 0
         var remainingBudget = maxTotalBytes
@@ -113,6 +115,7 @@ internal class InlineImageRenderer(
             when (protocol) {
                 TerminalImageProtocol.ITERM -> writeItermInlineImage(path.toPath().name, bytes, emit)
                 TerminalImageProtocol.KITTY -> writeKittyInlineImage(bytes, emit)
+                TerminalImageProtocol.SIXEL -> {} // unreachable: filtered out above
             }
             emit("\n")
             rendered++

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
@@ -551,7 +551,10 @@ internal class PickTui(
         path: String,
         panelRow: Int,
     ): Boolean {
-        val protocol = imageProtocol ?: return false
+        // SIXEL renders from app-transcoded pixels, not stored files; it is
+        // wired into this preview in #4848 and never selected until then
+        val protocol =
+            imageProtocol?.takeIf { it != TerminalImageProtocol.SIXEL } ?: return false
         val bytes =
             readImageWithinBudget(
                 path = path,
@@ -581,6 +584,7 @@ internal class PickTui(
                     widthCells = box.first,
                     heightCells = box.second,
                 )
+            TerminalImageProtocol.SIXEL -> {} // unreachable: filtered out above
         }
         terminal.rawPrint("${ESC}8")
         return true

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalImage.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalImage.kt
@@ -17,6 +17,13 @@ enum class TerminalImageProtocol {
 
     /** Kitty graphics protocol; PNG payloads only (`f=100`). */
     KITTY,
+
+    /**
+     * Sixel (DCS q): unlike the two protocols above, the payload is quantized
+     * pixels, not a passed-through image file. Never selected from the
+     * environment alone — TerminalProbe.kt must confirm it via DA1 first.
+     */
+    SIXEL,
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -40,6 +47,22 @@ internal fun detectTerminalImageProtocol(env: (String) -> String?): TerminalImag
         termProgram == "iTerm.app" || termProgram == "WezTerm" || termProgram == "mintty" -> TerminalImageProtocol.ITERM
         else -> null
     }
+}
+
+/**
+ * Whether the environment suggests a sixel-capable terminal: Windows Terminal
+ * (`WT_SESSION`; conhost never sets it) or one of the Linux sixel terminals.
+ * This is only a CANDIDATE — an older Windows Terminal (< 1.22) sets
+ * WT_SESSION without supporting sixel, so selecting SIXEL additionally
+ * requires the DA1 probe confirmation in TerminalProbe.kt; env evidence alone
+ * must never put escape garbage on screen.
+ */
+internal fun isSixelCandidate(env: (String) -> String?): Boolean {
+    if (!env("TMUX").isNullOrEmpty()) return false
+    val term = env("TERM").orEmpty()
+    if (term.startsWith("tmux") || term.startsWith("screen")) return false
+    if (!env("WT_SESSION").isNullOrEmpty()) return true
+    return term.contains("foot") || term.contains("mlterm") || term.contains("yaft")
 }
 
 // Spelled out as char codes so the source contains no literal control bytes

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalProbe.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalProbe.kt
@@ -1,0 +1,115 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+
+/**
+ * Everything the renderers need to know about inline image display.
+ *
+ * Sixel capability probing (design: ai/design/cli-sixel-support.md, issue
+ * #4847): environment variables only nominate sixel CANDIDATES (see
+ * [isSixelCandidate]); before SIXEL is ever selected, the terminal must
+ * answer a DA1 query (`CSI c`) with attribute 4. This is what keeps an older
+ * Windows Terminal — same `WT_SESSION`, no sixel — on the path fallback
+ * instead of receiving escape garbage.
+ */
+internal class TerminalImageDisplay(
+    val protocol: TerminalImageProtocol,
+    /** Terminal cell size in pixels; only meaningful for SIXEL layout. */
+    val cellWidthPx: Int = DEFAULT_CELL_WIDTH_PX,
+    val cellHeightPx: Int = DEFAULT_CELL_HEIGHT_PX,
+)
+
+/** Fallback cell size (~Windows Terminal default font) when CSI 16 t goes unanswered. */
+internal const val DEFAULT_CELL_WIDTH_PX = 10
+internal const val DEFAULT_CELL_HEIGHT_PX = 20
+
+/** Upper bound for a believable cell dimension reply, in pixels. */
+internal const val MAX_SANE_CELL_PX = 512
+
+/** Whole-transaction budget; a live terminal answers in single-digit millis. */
+internal const val SIXEL_PROBE_TIMEOUT_MILLIS = 250
+
+/**
+ * One write, two queries: XTWINOPS `CSI 16 t` (cell pixel size, may be
+ * ignored) then DA1 `CSI c` (universally answered). Replies preserve request
+ * order, so the DA1 reply doubles as the end-of-transaction marker.
+ */
+internal val SIXEL_PROBE_PAYLOAD: String = "$TERM_ESC[16t$TERM_ESC[c"
+
+/**
+ * Resolves which inline-image protocol to use, running the sixel probe when
+ * the environment nominates a candidate. Returns null when images should fall
+ * back to printed file paths. All effects are injectable; production callers
+ * pass Mordant's interactivity flags and the platform [queryTerminalRaw].
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun resolveTerminalImageDisplay(
+    stdinInteractive: Boolean,
+    stdoutInteractive: Boolean,
+    env: (String) -> String? = { getenv(it)?.toKString() },
+    query: (payload: String, timeoutMillis: Int, isComplete: (String) -> Boolean) -> String? =
+        ::queryTerminalRaw,
+): TerminalImageDisplay? {
+    detectTerminalImageProtocol(env)?.let { return TerminalImageDisplay(it) }
+    if (!isSixelCandidate(env)) return null
+    // The probe writes to the terminal and reads the reply off stdin; with
+    // either end redirected there is nothing safe to probe (and a pipe would
+    // swallow the escape bytes anyway)
+    if (!stdinInteractive || !stdoutInteractive) return null
+    val reply =
+        query(SIXEL_PROBE_PAYLOAD, SIXEL_PROBE_TIMEOUT_MILLIS, ::containsDa1Reply)
+            ?: return null
+    if (!parseDa1SixelSupport(reply)) return null
+    val cellSize = parseCellSizeReply(reply)
+    return TerminalImageDisplay(
+        protocol = TerminalImageProtocol.SIXEL,
+        cellWidthPx = cellSize?.first ?: DEFAULT_CELL_WIDTH_PX,
+        cellHeightPx = cellSize?.second ?: DEFAULT_CELL_HEIGHT_PX,
+    )
+}
+
+/** True once [buffer] holds a complete DA1 reply (`CSI ? ... c`). */
+internal fun containsDa1Reply(buffer: String): Boolean {
+    val start = buffer.indexOf("$TERM_ESC[?")
+    if (start < 0) return false
+    return buffer.indexOf('c', startIndex = start + 3) >= 0
+}
+
+/**
+ * Whether a DA1 reply advertises sixel. Format: `CSI ? class ; attr ; ... c`
+ * — the FIRST parameter is the device conformance class (62/63/...), not an
+ * attribute, so only the parameters after it may claim attribute 4 (sixel).
+ */
+internal fun parseDa1SixelSupport(reply: String): Boolean {
+    val start = reply.indexOf("$TERM_ESC[?")
+    if (start < 0) return false
+    val end = reply.indexOf('c', startIndex = start + 3)
+    if (end < 0) return false
+    return reply
+        .substring(start + 3, end)
+        .split(';')
+        .drop(1)
+        .any { it == "4" }
+}
+
+/**
+ * Parses the XTWINOPS cell-size reply `CSI 6 ; heightPx ; widthPx t` (height
+ * first!) into (widthPx, heightPx). Returns null when absent or implausible —
+ * the caller then assumes the [DEFAULT_CELL_WIDTH_PX] x
+ * [DEFAULT_CELL_HEIGHT_PX] cell.
+ */
+internal fun parseCellSizeReply(reply: String): Pair<Int, Int>? {
+    val marker = "$TERM_ESC[6;"
+    val start = reply.indexOf(marker)
+    if (start < 0) return null
+    val end = reply.indexOf('t', startIndex = start + marker.length)
+    if (end < 0) return null
+    val parts = reply.substring(start + marker.length, end).split(';')
+    if (parts.size != 2) return null
+    val height = parts[0].toIntOrNull() ?: return null
+    val width = parts[1].toIntOrNull() ?: return null
+    if (height !in 1..MAX_SANE_CELL_PX || width !in 1..MAX_SANE_CELL_PX) return null
+    return width to height
+}

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/TerminalProbeTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/TerminalProbeTest.kt
@@ -1,0 +1,165 @@
+package com.crosspaste.cli.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TerminalProbeTest {
+
+    private val esc = 27.toChar().toString()
+
+    private fun env(vararg pairs: Pair<String, String>): (String) -> String? = mapOf(*pairs)::get
+
+    // Windows Terminal >= 1.22 style DA1 reply (attribute 4 = sixel)
+    private val wtSixelReply = "$esc[?61;4;6;7;14;21;22;23;24;28;32;42c"
+
+    // Windows Terminal < 1.22 style DA1 reply: same class, no attribute 4
+    private val wtNoSixelReply = "$esc[?61;6;7;14;21;22;23;24;28;32;42c"
+
+    private val cellSizeReply = "$esc[6;20;10t"
+
+    @Test
+    fun sixelCandidateMatrix() {
+        assertTrue(isSixelCandidate(env("WT_SESSION" to "guid", "TERM" to "xterm-256color")))
+        assertTrue(isSixelCandidate(env("TERM" to "foot")))
+        assertTrue(isSixelCandidate(env("TERM" to "foot-extra")))
+        assertTrue(isSixelCandidate(env("TERM" to "mlterm")))
+        assertTrue(isSixelCandidate(env("TERM" to "yaft-256color")))
+        // conhost: no WT_SESSION, no sixel TERM
+        assertFalse(isSixelCandidate(env("TERM" to "xterm-256color")))
+        assertFalse(isSixelCandidate(env()))
+        // The multiplexer guard outranks every candidate signal
+        assertFalse(isSixelCandidate(env("WT_SESSION" to "guid", "TMUX" to "/tmp/tmux-1")))
+        assertFalse(isSixelCandidate(env("TERM" to "screen.foot")))
+        assertFalse(isSixelCandidate(env("TERM" to "tmux-256color", "WT_SESSION" to "guid")))
+    }
+
+    @Test
+    fun da1ReplyCompletionDetection() {
+        assertFalse(containsDa1Reply(""))
+        assertFalse(containsDa1Reply("$esc[?61;4"))
+        // The cell-size reply alone does not end the transaction
+        assertFalse(containsDa1Reply(cellSizeReply))
+        assertTrue(containsDa1Reply(wtSixelReply))
+        assertTrue(containsDa1Reply(cellSizeReply + wtSixelReply))
+    }
+
+    @Test
+    fun da1SixelAttributeParsing() {
+        assertTrue(parseDa1SixelSupport(wtSixelReply))
+        assertTrue(parseDa1SixelSupport("$esc[?63;1;2;3;4;7;29c")) // mlterm style
+        assertFalse(parseDa1SixelSupport(wtNoSixelReply))
+        assertFalse(parseDa1SixelSupport("$esc[?1;2c")) // VT100
+        assertFalse(parseDa1SixelSupport(""))
+        assertFalse(parseDa1SixelSupport("garbage"))
+        // A lone first parameter is the device class, never an attribute
+        assertFalse(parseDa1SixelSupport("$esc[?4c"))
+        // Attribute must match exactly, not as a substring
+        assertFalse(parseDa1SixelSupport("$esc[?62;14;42c"))
+    }
+
+    @Test
+    fun cellSizeReplyParsing() {
+        // Reply order is height;width — the parsed pair is (width, height)
+        assertEquals(10 to 20, parseCellSizeReply(cellSizeReply))
+        assertEquals(10 to 20, parseCellSizeReply(cellSizeReply + wtSixelReply))
+        assertNull(parseCellSizeReply(""))
+        assertNull(parseCellSizeReply(wtSixelReply))
+        assertNull(parseCellSizeReply("$esc[6;20t"))
+        assertNull(parseCellSizeReply("$esc[6;0;10t"))
+        assertNull(parseCellSizeReply("$esc[6;20;-1t"))
+        assertNull(parseCellSizeReply("$esc[6;9999;10t"))
+        assertNull(parseCellSizeReply("$esc[6;a;bt"))
+    }
+
+    private class RecordingQuery(
+        private val reply: String?,
+    ) {
+        var calls = 0
+        var lastPayload: String? = null
+
+        fun query(
+            payload: String,
+            timeoutMillis: Int,
+            isComplete: (String) -> Boolean,
+        ): String? {
+            calls++
+            lastPayload = payload
+            check(timeoutMillis > 0) { "probe must carry a positive timeout" }
+            // A real transaction would have stopped reading exactly here
+            reply?.let { check(isComplete(it) || !it.contains('c')) }
+            return reply
+        }
+    }
+
+    private fun resolve(
+        environment: (String) -> String?,
+        query: RecordingQuery,
+        stdinInteractive: Boolean = true,
+        stdoutInteractive: Boolean = true,
+    ): TerminalImageDisplay? =
+        resolveTerminalImageDisplay(
+            stdinInteractive = stdinInteractive,
+            stdoutInteractive = stdoutInteractive,
+            env = environment,
+            query = query::query,
+        )
+
+    @Test
+    fun knownProtocolsResolveWithoutProbing() {
+        val query = RecordingQuery(reply = wtSixelReply)
+        val display = resolve(env("TERM" to "xterm-kitty"), query)
+        assertEquals(TerminalImageProtocol.KITTY, display?.protocol)
+        assertEquals(0, query.calls, "kitty/iterm terminals must never be probed")
+    }
+
+    @Test
+    fun windowsTerminalWithSixelConfirmsAndParsesCellSize() {
+        val query = RecordingQuery(reply = cellSizeReply + wtSixelReply)
+        val display = resolve(env("WT_SESSION" to "guid"), query)
+        assertEquals(TerminalImageProtocol.SIXEL, display?.protocol)
+        assertEquals(10, display?.cellWidthPx)
+        assertEquals(20, display?.cellHeightPx)
+        assertEquals(1, query.calls)
+        assertEquals(SIXEL_PROBE_PAYLOAD, query.lastPayload)
+    }
+
+    @Test
+    fun unansweredCellSizeQueryFallsBackToDefaultCell() {
+        val query = RecordingQuery(reply = wtSixelReply)
+        val display = resolve(env("WT_SESSION" to "guid"), query)
+        assertEquals(TerminalImageProtocol.SIXEL, display?.protocol)
+        assertEquals(DEFAULT_CELL_WIDTH_PX, display?.cellWidthPx)
+        assertEquals(DEFAULT_CELL_HEIGHT_PX, display?.cellHeightPx)
+    }
+
+    @Test
+    fun oldWindowsTerminalWithoutSixelAttributeFallsBack() {
+        val query = RecordingQuery(reply = wtNoSixelReply)
+        assertNull(resolve(env("WT_SESSION" to "guid"), query))
+        assertEquals(1, query.calls)
+    }
+
+    @Test
+    fun probeTimeoutOrRawModeFailureFallsBack() {
+        assertNull(resolve(env("WT_SESSION" to "guid"), RecordingQuery(reply = "")))
+        assertNull(resolve(env("WT_SESSION" to "guid"), RecordingQuery(reply = null)))
+    }
+
+    @Test
+    fun nonInteractiveStreamsAreNeverProbed() {
+        val query = RecordingQuery(reply = wtSixelReply)
+        assertNull(resolve(env("WT_SESSION" to "guid"), query, stdinInteractive = false))
+        assertNull(resolve(env("WT_SESSION" to "guid"), query, stdoutInteractive = false))
+        assertEquals(0, query.calls)
+    }
+
+    @Test
+    fun unknownTerminalIsNeverProbed() {
+        val query = RecordingQuery(reply = wtSixelReply)
+        assertNull(resolve(env("TERM" to "xterm-256color"), query))
+        assertEquals(0, query.calls)
+    }
+}

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/TerminalQuery.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/TerminalQuery.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.cli.platform
 
+import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
@@ -14,6 +15,7 @@ import platform.windows.DWORDVar
 import platform.windows.GetConsoleMode
 import platform.windows.GetNumberOfConsoleInputEvents
 import platform.windows.GetStdHandle
+import platform.windows.HANDLE
 import platform.windows.INPUT_RECORD
 import platform.windows.INVALID_HANDLE_VALUE
 import platform.windows.KEY_EVENT
@@ -55,10 +57,6 @@ internal fun queryTerminalRaw(
         val savedOutputMode = alloc<DWORDVar>()
         if (GetConsoleMode(stdinHandle, savedInputMode.ptr) == 0) return null
         if (GetConsoleMode(stdoutHandle, savedOutputMode.ptr) == 0) return null
-        // Input: VT mode only — no echo, no line buffering, and the terminal
-        // reply arrives as an ESC character stream instead of key events.
-        // Output: VT processing so conpty forwards the query sequences to the
-        // terminal instead of printing them.
         if (SetConsoleMode(stdinHandle, VT_INPUT_MODE) == 0) return null
         if (SetConsoleMode(
                 stdoutHandle,
@@ -69,60 +67,95 @@ internal fun queryTerminalRaw(
             return null
         }
         try {
-            val bytes = payload.encodeToByteArray()
-            val written = alloc<DWORDVar>()
-            val writeOk =
-                bytes.usePinned { pinned ->
-                    WriteFile(
-                        stdoutHandle,
-                        pinned.addressOf(0),
-                        bytes.size.convert(),
-                        written.ptr,
-                        null,
-                    )
-                }
-            if (writeOk == 0 || written.value.toInt() != bytes.size) return ""
-            val reply = StringBuilder()
-            val deadline = TimeSource.Monotonic.markNow() + timeoutMillis.milliseconds
-            val records = allocArray<INPUT_RECORD>(INPUT_RECORD_BATCH)
-            val eventCount = alloc<DWORDVar>()
-            val readCount = alloc<DWORDVar>()
-            while (!isComplete(reply.toString())) {
-                val remaining = (deadline - TimeSource.Monotonic.markNow()).inWholeMilliseconds
-                if (remaining <= 0) break
-                // 0u == WAIT_OBJECT_0 (input available); timeout and failure
-                // codes are both non-zero (spelled out to dodge the header
-                // constant's platform-dependent Kotlin type)
-                if (WaitForSingleObject(stdinHandle, remaining.toUInt()) != 0u) break
-                if (GetNumberOfConsoleInputEvents(stdinHandle, eventCount.ptr) == 0) break
-                if (eventCount.value == 0u) continue
-                // ReadConsoleInput consumes the queued records, so non-key
-                // events (focus, resize) cannot leave the handle signaled
-                // forever; the VT reply itself arrives as key-down records
-                // each carrying one character.
-                if (ReadConsoleInputW(
-                        stdinHandle,
-                        records,
-                        INPUT_RECORD_BATCH.convert(),
-                        readCount.ptr,
-                    ) == 0
-                ) {
-                    break
-                }
-                for (i in 0 until readCount.value.toInt()) {
-                    val record = records[i]
-                    if (record.EventType.toInt() != KEY_EVENT) continue
-                    val keyEvent = record.Event.KeyEvent
-                    if (keyEvent.bKeyDown == 0) continue
-                    val char = keyEvent.uChar.UnicodeChar
-                    if (char.toInt() != 0) {
-                        reply.append(char.toInt().toChar())
-                    }
-                }
+            if (writeConsolePayload(stdoutHandle, payload)) {
+                readConsoleReply(stdinHandle, timeoutMillis, isComplete)
+            } else {
+                ""
             }
-            reply.toString()
         } finally {
             SetConsoleMode(stdinHandle, savedInputMode.value)
             SetConsoleMode(stdoutHandle, savedOutputMode.value)
         }
     }
+
+@OptIn(ExperimentalForeignApi::class)
+private fun writeConsolePayload(
+    stdoutHandle: HANDLE,
+    payload: String,
+): Boolean =
+    memScoped {
+        val bytes = payload.encodeToByteArray()
+        val written = alloc<DWORDVar>()
+        val writeOk =
+            bytes.usePinned { pinned ->
+                WriteFile(
+                    stdoutHandle,
+                    pinned.addressOf(0),
+                    bytes.size.convert(),
+                    written.ptr,
+                    null,
+                )
+            }
+        writeOk != 0 && written.value.toInt() == bytes.size
+    }
+
+@OptIn(ExperimentalForeignApi::class)
+private fun readConsoleReply(
+    stdinHandle: HANDLE,
+    timeoutMillis: Int,
+    isComplete: (String) -> Boolean,
+): String =
+    memScoped {
+        val reply = StringBuilder()
+        val deadline = TimeSource.Monotonic.markNow() + timeoutMillis.milliseconds
+        val records = allocArray<INPUT_RECORD>(INPUT_RECORD_BATCH)
+        val eventCount = alloc<DWORDVar>()
+        val readCount = alloc<DWORDVar>()
+        while (!isComplete(reply.toString())) {
+            val remaining = (deadline - TimeSource.Monotonic.markNow()).inWholeMilliseconds
+            if (remaining <= 0) break
+            // 0u == WAIT_OBJECT_0 (input available); timeout and failure
+            // codes are both non-zero (spelled out to dodge the header
+            // constant's platform-dependent Kotlin type)
+            if (WaitForSingleObject(stdinHandle, remaining.toUInt()) != 0u) break
+            if (GetNumberOfConsoleInputEvents(stdinHandle, eventCount.ptr) == 0) break
+            if (eventCount.value == 0u) continue
+            // ReadConsoleInput consumes the queued records, so non-key events
+            // (focus, resize) cannot leave the handle signaled forever; the
+            // VT reply itself arrives as key-down records carrying characters
+            if (ReadConsoleInputW(
+                    stdinHandle,
+                    records,
+                    INPUT_RECORD_BATCH.convert(),
+                    readCount.ptr,
+                ) == 0
+            ) {
+                break
+            }
+            appendKeyChars(records, readCount.value.toInt(), reply)
+        }
+        reply.toString()
+    }
+
+@OptIn(ExperimentalForeignApi::class)
+private fun appendKeyChars(
+    records: CPointer<INPUT_RECORD>,
+    count: Int,
+    reply: StringBuilder,
+) {
+    for (i in 0 until count) {
+        val record = records[i]
+        if (record.EventType.toInt() != KEY_EVENT) continue
+        val keyEvent = record.Event.KeyEvent
+        if (keyEvent.bKeyDown == 0) continue
+        val char = keyEvent.uChar.UnicodeChar.toInt()
+        if (char == 0) continue
+        // One record can carry a run of identical characters ("22" may
+        // arrive as a single record with wRepeatCount=2 — dropping the
+        // repeats would corrupt the DA1/cell-size reply); a zero count is
+        // defensively treated as one so a character is never lost
+        repeat(maxOf(keyEvent.wRepeatCount.toInt(), 1)) {
+            reply.append(char.toChar())
+        }
+    }
+}

--- a/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/TerminalQuery.kt
+++ b/cli/src/mingwNativeMain/kotlin/com/crosspaste/cli/platform/TerminalQuery.kt
@@ -1,0 +1,128 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import platform.windows.DWORDVar
+import platform.windows.GetConsoleMode
+import platform.windows.GetNumberOfConsoleInputEvents
+import platform.windows.GetStdHandle
+import platform.windows.INPUT_RECORD
+import platform.windows.INVALID_HANDLE_VALUE
+import platform.windows.KEY_EVENT
+import platform.windows.ReadConsoleInputW
+import platform.windows.STD_INPUT_HANDLE
+import platform.windows.STD_OUTPUT_HANDLE
+import platform.windows.SetConsoleMode
+import platform.windows.WaitForSingleObject
+import platform.windows.WriteFile
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
+
+// Console-mode flags spelled out locally so compilation does not depend on
+// how recent the bundled mingw-w64 headers are.
+private const val VT_INPUT_MODE: UInt = 0x0200u // ENABLE_VIRTUAL_TERMINAL_INPUT
+private const val VT_PROCESSED_OUTPUT: UInt = 0x0001u // ENABLE_PROCESSED_OUTPUT
+private const val VT_OUTPUT_PROCESSING: UInt = 0x0004u // ENABLE_VIRTUAL_TERMINAL_PROCESSING
+
+private const val INPUT_RECORD_BATCH = 32
+
+/**
+ * Windows variant of the raw-mode query transaction (contract documented on
+ * the POSIX sibling): VT input mode delivers the terminal's reply as an ESC
+ * character stream in key-down records, VT output processing makes conpty
+ * forward the query sequences to the hosting terminal.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun queryTerminalRaw(
+    payload: String,
+    timeoutMillis: Int,
+    isComplete: (String) -> Boolean,
+): String? =
+    memScoped {
+        val stdinHandle = GetStdHandle(STD_INPUT_HANDLE)
+        val stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE)
+        if (stdinHandle == null || stdinHandle == INVALID_HANDLE_VALUE) return null
+        if (stdoutHandle == null || stdoutHandle == INVALID_HANDLE_VALUE) return null
+        val savedInputMode = alloc<DWORDVar>()
+        val savedOutputMode = alloc<DWORDVar>()
+        if (GetConsoleMode(stdinHandle, savedInputMode.ptr) == 0) return null
+        if (GetConsoleMode(stdoutHandle, savedOutputMode.ptr) == 0) return null
+        // Input: VT mode only — no echo, no line buffering, and the terminal
+        // reply arrives as an ESC character stream instead of key events.
+        // Output: VT processing so conpty forwards the query sequences to the
+        // terminal instead of printing them.
+        if (SetConsoleMode(stdinHandle, VT_INPUT_MODE) == 0) return null
+        if (SetConsoleMode(
+                stdoutHandle,
+                savedOutputMode.value or VT_PROCESSED_OUTPUT or VT_OUTPUT_PROCESSING,
+            ) == 0
+        ) {
+            SetConsoleMode(stdinHandle, savedInputMode.value)
+            return null
+        }
+        try {
+            val bytes = payload.encodeToByteArray()
+            val written = alloc<DWORDVar>()
+            val writeOk =
+                bytes.usePinned { pinned ->
+                    WriteFile(
+                        stdoutHandle,
+                        pinned.addressOf(0),
+                        bytes.size.convert(),
+                        written.ptr,
+                        null,
+                    )
+                }
+            if (writeOk == 0 || written.value.toInt() != bytes.size) return ""
+            val reply = StringBuilder()
+            val deadline = TimeSource.Monotonic.markNow() + timeoutMillis.milliseconds
+            val records = allocArray<INPUT_RECORD>(INPUT_RECORD_BATCH)
+            val eventCount = alloc<DWORDVar>()
+            val readCount = alloc<DWORDVar>()
+            while (!isComplete(reply.toString())) {
+                val remaining = (deadline - TimeSource.Monotonic.markNow()).inWholeMilliseconds
+                if (remaining <= 0) break
+                // 0u == WAIT_OBJECT_0 (input available); timeout and failure
+                // codes are both non-zero (spelled out to dodge the header
+                // constant's platform-dependent Kotlin type)
+                if (WaitForSingleObject(stdinHandle, remaining.toUInt()) != 0u) break
+                if (GetNumberOfConsoleInputEvents(stdinHandle, eventCount.ptr) == 0) break
+                if (eventCount.value == 0u) continue
+                // ReadConsoleInput consumes the queued records, so non-key
+                // events (focus, resize) cannot leave the handle signaled
+                // forever; the VT reply itself arrives as key-down records
+                // each carrying one character.
+                if (ReadConsoleInputW(
+                        stdinHandle,
+                        records,
+                        INPUT_RECORD_BATCH.convert(),
+                        readCount.ptr,
+                    ) == 0
+                ) {
+                    break
+                }
+                for (i in 0 until readCount.value.toInt()) {
+                    val record = records[i]
+                    if (record.EventType.toInt() != KEY_EVENT) continue
+                    val keyEvent = record.Event.KeyEvent
+                    if (keyEvent.bKeyDown == 0) continue
+                    val char = keyEvent.uChar.UnicodeChar
+                    if (char.toInt() != 0) {
+                        reply.append(char.toInt().toChar())
+                    }
+                }
+            }
+            reply.toString()
+        } finally {
+            SetConsoleMode(stdinHandle, savedInputMode.value)
+            SetConsoleMode(stdoutHandle, savedOutputMode.value)
+        }
+    }

--- a/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/TerminalQuery.kt
+++ b/cli/src/posixNativeMain/kotlin/com/crosspaste/cli/platform/TerminalQuery.kt
@@ -1,0 +1,94 @@
+package com.crosspaste.cli.platform
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.readBytes
+import kotlinx.cinterop.set
+import kotlinx.cinterop.usePinned
+import platform.posix.ECHO
+import platform.posix.ICANON
+import platform.posix.POLLIN
+import platform.posix.STDIN_FILENO
+import platform.posix.STDOUT_FILENO
+import platform.posix.TCSANOW
+import platform.posix.VMIN
+import platform.posix.VTIME
+import platform.posix.poll
+import platform.posix.pollfd
+import platform.posix.read
+import platform.posix.tcgetattr
+import platform.posix.tcsetattr
+import platform.posix.termios
+import platform.posix.write
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
+
+private const val READ_CHUNK_BYTES = 256
+
+/**
+ * Runs one raw-mode query transaction against the controlling terminal:
+ * silences echo and line buffering, writes [payload] to stdout, accumulates
+ * reply bytes until [isComplete] says the transaction is done or
+ * [timeoutMillis] elapses, then restores the previous terminal state.
+ *
+ * Returns whatever was read — possibly incomplete or empty on timeout;
+ * parsers treat missing parts as absent — or null when the terminal could not
+ * be switched to raw mode at all. Callers must only invoke this when stdin
+ * and stdout are both interactive, and must NOT hold another raw-mode session
+ * (Mordant's picker raw mode) open at the same time: `pick` probes once
+ * before entering its TUI and caches the result. Deliberately not Mordant's
+ * RawModeScope — that parses input into key events and would consume or
+ * mangle the terminal's DA reply. (Per-platform like SecretInput, not
+ * expect/actual: cliNativeMain resolves it in each target compilation.)
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun queryTerminalRaw(
+    payload: String,
+    timeoutMillis: Int,
+    isComplete: (String) -> Boolean,
+): String? =
+    memScoped {
+        val saved = alloc<termios>()
+        if (tcgetattr(STDIN_FILENO, saved.ptr) != 0) return null
+        val raw = alloc<termios>()
+        if (tcgetattr(STDIN_FILENO, raw.ptr) != 0) return null
+        // No echo (the reply must not land on screen), no line buffering (it
+        // arrives without a newline); reads are non-blocking, poll() waits.
+        val cookedFlags = (ECHO or ICANON).inv()
+        raw.c_lflag = raw.c_lflag and cookedFlags.convert()
+        raw.c_cc[VMIN] = 0u
+        raw.c_cc[VTIME] = 0u
+        if (tcsetattr(STDIN_FILENO, TCSANOW, raw.ptr) != 0) return null
+        try {
+            val bytes = payload.encodeToByteArray()
+            val writeResult =
+                bytes.usePinned { pinned ->
+                    write(STDOUT_FILENO, pinned.addressOf(0), bytes.size.convert())
+                }
+            if (writeResult != bytes.size.toLong()) return ""
+            val reply = StringBuilder()
+            val deadline = TimeSource.Monotonic.markNow() + timeoutMillis.milliseconds
+            val buffer = allocArray<ByteVar>(READ_CHUNK_BYTES)
+            val fds = alloc<pollfd>()
+            fds.fd = STDIN_FILENO
+            fds.events = POLLIN.convert()
+            while (!isComplete(reply.toString())) {
+                val remaining = (deadline - TimeSource.Monotonic.markNow()).inWholeMilliseconds
+                if (remaining <= 0) break
+                fds.revents = 0
+                if (poll(fds.ptr, 1.convert(), remaining.toInt()) <= 0) break
+                val count = read(STDIN_FILENO, buffer, READ_CHUNK_BYTES.convert())
+                if (count <= 0) break
+                reply.append(buffer.readBytes(count.toInt()).decodeToString())
+            }
+            reply.toString()
+        } finally {
+            tcsetattr(STDIN_FILENO, TCSANOW, saved.ptr)
+        }
+    }


### PR DESCRIPTION
Closes #4847. Phase 3 of #4844 (sixel graphics support for Windows Terminal). Independent of the P1 encoder (#4849) and the P2 endpoint (#4850); everything meets in the P4 wiring (#4848).

## Summary

Adds the detection layer that decides when sixel may be used, built around one rule: **environment variables only nominate candidates — the terminal itself must confirm sixel via DA1 before a single escape byte of image data is emitted.** This is what keeps an older Windows Terminal (< 1.22, sets `WT_SESSION` but has no sixel) on the existing path fallback instead of receiving escape garbage, preserving the CLI's "unrecognized terminals never get garbage" rule.

## Implementation

- **`TerminalImageProtocol.SIXEL`** added to the enum. The existing env-only detection is unchanged for kitty/iTerm; the two exhaustive `when` renderers get unreachable SIXEL branches guarded at entry (rendering arrives in #4848).
- **`isSixelCandidate(env)`**: `WT_SESSION` non-empty (conhost never sets it), or `TERM` containing `foot` / `mlterm` / `yaft`; the tmux/screen guard outranks every candidate signal.
- **`TerminalProbe.kt`**: `resolveTerminalImageDisplay(stdinInteractive, stdoutInteractive, env, query)` — kitty/iTerm resolve without probing (zero cost); sixel candidates are probed only when both stdin and stdout are interactive. One write carries two queries: XTWINOPS `CSI 16 t` (cell pixel size, may be ignored) then DA1 `CSI c` (universally answered, so its reply doubles as the end-of-transaction marker). Attribute `4` in the DA1 reply confirms sixel; the cell size defaults to 10x20 px when unanswered. All parsers are pure functions; the DA1 parser skips the first parameter (device class, not an attribute) and matches `4` exactly.
- **`queryTerminalRaw`** (per-platform like `SecretInput`, not expect/actual — cliNativeMain resolves it in each target compilation):
  - POSIX: termios raw mode (no ECHO/ICANON, VMIN=0), `poll()`-driven reads against a monotonic deadline, termios restored in `finally`.
  - Windows: `ENABLE_VIRTUAL_TERMINAL_INPUT` so the reply arrives as an ESC character stream, VT output processing so conpty forwards the queries; the read loop drains `ReadConsoleInputW` records (consuming non-key events so they cannot leave the handle signaled forever) and collects key-down characters. Console modes restored in `finally`; mode flags are spelled out locally so compilation does not depend on mingw-w64 header vintage. Deliberately not Mordant's `RawModeScope`, which parses input into key events and would consume the DA reply.

## Tests

18 assertions-worth of fast-tier coverage in `TerminalProbeTest`: the candidate matrix (WT/foot/mlterm/yaft/conhost/tmux guard), DA1 completion detection, DA1 attribute parsing (WT with and without sixel, mlterm, VT100, lone class parameter, exact-match only), cell-size parsing (order, bounds, malformed), and resolver behavior with a recording fake query — kitty resolves without probing, WT+sixel confirms with parsed cell size, old-WT reply falls back, timeout/raw-mode failure falls back, non-interactive streams and non-candidate terminals are never probed.

`cli:macosArm64Test` passes; `cli:compileKotlinLinuxX64`, `cli:compileKotlinLinuxArm64`, and `cli:compileKotlinMingwX64` all compile (validates the per-platform termios/Console API usage); `ktlintCheck` passes. Real-terminal behavior on Windows Terminal is verified in P4 (#4848).