### PR TITLE
:bug: guard cli build script host lookups on unsupported K/N hosts

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -155,13 +155,21 @@ kotlin {
     }
 }
 
+// The host's own K/N target, or null on hosts Kotlin/Native cannot compile
+// from (e.g. linux-arm64): HostManager.host throws there instead of returning
+// null, and letting that escape at configuration time would break every
+// module's build — including :app, whose headless daemon runs fine on such
+// hosts (#4853). Host-only conveniences below degrade to no-ops instead.
+val hostNativeTarget =
+    runCatching {
+        kotlin.targets
+            .withType<KotlinNativeTarget>()
+            .firstOrNull { it.konanTarget == HostManager.host }
+    }.getOrNull()
+
 // Runs the CLI test suite for the host's own target — a stable task name for
 // CI and local use that doesn't depend on which machine invokes it.
-val hostTestTaskName =
-    kotlin.targets
-        .withType<KotlinNativeTarget>()
-        .firstOrNull { it.konanTarget == HostManager.host }
-        ?.let { "${it.name}Test" }
+val hostTestTaskName = hostNativeTarget?.let { "${it.name}Test" }
 
 tasks.register("cliNativeTest") {
     group = "verification"
@@ -223,9 +231,7 @@ abstract class CliRunTask : Exec() {
     }
 }
 
-kotlin.targets
-    .withType<KotlinNativeTarget>()
-    .firstOrNull { it.konanTarget == HostManager.host }
+hostNativeTarget
     ?.let { hostTarget ->
         val debugExecutable = hostTarget.binaries.getExecutable(NativeBuildType.DEBUG)
         tasks.register<CliRunTask>("run") {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -159,13 +159,15 @@ kotlin {
 // from (e.g. linux-arm64): HostManager.host throws there instead of returning
 // null, and letting that escape at configuration time would break every
 // module's build — including :app, whose headless daemon runs fine on such
-// hosts (#4853). Host-only conveniences below degrade to no-ops instead.
+// hosts (#4853). hostOrNull tolerates exactly the unsupported-host case, so
+// only the host-only conveniences below degrade to no-ops while any other
+// configuration error still fails the build.
 val hostNativeTarget =
-    runCatching {
+    HostManager.hostOrNull?.let { host ->
         kotlin.targets
             .withType<KotlinNativeTarget>()
-            .firstOrNull { it.konanTarget == HostManager.host }
-    }.getOrNull()
+            .firstOrNull { it.konanTarget == host }
+    }
 
 // Runs the CLI test suite for the host's own target — a stable task name for
 // CI and local use that doesn't depend on which machine invokes it.


### PR DESCRIPTION
Fixes #4853.

## Problem

`cli/build.gradle.kts` evaluated `HostManager.host` at configuration time in two places (the `cliNativeTest` host-test lookup and the `:cli:run` task registration). On hosts Kotlin/Native cannot compile from — linux-arm64 being the practical case — `HostManager.host` throws `TargetSupportException` ("Unknown host target: linux aarch64") instead of returning null, killing configuration for the whole build. That blocked even `./gradlew :app:run --args="--headless"`, which is otherwise a fully working scenario on arm64 Linux.

## Fix

Resolve the host K/N target once via `HostManager.hostOrNull` and share it between both call sites. `hostOrNull` tolerates exactly the unsupported-host case: on such hosts the host-only conveniences degrade to no-ops (`:cli:run` is not registered, `cliNativeTest` has no host test to depend on) while any other configuration error still fails the build loudly. No behavior change on supported hosts.

## Verification

- macOS host: `:cli:tasks` still lists `run` and `cliNativeTest`; configuration unchanged.
- Real linux-arm64 host (OrbStack Ubuntu 26.04 VM): configuration previously failed as described; with this change `:app:desktopMainClasses` builds successfully and `cliNativeTest` still registers (as an empty aggregate). Re-verified after switching from an initial `runCatching` approach to `hostOrNull`.