### PR TITLE
:hammer: restrict production libcrypto loading to the bundled library with fail-closed startup probe

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -81,7 +81,7 @@ class DesktopModule(
             appEnv = appEnv,
             developmentV3InteropEnabled =
                 appEnv == AppEnv.DEVELOPMENT && DevConfig.pairingV3InteropEnabled,
-            bundledLibcryptoPath = bundledLibcryptoPath(appEnv, platform, appPathProvider),
+            libcryptoResolution = desktopLibcryptoResolution(appEnv, platform, appPathProvider),
         )
 
     override fun appModule() =

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopModule.kt
@@ -81,6 +81,7 @@ class DesktopModule(
             appEnv = appEnv,
             developmentV3InteropEnabled =
                 appEnv == AppEnv.DEVELOPMENT && DevConfig.pairingV3InteropEnabled,
+            bundledLibcryptoPath = bundledLibcryptoPath(appEnv, platform, appPathProvider),
         )
 
     override fun appModule() =

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -60,6 +60,7 @@ import com.crosspaste.pairing.v3.PairingVersionCoordinator
 import com.crosspaste.pairing.v3.PakeProvider
 import com.crosspaste.pairing.v3.Spake2PakeProvider
 import com.crosspaste.pairing.v3.UnavailablePakeProvider
+import com.crosspaste.path.AppPathProvider
 import com.crosspaste.platform.Platform
 import com.crosspaste.sync.FilePushService
 import com.crosspaste.sync.GeneralNearbyDeviceManager
@@ -370,7 +371,8 @@ class DesktopPairingBackend(
 internal fun resolveDesktopPairingBackend(
     appEnv: AppEnv,
     developmentV3InteropEnabled: Boolean,
-    loadPakeProvider: () -> PakeProvider = { Spake2PakeProvider(OpenSslPakeEcOps.load()) },
+    bundledLibcryptoPath: String? = null,
+    loadPakeProvider: () -> PakeProvider = { Spake2PakeProvider(OpenSslPakeEcOps.load(bundledLibcryptoPath)) },
 ): DesktopPairingBackend {
     if (appEnv == AppEnv.DEVELOPMENT && developmentV3InteropEnabled) {
         // DEVELOPMENT interoperability only until the cross-platform security
@@ -388,6 +390,19 @@ internal fun resolveDesktopPairingBackend(
                     "OpenSSL libcrypto unavailable, pairing v3 stays disabled"
                 }
             }
+    } else if (bundledLibcryptoPath != null) {
+        // Startup probe for bundled builds (production/beta): loads the packaged
+        // libcrypto so real-device verification can confirm from the log which
+        // library resolved, and so a packaging regression surfaces as a warn
+        // instead of at rollout. The result is deliberately discarded — until
+        // PAIRING_VERSION is bumped (#4667) capability stays clamped below and
+        // the provider stays fail-closed.
+        runCatching { loadPakeProvider() }
+            .onFailure { e ->
+                KotlinLogging.logger {}.warn(e) {
+                    "bundled libcrypto probe failed; pairing v3 will be unavailable when rolled out"
+                }
+            }
     }
     // Keep non-development builds fail-closed even if the rollout constant is
     // changed before a reviewed provider is registered.
@@ -397,4 +412,31 @@ internal fun resolveDesktopPairingBackend(
             PairingV3.PROTOCOL_VERSION - 1,
         )
     return DesktopPairingBackend(PairingCapabilityFlag(clampedVersion), UnavailablePakeProvider)
+}
+
+/**
+ * Absolute path of the libcrypto shipped inside the installed package, or null
+ * in DEVELOPMENT/TEST, which keep resolving libcrypto from the environment.
+ *
+ * Conveyor moves the bare library inputs (conveyor.conf, pinned in
+ * app/openssl.yaml) into the packaged JVM's native-library directory — the
+ * same directory `skiko.library.path` points at and [AppPathProvider.pasteAppExePath]
+ * resolves on every platform (macOS `runtime/Contents/Home/lib`, Windows
+ * `bin`, Linux `runtime/lib`).
+ */
+internal fun bundledLibcryptoPath(
+    appEnv: AppEnv,
+    platform: Platform,
+    appPathProvider: AppPathProvider,
+): String? {
+    if (appEnv != AppEnv.PRODUCTION && appEnv != AppEnv.BETA) {
+        return null
+    }
+    val libName =
+        when {
+            platform.isMacos() -> "libcrypto.3.dylib"
+            platform.isWindows() -> "libcrypto-3-x64.dll"
+            else -> "libcrypto.so.3"
+        }
+    return appPathProvider.pasteAppExePath.resolve(libName).toString()
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -48,6 +48,7 @@ import com.crosspaste.net.ws.WsClientConnector
 import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsPendingRequests
 import com.crosspaste.net.ws.WsSessionManager
+import com.crosspaste.pairing.v3.LibCryptoResolution
 import com.crosspaste.pairing.v3.OpenSslPakeEcOps
 import com.crosspaste.pairing.v3.PairingAcceptanceWindow
 import com.crosspaste.pairing.v3.PairingCapabilityFlag
@@ -371,8 +372,8 @@ class DesktopPairingBackend(
 internal fun resolveDesktopPairingBackend(
     appEnv: AppEnv,
     developmentV3InteropEnabled: Boolean,
-    bundledLibcryptoPath: String? = null,
-    loadPakeProvider: () -> PakeProvider = { Spake2PakeProvider(OpenSslPakeEcOps.load(bundledLibcryptoPath)) },
+    libcryptoResolution: LibCryptoResolution = LibCryptoResolution.Environment,
+    loadPakeProvider: () -> PakeProvider = { Spake2PakeProvider(OpenSslPakeEcOps.load(libcryptoResolution)) },
 ): DesktopPairingBackend {
     if (appEnv == AppEnv.DEVELOPMENT && developmentV3InteropEnabled) {
         // DEVELOPMENT interoperability only until the cross-platform security
@@ -390,7 +391,7 @@ internal fun resolveDesktopPairingBackend(
                     "OpenSSL libcrypto unavailable, pairing v3 stays disabled"
                 }
             }
-    } else if (bundledLibcryptoPath != null) {
+    } else if (libcryptoResolution is LibCryptoResolution.Bundled) {
         // Startup probe for bundled builds (production/beta): loads the packaged
         // libcrypto so real-device verification can confirm from the log which
         // library resolved, and so a packaging regression surfaces as a warn
@@ -415,8 +416,8 @@ internal fun resolveDesktopPairingBackend(
 }
 
 /**
- * Absolute path of the libcrypto shipped inside the installed package, or null
- * in DEVELOPMENT/TEST, which keep resolving libcrypto from the environment.
+ * The libcrypto resolution for this build: [LibCryptoResolution.Bundled] in
+ * PRODUCTION/BETA, [LibCryptoResolution.Environment] in DEVELOPMENT/TEST.
  *
  * Conveyor moves the bare library inputs (conveyor.conf, pinned in
  * app/openssl.yaml) into the packaged JVM's native-library directory — the
@@ -424,13 +425,13 @@ internal fun resolveDesktopPairingBackend(
  * resolves on every platform (macOS `runtime/Contents/Home/lib`, Windows
  * `bin`, Linux `runtime/lib`).
  */
-internal fun bundledLibcryptoPath(
+internal fun desktopLibcryptoResolution(
     appEnv: AppEnv,
     platform: Platform,
     appPathProvider: AppPathProvider,
-): String? {
+): LibCryptoResolution {
     if (appEnv != AppEnv.PRODUCTION && appEnv != AppEnv.BETA) {
-        return null
+        return LibCryptoResolution.Environment
     }
     val libName =
         when {
@@ -438,5 +439,9 @@ internal fun bundledLibcryptoPath(
             platform.isWindows() -> "libcrypto-3-x64.dll"
             else -> "libcrypto.so.3"
         }
-    return appPathProvider.pasteAppExePath.resolve(libName).toString()
+    return LibCryptoResolution.Bundled(
+        appPathProvider.pasteAppExePath
+            .resolve(libName)
+            .toString(),
+    )
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/DesktopPairingCapabilityTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/DesktopPairingCapabilityTest.kt
@@ -5,9 +5,15 @@ import com.crosspaste.config.developmentPairingV3InteropEnabled
 import com.crosspaste.pairing.v3.PakeException
 import com.crosspaste.pairing.v3.TestPakeProvider
 import com.crosspaste.pairing.v3.UnavailablePakeProvider
+import com.crosspaste.path.AppPathProvider
+import com.crosspaste.platform.Platform
+import io.mockk.every
+import io.mockk.mockk
+import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -89,6 +95,78 @@ class DesktopPairingCapabilityTest {
             assertEquals(2, backend.capabilityFlag.advertisedPairingVersion)
             assertFalse(backend.capabilityFlag.isPairingV3Enabled)
             assertSame(UnavailablePakeProvider, backend.pakeProvider)
+        }
+    }
+
+    @Test
+    fun bundledBuildsProbeTheBackendButStayClampedToV2() {
+        listOf(AppEnv.PRODUCTION, AppEnv.BETA).forEach { appEnv ->
+            var probes = 0
+            val backend =
+                resolveDesktopPairingBackend(
+                    appEnv = appEnv,
+                    developmentV3InteropEnabled = false,
+                    bundledLibcryptoPath = "/opt/crosspaste/runtime/lib/libcrypto.so.3",
+                    loadPakeProvider = {
+                        probes++
+                        loadedProvider
+                    },
+                )
+
+            // The probe exists for packaging diagnostics only: even a working
+            // backend must not advertise v3 before the rollout PR (#4667).
+            assertEquals(1, probes)
+            assertEquals(2, backend.capabilityFlag.advertisedPairingVersion)
+            assertFalse(backend.capabilityFlag.isPairingV3Enabled)
+            assertSame(UnavailablePakeProvider, backend.pakeProvider)
+        }
+    }
+
+    @Test
+    fun bundledProbeFailureIsToleratedAndStaysClamped() {
+        val backend =
+            resolveDesktopPairingBackend(
+                appEnv = AppEnv.PRODUCTION,
+                developmentV3InteropEnabled = false,
+                bundledLibcryptoPath = "/missing/libcrypto.so.3",
+                loadPakeProvider = failingLoader,
+            )
+
+        assertEquals(2, backend.capabilityFlag.advertisedPairingVersion)
+        assertSame(UnavailablePakeProvider, backend.pakeProvider)
+    }
+
+    @Test
+    fun bundledLibcryptoPathResolvesPerPlatformUnderTheJvmLibDirectory() {
+        val appPathProvider =
+            mockk<AppPathProvider> {
+                every { pasteAppExePath } returns "/opt/crosspaste/runtime/lib".toPath()
+            }
+
+        listOf(
+            Platform(Platform.MACOS, "aarch64", 64, "15") to "libcrypto.3.dylib",
+            Platform(Platform.WINDOWS, "x86_64", 64, "11") to "libcrypto-3-x64.dll",
+            Platform(Platform.LINUX, "x86_64", 64, "6") to "libcrypto.so.3",
+        ).forEach { (platform, libName) ->
+            assertEquals(
+                "/opt/crosspaste/runtime/lib/$libName",
+                bundledLibcryptoPath(AppEnv.PRODUCTION, platform, appPathProvider),
+            )
+            assertEquals(
+                "/opt/crosspaste/runtime/lib/$libName",
+                bundledLibcryptoPath(AppEnv.BETA, platform, appPathProvider),
+            )
+        }
+    }
+
+    @Test
+    fun developmentAndTestBuildsHaveNoBundledLibcryptoPath() {
+        // Unstubbed mock: resolving any path in DEVELOPMENT/TEST would throw.
+        val untouchedPathProvider = mockk<AppPathProvider>()
+        val platform = Platform(Platform.MACOS, "aarch64", 64, "15")
+
+        listOf(AppEnv.DEVELOPMENT, AppEnv.TEST).forEach { appEnv ->
+            assertNull(bundledLibcryptoPath(appEnv, platform, untouchedPathProvider))
         }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/DesktopPairingCapabilityTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/DesktopPairingCapabilityTest.kt
@@ -2,6 +2,7 @@ package com.crosspaste
 
 import com.crosspaste.app.AppEnv
 import com.crosspaste.config.developmentPairingV3InteropEnabled
+import com.crosspaste.pairing.v3.LibCryptoResolution
 import com.crosspaste.pairing.v3.PakeException
 import com.crosspaste.pairing.v3.TestPakeProvider
 import com.crosspaste.pairing.v3.UnavailablePakeProvider
@@ -13,7 +14,6 @@ import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -106,7 +106,8 @@ class DesktopPairingCapabilityTest {
                 resolveDesktopPairingBackend(
                     appEnv = appEnv,
                     developmentV3InteropEnabled = false,
-                    bundledLibcryptoPath = "/opt/crosspaste/runtime/lib/libcrypto.so.3",
+                    libcryptoResolution =
+                        LibCryptoResolution.Bundled("/opt/crosspaste/runtime/lib/libcrypto.so.3"),
                     loadPakeProvider = {
                         probes++
                         loadedProvider
@@ -128,7 +129,7 @@ class DesktopPairingCapabilityTest {
             resolveDesktopPairingBackend(
                 appEnv = AppEnv.PRODUCTION,
                 developmentV3InteropEnabled = false,
-                bundledLibcryptoPath = "/missing/libcrypto.so.3",
+                libcryptoResolution = LibCryptoResolution.Bundled("/missing/libcrypto.so.3"),
                 loadPakeProvider = failingLoader,
             )
 
@@ -137,7 +138,23 @@ class DesktopPairingCapabilityTest {
     }
 
     @Test
-    fun bundledLibcryptoPathResolvesPerPlatformUnderTheJvmLibDirectory() {
+    fun environmentResolutionDoesNotProbeOutsideDevelopmentInterop() {
+        listOf(AppEnv.PRODUCTION, AppEnv.BETA, AppEnv.TEST).forEach { appEnv ->
+            val backend =
+                resolveDesktopPairingBackend(
+                    appEnv = appEnv,
+                    developmentV3InteropEnabled = false,
+                    libcryptoResolution = LibCryptoResolution.Environment,
+                    loadPakeProvider = forbiddenLoader,
+                )
+
+            assertEquals(2, backend.capabilityFlag.advertisedPairingVersion)
+            assertSame(UnavailablePakeProvider, backend.pakeProvider)
+        }
+    }
+
+    @Test
+    fun bundledResolutionResolvesPerPlatformUnderTheJvmLibDirectory() {
         val appPathProvider =
             mockk<AppPathProvider> {
                 every { pasteAppExePath } returns "/opt/crosspaste/runtime/lib".toPath()
@@ -148,25 +165,26 @@ class DesktopPairingCapabilityTest {
             Platform(Platform.WINDOWS, "x86_64", 64, "11") to "libcrypto-3-x64.dll",
             Platform(Platform.LINUX, "x86_64", 64, "6") to "libcrypto.so.3",
         ).forEach { (platform, libName) ->
-            assertEquals(
-                "/opt/crosspaste/runtime/lib/$libName",
-                bundledLibcryptoPath(AppEnv.PRODUCTION, platform, appPathProvider),
-            )
-            assertEquals(
-                "/opt/crosspaste/runtime/lib/$libName",
-                bundledLibcryptoPath(AppEnv.BETA, platform, appPathProvider),
-            )
+            listOf(AppEnv.PRODUCTION, AppEnv.BETA).forEach { appEnv ->
+                assertEquals(
+                    LibCryptoResolution.Bundled("/opt/crosspaste/runtime/lib/$libName"),
+                    desktopLibcryptoResolution(appEnv, platform, appPathProvider),
+                )
+            }
         }
     }
 
     @Test
-    fun developmentAndTestBuildsHaveNoBundledLibcryptoPath() {
+    fun developmentAndTestBuildsResolveFromTheEnvironment() {
         // Unstubbed mock: resolving any path in DEVELOPMENT/TEST would throw.
         val untouchedPathProvider = mockk<AppPathProvider>()
         val platform = Platform(Platform.MACOS, "aarch64", 64, "15")
 
         listOf(AppEnv.DEVELOPMENT, AppEnv.TEST).forEach { appEnv ->
-            assertNull(bundledLibcryptoPath(appEnv, platform, untouchedPathProvider))
+            assertEquals(
+                LibCryptoResolution.Environment,
+                desktopLibcryptoResolution(appEnv, platform, untouchedPathProvider),
+            )
         }
     }
 }

--- a/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
+++ b/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
@@ -357,8 +357,11 @@ class OpenSslPakeEcOps private constructor(
                     failures += candidate
                 }
             }
+            // Keyed on the build flavor, not on which candidate list was tried:
+            // even when an explicit override fails, a bundled build must never
+            // steer users toward installing a system OpenSSL it won't load.
             val remedy =
-                if (candidates == listOf(bundledLibraryPath)) {
+                if (bundledLibraryPath != null) {
                     "The bundled libcrypto is missing or unloadable; reinstalling the application should restore it, " +
                         "or point crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH at a reviewed libcrypto."
                 } else {

--- a/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
+++ b/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
@@ -6,6 +6,7 @@ import com.sun.jna.Native
 import com.sun.jna.NativeLibrary
 import com.sun.jna.Platform
 import com.sun.jna.Pointer
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 /**
  * JVM [PakeEcOps] backed by OpenSSL 3 libcrypto's low-level P-256 ops via JNA.
@@ -27,9 +28,11 @@ import com.sun.jna.Pointer
  * JVM `BigInteger` copies the BouncyCastle backend left behind for the GC.
  *
  * libcrypto is resolved from the `crosspaste.libcrypto.path` system property
- * or `CROSSPASTE_LIBCRYPTO_PATH` environment variable first, then from
- * per-platform well-known library names. [load] fails fast with a
- * [PakeException] when no candidate can be loaded.
+ * or `CROSSPASTE_LIBCRYPTO_PATH` environment variable first. Without an
+ * override, bundled builds (a non-null `bundledLibraryPath` passed to [load])
+ * resolve ONLY the libcrypto shipped inside the application package, while
+ * development/test builds fall back to per-platform well-known library names.
+ * [load] fails fast with a [PakeException] when no candidate can be loaded.
  */
 class OpenSslPakeEcOps private constructor(
     private val lib: LibCrypto,
@@ -309,19 +312,36 @@ class OpenSslPakeEcOps private constructor(
                 "BN_priv_rand_range",
             )
 
-        // A failed lazy initializer is not cached, so load() retries after e.g.
-        // the user installs OpenSSL or sets the override.
-        private val instance: OpenSslPakeEcOps by lazy { OpenSslPakeEcOps(loadLibCrypto()) }
+        private val logger = KotlinLogging.logger {}
+
+        private val lock = Any()
+
+        // A failed load is not cached, so load() retries after e.g. the user
+        // installs OpenSSL or sets the override. The first successful load pins
+        // the process-wide instance; later calls return it regardless of their
+        // bundledLibraryPath (each real process only ever uses one policy).
+        private var instance: OpenSslPakeEcOps? = null
 
         /**
          * Returns the process-wide ops instance (libcrypto loaded once), throwing
          * [PakeException] when no library candidate provides the full symbol set.
+         *
+         * [bundledLibraryPath] is the absolute path of the libcrypto shipped
+         * inside the application package. Passing it (production/beta builds)
+         * restricts resolution to explicit override → bundled library, with no
+         * fallback to system paths; null (development/test) keeps the
+         * environment's well-known candidates.
          */
-        fun load(): OpenSslPakeEcOps = instance
+        fun load(bundledLibraryPath: String? = null): OpenSslPakeEcOps =
+            synchronized(lock) {
+                instance
+                    ?: OpenSslPakeEcOps(loadLibCrypto(bundledLibraryPath)).also { instance = it }
+            }
 
-        private fun loadLibCrypto(): LibCrypto {
+        internal fun loadLibCrypto(bundledLibraryPath: String?): LibCrypto {
+            val candidates = libraryCandidates(bundledLibraryPath)
             val failures = mutableListOf<String>()
-            for (candidate in libraryCandidates()) {
+            for (candidate in candidates) {
                 try {
                     // Reject libraries missing any required symbol up front (e.g.
                     // Apple's system LibreSSL lacks parts of the OpenSSL 1.1.1+
@@ -329,25 +349,38 @@ class OpenSslPakeEcOps private constructor(
                     // of an UnsatisfiedLinkError in the middle of an operation.
                     val library = NativeLibrary.getInstance(candidate)
                     REQUIRED_SYMBOLS.forEach(library::getFunction)
+                    // Startup diagnostic for release verification: confirms the
+                    // bundled library (not a system one) is what actually loaded.
+                    logger.info { "pairing v3 libcrypto loaded from ${library.file?.absolutePath ?: candidate}" }
                     return Native.load(candidate, LibCrypto::class.java)
                 } catch (ignored: UnsatisfiedLinkError) {
                     failures += candidate
                 }
             }
-            throw PakeException(
-                "OpenSSL 3 libcrypto not found; tried ${failures.joinToString()}. " +
+            val remedy =
+                if (candidates == listOf(bundledLibraryPath)) {
+                    "The bundled libcrypto is missing or unloadable; reinstalling the application should restore it, " +
+                        "or point crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH at a reviewed libcrypto."
+                } else {
                     "Install OpenSSL 3 (e.g. brew install openssl@3) or point " +
-                    "crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH at a libcrypto with the full symbol set.",
-            )
+                        "crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH at a libcrypto with the full symbol set."
+                }
+            throw PakeException("OpenSSL 3 libcrypto not found; tried ${failures.joinToString()}. $remedy")
         }
 
-        private fun libraryCandidates(): List<String> {
+        internal fun libraryCandidates(bundledLibraryPath: String?): List<String> {
             val override =
                 System.getProperty("crosspaste.libcrypto.path")
                     ?: System.getenv("CROSSPASTE_LIBCRYPTO_PATH")
             if (override != null) {
                 return listOf(override)
             }
+            // Bundled builds resolve ONLY the packaged library: falling back to
+            // an unreviewed system libcrypto would silently void the
+            // constant-time premise this backend is reviewed under, so a
+            // missing bundled library fails closed (pairing v3 unavailable,
+            // v2 unaffected) instead.
+            bundledLibraryPath?.let { return listOf(it) }
             return when {
                 Platform.isMac() ->
                     listOf(

--- a/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
+++ b/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
@@ -9,6 +9,35 @@ import com.sun.jna.Pointer
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 /**
+ * How [OpenSslPakeEcOps.load] resolves the libcrypto to bind (unless an
+ * explicit override is set, which always wins for troubleshooting).
+ *
+ * The whole process uses exactly one resolution: the first successful [load]
+ * pins it, and a later call with a different resolution throws instead of
+ * silently reusing a library the caller's policy would not have accepted.
+ */
+sealed interface LibCryptoResolution {
+
+    /**
+     * Development/test: probe the environment's well-known per-platform
+     * locations (Homebrew, system libcrypto, ...).
+     */
+    data object Environment : LibCryptoResolution
+
+    /**
+     * Bundled builds (production/beta): resolve ONLY the libcrypto shipped
+     * inside the application package at [path]. There is deliberately no
+     * fallback to system paths — loading an unreviewed system libcrypto would
+     * silently void the constant-time premise this backend is reviewed under,
+     * so a missing bundled library fails closed (pairing v3 unavailable, v2
+     * unaffected) instead.
+     */
+    data class Bundled(
+        val path: String,
+    ) : LibCryptoResolution
+}
+
+/**
  * JVM [PakeEcOps] backed by OpenSSL 3 libcrypto's low-level P-256 ops via JNA.
  *
  * This is the constant-time backend candidate for RFC 9382 §7 (final sign-off
@@ -28,10 +57,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
  * JVM `BigInteger` copies the BouncyCastle backend left behind for the GC.
  *
  * libcrypto is resolved from the `crosspaste.libcrypto.path` system property
- * or `CROSSPASTE_LIBCRYPTO_PATH` environment variable first. Without an
- * override, bundled builds (a non-null `bundledLibraryPath` passed to [load])
- * resolve ONLY the libcrypto shipped inside the application package, while
- * development/test builds fall back to per-platform well-known library names.
+ * or `CROSSPASTE_LIBCRYPTO_PATH` environment variable first; without an
+ * override the [LibCryptoResolution] passed to [load] decides the candidates.
  * [load] fails fast with a [PakeException] when no candidate can be loaded.
  */
 class OpenSslPakeEcOps private constructor(
@@ -318,28 +345,39 @@ class OpenSslPakeEcOps private constructor(
 
         // A failed load is not cached, so load() retries after e.g. the user
         // installs OpenSSL or sets the override. The first successful load pins
-        // the process-wide instance; later calls return it regardless of their
-        // bundledLibraryPath (each real process only ever uses one policy).
-        private var instance: OpenSslPakeEcOps? = null
+        // the process-wide instance TOGETHER with the resolution it was loaded
+        // under, so the policy cannot be bypassed by call order.
+        private var loaded: Pair<LibCryptoResolution, OpenSslPakeEcOps>? = null
 
         /**
          * Returns the process-wide ops instance (libcrypto loaded once), throwing
-         * [PakeException] when no library candidate provides the full symbol set.
-         *
-         * [bundledLibraryPath] is the absolute path of the libcrypto shipped
-         * inside the application package. Passing it (production/beta builds)
-         * restricts resolution to explicit override → bundled library, with no
-         * fallback to system paths; null (development/test) keeps the
-         * environment's well-known candidates.
+         * [PakeException] when no library candidate provides the full symbol set —
+         * or when the instance was already loaded under a different [resolution].
          */
-        fun load(bundledLibraryPath: String? = null): OpenSslPakeEcOps =
+        fun load(resolution: LibCryptoResolution = LibCryptoResolution.Environment): OpenSslPakeEcOps =
             synchronized(lock) {
-                instance
-                    ?: OpenSslPakeEcOps(loadLibCrypto(bundledLibraryPath)).also { instance = it }
+                loaded?.let { (loadedResolution, ops) ->
+                    if (loadedResolution != resolution) {
+                        throw PakeException(
+                            "libcrypto is already loaded under $loadedResolution; " +
+                                "refusing to reuse it under $resolution",
+                        )
+                    }
+                    return ops
+                }
+                val (lib, libraryPath) = loadLibCrypto(resolution)
+                val ops = OpenSslPakeEcOps(lib)
+                // Startup diagnostic for release verification — logged only after
+                // the binding AND the P-256 group setup succeeded, so grepping it
+                // cannot produce a false green.
+                logger.info { "pairing v3 libcrypto loaded from $libraryPath" }
+                loaded = resolution to ops
+                ops
             }
 
-        internal fun loadLibCrypto(bundledLibraryPath: String?): LibCrypto {
-            val candidates = libraryCandidates(bundledLibraryPath)
+        internal fun loadLibCrypto(resolution: LibCryptoResolution): Pair<LibCrypto, String> {
+            val override = overridePath()
+            val candidates = libraryCandidates(resolution)
             val failures = mutableListOf<String>()
             for (candidate in candidates) {
                 try {
@@ -349,52 +387,47 @@ class OpenSslPakeEcOps private constructor(
                     // of an UnsatisfiedLinkError in the middle of an operation.
                     val library = NativeLibrary.getInstance(candidate)
                     REQUIRED_SYMBOLS.forEach(library::getFunction)
-                    // Startup diagnostic for release verification: confirms the
-                    // bundled library (not a system one) is what actually loaded.
-                    logger.info { "pairing v3 libcrypto loaded from ${library.file?.absolutePath ?: candidate}" }
-                    return Native.load(candidate, LibCrypto::class.java)
+                    return Native.load(candidate, LibCrypto::class.java) to
+                        (library.file?.absolutePath ?: candidate)
                 } catch (ignored: UnsatisfiedLinkError) {
                     failures += candidate
                 }
             }
-            // Keyed on the build flavor, not on which candidate list was tried:
-            // even when an explicit override fails, a bundled build must never
-            // steer users toward installing a system OpenSSL it won't load.
             val remedy =
-                if (bundledLibraryPath != null) {
-                    "The bundled libcrypto is missing or unloadable; reinstalling the application should restore it, " +
-                        "or point crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH at a reviewed libcrypto."
-                } else {
-                    "Install OpenSSL 3 (e.g. brew install openssl@3) or point " +
-                        "crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH at a libcrypto with the full symbol set."
+                when {
+                    override != null ->
+                        "The explicit libcrypto override failed to load; fix it, or remove " +
+                            "crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH to restore the default resolution."
+                    resolution is LibCryptoResolution.Bundled ->
+                        "The bundled libcrypto is missing or unloadable; reinstalling the application should restore it."
+                    else ->
+                        "Install OpenSSL 3 (e.g. brew install openssl@3) or point " +
+                            "crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH at a libcrypto with the full symbol set."
                 }
             throw PakeException("OpenSSL 3 libcrypto not found; tried ${failures.joinToString()}. $remedy")
         }
 
-        internal fun libraryCandidates(bundledLibraryPath: String?): List<String> {
-            val override =
-                System.getProperty("crosspaste.libcrypto.path")
-                    ?: System.getenv("CROSSPASTE_LIBCRYPTO_PATH")
-            if (override != null) {
-                return listOf(override)
-            }
-            // Bundled builds resolve ONLY the packaged library: falling back to
-            // an unreviewed system libcrypto would silently void the
-            // constant-time premise this backend is reviewed under, so a
-            // missing bundled library fails closed (pairing v3 unavailable,
-            // v2 unaffected) instead.
-            bundledLibraryPath?.let { return listOf(it) }
-            return when {
-                Platform.isMac() ->
-                    listOf(
-                        "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib",
-                        "/usr/local/opt/openssl@3/lib/libcrypto.3.dylib",
-                        "crypto",
-                    )
-                Platform.isWindows() -> listOf("libcrypto-3-x64", "libcrypto-3", "libcrypto")
-                else -> listOf("libcrypto.so.3", "crypto")
+        internal fun libraryCandidates(resolution: LibCryptoResolution): List<String> {
+            overridePath()?.let { return listOf(it) }
+            return when (resolution) {
+                is LibCryptoResolution.Bundled -> listOf(resolution.path)
+                LibCryptoResolution.Environment ->
+                    when {
+                        Platform.isMac() ->
+                            listOf(
+                                "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib",
+                                "/usr/local/opt/openssl@3/lib/libcrypto.3.dylib",
+                                "crypto",
+                            )
+                        Platform.isWindows() -> listOf("libcrypto-3-x64", "libcrypto-3", "libcrypto")
+                        else -> listOf("libcrypto.so.3", "crypto")
+                    }
             }
         }
+
+        private fun overridePath(): String? =
+            System.getProperty("crosspaste.libcrypto.path")
+                ?: System.getenv("CROSSPASTE_LIBCRYPTO_PATH")
     }
 }
 

--- a/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/OpenSslLibraryResolutionTest.kt
+++ b/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/OpenSslLibraryResolutionTest.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.pairing.v3
 
+import org.junit.Assume.assumeTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -11,8 +12,8 @@ import kotlin.test.assertTrue
  * [OpenSslPakeEcOps.load]: bundled builds must resolve only the packaged
  * library (no silent fallback to an unreviewed system libcrypto), while
  * development/test environments keep the well-known candidates. Tests that
- * depend on the absence of an override skip themselves when the ambient
- * environment sets CROSSPASTE_LIBCRYPTO_PATH.
+ * depend on the absence of an override report themselves as skipped (visibly,
+ * via JUnit assumptions) when the ambient environment sets one.
  */
 class OpenSslLibraryResolutionTest {
 
@@ -20,11 +21,17 @@ class OpenSslLibraryResolutionTest {
 
     private val bundledPath = "/opt/crosspaste/runtime/lib/libcrypto.so.3"
 
-    private fun hasEnvOverride(): Boolean = System.getenv("CROSSPASTE_LIBCRYPTO_PATH") != null
+    private fun assumeNoAmbientOverride() {
+        assumeTrue(
+            "ambient libcrypto override set; candidate-order assertions do not apply",
+            System.getProperty(overrideProperty) == null &&
+                System.getenv("CROSSPASTE_LIBCRYPTO_PATH") == null,
+        )
+    }
 
     @Test
     fun bundledPathIsTheOnlyCandidate() {
-        if (hasEnvOverride()) return
+        assumeNoAmbientOverride()
         assertEquals(
             listOf(bundledPath),
             OpenSslPakeEcOps.libraryCandidates(bundledPath),
@@ -46,7 +53,7 @@ class OpenSslLibraryResolutionTest {
 
     @Test
     fun environmentCandidatesApplyOnlyWithoutABundledPath() {
-        if (hasEnvOverride()) return
+        assumeNoAmbientOverride()
         val candidates = OpenSslPakeEcOps.libraryCandidates(null)
         // Every platform probes more than one well-known location in
         // development/test; none of them is an application-bundled path.
@@ -55,7 +62,7 @@ class OpenSslLibraryResolutionTest {
 
     @Test
     fun missingBundledLibraryFailsClosedWithoutSystemFallback() {
-        if (hasEnvOverride()) return
+        assumeNoAmbientOverride()
         val missing = "/nonexistent/crosspaste/libcrypto.so.3"
         val exception =
             assertFailsWith<PakeException> {

--- a/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/OpenSslLibraryResolutionTest.kt
+++ b/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/OpenSslLibraryResolutionTest.kt
@@ -1,0 +1,70 @@
+package com.crosspaste.pairing.v3
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers the libcrypto candidate resolution contract behind
+ * [OpenSslPakeEcOps.load]: bundled builds must resolve only the packaged
+ * library (no silent fallback to an unreviewed system libcrypto), while
+ * development/test environments keep the well-known candidates. Tests that
+ * depend on the absence of an override skip themselves when the ambient
+ * environment sets CROSSPASTE_LIBCRYPTO_PATH.
+ */
+class OpenSslLibraryResolutionTest {
+
+    private val overrideProperty = "crosspaste.libcrypto.path"
+
+    private val bundledPath = "/opt/crosspaste/runtime/lib/libcrypto.so.3"
+
+    private fun hasEnvOverride(): Boolean = System.getenv("CROSSPASTE_LIBCRYPTO_PATH") != null
+
+    @Test
+    fun bundledPathIsTheOnlyCandidate() {
+        if (hasEnvOverride()) return
+        assertEquals(
+            listOf(bundledPath),
+            OpenSslPakeEcOps.libraryCandidates(bundledPath),
+        )
+    }
+
+    @Test
+    fun explicitOverrideWinsOverTheBundledPath() {
+        System.setProperty(overrideProperty, "/tmp/custom-libcrypto.so")
+        try {
+            assertEquals(
+                listOf("/tmp/custom-libcrypto.so"),
+                OpenSslPakeEcOps.libraryCandidates(bundledPath),
+            )
+        } finally {
+            System.clearProperty(overrideProperty)
+        }
+    }
+
+    @Test
+    fun environmentCandidatesApplyOnlyWithoutABundledPath() {
+        if (hasEnvOverride()) return
+        val candidates = OpenSslPakeEcOps.libraryCandidates(null)
+        // Every platform probes more than one well-known location in
+        // development/test; none of them is an application-bundled path.
+        assertTrue(candidates.size > 1)
+    }
+
+    @Test
+    fun missingBundledLibraryFailsClosedWithoutSystemFallback() {
+        if (hasEnvOverride()) return
+        val missing = "/nonexistent/crosspaste/libcrypto.so.3"
+        val exception =
+            assertFailsWith<PakeException> {
+                OpenSslPakeEcOps.loadLibCrypto(missing)
+            }
+        val message = exception.message.orEmpty()
+        assertTrue(missing in message, "failure must name the bundled candidate: $message")
+        // The bundled-mode message must not steer users toward installing a
+        // system OpenSSL — production never falls back to it.
+        assertFalse("brew" in message, "bundled-mode remedy leaked the dev hint: $message")
+    }
+}

--- a/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/OpenSslLibraryResolutionTest.kt
+++ b/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/OpenSslLibraryResolutionTest.kt
@@ -9,17 +9,19 @@ import kotlin.test.assertTrue
 
 /**
  * Covers the libcrypto candidate resolution contract behind
- * [OpenSslPakeEcOps.load]: bundled builds must resolve only the packaged
- * library (no silent fallback to an unreviewed system libcrypto), while
- * development/test environments keep the well-known candidates. Tests that
- * depend on the absence of an override report themselves as skipped (visibly,
- * via JUnit assumptions) when the ambient environment sets one.
+ * [OpenSslPakeEcOps.load]: [LibCryptoResolution.Bundled] must resolve only the
+ * packaged library (no silent fallback to an unreviewed system libcrypto),
+ * [LibCryptoResolution.Environment] keeps the well-known candidates, and the
+ * process-wide instance is pinned to the resolution it was loaded under.
+ * Tests that depend on the absence of an override report themselves as
+ * skipped (visibly, via JUnit assumptions) when the ambient environment sets
+ * one.
  */
 class OpenSslLibraryResolutionTest {
 
     private val overrideProperty = "crosspaste.libcrypto.path"
 
-    private val bundledPath = "/opt/crosspaste/runtime/lib/libcrypto.so.3"
+    private val bundled = LibCryptoResolution.Bundled("/opt/crosspaste/runtime/lib/libcrypto.so.3")
 
     private fun assumeNoAmbientOverride() {
         assumeTrue(
@@ -29,32 +31,46 @@ class OpenSslLibraryResolutionTest {
         )
     }
 
+    private fun withOverrideProperty(
+        value: String,
+        block: () -> Unit,
+    ) {
+        val previous = System.getProperty(overrideProperty)
+        System.setProperty(overrideProperty, value)
+        try {
+            block()
+        } finally {
+            if (previous == null) {
+                System.clearProperty(overrideProperty)
+            } else {
+                System.setProperty(overrideProperty, previous)
+            }
+        }
+    }
+
     @Test
     fun bundledPathIsTheOnlyCandidate() {
         assumeNoAmbientOverride()
         assertEquals(
-            listOf(bundledPath),
-            OpenSslPakeEcOps.libraryCandidates(bundledPath),
+            listOf(bundled.path),
+            OpenSslPakeEcOps.libraryCandidates(bundled),
         )
     }
 
     @Test
     fun explicitOverrideWinsOverTheBundledPath() {
-        System.setProperty(overrideProperty, "/tmp/custom-libcrypto.so")
-        try {
+        withOverrideProperty("/tmp/custom-libcrypto.so") {
             assertEquals(
                 listOf("/tmp/custom-libcrypto.so"),
-                OpenSslPakeEcOps.libraryCandidates(bundledPath),
+                OpenSslPakeEcOps.libraryCandidates(bundled),
             )
-        } finally {
-            System.clearProperty(overrideProperty)
         }
     }
 
     @Test
-    fun environmentCandidatesApplyOnlyWithoutABundledPath() {
+    fun environmentResolutionProbesWellKnownCandidates() {
         assumeNoAmbientOverride()
-        val candidates = OpenSslPakeEcOps.libraryCandidates(null)
+        val candidates = OpenSslPakeEcOps.libraryCandidates(LibCryptoResolution.Environment)
         // Every platform probes more than one well-known location in
         // development/test; none of them is an application-bundled path.
         assertTrue(candidates.size > 1)
@@ -63,15 +79,43 @@ class OpenSslLibraryResolutionTest {
     @Test
     fun missingBundledLibraryFailsClosedWithoutSystemFallback() {
         assumeNoAmbientOverride()
-        val missing = "/nonexistent/crosspaste/libcrypto.so.3"
+        val missing = LibCryptoResolution.Bundled("/nonexistent/crosspaste/libcrypto.so.3")
         val exception =
             assertFailsWith<PakeException> {
                 OpenSslPakeEcOps.loadLibCrypto(missing)
             }
         val message = exception.message.orEmpty()
-        assertTrue(missing in message, "failure must name the bundled candidate: $message")
+        assertTrue(missing.path in message, "failure must name the bundled candidate: $message")
         // The bundled-mode message must not steer users toward installing a
         // system OpenSSL — production never falls back to it.
         assertFalse("brew" in message, "bundled-mode remedy leaked the dev hint: $message")
+    }
+
+    @Test
+    fun failedOverrideRemedyPointsAtTheOverride() {
+        withOverrideProperty("/nonexistent/override-libcrypto.so") {
+            val exception =
+                assertFailsWith<PakeException> {
+                    OpenSslPakeEcOps.loadLibCrypto(bundled)
+                }
+            val message = exception.message.orEmpty()
+            // The bundled library was never tried, so the remedy must point at
+            // the override instead of suggesting a reinstall.
+            assertTrue("override" in message, "remedy must call out the override: $message")
+            assertFalse("reinstalling" in message, "remedy must not suggest a reinstall: $message")
+        }
+    }
+
+    @Test
+    fun aDifferentResolutionAfterTheFirstLoadFailsClosed() {
+        // The desktop test suites load libcrypto from the environment (see
+        // Spake2PakeProviderTest), so the process-wide instance is pinned to
+        // Environment: a bundled-only request must not reuse it.
+        OpenSslPakeEcOps.load()
+        val exception =
+            assertFailsWith<PakeException> {
+                OpenSslPakeEcOps.load(bundled)
+            }
+        assertTrue("already loaded" in exception.message.orEmpty())
     }
 }


### PR DESCRIPTION
Closes #4864

## What

Pairing v3 rollout step B3: production/beta builds now bind the SPAKE2 backend's libcrypto exclusively from the library bundled by #4863, never from the user's system.

- **`OpenSslPakeEcOps` (core desktopMain)**: the loading policy is now an explicit type, `LibCryptoResolution` — `Environment` (dev/test: well-known per-platform candidates, unchanged behavior) or `Bundled(path)` (resolve only the packaged library; no system fallback; a missing bundled library fails closed with `PakeException` while pairing v2 keeps working). An explicit override (`crosspaste.libcrypto.path` / `CROSSPASTE_LIBCRYPTO_PATH`) still wins in both modes for troubleshooting. The process-wide instance is cached together with the resolution it was loaded under; a later `load()` with a different resolution throws instead of silently reusing the instance, so the policy cannot be bypassed by call order. The success log line (`pairing v3 libcrypto loaded from <path>`) is emitted only after both the JNA binding and the P-256 group setup succeed, so release verification cannot grep a false green. Failure messages are policy-aware (a bundled build never suggests installing a system OpenSSL; a failed override points at the override).
- **`DesktopNetworkModule` / `DesktopModule` (app)**: `desktopLibcryptoResolution()` picks `Bundled(pasteAppExePath + <platform lib name>)` for PRODUCTION/BETA and `Environment` otherwise. `pasteAppExePath` resolves to the packaged JVM's native-library directory on all three platforms (macOS `runtime/Contents/Home/lib`, Windows `bin`, Linux `runtime/lib`) — verified against real installed packages; it is the directory Conveyor moves the bare libcrypto inputs into, and the library names match `conveyor.conf` / `app/openssl.yaml` exactly. Bundled builds probe-load the library at startup for diagnostics; the result is deliberately discarded — the advertised capability stays clamped to v2 and the provider stays `UnavailablePakeProvider` until the rollout PR (#4667).

## Review

Independently reviewed (cold read of the full diff), plus a second review round:

- Verified against JNA 5.19.1 sources that an absolute-path load has no hidden system fallback on any platform (absolute paths bypass `jna.library.path` and `matchLibrary` search), so fail-closed holds.
- Confirmed TEST/DEVELOPMENT never trigger the probe and dev interop behavior is unchanged; the capability clamp and `UnavailablePakeProvider` registration are untouched.
- Fixed from review: the singleton could previously be pinned by an earlier `load()` under a different policy (now throws); the success log could fire before backend construction completed (now logged after full setup); failure-message wording and test hygiene (visible JUnit assumptions, save/restore of the override property).
- Known gap, deliberately deferred to release verification: the `pasteAppExePath` = Conveyor library directory assumption is confirmed for the standard zip/deb/tar.gz layouts; MSIX and AppImage variants will be checked during per-platform release verification. A mismatch there degrades to a warning + pairing v3 unavailable (fail-closed), never a crash.

## Tests

- New `OpenSslLibraryResolutionTest` (core): candidate order per resolution, override precedence, fail-closed on a missing bundled library, policy-aware error messages, resolution pinning.
- Extended `DesktopPairingCapabilityTest` (app): bundled builds probe exactly once and stay clamped to v2, probe failure is tolerated, dev/test resolve `Environment` without touching the path provider, per-platform bundled path mapping.
- Full fast tier (`core:desktopTest` + `app:desktopTest`) green.