### PR TITLE
:bug: map missing native graphics library to actionable 503 in CLI image route

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -377,7 +377,10 @@ private fun readImageBytesBounded(
  * straight-alpha RGBA8888 with the exact dimensions in X-Image-Width /
  * X-Image-Height headers. Every not-servable case — unknown id, no file at
  * the index, unreadable/oversized file, undecodable bytes — is a 404 with a
- * message; the CLI falls back to printing paths on any non-200.
+ * message, except an unavailable native decode backend (missing libGL on a
+ * headless server, #4854), which is a 503 whose message carries the remedy;
+ * the CLI falls back to printing paths on any non-200 and surfaces the 503
+ * message.
  */
 private suspend fun handlePasteImage(
     call: ApplicationCall,
@@ -422,6 +425,11 @@ private suspend fun handlePasteImage(
             // as ExceptionInInitializerError on first use and NoClassDefFoundError
             // on every later call, and stays broken for the process lifetime, so
             // the remedy must include a restart.
+            cliLogger.warn {
+                "CLI image transcode unavailable: native graphics library failed to " +
+                    "load (${e.message ?: e::class.simpleName}). On Debian/Ubuntu " +
+                    "install libgl1 and libegl1, then restart CrossPaste."
+            }
             call.respond(
                 HttpStatusCode.ServiceUnavailable,
                 CliMessageDto(

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -409,11 +409,28 @@ private suspend fun handlePasteImage(
                 return
             }
     val raw =
-        withContext(ioDispatcher) {
-            cliImageTranscodeSemaphore.withPermit {
-                readImageBytesBounded(path.toFile(), CLI_IMAGE_MAX_SOURCE_BYTES)
-                    ?.let { CliImageTranscoder.transcode(it, maxWidth, maxHeight) }
+        try {
+            withContext(ioDispatcher) {
+                cliImageTranscodeSemaphore.withPermit {
+                    readImageBytesBounded(path.toFile(), CLI_IMAGE_MAX_SOURCE_BYTES)
+                        ?.let { CliImageTranscoder.transcode(it, maxWidth, maxHeight) }
+                }
             }
+        } catch (e: LinkageError) {
+            // Skia's native library failed to load — on headless Linux servers
+            // this means libGL.so.1/libEGL.so.1 are missing (#4854). It surfaces
+            // as ExceptionInInitializerError on first use and NoClassDefFoundError
+            // on every later call, and stays broken for the process lifetime, so
+            // the remedy must include a restart.
+            call.respond(
+                HttpStatusCode.ServiceUnavailable,
+                CliMessageDto(
+                    "Image decoding is unavailable: CrossPaste could not load its " +
+                        "native graphics library (${e.message ?: e::class.simpleName}). " +
+                        "On Debian/Ubuntu install libgl1 and libegl1, then restart CrossPaste.",
+                ),
+            )
+            return
         }
     if (raw == null) {
         call.respond(

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -52,7 +52,9 @@ import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.slot
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.withTimeoutOrNull
@@ -341,6 +343,29 @@ class CliRoutingTest {
             // Without the 1000 px clamp this would come back at 2000x100
             assertEquals("1000", response.headers[CLI_IMAGE_WIDTH_HEADER])
             assertEquals("50", response.headers[CLI_IMAGE_HEIGHT_HEADER])
+        }
+    }
+
+    @Test
+    fun `image endpoint maps native graphics load failure to actionable 503`() {
+        val fixture = Fixture()
+        coEvery { fixture.pasteDao.getNoDeletePasteData(11L) } returns
+            imagePasteDataOnDisk(11L, pngBytes(4, 2, 0xFFFF0000.toInt()))
+        // A missing libGL surfaces as an Error (skiko class-init failure),
+        // which the transcoder's Exception handling cannot catch (#4854)
+        mockkObject(CliImageTranscoder)
+        try {
+            every { CliImageTranscoder.transcode(any(), any(), any()) } throws
+                NoClassDefFoundError("Could not initialize class org.jetbrains.skia.Image")
+            withCliRouting(fixture) {
+                val response = client.get("/cli/paste/11/image?maxWidth=100&maxHeight=100")
+                assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+                val message = response.bodyAsText()
+                assertContains(message, "libgl1")
+                assertContains(message, "restart")
+            }
+        } finally {
+            unmockkObject(CliImageTranscoder)
         }
     }
 

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteCommand.kt
@@ -221,10 +221,17 @@ class PasteCommand : CliktCommand(name = "paste") {
             note = { echo("  $it") },
             sixelFetch = { index ->
                 // Any failure — including 404 from an app that predates the
-                // endpoint — falls back to the paths printed above
+                // endpoint — falls back to the paths printed above. The one
+                // exception: a 503 with a structured message is the app saying
+                // its decode backend is down (e.g. missing libGL on a headless
+                // server, #4854) — that remedy must reach the user, not vanish
+                // into a silent fallback.
                 try {
                     client.getRawImage(detail.id, index, sixelMaxWidthPx, sixelMaxHeightPx)
-                } catch (_: CliClientException) {
+                } catch (e: CliClientException) {
+                    if (e.statusCode == 503 && e.hasServerMessage) {
+                        throw PreviewUnavailableException(e.message ?: "Image preview unavailable.")
+                    }
                     null
                 } catch (_: AppNotRunningException) {
                     null

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/PasteImageOutput.kt
@@ -39,6 +39,17 @@ internal fun resolveRawImageAction(filePaths: List<String>): RawImageAction =
     }
 
 /**
+ * Thrown by a sixelFetch when the app reports its image decode backend is
+ * unavailable (HTTP 503, e.g. missing native graphics libraries on a headless
+ * server, #4854). Unlike a null fetch result — a per-image skip — this is a
+ * process-wide condition: the renderer stops fetching and surfaces the
+ * server's actionable message once instead of failing image by image.
+ */
+internal class PreviewUnavailableException(
+    message: String,
+) : Exception(message)
+
+/**
  * Streams a stored image file to stdout in 64 KiB chunks. All effects are
  * injectable so tests can pin the byte fidelity and the failure paths;
  * production uses the binary-safe stdout primitives (on Windows the CRT is
@@ -101,6 +112,7 @@ internal class InlineImageRenderer(
         var inspected = 0
         var remainingBudget = maxTotalBytes
         var skipped = 0
+        var unavailableMessage: String? = null
         for ((index, path) in paths.withIndex()) {
             if (rendered >= maxImages || inspected >= maxCandidates || remainingBudget <= 0) {
                 skipped += paths.size - index
@@ -108,11 +120,19 @@ internal class InlineImageRenderer(
             }
             inspected++
             val consumed =
-                when (protocol) {
-                    TerminalImageProtocol.ITERM,
-                    TerminalImageProtocol.KITTY,
-                    -> emitFromFile(protocol, path, remainingBudget)
-                    TerminalImageProtocol.SIXEL -> emitFromFetch(index, remainingBudget)
+                try {
+                    when (protocol) {
+                        TerminalImageProtocol.ITERM,
+                        TerminalImageProtocol.KITTY,
+                        -> emitFromFile(protocol, path, remainingBudget)
+                        TerminalImageProtocol.SIXEL -> emitFromFetch(index, remainingBudget)
+                    }
+                } catch (e: PreviewUnavailableException) {
+                    // Process-wide backend failure: every further fetch would
+                    // fail the same way, so stop and report once
+                    unavailableMessage = e.message
+                    skipped += paths.size - index
+                    break
                 }
             if (consumed == null) {
                 skipped++
@@ -125,6 +145,7 @@ internal class InlineImageRenderer(
         if (skipped > 0) {
             note("($skipped image(s) not previewed; file paths listed above)")
         }
+        unavailableMessage?.let { note(it) }
     }
 
     /** Returns the payload bytes consumed, or null when the image is skipped. */

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PasteImageOutputTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/PasteImageOutputTest.kt
@@ -297,6 +297,29 @@ class PasteImageOutputTest {
         }
 
     @Test
+    fun sixelBackendUnavailableStopsFetchingAndSurfacesTheServerMessage() =
+        runTest {
+            val remedy = "Image decoding is unavailable: install libgl1 and libegl1, then restart CrossPaste."
+            var fetches = 0
+            val (emitted, notes) =
+                renderer(
+                    paths = listOf("/a.png", "/b.png", "/c.png"),
+                    protocol = TerminalImageProtocol.SIXEL,
+                    sixelFetch = {
+                        fetches++
+                        throw PreviewUnavailableException(remedy)
+                    },
+                )
+            // A process-wide backend failure must not be retried per image
+            assertEquals(1, fetches)
+            assertTrue(emitted.isEmpty())
+            assertEquals(
+                listOf("(3 image(s) not previewed; file paths listed above)", remedy),
+                notes,
+            )
+        }
+
+    @Test
     fun sixelBudgetCountsFetchedRgbaBytes() =
         runTest {
             // Each 2x2 fetch is 16 RGBA bytes; a 24-byte budget fits one


### PR DESCRIPTION
Fixes #4854.

## Problem

On a Linux system without OpenGL userspace libraries (minimal servers/containers — no `libGL.so.1`/`libEGL.so.1`), the CLI image preview endpoint `GET /cli/paste/{id}/image` returned an opaque `500 {"message":"Could not initialize class org.jetbrains.skia.Image"}`. The skiko native load failure surfaces as `ExceptionInInitializerError` / `NoClassDefFoundError`, which are `Error`s — the transcoder's `catch (Exception)` never sees them, so they escaped as a generic 500 whose text names JVM internals instead of the missing packages. The failure is also permanent for the process lifetime, which nothing hinted at, and the CLI silently fell back to printing file paths, so an end user never saw any of it.

The official deb is unaffected (its generated `Depends` already includes `libgl1` and `libegl1 | libegl-mali-xlnx`, verified against the 2.2.0.2502 arm64 package); this hits AppImage/tarball/source runs on headless machines — exactly the headless-daemon audience.

## Fix

Three layers, so the remedy actually reaches a person:

- **Server**: `handlePasteImage` catches `LinkageError` around the transcode and responds `503 Service Unavailable` with an actionable message ("…install libgl1 and libegl1, then restart CrossPaste"), and logs the same remedy at WARN so daemon logs are self-diagnosing.
- **CLI (`paste`)**: a 503 with a structured server message is translated into `PreviewUnavailableException`; `InlineImageRenderer` treats it as a process-wide condition — stops fetching after the first failure instead of retrying per image, keeps the usual "N image(s) not previewed" note, and prints the server's remedy once. All other failures (including 404 from an older app) keep the silent path fallback.
- **Docs**: the endpoint KDoc now documents the 503 case alongside the 404s.

`pick`'s TUI keeps its silent path fallback (there is no good place for a one-off message in the panel); the daemon-side WARN log covers diagnosability there.

## Verification

- New fast-tier test in `CliRoutingTest` mocks the transcoder to throw `NoClassDefFoundError` and asserts the 503 mapping with the remedy in the body.
- New CLI test in `PasteImageOutputTest` asserts the renderer stops after one failed fetch and surfaces the server message once (`:cli:cliNativeTest` green).
- The original failure was reproduced end to end on a fresh Ubuntu arm64 VM (missing `libGL.so.1`/`libEGL.so.1` confirmed via `ldd` on the skiko native library; installing `libgl1 libegl1` and restarting the daemon restored 200 RGBA responses).