### PR TITLE
:sparkles: wire sixel rendering into paste inline previews and the pick panel

### DIFF
--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/api/CliClient.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/api/CliClient.kt
@@ -173,7 +173,7 @@ class CliClient(
                 "/cli/paste/$id/image?index=$index&maxWidth=$boxWidth&maxHeight=$boxHeight",
             )
         if (!response.status.isSuccess()) {
-            val serverMessage = extractMessage(response.bodyAsText())
+            val serverMessage = readBodyForImage { extractMessage(response.bodyAsText()) }
             throw CliClientException(
                 serverMessage ?: "Request failed with status ${response.status}",
                 statusCode = response.status.value,
@@ -189,7 +189,9 @@ class CliClient(
         ) {
             throw CliClientException("Unexpected image dimensions from CrossPaste: $width x $height")
         }
-        val rgba = response.readRawBytes()
+        val rgba =
+            readBodyForImage { response.readRawBytes() }
+                ?: throw CliClientException("Failed to read the image payload from CrossPaste.")
         if (rgba.size != width * height * 4) {
             throw CliClientException(
                 "Image payload size ${rgba.size} does not match $width x $height RGBA.",
@@ -197,6 +199,22 @@ class CliClient(
         }
         return CliRawImage(width, height, rgba)
     }
+
+    /**
+     * Body reads happen after [request] returns, so a mid-transfer socket
+     * failure would otherwise throw a raw ktor exception — escaping the
+     * documented contract that every [getRawImage] failure is a
+     * [CliClientException] (callers catch it and fall back to printing
+     * paths). Null means the read failed.
+     */
+    private suspend fun <T> readBodyForImage(read: suspend () -> T): T? =
+        try {
+            read()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
 
     /**
      * Opens a long-lived streaming GET (the /cli/watch NDJSON feed) and hands

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
@@ -1,7 +1,11 @@
 package com.crosspaste.cli.commands
 
 import com.crosspaste.cli.CliContext
-import com.crosspaste.cli.platform.detectTerminalImageProtocol
+import com.crosspaste.cli.api.AppNotRunningException
+import com.crosspaste.cli.api.CLI_IMAGE_MAX_BOX_PX
+import com.crosspaste.cli.api.CliClient
+import com.crosspaste.cli.api.CliClientException
+import com.crosspaste.cli.platform.resolveTerminalImageDisplay
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.ProgramResult
@@ -79,7 +83,7 @@ class PasteCommand : CliktCommand(name = "paste") {
                 raw -> printRawContent(detail)
                 summary -> printContentOnly(detail, detail.content)
                 ctx.json -> echo(cliJson.encodeToString(PasteDetailResponse.serializer(), detail))
-                else -> printDetail(detail)
+                else -> printDetail(client, detail)
             }
         }
     }
@@ -158,7 +162,10 @@ class PasteCommand : CliktCommand(name = "paste") {
         }
     }
 
-    private fun printDetail(detail: PasteDetailResponse) {
+    private suspend fun printDetail(
+        client: CliClient,
+        detail: PasteDetailResponse,
+    ) {
         val fav = if (detail.tagged) " [tagged]" else ""
         val remote = if (detail.remote) " (remote)" else ""
         echo("Paste #${detail.id}$fav$remote")
@@ -178,7 +185,7 @@ class PasteCommand : CliktCommand(name = "paste") {
             }
         }
         if (detail.typeName == "image" && terminal.terminalInfo.outputInteractive) {
-            renderInlineImages(detail)
+            renderInlineImages(client, detail)
         }
     }
 
@@ -187,12 +194,38 @@ class PasteCommand : CliktCommand(name = "paste") {
      * absolute paths printed above are the fallback. Escape sequences go
      * through stdlib print like [printContentOnly]: Mordant re-renders
      * strings and would mangle them.
+     *
+     * Sixel candidates run the DA1 probe inside [resolveTerminalImageDisplay]
+     * here (stdout is interactive per the caller's guard; the probe also
+     * requires interactive stdin). Sixel pixels come from the app's transcode
+     * endpoint at final display size: the terminal width in cells times the
+     * probed cell pixel width, height capped only by the endpoint's box clamp
+     * — tall images scroll like text, matching the other protocols' behavior.
      */
-    private fun renderInlineImages(detail: PasteDetailResponse) {
+    private suspend fun renderInlineImages(
+        client: CliClient,
+        detail: PasteDetailResponse,
+    ) {
+        val info = terminal.terminalInfo
+        val display =
+            resolveTerminalImageDisplay(info.inputInteractive, info.outputInteractive) ?: return
+        val sixelMaxWidthPx =
+            (terminal.size.width * display.cellWidthPx).coerceIn(1, CLI_IMAGE_MAX_BOX_PX)
         InlineImageRenderer(
-            protocol = detectTerminalImageProtocol(),
+            protocol = display.protocol,
             emit = { print(it) },
             note = { echo("  $it") },
+            sixelFetch = { index ->
+                // Any failure — including 404 from an app that predates the
+                // endpoint — falls back to the paths printed above
+                try {
+                    client.getRawImage(detail.id, index, sixelMaxWidthPx, CLI_IMAGE_MAX_BOX_PX)
+                } catch (_: CliClientException) {
+                    null
+                } catch (_: AppNotRunningException) {
+                    null
+                }
+            },
         ).render(detail.filePaths)
     }
 }

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
@@ -6,6 +6,7 @@ import com.crosspaste.cli.api.CLI_IMAGE_MAX_BOX_PX
 import com.crosspaste.cli.api.CliClient
 import com.crosspaste.cli.api.CliClientException
 import com.crosspaste.cli.platform.resolveTerminalImageDisplay
+import com.crosspaste.cli.platform.sixelPixelBox
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.ProgramResult
@@ -209,8 +210,11 @@ class PasteCommand : CliktCommand(name = "paste") {
         val info = terminal.terminalInfo
         val display =
             resolveTerminalImageDisplay(info.inputInteractive, info.outputInteractive) ?: return
-        val sixelMaxWidthPx =
-            (terminal.size.width * display.cellWidthPx).coerceIn(1, CLI_IMAGE_MAX_BOX_PX)
+        // Rows = the endpoint's box clamp in cells: with any cell height the
+        // pixel height saturates at CLI_IMAGE_MAX_BOX_PX, i.e. "as tall as
+        // the endpoint allows" — paste deliberately has no row limit
+        val (sixelMaxWidthPx, sixelMaxHeightPx) =
+            sixelPixelBox(terminal.size.width, CLI_IMAGE_MAX_BOX_PX, display)
         InlineImageRenderer(
             protocol = display.protocol,
             emit = { print(it) },
@@ -219,7 +223,7 @@ class PasteCommand : CliktCommand(name = "paste") {
                 // Any failure — including 404 from an app that predates the
                 // endpoint — falls back to the paths printed above
                 try {
-                    client.getRawImage(detail.id, index, sixelMaxWidthPx, CLI_IMAGE_MAX_BOX_PX)
+                    client.getRawImage(detail.id, index, sixelMaxWidthPx, sixelMaxHeightPx)
                 } catch (_: CliClientException) {
                     null
                 } catch (_: AppNotRunningException) {

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.cli.commands
 
+import com.crosspaste.cli.api.CliRawImage
 import com.crosspaste.cli.platform.PNG_SIGNATURE_SIZE
 import com.crosspaste.cli.platform.TerminalImageProtocol
 import com.crosspaste.cli.platform.flushStdout
@@ -8,6 +9,7 @@ import com.crosspaste.cli.platform.prepareStdoutForBinary
 import com.crosspaste.cli.platform.writeBytesToStdout
 import com.crosspaste.cli.platform.writeItermInlineImage
 import com.crosspaste.cli.platform.writeKittyInlineImage
+import com.crosspaste.cli.platform.writeSixelInlineImage
 import okio.FileSystem
 import okio.IOException
 import okio.Path.Companion.toPath
@@ -71,6 +73,11 @@ internal class ImageByteStreamer(
  * thousands of entries, and previewing must never turn one `paste` into a
  * multi-gigabyte read. Skipped images are summarized in a single note; their
  * paths are already listed in the detail view.
+ *
+ * ITERM/KITTY transmit the stored file as-is; SIXEL instead renders pixels
+ * from [sixelFetch] — the app's transcode endpoint (the CLI never decodes
+ * image files). A null fetch result (older app without the endpoint, or an
+ * undecodable file) skips the image, same as an unreadable file.
  */
 internal class InlineImageRenderer(
     private val protocol: TerminalImageProtocol?,
@@ -80,6 +87,7 @@ internal class InlineImageRenderer(
     private val maxImages: Int = MAX_PREVIEW_IMAGES,
     private val maxCandidates: Int = MAX_PREVIEW_CANDIDATES,
     private val maxTotalBytes: Long = MAX_PREVIEW_TOTAL_BYTES,
+    private val sixelFetch: suspend (index: Int) -> CliRawImage? = { null },
 ) {
     companion object {
         internal const val MAX_PREVIEW_IMAGES = 4
@@ -87,10 +95,8 @@ internal class InlineImageRenderer(
         internal const val MAX_PREVIEW_TOTAL_BYTES = 20L * 1024 * 1024
     }
 
-    fun render(paths: List<String>) {
-        // SIXEL renders from app-transcoded pixels, not stored files; it is
-        // wired into this renderer in #4848 and never selected until then
-        val protocol = protocol?.takeIf { it != TerminalImageProtocol.SIXEL } ?: return
+    suspend fun render(paths: List<String>) {
+        val protocol = protocol ?: return
         var rendered = 0
         var inspected = 0
         var remainingBudget = maxTotalBytes
@@ -101,22 +107,18 @@ internal class InlineImageRenderer(
                 break
             }
             inspected++
-            val bytes =
-                readWithinBudget(
-                    path = path,
-                    budget = remainingBudget,
-                    requirePng = protocol == TerminalImageProtocol.KITTY,
-                )
-            if (bytes == null) {
+            val consumed =
+                when (protocol) {
+                    TerminalImageProtocol.ITERM,
+                    TerminalImageProtocol.KITTY,
+                    -> emitFromFile(protocol, path, remainingBudget)
+                    TerminalImageProtocol.SIXEL -> emitFromFetch(index, remainingBudget)
+                }
+            if (consumed == null) {
                 skipped++
                 continue
             }
-            remainingBudget -= bytes.size
-            when (protocol) {
-                TerminalImageProtocol.ITERM -> writeItermInlineImage(path.toPath().name, bytes, emit)
-                TerminalImageProtocol.KITTY -> writeKittyInlineImage(bytes, emit)
-                TerminalImageProtocol.SIXEL -> {} // unreachable: filtered out above
-            }
+            remainingBudget -= consumed
             emit("\n")
             rendered++
         }
@@ -125,11 +127,39 @@ internal class InlineImageRenderer(
         }
     }
 
-    private fun readWithinBudget(
+    /** Returns the payload bytes consumed, or null when the image is skipped. */
+    private fun emitFromFile(
+        protocol: TerminalImageProtocol,
         path: String,
         budget: Long,
-        requirePng: Boolean,
-    ): ByteArray? = readImageWithinBudget(path, budget, requirePng, fileSystem)
+    ): Long? {
+        val bytes =
+            readImageWithinBudget(
+                path = path,
+                budget = budget,
+                requirePng = protocol == TerminalImageProtocol.KITTY,
+                fileSystem = fileSystem,
+            ) ?: return null
+        when (protocol) {
+            TerminalImageProtocol.ITERM -> writeItermInlineImage(path.toPath().name, bytes, emit)
+            else -> writeKittyInlineImage(bytes, emit)
+        }
+        return bytes.size.toLong()
+    }
+
+    /** Returns the RGBA bytes consumed, or null when the image is skipped. */
+    private suspend fun emitFromFetch(
+        index: Int,
+        budget: Long,
+    ): Long? {
+        val image = sixelFetch(index) ?: return null
+        // The size is only known after the fetch, so an over-budget image
+        // costs one wasted transcode round trip — acceptable, since the
+        // request box bounds every reply to a few MB
+        if (image.rgba.size > budget) return null
+        writeSixelInlineImage(image.rgba, image.width, image.height, emit)
+        return image.rgba.size.toLong()
+    }
 }
 
 /** Shared budget-guarded image read (used by `paste` previews and `pick`). */

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PickCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PickCommand.kt
@@ -9,7 +9,9 @@ import com.crosspaste.cli.commands.pick.PickFilters
 import com.crosspaste.cli.commands.pick.PickOutcome
 import com.crosspaste.cli.commands.pick.PickState
 import com.crosspaste.cli.commands.pick.PickTui
+import com.crosspaste.cli.platform.TerminalImageDisplay
 import com.crosspaste.cli.platform.installTerminalGuard
+import com.crosspaste.cli.platform.resolveTerminalImageDisplay
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.ProgramResult
@@ -78,8 +80,14 @@ class PickCommand : CliktCommand(name = "pick") {
         // External SIGTERM/console-close must not strand the shell in raw
         // mode on the alternate screen (in-band Ctrl-C is a key event)
         installTerminalGuard()
+        // Probed once per command and BEFORE Mordant's raw mode: the sixel
+        // DA1 probe runs its own raw-mode transaction, and Mordant's
+        // key-event parser would eat or garble the reply. Ctrl-E editor
+        // round trips reuse the cached result.
+        val imageDisplay =
+            resolveTerminalImageDisplay(info.inputInteractive, info.outputInteractive)
         while (true) {
-            when (val outcome = runPickSession()) {
+            when (val outcome = runPickSession(imageDisplay)) {
                 is PickOutcome.Copied -> return
                 is PickOutcome.Edit -> editPasteFlow(outcome.item.id, jsonOutput = ctx.json)
                 PickOutcome.Cancelled -> throw ProgramResult(EXIT_CODE_CANCELLED)
@@ -88,11 +96,11 @@ class PickCommand : CliktCommand(name = "pick") {
         }
     }
 
-    private fun runPickSession(): PickOutcome? {
+    private fun runPickSession(imageDisplay: TerminalImageDisplay?): PickOutcome? {
         var outcome: PickOutcome? = null
         runCli { client ->
             val state = sessionState ?: createState(client).also { sessionState = it }
-            val result = PickTui(terminal, client, state, limit).run()
+            val result = PickTui(terminal, client, state, limit, imageDisplay).run()
             if (result is PickOutcome.Copied) {
                 val response = copyById(client, result.item.id)
                 reportCopied(result, response)

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
@@ -132,14 +132,12 @@ private sealed interface FetchMsg {
 
     /**
      * Transcoded pixels for the sixel preview (null image = fetch failed).
-     * The requested cell box rides along so a reply that no longer matches
-     * the current panel geometry (resized meanwhile) is discarded — the
-     * resize repaint has already scheduled a fresh fetch.
+     * The full request key rides along: only the reply matching the ACTIVE
+     * key (same generation, paste, and cell box) is honored — anything else
+     * is a superseded or cancelled request racing back.
      */
     data class SixelPixels(
-        val id: Long,
-        val boxColumns: Int,
-        val boxRows: Int,
+        val key: SixelRequestKey,
         val image: CliRawImage?,
     ) : FetchMsg
 }
@@ -228,7 +226,7 @@ internal class PickTui(
         private var imageDrawnId: Long? = null
         private var imageFailedId: Long? = null
         private var imageDeadline: TimeMark? = null
-        private var sixelInFlightId: Long? = null
+        private val sixelFetch = SixelFetchState()
         private var sixelJob: Job? = null
         private var lastPanelRow: Int? = null
         private var lastSize: Pair<Int, Int>? = null
@@ -540,16 +538,16 @@ internal class PickTui(
         }
 
         private fun launchSixelFetch(id: Long) {
-            // One in-flight fetch per paste is enough: repaints keep
-            // rescheduling draws, and the reply itself completes the draw
-            if (sixelInFlightId == id) return
             val display = imageDisplay ?: return
             val (maxColumns, maxRows) = previewImageCellBox()
+            // Null = an IDENTICAL request (same paste and box) is in flight
+            // and its reply will complete this draw. A same-paste request for
+            // a new box (resize) gets a fresh key and supersedes the old one.
+            val key = sixelFetch.nextRequest(id, maxColumns, maxRows) ?: return
             val (maxWidthPx, maxHeightPx) = sixelPixelBox(maxColumns, maxRows, display)
             // The superseded fetch's reply would be dropped as stale anyway;
             // cancelling frees the connection instead of letting it run out
             sixelJob?.cancel()
-            sixelInFlightId = id
             sixelJob =
                 fetchScope.launch(Dispatchers.Default) {
                     val image =
@@ -567,47 +565,51 @@ internal class PickTui(
                         } catch (_: AppNotRunningException) {
                             null
                         }
-                    results.trySend(FetchMsg.SixelPixels(id, maxColumns, maxRows, image))
+                    results.trySend(FetchMsg.SixelPixels(key, image))
                 }
         }
 
-        /**
-         * Aborts any in-flight sixel fetch. Clearing [sixelInFlightId] with
-         * it is mandatory: a cancelled fetch never posts its reply, and a
-         * stale in-flight marker would block re-fetching the same paste when
-         * the user selects it again.
-         */
+        /** Aborts any in-flight sixel fetch (job AND active-key bookkeeping). */
         private fun cancelSixelFetch() {
             sixelJob?.cancel()
             sixelJob = null
-            sixelInFlightId = null
+            sixelFetch.cancel()
         }
 
         /**
          * Draws a fetched sixel reply — the app already scaled the pixels to
          * the requested panel box, so this is pure encoding plus escape
-         * output, fast enough for the loop thread. Stale replies (selection
-         * moved on, panel resized, a repaint is pending) are dropped; the
-         * repaint that superseded them has already rescheduled a fresh draw.
+         * output, fast enough for the loop thread. Only the reply matching
+         * the ACTIVE request key may clear that state or draw; anything else
+         * (superseded box or paste, cancelled generation racing back) is
+         * dropped without touching it.
          */
         private fun onSixelPixels(msg: FetchMsg.SixelPixels) {
-            if (sixelInFlightId == msg.id) sixelInFlightId = null
+            if (!sixelFetch.onReply(msg.key)) return
+            sixelJob = null
             val candidate = imageCandidate(previewDetail)
             val panelRow = lastPanelRow
-            if (candidate?.first?.id != msg.id || panelRow == null || dirty) return
-            if (msg.boxColumns to msg.boxRows != previewImageCellBox()) return
+            if (candidate?.first?.id != msg.key.pasteId || panelRow == null || dirty) return
+            // A resize whose refetch deadline has not fired yet leaves this
+            // reply active but sized for the OLD box; drawing it could
+            // overflow the new panel. The pending deadline redraws instead.
+            if (msg.key.boxColumns to msg.key.boxRows != previewImageCellBox()) return
             val image = msg.image
             if (image == null) {
                 // Repaint with the path fallback instead of leaving the
                 // reserved lines blank
-                imageFailedId = msg.id
+                imageFailedId = msg.key.pasteId
                 dirty = true
                 return
             }
             terminal.rawPrint("${ESC}7$ESC[${panelRow + 2};3H")
             writeSixelInlineImage(image.rgba, image.width, image.height) { terminal.rawPrint(it) }
             terminal.rawPrint("${ESC}8")
-            imageDrawnId = msg.id
+            imageDrawnId = msg.key.pasteId
+            // This draw satisfies any redraw scheduled while the fetch was in
+            // flight — without this, that deadline would relaunch the same
+            // fetch and transcode a second time for nothing
+            imageDeadline = null
         }
 
         private suspend fun applyEffect(effect: PickEffect): PickOutcome? =

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
@@ -1,14 +1,17 @@
 package com.crosspaste.cli.commands.pick
 
+import com.crosspaste.cli.api.AppNotRunningException
 import com.crosspaste.cli.api.CliClient
+import com.crosspaste.cli.api.CliClientException
+import com.crosspaste.cli.api.CliRawImage
 import com.crosspaste.cli.commands.PasteDetailResponse
 import com.crosspaste.cli.commands.PasteListResponse
 import com.crosspaste.cli.commands.PasteSummaryDto
 import com.crosspaste.cli.commands.buildListQuery
 import com.crosspaste.cli.commands.formatSize
 import com.crosspaste.cli.commands.readImageWithinBudget
+import com.crosspaste.cli.platform.TerminalImageDisplay
 import com.crosspaste.cli.platform.TerminalImageProtocol
-import com.crosspaste.cli.platform.detectTerminalImageProtocol
 import com.crosspaste.cli.platform.fitImageCellBox
 import com.crosspaste.cli.platform.isRawModeReadTimeout
 import com.crosspaste.cli.platform.kittyDeleteImages
@@ -16,6 +19,7 @@ import com.crosspaste.cli.platform.parsePngDimensions
 import com.crosspaste.cli.platform.restoreConsoleModes
 import com.crosspaste.cli.platform.writeItermInlineImage
 import com.crosspaste.cli.platform.writeKittyInlineImage
+import com.crosspaste.cli.platform.writeSixelInlineImage
 import com.github.ajalt.mordant.input.RawModeScope
 import com.github.ajalt.mordant.input.enterRawMode
 import com.github.ajalt.mordant.terminal.Terminal
@@ -124,6 +128,19 @@ private sealed interface FetchMsg {
         val key: RequestKey,
         val cause: Throwable,
     ) : FetchMsg
+
+    /**
+     * Transcoded pixels for the sixel preview (null image = fetch failed).
+     * The requested cell box rides along so a reply that no longer matches
+     * the current panel geometry (resized meanwhile) is discarded — the
+     * resize repaint has already scheduled a fresh fetch.
+     */
+    data class SixelPixels(
+        val id: Long,
+        val boxColumns: Int,
+        val boxRows: Int,
+        val image: CliRawImage?,
+    ) : FetchMsg
 }
 
 /**
@@ -137,9 +154,11 @@ internal class PickTui(
     private val client: CliClient,
     private val state: PickState,
     private val limit: Int,
+    /** Resolved (and sixel-probed) by PickCommand BEFORE Mordant's raw mode. */
+    private val imageDisplay: TerminalImageDisplay?,
 ) {
     private val timeSource = TimeSource.Monotonic
-    private val imageProtocol = detectTerminalImageProtocol()
+    private val imageProtocol = imageDisplay?.protocol
 
     suspend fun run(): PickOutcome =
         coroutineScope {
@@ -208,6 +227,7 @@ internal class PickTui(
         private var imageDrawnId: Long? = null
         private var imageFailedId: Long? = null
         private var imageDeadline: TimeMark? = null
+        private var sixelInFlightId: Long? = null
         private var lastPanelRow: Int? = null
         private var lastSize: Pair<Int, Int>? = null
         private var lastRefreshAt = timeSource.markNow()
@@ -368,6 +388,7 @@ internal class PickTui(
                     is FetchMsg.ListResult -> onListResult(msg)
                     is FetchMsg.Preview -> onPreview(msg)
                     is FetchMsg.Failed -> onFailed(msg)
+                    is FetchMsg.SixelPixels -> onSixelPixels(msg)
                 }
                 refreshSpinner()
             }
@@ -473,14 +494,14 @@ internal class PickTui(
             lastPanelRow =
                 paint(spinnerFrame, previewDetail, imageFailedId, flashSelected = false)
                     .previewPanelRow
-            // Repaints erase iTerm images (they live in cells); kitty
-            // placements survive text redraws, so only a new selection
-            // needs a retransmit there
+            // Repaints erase iTerm and sixel images (their pixels live in
+            // cells); kitty placements survive text redraws, so only a new
+            // selection needs a retransmit there
             val candidate = imageCandidate(previewDetail)
             if (candidate != null && lastPanelRow != null) {
                 val needsDraw =
                     imageDrawnId != candidate.first.id ||
-                        imageProtocol == TerminalImageProtocol.ITERM
+                        imageProtocol != TerminalImageProtocol.KITTY
                 if (needsDraw) imageDeadline = timeSource.markNow()
             } else {
                 deleteDrawnKittyImage()
@@ -495,6 +516,14 @@ internal class PickTui(
             imageDeadline = null
             val candidate = imageCandidate(previewDetail) ?: return
             val panelRow = lastPanelRow ?: return
+            if (imageProtocol == TerminalImageProtocol.SIXEL) {
+                // Sixel pixels come from the app's transcode endpoint; the
+                // fetch must not run inside the event loop (a slow transcode
+                // would freeze input), so it goes async like the other fetches
+                // and the reply draws via onSixelPixels
+                launchSixelFetch(candidate.first.id)
+                return
+            }
             if (drawInlineImage(candidate.second, panelRow)) {
                 imageDrawnId = candidate.first.id
             } else {
@@ -503,6 +532,60 @@ internal class PickTui(
                 imageFailedId = candidate.first.id
                 dirty = true
             }
+        }
+
+        private fun launchSixelFetch(id: Long) {
+            // One in-flight fetch per paste is enough: repaints keep
+            // rescheduling draws, and the reply itself completes the draw
+            if (sixelInFlightId == id) return
+            val display = imageDisplay ?: return
+            val (maxColumns, maxRows) = previewImageCellBox()
+            sixelInFlightId = id
+            fetchScope.launch(Dispatchers.Default) {
+                val image =
+                    try {
+                        client.getRawImage(
+                            id = id,
+                            index = 0,
+                            maxWidth = maxColumns * display.cellWidthPx,
+                            maxHeight = maxRows * display.cellHeightPx,
+                        )
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (_: CliClientException) {
+                        null
+                    } catch (_: AppNotRunningException) {
+                        null
+                    }
+                results.trySend(FetchMsg.SixelPixels(id, maxColumns, maxRows, image))
+            }
+        }
+
+        /**
+         * Draws a fetched sixel reply — the app already scaled the pixels to
+         * the requested panel box, so this is pure encoding plus escape
+         * output, fast enough for the loop thread. Stale replies (selection
+         * moved on, panel resized, a repaint is pending) are dropped; the
+         * repaint that superseded them has already rescheduled a fresh draw.
+         */
+        private fun onSixelPixels(msg: FetchMsg.SixelPixels) {
+            if (sixelInFlightId == msg.id) sixelInFlightId = null
+            val candidate = imageCandidate(previewDetail)
+            val panelRow = lastPanelRow
+            if (candidate?.first?.id != msg.id || panelRow == null || dirty) return
+            if (msg.boxColumns to msg.boxRows != previewImageCellBox()) return
+            val image = msg.image
+            if (image == null) {
+                // Repaint with the path fallback instead of leaving the
+                // reserved lines blank
+                imageFailedId = msg.id
+                dirty = true
+                return
+            }
+            terminal.rawPrint("${ESC}7$ESC[${panelRow + 2};3H")
+            writeSixelInlineImage(image.rgba, image.width, image.height) { terminal.rawPrint(it) }
+            terminal.rawPrint("${ESC}8")
+            imageDrawnId = msg.id
         }
 
         private suspend fun applyEffect(effect: PickEffect): PickOutcome? =
@@ -542,17 +625,27 @@ internal class PickTui(
         )
 
     /**
+     * The preview panel's image cell box. For sixel this times the probed
+     * cell pixel size becomes the requested pixel box, so the app's reply
+     * never occupies more rows than the panel reserves — and the box bounds
+     * the payload, so no [MAX_PICK_IMAGE_BYTES] cap is needed there.
+     */
+    private fun previewImageCellBox(): Pair<Int, Int> {
+        val maxColumns = (terminal.size.width - 6).coerceIn(10, IMAGE_MAX_COLUMNS)
+        return maxColumns to (PREVIEW_PANEL_LINES - 1)
+    }
+
+    /**
      * Transmits the first stored image into the preview panel, display-bounded
      * to a cell box (the terminal scales; the CLI still never decodes pixels).
      * Runs only after [IMAGE_DRAW_IDLE] of quiet — the payload is the whole
-     * encoded file.
+     * encoded file. SIXEL never reaches this: its pixels arrive async from
+     * the app's transcode endpoint and draw via onSixelPixels.
      */
     private fun drawInlineImage(
         path: String,
         panelRow: Int,
     ): Boolean {
-        // SIXEL renders from app-transcoded pixels, not stored files; it is
-        // wired into this preview in #4848 and never selected until then
         val protocol =
             imageProtocol?.takeIf { it != TerminalImageProtocol.SIXEL } ?: return false
         val bytes =
@@ -561,8 +654,7 @@ internal class PickTui(
                 budget = MAX_PICK_IMAGE_BYTES,
                 requirePng = protocol == TerminalImageProtocol.KITTY,
             ) ?: return false
-        val maxColumns = (terminal.size.width - 6).coerceIn(10, IMAGE_MAX_COLUMNS)
-        val maxRows = PREVIEW_PANEL_LINES - 1
+        val (maxColumns, maxRows) = previewImageCellBox()
         // PNG headers carry the pixel size; other formats (iTerm only) fall
         // back to the full box, which iTerm letterboxes itself
         val box =
@@ -571,20 +663,17 @@ internal class PickTui(
         val write: (String) -> Unit = { terminal.rawPrint(it) }
         // Save the cursor, draw at the panel's first content row, restore
         terminal.rawPrint("${ESC}7$ESC[${panelRow + 2};3H")
-        when (protocol) {
-            TerminalImageProtocol.KITTY -> {
-                kittyDeleteImages(write)
-                writeKittyInlineImage(bytes, write, columns = box.first, rows = box.second)
-            }
-            TerminalImageProtocol.ITERM ->
-                writeItermInlineImage(
-                    name = path.toPath().name,
-                    bytes = bytes,
-                    write = write,
-                    widthCells = box.first,
-                    heightCells = box.second,
-                )
-            TerminalImageProtocol.SIXEL -> {} // unreachable: filtered out above
+        if (protocol == TerminalImageProtocol.KITTY) {
+            kittyDeleteImages(write)
+            writeKittyInlineImage(bytes, write, columns = box.first, rows = box.second)
+        } else {
+            writeItermInlineImage(
+                name = path.toPath().name,
+                bytes = bytes,
+                write = write,
+                widthCells = box.first,
+                heightCells = box.second,
+            )
         }
         terminal.rawPrint("${ESC}8")
         return true

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/PickTui.kt
@@ -17,6 +17,7 @@ import com.crosspaste.cli.platform.isRawModeReadTimeout
 import com.crosspaste.cli.platform.kittyDeleteImages
 import com.crosspaste.cli.platform.parsePngDimensions
 import com.crosspaste.cli.platform.restoreConsoleModes
+import com.crosspaste.cli.platform.sixelPixelBox
 import com.crosspaste.cli.platform.writeItermInlineImage
 import com.crosspaste.cli.platform.writeKittyInlineImage
 import com.crosspaste.cli.platform.writeSixelInlineImage
@@ -228,6 +229,7 @@ internal class PickTui(
         private var imageFailedId: Long? = null
         private var imageDeadline: TimeMark? = null
         private var sixelInFlightId: Long? = null
+        private var sixelJob: Job? = null
         private var lastPanelRow: Int? = null
         private var lastSize: Pair<Int, Int>? = null
         private var lastRefreshAt = timeSource.markNow()
@@ -504,6 +506,9 @@ internal class PickTui(
                         imageProtocol != TerminalImageProtocol.KITTY
                 if (needsDraw) imageDeadline = timeSource.markNow()
             } else {
+                // No image to show anymore (selection moved off an image,
+                // preview closed): stop any fetch still running for the old one
+                cancelSixelFetch()
                 deleteDrawnKittyImage()
                 imageDrawnId = null
                 imageDeadline = null
@@ -540,25 +545,42 @@ internal class PickTui(
             if (sixelInFlightId == id) return
             val display = imageDisplay ?: return
             val (maxColumns, maxRows) = previewImageCellBox()
+            val (maxWidthPx, maxHeightPx) = sixelPixelBox(maxColumns, maxRows, display)
+            // The superseded fetch's reply would be dropped as stale anyway;
+            // cancelling frees the connection instead of letting it run out
+            sixelJob?.cancel()
             sixelInFlightId = id
-            fetchScope.launch(Dispatchers.Default) {
-                val image =
-                    try {
-                        client.getRawImage(
-                            id = id,
-                            index = 0,
-                            maxWidth = maxColumns * display.cellWidthPx,
-                            maxHeight = maxRows * display.cellHeightPx,
-                        )
-                    } catch (e: kotlinx.coroutines.CancellationException) {
-                        throw e
-                    } catch (_: CliClientException) {
-                        null
-                    } catch (_: AppNotRunningException) {
-                        null
-                    }
-                results.trySend(FetchMsg.SixelPixels(id, maxColumns, maxRows, image))
-            }
+            sixelJob =
+                fetchScope.launch(Dispatchers.Default) {
+                    val image =
+                        try {
+                            client.getRawImage(
+                                id = id,
+                                index = 0,
+                                maxWidth = maxWidthPx,
+                                maxHeight = maxHeightPx,
+                            )
+                        } catch (e: kotlinx.coroutines.CancellationException) {
+                            throw e
+                        } catch (_: CliClientException) {
+                            null
+                        } catch (_: AppNotRunningException) {
+                            null
+                        }
+                    results.trySend(FetchMsg.SixelPixels(id, maxColumns, maxRows, image))
+                }
+        }
+
+        /**
+         * Aborts any in-flight sixel fetch. Clearing [sixelInFlightId] with
+         * it is mandatory: a cancelled fetch never posts its reply, and a
+         * stale in-flight marker would block re-fetching the same paste when
+         * the user selects it again.
+         */
+        private fun cancelSixelFetch() {
+            sixelJob?.cancel()
+            sixelJob = null
+            sixelInFlightId = null
         }
 
         /**

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/SixelFetchState.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/pick/SixelFetchState.kt
@@ -1,0 +1,78 @@
+package com.crosspaste.cli.commands.pick
+
+/**
+ * Identifies one sixel pixel fetch completely: WHAT is being fetched (paste
+ * id plus the requested cell box) and WHICH attempt it is ([generation]).
+ * The generation makes keys unique across cancel/re-request cycles, so a
+ * cancelled request's reply racing back can never be mistaken for the reply
+ * to a newer identical request.
+ */
+internal data class SixelRequestKey(
+    val generation: Int,
+    val pasteId: Long,
+    val boxColumns: Int,
+    val boxRows: Int,
+)
+
+/**
+ * The pick panel's sixel fetch bookkeeping, pure so the request lifecycle is
+ * unit-testable. At most one request is active; a reply only counts when its
+ * key equals the active key exactly.
+ *
+ * The box being part of the identity is what keeps post-resize redraws
+ * alive: a same-paste request for a DIFFERENT box supersedes the in-flight
+ * one instead of being swallowed by an id-only guard (which would consume
+ * the redraw deadline with nothing left to answer it — the old-box reply
+ * gets discarded and the image never reappears).
+ */
+internal class SixelFetchState {
+    private var generation = 0
+    private var activeKey: SixelRequestKey? = null
+
+    /**
+     * Registers the request to launch and returns its key, or null when an
+     * identical request (same paste AND same box) is already in flight —
+     * its reply will complete the draw, nothing new to launch. A non-null
+     * return supersedes any active request; the caller must cancel that
+     * request's job.
+     */
+    fun nextRequest(
+        pasteId: Long,
+        boxColumns: Int,
+        boxRows: Int,
+    ): SixelRequestKey? {
+        val active = activeKey
+        if (active != null &&
+            active.pasteId == pasteId &&
+            active.boxColumns == boxColumns &&
+            active.boxRows == boxRows
+        ) {
+            return null
+        }
+        return SixelRequestKey(++generation, pasteId, boxColumns, boxRows)
+            .also { activeKey = it }
+    }
+
+    /**
+     * Forgets the active request (the caller cancels its job). Mandatory
+     * alongside the job cancel: a cancelled fetch never posts its reply, and
+     * a stale active key would block re-fetching the same paste and box when
+     * the user selects it again.
+     */
+    fun cancel() {
+        activeKey = null
+    }
+
+    /**
+     * True when [key] is exactly the reply this state is waiting on — the
+     * active request is then cleared (a second identical reply returns
+     * false). False for anything stale: a superseded box or paste, or a
+     * cancelled generation racing back; the active request, if any, stays
+     * armed and untouched.
+     */
+    fun onReply(key: SixelRequestKey): Boolean {
+        if (key != activeKey) return false
+        activeKey = null
+        return true
+    }
+}

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalProbe.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/platform/TerminalProbe.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.cli.platform
 
+import com.crosspaste.cli.api.CLI_IMAGE_MAX_BOX_PX
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 import platform.posix.getenv
@@ -68,6 +69,25 @@ internal fun resolveTerminalImageDisplay(
         cellWidthPx = cellSize?.first ?: DEFAULT_CELL_WIDTH_PX,
         cellHeightPx = cellSize?.second ?: DEFAULT_CELL_HEIGHT_PX,
     )
+}
+
+/**
+ * Converts a display cell box into the pixel box to request from the app's
+ * transcode endpoint: cells times the probed (or default) cell pixel size.
+ * Long intermediates plus the [CLI_IMAGE_MAX_BOX_PX] clamp keep degenerate
+ * inputs — a lying terminal, a huge COLUMNS override — from overflowing Int
+ * or requesting an unbounded transcode; the floor of 1 keeps a zero-sized
+ * terminal report from producing an invalid request.
+ */
+internal fun sixelPixelBox(
+    columns: Int,
+    rows: Int,
+    display: TerminalImageDisplay,
+): Pair<Int, Int> {
+    val maxBox = CLI_IMAGE_MAX_BOX_PX.toLong()
+    val width = (columns.toLong() * display.cellWidthPx).coerceIn(1L, maxBox).toInt()
+    val height = (rows.toLong() * display.cellHeightPx).coerceIn(1L, maxBox).toInt()
+    return width to height
 }
 
 /** True once [buffer] holds a complete DA1 reply (`CSI ? ... c`). */

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PasteImageOutputTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PasteImageOutputTest.kt
@@ -1,7 +1,9 @@
 package com.crosspaste.cli.commands
 
+import com.crosspaste.cli.api.CliRawImage
 import com.crosspaste.cli.platform.StdoutWriteException
 import com.crosspaste.cli.platform.TerminalImageProtocol
+import kotlinx.coroutines.test.runTest
 import okio.Buffer
 import okio.FileSystem
 import okio.ForwardingFileSystem
@@ -101,13 +103,14 @@ class PasteImageOutputTest {
 
     // region InlineImageRenderer
 
-    private fun renderer(
+    private suspend fun renderer(
         paths: List<String>,
         protocol: TerminalImageProtocol? = TerminalImageProtocol.ITERM,
         fileSystem: FileSystem = fs,
         maxImages: Int = 4,
         maxCandidates: Int = 16,
         maxTotalBytes: Long = 1_000_000,
+        sixelFetch: suspend (Int) -> CliRawImage? = { null },
     ): Pair<StringBuilder, MutableList<String>> {
         val emitted = StringBuilder()
         val notes = mutableListOf<String>()
@@ -119,6 +122,7 @@ class PasteImageOutputTest {
             maxImages = maxImages,
             maxCandidates = maxCandidates,
             maxTotalBytes = maxTotalBytes,
+            sixelFetch = sixelFetch,
         ).render(paths)
         return emitted to notes
     }
@@ -126,116 +130,186 @@ class PasteImageOutputTest {
     private fun countItermHeaders(emitted: CharSequence): Int = "File=inline=1".toRegex().findAll(emitted).count()
 
     @Test
-    fun previewStopsAtTheImageCountCeiling() {
-        val dir = tempDir()
-        val paths = (1..6).map { writePng(dir, "img$it.png", 64).toString() }
-        val (emitted, notes) = renderer(paths, maxImages = 4)
-        assertEquals(4, countItermHeaders(emitted))
-        assertEquals(listOf("(2 image(s) not previewed; file paths listed above)"), notes)
-    }
-
-    @Test
-    fun previewStopsAtTheTotalByteBudget() {
-        val dir = tempDir()
-        val paths = (1..3).map { writePng(dir, "img$it.png", 400).toString() }
-        // Each file is ~408 bytes; a 900-byte budget fits exactly two
-        val (emitted, notes) = renderer(paths, maxTotalBytes = 900)
-        assertEquals(2, countItermHeaders(emitted))
-        assertEquals(listOf("(1 image(s) not previewed; file paths listed above)"), notes)
-    }
-
-    @Test
-    fun unreadableImagesAreSkippedWithANote() {
-        val dir = tempDir()
-        val good = writePng(dir, "good.png", 64).toString()
-        val missing = (dir / "missing.png").toString()
-        val (emitted, notes) = renderer(listOf(missing, good))
-        assertEquals(1, countItermHeaders(emitted))
-        assertEquals(1, notes.size)
-    }
-
-    @Test
-    fun kittyOnlyPreviewsPngPayloads() {
-        val dir = tempDir()
-        val png = writePng(dir, "a.png", 64).toString()
-        val jpegPath = dir / "b.jpg"
-        fs.write(jpegPath) { write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())) }
-        val (emitted, notes) = renderer(listOf(png, jpegPath.toString()), protocol = TerminalImageProtocol.KITTY)
-        assertTrue(emitted.contains("a=T,f=100,"))
-        assertEquals(1, "a=T".toRegex().findAll(emitted).count())
-        assertEquals(1, notes.size)
-    }
-
-    @Test
-    fun unsupportedKittyImagesCountTowardTheCandidateCeiling() {
-        val dir = tempDir()
-        val jpegPaths =
-            (1..4).map { index ->
-                val path = dir / "image$index.jpg"
-                fs.write(path) {
-                    write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()))
-                    write(ByteArray(64 * 1024))
-                }
-                path.toString()
-            }
-        val png = writePng(dir, "later.png", 64).toString()
-
-        val (emitted, notes) =
-            renderer(
-                paths = jpegPaths + png,
-                protocol = TerminalImageProtocol.KITTY,
-                maxCandidates = 4,
-            )
-
-        assertTrue(emitted.isEmpty())
-        assertEquals(listOf("(5 image(s) not previewed; file paths listed above)"), notes)
-    }
-
-    @Test
-    fun kittyRejectsJpegAfterReadingOnlyItsSignatureBuffer() {
-        val dir = tempDir()
-        val jpeg = dir / "large.jpg"
-        val jpegSize = 1024 * 1024
-        fs.write(jpeg) {
-            write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()))
-            write(ByteArray(jpegSize - 3))
+    fun previewStopsAtTheImageCountCeiling() =
+        runTest {
+            val dir = tempDir()
+            val paths = (1..6).map { writePng(dir, "img$it.png", 64).toString() }
+            val (emitted, notes) = renderer(paths, maxImages = 4)
+            assertEquals(4, countItermHeaders(emitted))
+            assertEquals(listOf("(2 image(s) not previewed; file paths listed above)"), notes)
         }
 
-        var bytesRead = 0L
-        val countingFileSystem =
-            object : ForwardingFileSystem(fs) {
-                override fun source(file: Path): Source =
-                    object : ForwardingSource(super.source(file)) {
-                        override fun read(
-                            sink: Buffer,
-                            byteCount: Long,
-                        ): Long =
-                            super.read(sink, byteCount).also { read ->
-                                if (read > 0) bytesRead += read
-                            }
+    @Test
+    fun previewStopsAtTheTotalByteBudget() =
+        runTest {
+            val dir = tempDir()
+            val paths = (1..3).map { writePng(dir, "img$it.png", 400).toString() }
+            // Each file is ~408 bytes; a 900-byte budget fits exactly two
+            val (emitted, notes) = renderer(paths, maxTotalBytes = 900)
+            assertEquals(2, countItermHeaders(emitted))
+            assertEquals(listOf("(1 image(s) not previewed; file paths listed above)"), notes)
+        }
+
+    @Test
+    fun unreadableImagesAreSkippedWithANote() =
+        runTest {
+            val dir = tempDir()
+            val good = writePng(dir, "good.png", 64).toString()
+            val missing = (dir / "missing.png").toString()
+            val (emitted, notes) = renderer(listOf(missing, good))
+            assertEquals(1, countItermHeaders(emitted))
+            assertEquals(1, notes.size)
+        }
+
+    @Test
+    fun kittyOnlyPreviewsPngPayloads() =
+        runTest {
+            val dir = tempDir()
+            val png = writePng(dir, "a.png", 64).toString()
+            val jpegPath = dir / "b.jpg"
+            fs.write(jpegPath) { write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())) }
+            val (emitted, notes) = renderer(listOf(png, jpegPath.toString()), protocol = TerminalImageProtocol.KITTY)
+            assertTrue(emitted.contains("a=T,f=100,"))
+            assertEquals(1, "a=T".toRegex().findAll(emitted).count())
+            assertEquals(1, notes.size)
+        }
+
+    @Test
+    fun unsupportedKittyImagesCountTowardTheCandidateCeiling() =
+        runTest {
+            val dir = tempDir()
+            val jpegPaths =
+                (1..4).map { index ->
+                    val path = dir / "image$index.jpg"
+                    fs.write(path) {
+                        write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()))
+                        write(ByteArray(64 * 1024))
                     }
+                    path.toString()
+                }
+            val png = writePng(dir, "later.png", 64).toString()
+
+            val (emitted, notes) =
+                renderer(
+                    paths = jpegPaths + png,
+                    protocol = TerminalImageProtocol.KITTY,
+                    maxCandidates = 4,
+                )
+
+            assertTrue(emitted.isEmpty())
+            assertEquals(listOf("(5 image(s) not previewed; file paths listed above)"), notes)
+        }
+
+    @Test
+    fun kittyRejectsJpegAfterReadingOnlyItsSignatureBuffer() =
+        runTest {
+            val dir = tempDir()
+            val jpeg = dir / "large.jpg"
+            val jpegSize = 1024 * 1024
+            fs.write(jpeg) {
+                write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()))
+                write(ByteArray(jpegSize - 3))
             }
 
-        val (emitted, notes) =
-            renderer(
-                paths = listOf(jpeg.toString()),
-                protocol = TerminalImageProtocol.KITTY,
-                fileSystem = countingFileSystem,
-            )
+            var bytesRead = 0L
+            val countingFileSystem =
+                object : ForwardingFileSystem(fs) {
+                    override fun source(file: Path): Source =
+                        object : ForwardingSource(super.source(file)) {
+                            override fun read(
+                                sink: Buffer,
+                                byteCount: Long,
+                            ): Long =
+                                super.read(sink, byteCount).also { read ->
+                                    if (read > 0) bytesRead += read
+                                }
+                        }
+                }
 
-        assertTrue(emitted.isEmpty())
-        assertEquals(1, notes.size)
-        assertTrue(bytesRead < jpegSize, "unsupported JPEG payload must not be read in full")
+            val (emitted, notes) =
+                renderer(
+                    paths = listOf(jpeg.toString()),
+                    protocol = TerminalImageProtocol.KITTY,
+                    fileSystem = countingFileSystem,
+                )
+
+            assertTrue(emitted.isEmpty())
+            assertEquals(1, notes.size)
+            assertTrue(bytesRead < jpegSize, "unsupported JPEG payload must not be read in full")
+        }
+
+    @Test
+    fun noProtocolMeansNoOutputAtAll() =
+        runTest {
+            val dir = tempDir()
+            val path = writePng(dir, "a.png", 64).toString()
+            val (emitted, notes) = renderer(listOf(path), protocol = null)
+            assertEquals(0, emitted.length)
+            assertTrue(notes.isEmpty())
+        }
+
+    private val sixelHeader = "${27.toChar()}P0;1;0q"
+
+    /** Opaque single-color image; size in bytes is width * height * 4. */
+    private fun rawImage(
+        width: Int,
+        height: Int,
+    ): CliRawImage {
+        val rgba = ByteArray(width * height * 4)
+        for (i in 0 until width * height) {
+            rgba[i * 4] = 0xFF.toByte()
+            rgba[i * 4 + 3] = 0xFF.toByte()
+        }
+        return CliRawImage(width, height, rgba)
     }
 
     @Test
-    fun noProtocolMeansNoOutputAtAll() {
-        val dir = tempDir()
-        val path = writePng(dir, "a.png", 64).toString()
-        val (emitted, notes) = renderer(listOf(path), protocol = null)
-        assertEquals(0, emitted.length)
-        assertTrue(notes.isEmpty())
-    }
+    fun sixelRendersFetchedPixelsPerIndex() =
+        runTest {
+            val fetched = mutableListOf<Int>()
+            val (emitted, notes) =
+                renderer(
+                    paths = listOf("/a.png", "/b.jpg"),
+                    protocol = TerminalImageProtocol.SIXEL,
+                    sixelFetch = { index ->
+                        fetched.add(index)
+                        rawImage(2, 2)
+                    },
+                )
+            // The fetch index addresses the paste's file list, matching paths
+            assertEquals(listOf(0, 1), fetched)
+            assertEquals(2, emitted.split(sixelHeader).size - 1)
+            assertTrue(emitted.endsWith("${27.toChar()}\\\n"))
+            assertTrue(notes.isEmpty())
+        }
+
+    @Test
+    fun sixelFetchFailureSkipsWithANote() =
+        runTest {
+            val (emitted, notes) =
+                renderer(
+                    paths = listOf("/a.png"),
+                    protocol = TerminalImageProtocol.SIXEL,
+                    sixelFetch = { null },
+                )
+            assertTrue(emitted.isEmpty())
+            assertEquals(listOf("(1 image(s) not previewed; file paths listed above)"), notes)
+        }
+
+    @Test
+    fun sixelBudgetCountsFetchedRgbaBytes() =
+        runTest {
+            // Each 2x2 fetch is 16 RGBA bytes; a 24-byte budget fits one
+            val (emitted, notes) =
+                renderer(
+                    paths = listOf("/a.png", "/b.png", "/c.png"),
+                    protocol = TerminalImageProtocol.SIXEL,
+                    maxTotalBytes = 24,
+                    sixelFetch = { rawImage(2, 2) },
+                )
+            assertEquals(1, emitted.split(sixelHeader).size - 1)
+            assertEquals(listOf("(2 image(s) not previewed; file paths listed above)"), notes)
+        }
 
     // endregion
 }

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/pick/SixelFetchStateTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/pick/SixelFetchStateTest.kt
@@ -1,0 +1,63 @@
+package com.crosspaste.cli.commands.pick
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SixelFetchStateTest {
+
+    @Test
+    fun resizeWhileInFlightLaunchesForTheNewBoxAndDropsTheOldReply() {
+        val state = SixelFetchState()
+        val oldBox = assertNotNull(state.nextRequest(7, 60, 9))
+        // Same paste, new box after a resize: an id-only guard would swallow
+        // this and the image would never reappear — it must launch anew
+        val newBox = assertNotNull(state.nextRequest(7, 40, 9))
+        assertNotEquals(oldBox, newBox)
+        // The old-box reply racing back is stale and must not clear the
+        // active request the panel is still waiting on
+        assertFalse(state.onReply(oldBox))
+        assertTrue(state.onReply(newBox))
+    }
+
+    @Test
+    fun cancelThenReselectingTheSamePasteCannotAdoptTheOldReply() {
+        val state = SixelFetchState()
+        val cancelled = assertNotNull(state.nextRequest(7, 60, 9))
+        state.cancel()
+        // Re-request after cancel must not be blocked by stale bookkeeping...
+        val fresh = assertNotNull(state.nextRequest(7, 60, 9))
+        // ...and the generation keeps the cancelled attempt's key distinct
+        // even though paste and box are identical
+        assertNotEquals(cancelled, fresh)
+        assertFalse(state.onReply(cancelled))
+        assertTrue(state.onReply(fresh))
+    }
+
+    @Test
+    fun identicalInFlightRequestIsReusedAndItsReplyCompletesExactlyOnce() {
+        val state = SixelFetchState()
+        val key = assertNotNull(state.nextRequest(7, 60, 9))
+        // Rescheduled draws for the same paste and box ride the in-flight
+        // request instead of relaunching a duplicate transcode
+        assertNull(state.nextRequest(7, 60, 9))
+        assertTrue(state.onReply(key))
+        // A duplicate reply cannot complete a second time
+        assertFalse(state.onReply(key))
+        // Once answered, the same request may be issued again (e.g. a repaint
+        // erased the drawn image)
+        assertNotNull(state.nextRequest(7, 60, 9))
+    }
+
+    @Test
+    fun selectionChangeSupersedesTheInFlightPaste() {
+        val state = SixelFetchState()
+        val first = assertNotNull(state.nextRequest(7, 60, 9))
+        val second = assertNotNull(state.nextRequest(8, 60, 9))
+        assertFalse(state.onReply(first))
+        assertTrue(state.onReply(second))
+    }
+}

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/TerminalProbeTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/platform/TerminalProbeTest.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.cli.platform
 
+import com.crosspaste.cli.api.CLI_IMAGE_MAX_BOX_PX
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -162,4 +163,54 @@ class TerminalProbeTest {
         assertNull(resolve(env("TERM" to "xterm-256color"), query))
         assertEquals(0, query.calls)
     }
+
+    // region sixelPixelBox
+
+    private val defaultCellDisplay = TerminalImageDisplay(TerminalImageProtocol.SIXEL)
+
+    @Test
+    fun pixelBoxUsesTheDefaultCellWhenTheProbeGaveNone() {
+        // pick's panel box (60 columns x 9 rows) under the 10x20 assumption
+        assertEquals(600 to 180, sixelPixelBox(60, 9, defaultCellDisplay))
+    }
+
+    @Test
+    fun pixelBoxUsesProbedCellMetrics() {
+        val probed =
+            TerminalImageDisplay(
+                TerminalImageProtocol.SIXEL,
+                cellWidthPx = 8,
+                cellHeightPx = 16,
+            )
+        assertEquals(480 to 144, sixelPixelBox(60, 9, probed))
+        // A large probed cell saturates at the endpoint clamp per axis
+        val big =
+            TerminalImageDisplay(
+                TerminalImageProtocol.SIXEL,
+                cellWidthPx = 512,
+                cellHeightPx = 512,
+            )
+        assertEquals(CLI_IMAGE_MAX_BOX_PX to CLI_IMAGE_MAX_BOX_PX, sixelPixelBox(60, 9, big))
+    }
+
+    @Test
+    fun pixelBoxClampsToTheEndpointBoxAndNeverOverflows() {
+        // A huge COLUMNS override must saturate, not wrap negative
+        assertEquals(
+            CLI_IMAGE_MAX_BOX_PX to 180,
+            sixelPixelBox(Int.MAX_VALUE, 9, defaultCellDisplay),
+        )
+        assertEquals(
+            CLI_IMAGE_MAX_BOX_PX to CLI_IMAGE_MAX_BOX_PX,
+            sixelPixelBox(200, 100, defaultCellDisplay),
+        )
+    }
+
+    @Test
+    fun pixelBoxFloorsDegenerateCellCountsAtOnePixel() {
+        assertEquals(1 to 180, sixelPixelBox(0, 9, defaultCellDisplay))
+        assertEquals(1 to 1, sixelPixelBox(-5, -1, defaultCellDisplay))
+    }
+
+    // endregion
 }


### PR DESCRIPTION
Part of #4844; implements the wiring phase of #4848 (real-hardware verification on Windows Terminal remains to close the issue). Design: `ai/design/cli-sixel-support.md` §2–§4; builds on the merged P1 encoder (#4849), P2 transcode endpoint (#4850), and P3 DA1 probe (#4851).

## What changed

### `paste` inline preview (`PasteImageOutput.kt`, `PasteCommand.kt`)
- `InlineImageRenderer` now supports SIXEL: instead of passing the stored file through (iTerm/kitty), it renders pixels from an injected `sixelFetch` — the app's `GET /cli/paste/{id}/image` transcode endpoint — keeping the "CLI never decodes image files" rule.
- `PasteCommand` resolves the protocol via `resolveTerminalImageDisplay` (env candidates + DA1 probe confirmation, only when both stdin/stdout are interactive) and requests pixels at terminal width × the probed cell pixel width; height is capped only by the endpoint's 1000 px box clamp, so tall images scroll like text.
- Every fetch failure — including 404 from an app that predates the endpoint — falls back to the file paths already printed above, counted in the existing "not previewed" note. The 20 MiB total budget now counts fetched RGBA bytes for sixel.

### `pick` preview panel (`PickCommand.kt`, `PickTui.kt`)
- The sixel probe runs once per command, BEFORE Mordant's raw mode (its key-event parser would eat the DA1 reply), and the cached `TerminalImageDisplay` is reused across Ctrl-E editor round trips.
- The sixel fetch is async on `fetchScope` like the list/preview fetches, so a slow transcode cannot freeze the key loop; the reply draws via a new `FetchMsg.SixelPixels` message. Stale replies (selection moved, panel resized, repaint pending) are dropped — the superseding repaint has already rescheduled a fresh draw.
- The app scales pixels to exactly the panel cell box × probed cell pixel size, so the reply never occupies more rows than the panel reserves. Like iTerm, sixel pixels live in cells: repaints erase them, so the retransmit condition became `protocol != KITTY`.

### Hardening (from review)
- `CliClient.getRawImage` now wraps response-body reads: a mid-transfer socket failure surfaces as `CliClientException` per its documented contract instead of a raw ktor exception tearing down the command/picker.

## Tests
- `PasteImageOutputTest` adapted to the now-suspend `render` (`runTest`) and extended with sixel cases: per-index fetch + emitted DCS framing, fetch-failure fallback note, and RGBA-byte budget accounting.
- Existing iTerm/kitty ceilings and detection/probe suites unchanged and green.
- Verified: `cli:macosArm64Test`, `mingwX64`/`linuxX64` cross-compiles, `ktlintCheck`.

## Remaining for #4848
Real-hardware verification on Windows Terminal ≥ 1.22 (Parallels VM): `paste` single/multi-image, transparent PNG, JPEG; `pick` preview draw/erase/scroll behavior; degradation matrix (conhost, piped stdout, old app + new CLI).