### PR TITLE
:construction_worker: bundle pinned OpenSSL libcrypto into desktop packages via Conveyor

### DIFF
--- a/.github/workflows/build-beta-linux.yml
+++ b/.github/workflows/build-beta-linux.yml
@@ -95,6 +95,14 @@ jobs:
           path: ./app/jbr
           key: jbr-${{ hashFiles('**/jbr.yaml') }}
 
+      - name: Cache OpenSSL libcrypto binaries
+        uses: actions/cache@v5
+        with:
+          path: ./app/openssl
+          # Linux-only subset (see prepareOpenSslLibs below), so use a key
+          # distinct from the release workflow's full five-target cache.
+          key: openssl-linux-${{ hashFiles('**/openssl.yaml') }}
+
       - name: Build with Gradle
         run: ./gradlew app:build -PintegrationTests
 
@@ -108,6 +116,9 @@ jobs:
         run: |
           VERSION=$(grep '^version=' app/src/desktopMain/resources/crosspaste-version.properties | cut -d= -f2)
           ./gradlew :cli:assembleDistLinuxX64 :cli:assembleDistLinuxArm64 "-PcliVersion=${VERSION}.${REVISION}"
+
+      - name: Prepare OpenSSL libcrypto jars
+        run: ./gradlew app:prepareOpenSslLibs "-PopenSslTargets=linux-x64,linux-arm64"
 
       - name: Prepare Conveyor config (Linux only)
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -197,6 +197,12 @@ jobs:
           path: ./app/jbr
           key: jbr-${{ hashFiles('**/jbr.yaml') }}
 
+      - name: Cache OpenSSL libcrypto binaries
+        uses: actions/cache@v5
+        with:
+          path: ./app/openssl
+          key: openssl-${{ hashFiles('**/openssl.yaml') }}
+
       - name: Restore dylib cache for x86_64
         uses: actions/cache/restore@v5
         with:
@@ -255,6 +261,9 @@ jobs:
           else
             echo "Directory does not exist!"
           fi
+
+      - name: Prepare OpenSSL libcrypto jars
+        run: ./gradlew app:prepareOpenSslLibs
 
       - name: Prepare Dependency
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       app: ${{ steps.filter.outputs.app }}
       cli: ${{ steps.filter.outputs.cli }}
       web: ${{ steps.filter.outputs.web }}
+      openssl: ${{ steps.filter.outputs.openssl }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -59,6 +60,13 @@ jobs:
               - 'settings.gradle.kts'
               - 'build.gradle.kts'
               - 'gradle.properties'
+              - '.github/workflows/ci.yml'
+            # Bundled libcrypto pin: verify the download chain on the PR
+            # instead of discovering a bad URL/SHA at release packaging time.
+            openssl:
+              - 'app/openssl.yaml'
+              - 'conveyor.conf'
+              - 'app/build.gradle.kts'
               - '.github/workflows/ci.yml'
 
   app-build:
@@ -206,8 +214,43 @@ jobs:
         working-directory: web
         run: npm test
 
+  # Verifies the pinned libcrypto download chain (URL reachable, SHA-256
+  # matching, staged paths lining up with conveyor.conf) whenever the pin or
+  # packaging config changes, so a bad pin fails on the PR instead of at
+  # release packaging time. No package is built here.
+  openssl-verify:
+    needs: changes
+    if: needs.changes.outputs.openssl == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          check-latest: true
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Download and verify pinned libcrypto binaries
+        run: ./gradlew app:prepareOpenSslLibs
+
+      - name: Check staged files match conveyor.conf inputs
+        run: |
+          missing=0
+          for path in $(grep -o '"app/openssl/[^"]*"' conveyor.conf | tr -d '"'); do
+            if [ ! -f "$path" ]; then
+              echo "conveyor.conf references missing file: $path"
+              missing=1
+            fi
+          done
+          exit $missing
+
   ci:
-    needs: [app-build, cli-build, web-build]
+    needs: [app-build, cli-build, web-build, openssl-verify]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -217,10 +260,12 @@ jobs:
           app_result="${{ needs.app-build.result }}"
           cli_result="${{ needs.cli-build.result }}"
           web_result="${{ needs.web-build.result }}"
+          openssl_result="${{ needs.openssl-verify.result }}"
           echo "app-build: $app_result"
           echo "cli-build: $cli_result"
           echo "web-build: $web_result"
-          for result in "$app_result" "$cli_result" "$web_result"; do
+          echo "openssl-verify: $openssl_result"
+          for result in "$app_result" "$cli_result" "$web_result" "$openssl_result"; do
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
               echo "CI failed"
               exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ app/GPUCache/
 app/build/
 app/dylib/
 app/jbr/
+app/openssl/
 logs/
 kotlin-js-store/
 node_modules/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,8 +9,6 @@ import org.yaml.snakeyaml.constructor.Constructor
 import java.io.FileReader
 import java.security.MessageDigest
 import java.util.Properties
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
 
 val versionProperties = Properties()
 versionProperties.load(
@@ -695,17 +693,16 @@ data class JbrDetails(
     var sha512: String = "",
 )
 
-// Downloads the pinned libcrypto binaries (openssl.yaml) and wraps each into a
-// thin jar whose only entry is the library under its runtime file name.
-// conveyor.conf feeds these jars to Conveyor as per-machine inputs, so its
-// extract-native-libraries step lands the library in the JVM lib directory
-// (= skiko.library.path) and signs it — the same pipeline as the skiko and
-// tesseract platform jars. Packaging-only: dev/test resolve libcrypto from the
-// environment and never run this task. The checksum chain ends at the
-// downloaded library file; the jar step is a local lossless copy.
+// Downloads the pinned libcrypto binaries (openssl.yaml) and stages each at
+// openssl/<target>/<runtime lib name>. conveyor.conf adds those files as bare
+// per-machine inputs; Conveyor moves shared libraries from inputs into the JVM
+// lib directory (= skiko.library.path) and signs them — the same directory the
+// skiko/tesseract natives land in. Packaging-only: dev/test resolve libcrypto
+// from the environment and never run this task. The checksum chain ends at the
+// downloaded file; the staging step is a local lossless copy.
 tasks.register("prepareOpenSslLibs") {
     group = "build"
-    description = "Download pinned libcrypto binaries and wrap them into per-platform jars for Conveyor bundling."
+    description = "Download pinned libcrypto binaries and stage them per platform for Conveyor bundling."
 
     val openSslYamlFile = project.projectDir.resolve("openssl.yaml")
     val openSslDir = project.projectDir.resolve("openssl")
@@ -731,16 +728,15 @@ tasks.register("prepareOpenSslLibs") {
                 allTargets.filterKeys(names::contains)
             } ?: allTargets
         openSslDir.mkdirs()
-        // Drop leftovers from earlier versions (stale files keyed by the full
+        // Drop leftovers from earlier versions (stale entries keyed by the full
         // target set, so a filtered run never deletes other targets' files).
-        val expectedFiles =
-            allTargets
-                .flatMap { (target, details) ->
-                    listOf(details.url.substringAfterLast("/"), "crosspaste-libcrypto-$target.jar")
-                }.toSet()
-        openSslDir.listFiles()?.forEach { file ->
-            if (file.isFile && file.name !in expectedFiles) {
-                file.delete()
+        val expectedDownloads = allTargets.map { (_, details) -> details.url.substringAfterLast("/") }.toSet()
+        openSslDir.listFiles()?.forEach { entry ->
+            if (entry.isFile && entry.name !in expectedDownloads) {
+                entry.delete()
+            }
+            if (entry.isDirectory && entry.name !in allTargets) {
+                entry.deleteRecursively()
             }
         }
         selectedTargets.forEach { (target, details) ->
@@ -759,12 +755,14 @@ tasks.register("prepareOpenSslLibs") {
                     "SHA-256 mismatch for ${libFile.name}: expected ${details.sha256}, got $actualSha256",
                 )
             }
-            val jarFile = openSslDir.resolve("crosspaste-libcrypto-$target.jar")
-            ZipOutputStream(jarFile.outputStream().buffered()).use { zip ->
-                zip.putNextEntry(ZipEntry(details.libName))
-                libFile.inputStream().use { it.copyTo(zip) }
-                zip.closeEntry()
+            val targetDir = openSslDir.resolve(target)
+            targetDir.mkdirs()
+            targetDir.listFiles()?.forEach { staged ->
+                if (staged.name != details.libName) {
+                    staged.delete()
+                }
             }
+            libFile.copyTo(targetDir.resolve(details.libName), overwrite = true)
         }
     }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,10 @@ import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.Constructor
 import java.io.FileReader
+import java.security.MessageDigest
 import java.util.Properties
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 val versionProperties = Properties()
 versionProperties.load(
@@ -690,4 +693,113 @@ data class JbrReleases(
 data class JbrDetails(
     var url: String = "",
     var sha512: String = "",
+)
+
+// Downloads the pinned libcrypto binaries (openssl.yaml) and wraps each into a
+// thin jar whose only entry is the library under its runtime file name.
+// conveyor.conf feeds these jars to Conveyor as per-machine inputs, so its
+// extract-native-libraries step lands the library in the JVM lib directory
+// (= skiko.library.path) and signs it — the same pipeline as the skiko and
+// tesseract platform jars. Packaging-only: dev/test resolve libcrypto from the
+// environment and never run this task. The checksum chain ends at the
+// downloaded library file; the jar step is a local lossless copy.
+tasks.register("prepareOpenSslLibs") {
+    group = "build"
+    description = "Download pinned libcrypto binaries and wrap them into per-platform jars for Conveyor bundling."
+
+    val openSslYamlFile = project.projectDir.resolve("openssl.yaml")
+    val openSslDir = project.projectDir.resolve("openssl")
+
+    // Optional target subset (-PopenSslTargets=linux-x64,linux-arm64) so
+    // machine-scoped CI builds (e.g. the linux-only beta) don't couple their
+    // success to the reachability of the other platforms' binaries.
+    val requestedTargets = providers.gradleProperty("openSslTargets")
+
+    inputs.file(openSslYamlFile)
+    inputs.property("openSslTargets", requestedTargets.orElse(""))
+    outputs.dir(openSslDir)
+
+    doLast {
+        val allTargets = loadOpenSslReleases(openSslYamlFile).openssl.targets
+        val selectedTargets =
+            requestedTargets.orNull?.split(",")?.map(String::trim)?.let { names ->
+                names.forEach { name ->
+                    if (name !in allTargets) {
+                        throw GradleException("Unknown OpenSSL target '$name'; openssl.yaml defines ${allTargets.keys}")
+                    }
+                }
+                allTargets.filterKeys(names::contains)
+            } ?: allTargets
+        openSslDir.mkdirs()
+        // Drop leftovers from earlier versions (stale files keyed by the full
+        // target set, so a filtered run never deletes other targets' files).
+        val expectedFiles =
+            allTargets
+                .flatMap { (target, details) ->
+                    listOf(details.url.substringAfterLast("/"), "crosspaste-libcrypto-$target.jar")
+                }.toSet()
+        openSslDir.listFiles()?.forEach { file ->
+            if (file.isFile && file.name !in expectedFiles) {
+                file.delete()
+            }
+        }
+        selectedTargets.forEach { (target, details) ->
+            val libFile = openSslDir.resolve(details.url.substringAfterLast("/"))
+            if (!libFile.exists() || sha256Hex(libFile) != details.sha256) {
+                download.run {
+                    src { details.url }
+                    dest { openSslDir }
+                    overwrite(true)
+                    tempAndMove(true)
+                }
+            }
+            val actualSha256 = sha256Hex(libFile)
+            if (actualSha256 != details.sha256) {
+                throw GradleException(
+                    "SHA-256 mismatch for ${libFile.name}: expected ${details.sha256}, got $actualSha256",
+                )
+            }
+            val jarFile = openSslDir.resolve("crosspaste-libcrypto-$target.jar")
+            ZipOutputStream(jarFile.outputStream().buffered()).use { zip ->
+                zip.putNextEntry(ZipEntry(details.libName))
+                libFile.inputStream().use { it.copyTo(zip) }
+                zip.closeEntry()
+            }
+        }
+    }
+}
+
+fun sha256Hex(file: File): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    file.inputStream().use { input ->
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            digest.update(buffer, 0, read)
+        }
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }
+}
+
+fun loadOpenSslReleases(file: File): OpenSslReleases {
+    val yaml = Yaml(Constructor(OpenSslReleases::class.java, LoaderOptions()))
+    file.inputStream().use {
+        return yaml.load(it)
+    }
+}
+
+data class OpenSslReleases(
+    var openssl: OpenSslConfig = OpenSslConfig(),
+)
+
+data class OpenSslConfig(
+    var version: String = "",
+    var targets: Map<String, OpenSslTarget> = mutableMapOf(),
+)
+
+data class OpenSslTarget(
+    var url: String = "",
+    var sha256: String = "",
+    var libName: String = "",
 )

--- a/app/openssl.yaml
+++ b/app/openssl.yaml
@@ -1,0 +1,37 @@
+# Pinned OpenSSL libcrypto binaries bundled with the desktop app for the
+# pairing v3 SPAKE2 backend (OpenSslPakeEcOps). Built by our own CI at
+# https://github.com/CrossPaste/openssl-builds (fork of whyoleg/openssl-builds,
+# scripts unchanged; sources from the official OpenSSL tarball). Downloaded and
+# verified by the app:prepareOpenSslLibs Gradle task, then wrapped into thin
+# per-platform jars that conveyor.conf feeds to Conveyor, whose
+# extract-native-libraries step places the library into the JVM lib directory
+# and signs it. Keep the K/Native prebuilt (cryptography-provider-openssl3)
+# version aligned when bumping so all platforms review the same OpenSSL.
+#
+# When adopting a new version: rebuild via the fork's workflows (windows needs
+# build-windows.yaml), verify the ecp_nistz256 assembly is present (see the
+# fork release notes for the checklist), publish a fork release, then update
+# every url/sha256 here.
+openssl:
+  version: 3.6.0
+  targets:
+    macos-arm64:
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-macos-arm64.dylib
+      sha256: fd9a1293128c129f99d58749e2f3c18d0567f485d7b134bd2576f1ce274ab027
+      libName: libcrypto.3.dylib
+    macos-x64:
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-macos-x64.dylib
+      sha256: 1b68742cd3f8099ab4ebf9465a54b3c4c78ed3ec5f5acd13de0f5e3adc0a97d2
+      libName: libcrypto.3.dylib
+    linux-x64:
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-linux-x64.so
+      sha256: 7cc44876e0c5769adc40d451564e40dca0cd45210d6fb6f719a6a5de02512235
+      libName: libcrypto.so.3
+    linux-arm64:
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-linux-arm64.so
+      sha256: ab2c449a0bdc39bbcbc66d0528522df77cf71e289a93ab922297f505a417040e
+      libName: libcrypto.so.3
+    windows-x64:
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-windows-x64.dll
+      sha256: a547e4f4085a19b91edd8e5aba0c253fc1efe1fed276eec903edc20ad1d66518
+      libName: libcrypto-3-x64.dll

--- a/app/openssl.yaml
+++ b/app/openssl.yaml
@@ -1,37 +1,41 @@
 # Pinned OpenSSL libcrypto binaries bundled with the desktop app for the
 # pairing v3 SPAKE2 backend (OpenSslPakeEcOps). Built by our own CI at
-# https://github.com/CrossPaste/openssl-builds (fork of whyoleg/openssl-builds,
-# scripts unchanged; sources from the official OpenSSL tarball). Downloaded and
-# verified by the app:prepareOpenSslLibs Gradle task, then wrapped into thin
-# per-platform jars that conveyor.conf feeds to Conveyor, whose
-# extract-native-libraries step places the library into the JVM lib directory
-# and signs it. Keep the K/Native prebuilt (cryptography-provider-openssl3)
-# version aligned when bumping so all platforms review the same OpenSSL.
+# https://github.com/CrossPaste/openssl-builds (fork of whyoleg/openssl-builds;
+# sources from the official OpenSSL tarball, one fork change: the msvc step
+# passes vs_version=18 for current windows-latest images). Downloaded and
+# verified by the app:prepareOpenSslLibs Gradle task, then staged bare at
+# app/openssl/<target>/<libName> for conveyor.conf, which ships each library
+# into the JVM lib directory and signs it. Keep the K/Native prebuilt
+# (cryptography-provider-openssl3) version aligned when bumping so all
+# platforms review the same OpenSSL.
 #
-# When adopting a new version: rebuild via the fork's workflows (windows needs
-# build-windows.yaml), verify the ecp_nistz256 assembly is present (see the
-# fork release notes for the checklist), publish a fork release, then update
-# every url/sha256 here.
+# When bumping: check https://openssl-library.org/news/vulnerabilities/ for
+# the latest released 3.x patch line first, dispatch the fork's Build workflow
+# for that version, verify per the fork release-notes checklist (ecp_nistz256
+# assembly, exported symbols, macOS minos, RFC 9382 vectors), publish a fork
+# release, then update version and every url/sha256 here. The bundled
+# LICENSE.txt (app/third-party/licenses/openssl) rarely changes but confirm it
+# still matches the tag.
 openssl:
-  version: 3.6.0
+  version: 3.6.3
   targets:
     macos-arm64:
-      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-macos-arm64.dylib
-      sha256: fd9a1293128c129f99d58749e2f3c18d0567f485d7b134bd2576f1ce274ab027
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.3/libcrypto-3.6.3-macos-arm64.dylib
+      sha256: bea941518760a9329f8b88dec6b72f8d0ecf1b269ba061cca25778255b757694
       libName: libcrypto.3.dylib
     macos-x64:
-      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-macos-x64.dylib
-      sha256: 1b68742cd3f8099ab4ebf9465a54b3c4c78ed3ec5f5acd13de0f5e3adc0a97d2
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.3/libcrypto-3.6.3-macos-x64.dylib
+      sha256: 77192b978e8137ef5a78a04d8fd24d2209ac62e2189abb7436cb4371989d5f49
       libName: libcrypto.3.dylib
     linux-x64:
-      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-linux-x64.so
-      sha256: 7cc44876e0c5769adc40d451564e40dca0cd45210d6fb6f719a6a5de02512235
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.3/libcrypto-3.6.3-linux-x64.so
+      sha256: 8d415d70d33924a08a3a678cc98f0e143f7eef77202305cb51e5fc923e0d8ef9
       libName: libcrypto.so.3
     linux-arm64:
-      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-linux-arm64.so
-      sha256: ab2c449a0bdc39bbcbc66d0528522df77cf71e289a93ab922297f505a417040e
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.3/libcrypto-3.6.3-linux-arm64.so
+      sha256: 9153431769ed569e85304b4ca194a142d8b298a297788334d1fe7f8dc3e2e2e5
       libName: libcrypto.so.3
     windows-x64:
-      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.0/libcrypto-3.6.0-windows-x64.dll
-      sha256: a547e4f4085a19b91edd8e5aba0c253fc1efe1fed276eec903edc20ad1d66518
+      url: https://github.com/CrossPaste/openssl-builds/releases/download/3.6.3/libcrypto-3.6.3-windows-x64.dll
+      sha256: 5f57d6daa71ee2dbb17feaa9ccd93153cd28c2c0369e083bc986975fb40211e0
       libName: libcrypto-3-x64.dll

--- a/app/third-party/licenses/openssl/LICENSE.txt
+++ b/app/third-party/licenses/openssl/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -29,6 +29,16 @@ app {
     linux.aarch64.inputs += "app/jbr/jbrsdk-21.0.9-linux-aarch64-b1163.94.tar.gz"
   }
 
+  // OpenSSL libcrypto for the pairing v3 SPAKE2 backend, pinned in
+  // app/openssl.yaml and produced by `./gradlew app:prepareOpenSslLibs`.
+  // Thin jars so extract-native-libraries places the library in the JVM lib
+  // directory and signs it (same pipeline as the skiko/tesseract jars).
+  mac.aarch64.inputs += "app/openssl/crosspaste-libcrypto-macos-arm64.jar"
+  mac.amd64.inputs += "app/openssl/crosspaste-libcrypto-macos-x64.jar"
+  windows.amd64.inputs += "app/openssl/crosspaste-libcrypto-windows-x64.jar"
+  linux.amd64.inputs += "app/openssl/crosspaste-libcrypto-linux-x64.jar"
+  linux.aarch64.inputs += "app/openssl/crosspaste-libcrypto-linux-arm64.jar"
+
   mac {
     bundle-extras += "app/script/mac_start.sh" -> "bin/start.sh"
     icons = "app/src/desktopMain/composeResources/drawable/crosspaste_mac.png"

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -30,14 +30,18 @@ app {
   }
 
   // OpenSSL libcrypto for the pairing v3 SPAKE2 backend, pinned in
-  // app/openssl.yaml and produced by `./gradlew app:prepareOpenSslLibs`.
-  // Thin jars so extract-native-libraries places the library in the JVM lib
-  // directory and signs it (same pipeline as the skiko/tesseract jars).
-  mac.aarch64.inputs += "app/openssl/crosspaste-libcrypto-macos-arm64.jar"
-  mac.amd64.inputs += "app/openssl/crosspaste-libcrypto-macos-x64.jar"
-  windows.amd64.inputs += "app/openssl/crosspaste-libcrypto-windows-x64.jar"
-  linux.amd64.inputs += "app/openssl/crosspaste-libcrypto-linux-x64.jar"
-  linux.aarch64.inputs += "app/openssl/crosspaste-libcrypto-linux-arm64.jar"
+  // app/openssl.yaml and staged by `./gradlew app:prepareOpenSslLibs`.
+  // Bare shared libraries in inputs are moved to the JVM lib directory
+  // (= skiko.library.path) and signed, next to the skiko/tesseract natives.
+  mac.aarch64.inputs += "app/openssl/macos-arm64/libcrypto.3.dylib"
+  mac.amd64.inputs += "app/openssl/macos-x64/libcrypto.3.dylib"
+  windows.amd64.inputs += "app/openssl/windows-x64/libcrypto-3-x64.dll"
+  linux.amd64.inputs += "app/openssl/linux-x64/libcrypto.so.3"
+  linux.aarch64.inputs += "app/openssl/linux-arm64/libcrypto.so.3"
+
+  // Third-party license texts shipped with every package (OpenSSL is
+  // Apache-2.0: redistribution of the binary requires the license copy).
+  inputs += "app/third-party"
 
   mac {
     bundle-extras += "app/script/mac_start.sh" -> "bin/start.sh"


### PR DESCRIPTION
Closes #4862

## What

Bundles our own CI-built OpenSSL 3.6.0 libcrypto with every desktop package, as the packaging prerequisite for enabling pairing v3. Production behavior is unchanged: the runtime still resolves libcrypto exactly as before, and v3 stays fail-closed behind `PAIRING_VERSION=2`.

- **`app/openssl.yaml`** — pins per-target download URL + SHA-256 for the five desktop libraries, sourced from the [CrossPaste/openssl-builds 3.6.0 release](https://github.com/CrossPaste/openssl-builds/releases/tag/3.6.0) (fork of whyoleg/openssl-builds with unchanged build scripts; per-target `ecp_nistz256` assembly and symbol exports verified, RFC 9382 vectors green against the built macos-arm64 dylib).
- **`prepareOpenSslLibs` Gradle task** — downloads each pinned library, verifies SHA-256 (re-downloads on corrupted cache, hard-fails on mismatch), prunes stale files from earlier versions, and wraps each library into a thin jar whose only entry is the library under its runtime file name (`libcrypto.3.dylib` / `libcrypto.so.3` / `libcrypto-3-x64.dll`). `-PopenSslTargets=` selects a subset so machine-scoped CI builds don't depend on other platforms' binaries.
- **`conveyor.conf`** — adds the five jars as per-machine inputs. Conveyor's `extract-native-libraries` step places the library into the JVM lib directory (= `skiko.library.path`) and signs/notarizes it, the same pipeline already proven by the skiko/javacpp/tesseract platform jars.
- **CI** — release and beta workflows run the task before the Conveyor build with a cache keyed on `openssl.yaml` (the linux-only beta uses a distinct key and the linux target subset).

## Verification

- Full run downloads all five libraries and produces the five jars; jar entry round-trips to the pinned SHA-256.
- Second run is `UP-TO-DATE`; a tampered cached library is detected and re-downloaded; a stale old-version file is pruned; an unknown `-PopenSslTargets` name fails fast.
- `conveyor json` on the local mac config resolves `crosspaste-libcrypto-macos-arm64.jar` into `mac.aarch64` inputs (HOCON valid, path correct).
- `ktlintCheck` and `writeConveyorConfig -PappEnv=PRODUCTION` pass.

## Out of scope (follow-ups)

Runtime resolution tightening in `OpenSslPakeEcOps` (bundled path first, no system-path fallback in production), real-machine load verification of all five packages, and the `PAIRING_VERSION` bump.