### PR TITLE
:bug: cap cumulative pairing v3 online PIN guesses and harden OpenSSL secret hygiene

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -22,6 +22,7 @@ import com.crosspaste.net.ws.WsMessageHandler
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.pairing.v3.PairingProtocolV3Service
 import com.crosspaste.pairing.v3.PairingVersionCoordinator
+import com.crosspaste.pairing.v3.WindowOpenSource
 import com.crosspaste.paste.CacheManager
 import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteboardService
@@ -125,7 +126,7 @@ open class DefaultServerModule(
                     ::releasePendingKeyExchange,
                     pairingVersionCoordinator,
                     pairingProtocolV3Service::hasActiveSession,
-                    pairingProtocolV3Service.acceptanceWindow::open,
+                    { pairingProtocolV3Service.acceptanceWindow.open(WindowOpenSource.REMOTE) },
                 )
                 pairingV3Routing(
                     pairingProtocolV3Service,

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -57,7 +57,9 @@ fun Routing.syncRouting(
     // No-downgrade rule (pairing v3 design §17.2): while a v3 pairing session is
     // active for a peer, that peer must not be able to fall back to v2 trust.
     hasActivePairingV3Session: (String) -> Boolean = { false },
-    openPairingV3AcceptanceWindow: () -> Unit = {},
+    // Returns false when the acceptance window is locked (its proof-failure budget is
+    // spent) — a remote request cannot re-open it; a local Add Device gesture must.
+    openPairingV3AcceptanceWindow: () -> Boolean = { true },
     controlChallengeStore: ControlChallengeStore = ControlChallengeStore(),
 ) {
     val logger = KotlinLogging.logger {}
@@ -216,8 +218,12 @@ fun Routing.syncRouting(
             failResponse(call, StandardErrorCode.REMOTE_SHOW_PAIRING_CODE_DISABLED.toErrorCode())
             return@get
         }
+        if (!openPairingV3AcceptanceWindow()) {
+            logger.info { "show pairing code rejected (window locked) from $host" }
+            failResponse(call, StandardErrorCode.REMOTE_SHOW_PAIRING_CODE_LOCKED.toErrorCode())
+            return@get
+        }
         appTokenApi.showPairingCode()
-        openPairingV3AcceptanceWindow()
         logger.info { "show pairing code requested from $host" }
         successResponse(call)
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingAcceptanceWindow.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingAcceptanceWindow.kt
@@ -36,9 +36,24 @@ enum class WindowOpenSource {
  * clears the lock and resets the budget.
  */
 class PairingAcceptanceWindow(
-    private val maxProofFailures: Int = PairingV3.MAX_ACCEPTOR_PROOF_FAILURES,
+    internal val maxProofFailures: Int = PairingV3.MAX_ACCEPTOR_PROOF_FAILURES,
     private val nowEpochMillis: () -> Long = { DateUtils.nowEpochMilliseconds() },
 ) {
+
+    private data class WindowState(
+        val openUntil: Long = 0L,
+        val proofFailures: Int = 0,
+        val inFlightProofs: Int = 0,
+        val locked: Boolean = false,
+    )
+
+    init {
+        require(maxProofFailures > 0) { "maxProofFailures must be positive" }
+    }
+
+    // One atomic state is the security source of truth. The public flows below are
+    // observational projections for Compose; authorization never reads them.
+    private val state = atomic(WindowState())
 
     private val _openUntil = MutableStateFlow(0L)
 
@@ -50,10 +65,6 @@ class PairingAcceptanceWindow(
     /** True once the failure budget is spent; cleared only by a LOCAL open. UI observes this. */
     val locked: StateFlow<Boolean> = _locked.asStateFlow()
 
-    // Accumulates across peers/generations so identity/fingerprint rotation cannot
-    // dodge the ceiling. Atomic because proof handling runs concurrently per session.
-    private val proofFailures = atomic(0)
-
     /**
      * Opens (or renews) the window. A LOCAL open always succeeds and resets the
      * failure budget and lock. A REMOTE open is refused (returns false, no-op) while
@@ -63,18 +74,27 @@ class PairingAcceptanceWindow(
         source: WindowOpenSource,
         duration: Duration = DEFAULT_WINDOW_DURATION,
     ): Boolean {
-        when (source) {
-            WindowOpenSource.LOCAL -> {
-                proofFailures.value = 0
-                _locked.value = false
+        val openUntil = nowEpochMillis() + duration.inWholeMilliseconds
+        while (true) {
+            val current = state.value
+            if (source == WindowOpenSource.REMOTE && current.locked) {
+                return false
             }
-            WindowOpenSource.REMOTE ->
-                if (_locked.value) {
-                    return false
+            val updated =
+                when (source) {
+                    WindowOpenSource.LOCAL ->
+                        current.copy(
+                            openUntil = openUntil,
+                            proofFailures = 0,
+                            locked = false,
+                        )
+                    WindowOpenSource.REMOTE -> current.copy(openUntil = openUntil)
                 }
+            if (state.compareAndSet(current, updated)) {
+                publishState()
+                return true
+            }
         }
-        _openUntil.value = nowEpochMillis() + duration.inWholeMilliseconds
-        return true
     }
 
     /**
@@ -83,31 +103,107 @@ class PairingAcceptanceWindow(
      * open does not silently refill an attacker's guess budget. No-op while locked.
      */
     fun extend(duration: Duration = DEFAULT_WINDOW_DURATION) {
-        if (_locked.value) {
-            return
+        val openUntil = nowEpochMillis() + duration.inWholeMilliseconds
+        while (true) {
+            val current = state.value
+            if (current.locked) {
+                return
+            }
+            if (state.compareAndSet(current, current.copy(openUntil = openUntil))) {
+                publishState()
+                return
+            }
         }
-        _openUntil.value = nowEpochMillis() + duration.inWholeMilliseconds
     }
 
     /**
-     * Records one proof failure against the cumulative budget. When the budget is
-     * spent the window closes and locks until a LOCAL open resets it. Returns true
-     * when this failure triggered the lock.
+     * Reserves one online proof attempt. Failed and in-flight attempts jointly consume
+     * the ceiling, so concurrent sessions cannot overshoot it. A successful proof (or
+     * a request rejected before cryptographic verification) releases its reservation.
      */
-    fun recordProofFailure(): Boolean {
-        if (proofFailures.incrementAndGet() >= maxProofFailures) {
-            _locked.value = true
-            _openUntil.value = 0L
-            return true
+    internal fun tryBeginProofAttempt(): ProofAttempt? {
+        while (true) {
+            val current = state.value
+            if (current.locked || current.proofFailures + current.inFlightProofs >= maxProofFailures) {
+                return null
+            }
+            val updated = current.copy(inFlightProofs = current.inFlightProofs + 1)
+            if (state.compareAndSet(current, updated)) {
+                return ProofAttempt(this)
+            }
         }
-        return false
     }
 
     fun close() {
-        _openUntil.value = 0L
+        updateState { current -> current.copy(openUntil = 0L) }
     }
 
-    fun isOpen(): Boolean = nowEpochMillis() < _openUntil.value
+    fun isOpen(): Boolean {
+        val current = state.value
+        return !current.locked && nowEpochMillis() < current.openUntil
+    }
+
+    fun isLocked(): Boolean = state.value.locked
+
+    private fun completeProofAttempt(failed: Boolean): Boolean {
+        while (true) {
+            val current = state.value
+            check(current.inFlightProofs > 0) { "proof attempt completed without a reservation" }
+            val proofFailures = current.proofFailures + if (failed) 1 else 0
+            val locked = current.locked || proofFailures >= maxProofFailures
+            val updated =
+                current.copy(
+                    openUntil = if (locked) 0L else current.openUntil,
+                    proofFailures = proofFailures,
+                    inFlightProofs = current.inFlightProofs - 1,
+                    locked = locked,
+                )
+            if (state.compareAndSet(current, updated)) {
+                publishState()
+                return !current.locked && locked
+            }
+        }
+    }
+
+    private inline fun updateState(transform: (WindowState) -> WindowState) {
+        while (true) {
+            val current = state.value
+            if (state.compareAndSet(current, transform(current))) {
+                publishState()
+                return
+            }
+        }
+    }
+
+    // A publisher that raced with a newer transition loops until both projections
+    // reflect the latest atomic state, so observers cannot remain permanently stale.
+    private fun publishState() {
+        while (true) {
+            val snapshot = state.value
+            _openUntil.value = snapshot.openUntil
+            _locked.value = snapshot.locked
+            if (state.value === snapshot) {
+                return
+            }
+        }
+    }
+
+    internal class ProofAttempt internal constructor(
+        private val window: PairingAcceptanceWindow,
+    ) {
+        private val active = atomic(true)
+
+        /** Converts this reservation into a failed guess. Returns true when it locks the window. */
+        fun recordFailure(): Boolean =
+            active.compareAndSet(expect = true, update = false) && window.completeProofAttempt(failed = true)
+
+        /** Releases a successful or otherwise unevaluated attempt. Idempotent. */
+        fun release() {
+            if (active.compareAndSet(expect = true, update = false)) {
+                window.completeProofAttempt(failed = false)
+            }
+        }
+    }
 
     companion object {
         val DEFAULT_WINDOW_DURATION: Duration = 5.minutes

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingAcceptanceWindow.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingAcceptanceWindow.kt
@@ -1,11 +1,23 @@
 package com.crosspaste.pairing.v3
 
 import com.crosspaste.utils.DateUtils
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+
+/** Who is asking to open/extend the acceptance window. */
+enum class WindowOpenSource {
+    /** A local user gesture (the Add Device screen is in the foreground). Trusted:
+     *  it resets the proof-failure budget and clears a lock. */
+    LOCAL,
+
+    /** A remote `/sync/showPairingCode` request. Untrusted: honoured only while the
+     *  window is not locked, and never resets the failure budget. */
+    REMOTE,
+}
 
 /**
  * Explicit pairing-acceptance window on the acceptor.
@@ -13,8 +25,18 @@ import kotlin.time.Duration.Companion.minutes
  * Incoming v3 intents are only accepted while this window is open — typically while
  * the user has the Add Device screen visible. This prevents arbitrary local-network
  * clients from continuously creating PIN cards or exhausting session capacity.
+ *
+ * The window also carries a cumulative proof-failure budget
+ * ([PairingV3.MAX_ACCEPTOR_PROOF_FAILURES], across all peers and generations). A
+ * failed proof rotates a fresh PIN immediately, so per-generation attempt caps alone
+ * put no ceiling on the total number of online PIN guesses. When the budget is spent
+ * the window closes and locks: a [WindowOpenSource.REMOTE] open is refused, so an
+ * unattended attacker cannot re-open it via `/sync/showPairingCode` and keep guessing.
+ * Only a [WindowOpenSource.LOCAL] open (a user re-entering the Add Device screen)
+ * clears the lock and resets the budget.
  */
 class PairingAcceptanceWindow(
+    private val maxProofFailures: Int = PairingV3.MAX_ACCEPTOR_PROOF_FAILURES,
     private val nowEpochMillis: () -> Long = { DateUtils.nowEpochMilliseconds() },
 ) {
 
@@ -23,8 +45,62 @@ class PairingAcceptanceWindow(
     /** Epoch millis until which the window is open; 0 when closed. UI observes this. */
     val openUntil: StateFlow<Long> = _openUntil.asStateFlow()
 
-    fun open(duration: Duration = DEFAULT_WINDOW_DURATION) {
+    private val _locked = MutableStateFlow(false)
+
+    /** True once the failure budget is spent; cleared only by a LOCAL open. UI observes this. */
+    val locked: StateFlow<Boolean> = _locked.asStateFlow()
+
+    // Accumulates across peers/generations so identity/fingerprint rotation cannot
+    // dodge the ceiling. Atomic because proof handling runs concurrently per session.
+    private val proofFailures = atomic(0)
+
+    /**
+     * Opens (or renews) the window. A LOCAL open always succeeds and resets the
+     * failure budget and lock. A REMOTE open is refused (returns false, no-op) while
+     * locked, and otherwise renews without touching the budget.
+     */
+    fun open(
+        source: WindowOpenSource,
+        duration: Duration = DEFAULT_WINDOW_DURATION,
+    ): Boolean {
+        when (source) {
+            WindowOpenSource.LOCAL -> {
+                proofFailures.value = 0
+                _locked.value = false
+            }
+            WindowOpenSource.REMOTE ->
+                if (_locked.value) {
+                    return false
+                }
+        }
         _openUntil.value = nowEpochMillis() + duration.inWholeMilliseconds
+        return true
+    }
+
+    /**
+     * Extends an already-open window without resetting the failure budget or clearing
+     * a lock — used by the local UI renewal loop, so keeping the Add Device screen
+     * open does not silently refill an attacker's guess budget. No-op while locked.
+     */
+    fun extend(duration: Duration = DEFAULT_WINDOW_DURATION) {
+        if (_locked.value) {
+            return
+        }
+        _openUntil.value = nowEpochMillis() + duration.inWholeMilliseconds
+    }
+
+    /**
+     * Records one proof failure against the cumulative budget. When the budget is
+     * spent the window closes and locks until a LOCAL open resets it. Returns true
+     * when this failure triggered the lock.
+     */
+    fun recordProofFailure(): Boolean {
+        if (proofFailures.incrementAndGet() >= maxProofFailures) {
+            _locked.value = true
+            _openUntil.value = 0L
+            return true
+        }
+        return false
     }
 
     fun close() {

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
@@ -319,105 +319,118 @@ class PairingProtocolV3Service(
         if (!rateLimiter.tryAcquire(source)) {
             return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_RATE_LIMITED)
         }
-        val negotiating =
+        val proofAttempt =
+            acceptanceWindow.tryBeginProofAttempt()
+                ?: return PairingV3ServerResult.Refused(
+                    if (acceptanceWindow.isLocked()) {
+                        PairingV3ErrorCode.PAIRING_DISABLED
+                    } else {
+                        PairingV3ErrorCode.PAIRING_RATE_LIMITED
+                    },
+                )
+        try {
+            val negotiating =
+                when (
+                    val begun =
+                        sessionStore.beginProof(
+                            sessionId,
+                            proof.tokenGeneration,
+                            generationGrace.inWholeMilliseconds,
+                        )
+                ) {
+                    is PairingBeginProofResult.Proceed -> begun.session
+                    PairingBeginProofResult.WrongGeneration,
+                    PairingBeginProofResult.PinExpired,
+                    PairingBeginProofResult.AttemptsExhausted,
+                    PairingBeginProofResult.GenerationNotReady,
+                    ->
+                        return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_PIN_EXPIRED)
+
+                    is PairingBeginProofResult.InvalidState ->
+                        return PairingV3ServerResult.Refused(stateRefusalCode(begun.actual))
+
+                    PairingBeginProofResult.NotFound ->
+                        return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_SESSION_NOT_FOUND)
+                }
+            val pakeSession =
+                negotiating.pakeSession
+                    ?: return proofFailure(sessionId, proofAttempt)
+            val acceptorShare =
+                negotiating.localPakeShare
+                    ?: return proofFailure(sessionId, proofAttempt)
+            val sharedSecret =
+                runCatching { pakeSession.deriveSharedSecret(proof.initiatorPakeShare) }
+                    .getOrNull()
+                    ?: return proofFailure(sessionId, proofAttempt)
+            val transcriptHash =
+                PairingTranscriptCodec.transcriptHash(
+                    buildTranscript(negotiating, proof.initiatorPakeShare, acceptorShare),
+                )
+            if (!transcriptHash.contentEquals(proof.transcriptHash)) {
+                sharedSecret.fill(0)
+                return proofFailure(sessionId, proofAttempt)
+            }
+            val keys = PairingKeySchedule.deriveSessionKeys(transcriptHash, sharedSecret)
+            sharedSecret.fill(0)
+            val expectedConfirmation = PairingKeySchedule.initiatorConfirmation(keys, transcriptHash)
+            if (!PairingKeySchedule.constantTimeEquals(expectedConfirmation, proof.initiatorKeyConfirmation)) {
+                keys.clear()
+                return proofFailure(sessionId, proofAttempt)
+            }
+            val identityValid =
+                runCatching {
+                    val peerSignKey = secureKeyPairSerializer.decodeSignPublicKey(negotiating.peerSignPublicKey)
+                    CryptographyUtils.verifyData(peerSignKey, proof.initiatorIdentitySignature) {
+                        PairingKeySchedule.identitySignaturePayload(PakeRole.INITIATOR, transcriptHash)
+                    }
+                }.getOrDefault(false)
+            if (!identityValid) {
+                keys.clear()
+                return proofFailure(sessionId, proofAttempt)
+            }
             when (
-                val begun =
-                    sessionStore.beginProof(
+                val confirmed =
+                    sessionStore.completeProof(
                         sessionId,
                         proof.tokenGeneration,
-                        generationGrace.inWholeMilliseconds,
+                        transcriptHash,
+                        keys,
+                        proof.initiatorPakeShare,
                     )
             ) {
-                is PairingBeginProofResult.Proceed -> begun.session
-                PairingBeginProofResult.WrongGeneration,
-                PairingBeginProofResult.PinExpired,
-                PairingBeginProofResult.AttemptsExhausted,
-                PairingBeginProofResult.GenerationNotReady,
-                ->
+                is PairingCompleteProofResult.Confirmed -> Unit
+                PairingCompleteProofResult.WrongGeneration,
+                PairingCompleteProofResult.DeadlineExceeded,
+                -> {
+                    keys.clear()
                     return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_PIN_EXPIRED)
-
-                is PairingBeginProofResult.InvalidState ->
-                    return PairingV3ServerResult.Refused(stateRefusalCode(begun.actual))
-
-                PairingBeginProofResult.NotFound ->
-                    return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_SESSION_NOT_FOUND)
-            }
-        val pakeSession =
-            negotiating.pakeSession
-                ?: return proofFailure(sessionId)
-        val acceptorShare =
-            negotiating.localPakeShare
-                ?: return proofFailure(sessionId)
-        val sharedSecret =
-            runCatching { pakeSession.deriveSharedSecret(proof.initiatorPakeShare) }
-                .getOrNull()
-                ?: return proofFailure(sessionId)
-        val transcriptHash =
-            PairingTranscriptCodec.transcriptHash(
-                buildTranscript(negotiating, proof.initiatorPakeShare, acceptorShare),
-            )
-        if (!transcriptHash.contentEquals(proof.transcriptHash)) {
-            sharedSecret.fill(0)
-            return proofFailure(sessionId)
-        }
-        val keys = PairingKeySchedule.deriveSessionKeys(transcriptHash, sharedSecret)
-        sharedSecret.fill(0)
-        val expectedConfirmation = PairingKeySchedule.initiatorConfirmation(keys, transcriptHash)
-        if (!PairingKeySchedule.constantTimeEquals(expectedConfirmation, proof.initiatorKeyConfirmation)) {
-            keys.clear()
-            return proofFailure(sessionId)
-        }
-        val identityValid =
-            runCatching {
-                val peerSignKey = secureKeyPairSerializer.decodeSignPublicKey(negotiating.peerSignPublicKey)
-                CryptographyUtils.verifyData(peerSignKey, proof.initiatorIdentitySignature) {
-                    PairingKeySchedule.identitySignaturePayload(PakeRole.INITIATOR, transcriptHash)
                 }
-            }.getOrDefault(false)
-        if (!identityValid) {
-            keys.clear()
-            return proofFailure(sessionId)
-        }
-        when (
-            val confirmed =
-                sessionStore.completeProof(
-                    sessionId,
-                    proof.tokenGeneration,
-                    transcriptHash,
-                    keys,
-                    proof.initiatorPakeShare,
+
+                is PairingCompleteProofResult.InvalidState -> {
+                    keys.clear()
+                    return PairingV3ServerResult.Refused(stateRefusalCode(confirmed.actual))
+                }
+
+                PairingCompleteProofResult.NotFound -> {
+                    keys.clear()
+                    return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_SESSION_NOT_FOUND)
+                }
+            }
+            val response =
+                PairingProofResponseV3(
+                    sessionId = proof.sessionId,
+                    transcriptHash = transcriptHash,
+                    acceptorKeyConfirmation = PairingKeySchedule.acceptorConfirmation(keys, transcriptHash),
+                    acceptorIdentitySignature =
+                        CryptographyUtils.signData(secureStore.secureKeyPair.signKeyPair.privateKey) {
+                            PairingKeySchedule.identitySignaturePayload(PakeRole.ACCEPTOR, transcriptHash)
+                        },
                 )
-        ) {
-            is PairingCompleteProofResult.Confirmed -> Unit
-            PairingCompleteProofResult.WrongGeneration,
-            PairingCompleteProofResult.DeadlineExceeded,
-            -> {
-                keys.clear()
-                return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_PIN_EXPIRED)
-            }
-
-            is PairingCompleteProofResult.InvalidState -> {
-                keys.clear()
-                return PairingV3ServerResult.Refused(stateRefusalCode(confirmed.actual))
-            }
-
-            PairingCompleteProofResult.NotFound -> {
-                keys.clear()
-                return PairingV3ServerResult.Refused(PairingV3ErrorCode.PAIRING_SESSION_NOT_FOUND)
-            }
+            logger.info { "pairing v3 proof accepted session=${shortId(sessionId)}" }
+            return PairingV3ServerResult.Ok(response)
+        } finally {
+            proofAttempt.release()
         }
-        val response =
-            PairingProofResponseV3(
-                sessionId = proof.sessionId,
-                transcriptHash = transcriptHash,
-                acceptorKeyConfirmation = PairingKeySchedule.acceptorConfirmation(keys, transcriptHash),
-                acceptorIdentitySignature =
-                    CryptographyUtils.signData(secureStore.secureKeyPair.signKeyPair.privateKey) {
-                        PairingKeySchedule.identitySignaturePayload(PakeRole.ACCEPTOR, transcriptHash)
-                    },
-            )
-        logger.info { "pairing v3 proof accepted session=${shortId(sessionId)}" }
-        return PairingV3ServerResult.Ok(response)
     }
 
     suspend fun handleCommit(
@@ -1304,11 +1317,14 @@ class PairingProtocolV3Service(
     // therefore spend the same budgets: the per-generation attempt cap (via
     // recordProofFailure) AND the window-wide cumulative failure budget, so an
     // attacker cannot use the identity-element path as a second, unbudgeted guess.
-    private suspend fun proofFailure(sessionId: String): PairingV3ServerResult.Refused {
+    private suspend fun proofFailure(
+        sessionId: String,
+        proofAttempt: PairingAcceptanceWindow.ProofAttempt,
+    ): PairingV3ServerResult.Refused {
         sessionStore.recordProofFailure(sessionId)
-        if (acceptanceWindow.recordProofFailure()) {
+        if (proofAttempt.recordFailure()) {
             logger.warn {
-                "pairing v3 acceptance window locked after ${PairingV3.MAX_ACCEPTOR_PROOF_FAILURES} " +
+                "pairing v3 acceptance window locked after ${acceptanceWindow.maxProofFailures} " +
                     "proof failures; a local Add Device gesture is required to resume"
             }
         }

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
@@ -1297,8 +1297,21 @@ class PairingProtocolV3Service(
         initiatorRuntimes.remove(sessionId)
     }
 
+    // The single funnel for every acceptor-side proof rejection — a wrong PIN, a
+    // transcript/confirmation/identity mismatch, AND a PakeException from
+    // deriveSharedSecret (an attacker's identity-element share for a guessed PIN
+    // surfaces here, not as a distinguishable later failure). Every one of them must
+    // therefore spend the same budgets: the per-generation attempt cap (via
+    // recordProofFailure) AND the window-wide cumulative failure budget, so an
+    // attacker cannot use the identity-element path as a second, unbudgeted guess.
     private suspend fun proofFailure(sessionId: String): PairingV3ServerResult.Refused {
         sessionStore.recordProofFailure(sessionId)
+        if (acceptanceWindow.recordProofFailure()) {
+            logger.warn {
+                "pairing v3 acceptance window locked after ${PairingV3.MAX_ACCEPTOR_PROOF_FAILURES} " +
+                    "proof failures; a local Add Device gesture is required to resume"
+            }
+        }
         // The failed proof invalidated the generation; rotate a fresh PIN right away
         // instead of leaving the session unusable until the scheduled wake-up.
         acceptorRuntimes[sessionId]?.rotationNudge?.trySend(Unit)

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/GeneralSyncHandler.kt
@@ -229,16 +229,12 @@ class GeneralSyncHandler(
         emitEvent(SyncEvent.ShowToken(currentSyncRuntimeInfo))
     }
 
-    override suspend fun showPairingCode() {
+    override suspend fun showPairingCode(): ShowPairingCodeResult {
         val event = SyncEvent.ShowPairingCode(currentSyncRuntimeInfo)
         emitEvent(event)
-        val pairingCodeShown =
-            withTimeoutOrNull(5.seconds) {
-                event.completionSignal.await()
-            } ?: false
-        check(pairingCodeShown) {
-            "Unable to process remote pairing-code request for ${currentSyncRuntimeInfo.appInstanceId}"
-        }
+        return withTimeoutOrNull(5.seconds) {
+            event.completionSignal.await()
+        } ?: ShowPairingCodeResult.UNAVAILABLE
     }
 
     override suspend fun notifyExit() {

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/MarketingSyncHandler.kt
@@ -56,8 +56,7 @@ class MarketingSyncHandler(
     override suspend fun showToken() {
     }
 
-    override suspend fun showPairingCode() {
-    }
+    override suspend fun showPairingCode(): ShowPairingCodeResult = ShowPairingCodeResult.UNAVAILABLE
 
     override suspend fun notifyExit() {
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncDeviceManager.kt
@@ -3,6 +3,8 @@ package com.crosspaste.sync
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
+import com.crosspaste.exception.StandardErrorCode
+import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.ws.WsEnvelope
@@ -135,25 +137,34 @@ class SyncDeviceManager(
         }
     }
 
-    suspend fun showPairingCode(syncRuntimeInfo: SyncRuntimeInfo): Boolean {
-        if (syncRuntimeInfo.connectState != SyncState.UNVERIFIED) return false
-        val host = syncRuntimeInfo.connectHostAddress ?: return false
+    suspend fun showPairingCode(syncRuntimeInfo: SyncRuntimeInfo): ShowPairingCodeResult {
+        if (syncRuntimeInfo.connectState != SyncState.UNVERIFIED) return ShowPairingCodeResult.UNAVAILABLE
+        val host = syncRuntimeInfo.connectHostAddress ?: return ShowPairingCodeResult.UNAVAILABLE
         val hostAndPort = HostAndPort(host, syncRuntimeInfo.port)
         val result =
             syncClientApi.showPairingCode {
                 buildUrl(hostAndPort)
             }
-        return if (result is SuccessResult) {
-            logger.info { "showPairingCode success $host ${syncRuntimeInfo.port}" }
-            true
-        } else {
-            syncRuntimeInfoDao.updateConnectInfo(
-                syncRuntimeInfo.copy(
-                    connectState = SyncState.DISCONNECTED,
-                    modifyTime = nowEpochMilliseconds(),
-                ),
-            )
-            false
+        return when {
+            result is SuccessResult -> {
+                logger.info { "showPairingCode success $host ${syncRuntimeInfo.port}" }
+                ShowPairingCodeResult.SHOWN
+            }
+            result is FailureResult &&
+                result.exception.getErrorCode().code in
+                setOf(
+                    StandardErrorCode.REMOTE_SHOW_PAIRING_CODE_DISABLED.getCode(),
+                    StandardErrorCode.REMOTE_SHOW_PAIRING_CODE_LOCKED.getCode(),
+                ) -> ShowPairingCodeResult.NOT_ACCEPTING
+            else -> {
+                syncRuntimeInfoDao.updateConnectInfo(
+                    syncRuntimeInfo.copy(
+                        connectState = SyncState.DISCONNECTED,
+                        modifyTime = nowEpochMilliseconds(),
+                    ),
+                )
+                ShowPairingCodeResult.UNAVAILABLE
+            }
         }
     }
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncEvent.kt
@@ -93,7 +93,7 @@ sealed interface SyncEvent {
 
     data class ShowPairingCode(
         override val syncRuntimeInfo: SyncRuntimeInfo,
-        val completionSignal: CompletableDeferred<Boolean> = CompletableDeferred(),
+        val completionSignal: CompletableDeferred<ShowPairingCodeResult> = CompletableDeferred(),
     ) : SyncRunTimeInfoEvent {
         override fun toString(): String = "ShowPairingCode ${syncRuntimeInfo.appInstanceId}"
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncHandler.kt
@@ -6,6 +6,18 @@ import com.crosspaste.net.VersionRelation
 import com.crosspaste.platform.Platform
 import kotlinx.coroutines.flow.StateFlow
 
+/** Outcome of asking an unverified peer to surface and open its v3 pairing window. */
+enum class ShowPairingCodeResult {
+    /** The peer accepted the request and opened its pairing UI/window. */
+    SHOWN,
+
+    /** The peer is reachable but policy currently forbids opening the window. */
+    NOT_ACCEPTING,
+
+    /** The request could not be delivered or the peer is not in a requestable state. */
+    UNAVAILABLE,
+}
+
 interface SyncHandler {
 
     val syncRuntimeInfoFlow: StateFlow<SyncRuntimeInfo>
@@ -71,7 +83,7 @@ interface SyncHandler {
 
     suspend fun showToken()
 
-    suspend fun showPairingCode()
+    suspend fun showPairingCode(): ShowPairingCodeResult
 
     suspend fun notifyExit()
 

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/SyncResolver.kt
@@ -179,7 +179,7 @@ class SyncResolver(
                 event.callback.onComplete()
             }
             if (event is SyncEvent.ShowPairingCode) {
-                event.completionSignal.complete(false)
+                event.completionSignal.complete(ShowPairingCodeResult.UNAVAILABLE)
             }
         }
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingCodeContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingCodeContentView.kt
@@ -142,6 +142,22 @@ fun PairingCodeContentView() {
 
             Spacer(modifier = Modifier.height(medium))
 
+            val acceptanceLocked by pairingV3UiController.acceptanceLocked.collectAsState()
+            if (acceptanceLocked) {
+                Text(
+                    text = copywriter.getText("pairing_v3_window_locked"),
+                    modifier =
+                        Modifier
+                            .clip(mediumRoundedCornerShape)
+                            .background(MaterialTheme.colorScheme.errorContainer)
+                            .padding(horizontal = medium, vertical = small2X),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(modifier = Modifier.height(medium))
+            }
+
             Text(
                 text = copywriter.getText("qr_scan_title"),
                 style =

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3TokenCards.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3TokenCards.kt
@@ -31,9 +31,14 @@ fun PairingV3AcceptanceWindowEffect(controller: PairingV3UiController = koinInje
     // is renewed well before expiry; otherwise incoming intents would be silently
     // refused after the window lapsed while the screen was still on screen.
     LaunchedEffect(controller) {
+        // First arm is a genuine local gesture (screen entered): it resets the
+        // proof-failure budget and clears any lock. Subsequent arms only renew the
+        // window; renewing must NOT reset the budget, or keeping this screen open
+        // would let an attacker's guess budget refill every half-window.
+        controller.openAcceptanceWindow()
         while (true) {
-            controller.openAcceptanceWindow()
             delay(PairingAcceptanceWindow.DEFAULT_WINDOW_DURATION / 2)
+            controller.renewAcceptanceWindow()
         }
     }
     DisposableEffect(controller) {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
@@ -7,6 +7,7 @@ import com.crosspaste.pairing.v3.PairingSessionUiState
 import com.crosspaste.pairing.v3.PairingV3PinResult
 import com.crosspaste.pairing.v3.PairingV3RefreshResult
 import com.crosspaste.pairing.v3.PairingV3StartResult
+import com.crosspaste.pairing.v3.WindowOpenSource
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.sync.V3Pin
 import com.crosspaste.utils.HostAndPort
@@ -24,7 +25,13 @@ interface PairingV3UiController {
 
     val acceptanceOpenUntil: StateFlow<Long>
 
+    /** A local user gesture entering the Add Device screen: opens the window and
+     *  resets the proof-failure budget / clears any lock. */
     fun openAcceptanceWindow()
+
+    /** Renews an already-open window (the on-screen keep-alive loop) WITHOUT resetting
+     *  the failure budget, so keeping the screen open cannot refill a guess budget. */
+    fun renewAcceptanceWindow()
 
     fun closeAcceptanceWindow()
 
@@ -104,7 +111,11 @@ class DefaultPairingV3UiController(
         pairingProtocolV3Service.acceptanceWindow.openUntil
 
     override fun openAcceptanceWindow() {
-        pairingProtocolV3Service.acceptanceWindow.open()
+        pairingProtocolV3Service.acceptanceWindow.open(WindowOpenSource.LOCAL)
+    }
+
+    override fun renewAcceptanceWindow() {
+        pairingProtocolV3Service.acceptanceWindow.extend()
     }
 
     override fun closeAcceptanceWindow() {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
@@ -8,6 +8,7 @@ import com.crosspaste.pairing.v3.PairingV3PinResult
 import com.crosspaste.pairing.v3.PairingV3RefreshResult
 import com.crosspaste.pairing.v3.PairingV3StartResult
 import com.crosspaste.pairing.v3.WindowOpenSource
+import com.crosspaste.sync.ShowPairingCodeResult
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.sync.V3Pin
 import com.crosspaste.utils.HostAndPort
@@ -142,7 +143,19 @@ class DefaultPairingV3UiController(
                         PairingV3UiError.NETWORK_FAILURE,
                         PairingV3Recovery.RETRY_START,
                     )
-            target.showPairingCode()
+            when (target.showPairingCode()) {
+                ShowPairingCodeResult.SHOWN -> Unit
+                ShowPairingCodeResult.NOT_ACCEPTING ->
+                    return@withContext PairingV3UiResult.Error(
+                        PairingV3UiError.NOT_ACCEPTING,
+                        PairingV3Recovery.RETRY_START,
+                    )
+                ShowPairingCodeResult.UNAVAILABLE ->
+                    return@withContext PairingV3UiResult.Error(
+                        PairingV3UiError.NETWORK_FAILURE,
+                        PairingV3Recovery.RETRY_START,
+                    )
+            }
             pairingProtocolV3Service
                 .startPairing(
                     targetAppInstanceId = peerAppInstanceId,
@@ -223,7 +236,7 @@ class DefaultPairingV3UiController(
 
     private data class PairingTarget(
         val displayName: String,
-        val showPairingCode: suspend () -> Unit,
+        val showPairingCode: suspend () -> ShowPairingCodeResult,
         val toUrl: io.ktor.http.URLBuilder.() -> Unit,
     )
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
@@ -25,6 +25,11 @@ interface PairingV3UiController {
 
     val acceptanceOpenUntil: StateFlow<Long>
 
+    /** True once the acceptance window locked itself after too many failed proofs;
+     *  the pairing screen shows a hint, and re-entering it ([openAcceptanceWindow])
+     *  is the only way to clear it. */
+    val acceptanceLocked: StateFlow<Boolean>
+
     /** A local user gesture entering the Add Device screen: opens the window and
      *  resets the proof-failure budget / clears any lock. */
     fun openAcceptanceWindow()
@@ -109,6 +114,9 @@ class DefaultPairingV3UiController(
 
     override val acceptanceOpenUntil: StateFlow<Long> =
         pairingProtocolV3Service.acceptanceWindow.openUntil
+
+    override val acceptanceLocked: StateFlow<Boolean> =
+        pairingProtocolV3Service.acceptanceWindow.locked
 
     override fun openAcceptanceWindow() {
         pairingProtocolV3Service.acceptanceWindow.open(WindowOpenSource.LOCAL)

--- a/app/src/desktopMain/resources/i18n/de.properties
+++ b/app/src/desktopMain/resources/i18n/de.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=Kopplungssitzung abgelaufen
 pairing_v3_trusted=Vertrauenswürdig
 pairing_v3_unsupported=Sichere PIN-Kopplung ist für dieses Gerät nicht verfügbar.
 pairing_v3_waiting=Warten auf PIN
+pairing_v3_window_locked=Kopplung nach zu vielen Fehlversuchen gesperrt. Verlassen Sie diesen Bildschirm und öffnen Sie ihn erneut, um fortzufahren.
 paste=Einfügen
 paste_action=Einfügeaktion
 paste_local_last=Neueste lokale Daten einfügen

--- a/app/src/desktopMain/resources/i18n/en.properties
+++ b/app/src/desktopMain/resources/i18n/en.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=Pairing session expired
 pairing_v3_trusted=Trusted
 pairing_v3_unsupported=Secure PIN pairing is not available for this device.
 pairing_v3_waiting=Waiting for PIN
+pairing_v3_window_locked=Pairing locked after too many failed attempts. Leave and reopen this screen to resume.
 paste=Paste
 paste_action=Paste Action
 paste_local_last=Paste Latest Local Data

--- a/app/src/desktopMain/resources/i18n/es.properties
+++ b/app/src/desktopMain/resources/i18n/es.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=La sesión de emparejamiento ha caducado
 pairing_v3_trusted=De confianza
 pairing_v3_unsupported=El emparejamiento seguro mediante PIN no está disponible para este dispositivo.
 pairing_v3_waiting=Esperando el PIN
+pairing_v3_window_locked=Emparejamiento bloqueado tras demasiados intentos fallidos. Sal de esta pantalla y vuelve a abrirla para continuar.
 paste=Pegar
 paste_action=Acción de pegar
 paste_local_last=Pegar último local

--- a/app/src/desktopMain/resources/i18n/fa.properties
+++ b/app/src/desktopMain/resources/i18n/fa.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=نشست جفت‌سازی منقضی شد
 pairing_v3_trusted=مورد اعتماد
 pairing_v3_unsupported=جفت‌سازی امن با پین برای این دستگاه در دسترس نیست.
 pairing_v3_waiting=در انتظار پین
+pairing_v3_window_locked=پس از تلاش‌های ناموفق زیاد، جفت‌سازی قفل شد. برای ازسرگیری، از این صفحه خارج شوید و دوباره آن را باز کنید.
 paste=چسباندن
 paste_action=عمل چسباندن
 paste_local_last=چسباندن آخرین داده محلی

--- a/app/src/desktopMain/resources/i18n/fr.properties
+++ b/app/src/desktopMain/resources/i18n/fr.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=La session de jumelage a expiré
 pairing_v3_trusted=Approuvé
 pairing_v3_unsupported=Le jumelage sécurisé par code PIN n’est pas disponible pour cet appareil.
 pairing_v3_waiting=En attente du code PIN
+pairing_v3_window_locked=Appairage verrouillé après trop de tentatives échouées. Quittez cet écran et rouvrez-le pour reprendre.
 paste=Coller
 paste_action=Action de coller
 paste_local_last=Coller les dernières données locales

--- a/app/src/desktopMain/resources/i18n/ja.properties
+++ b/app/src/desktopMain/resources/i18n/ja.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=ペアリングセッションの有効期限が切�
 pairing_v3_trusted=信頼済み
 pairing_v3_unsupported=このデバイスでは安全な PIN ペアリングを利用できません。
 pairing_v3_waiting=PIN の入力待ち
+pairing_v3_window_locked=失敗が続いたためペアリングがロックされました。この画面を一度閉じて開き直すと再開できます。
 paste=ペースト
 paste_action=貼り付けアクション
 paste_local_last=ローカルの最新データをペースト

--- a/app/src/desktopMain/resources/i18n/ko.properties
+++ b/app/src/desktopMain/resources/i18n/ko.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=페어링 세션이 만료되었습니다
 pairing_v3_trusted=신뢰함
 pairing_v3_unsupported=이 기기에서는 안전한 PIN 페어링을 사용할 수 없습니다.
 pairing_v3_waiting=PIN 대기 중
+pairing_v3_window_locked=시도 실패가 너무 많아 페어링이 잠겼습니다. 이 화면을 나갔다가 다시 열면 재개됩니다.
 paste=붙여넣기
 paste_action=붙여넣기 동작
 paste_local_last=로컬최신데이터붙여넣기

--- a/app/src/desktopMain/resources/i18n/pt.properties
+++ b/app/src/desktopMain/resources/i18n/pt.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=A sessão de emparelhamento expirou
 pairing_v3_trusted=Fidedigno
 pairing_v3_unsupported=O emparelhamento seguro por PIN não está disponível para este dispositivo.
 pairing_v3_waiting=A aguardar o PIN
+pairing_v3_window_locked=Emparelhamento bloqueado após demasiadas tentativas falhadas. Sai deste ecrã e abre-o novamente para retomar.
 paste=Colar
 paste_action=Ação de colar
 paste_local_last=Colar último local

--- a/app/src/desktopMain/resources/i18n/zh.properties
+++ b/app/src/desktopMain/resources/i18n/zh.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=配对会话已过期
 pairing_v3_trusted=已信任
 pairing_v3_unsupported=此设备不支持安全 PIN 配对。
 pairing_v3_waiting=等待输入 PIN
+pairing_v3_window_locked=因多次失败，配对已锁定。请离开并重新打开此界面以恢复。
 paste=粘贴数据
 paste_action=粘贴动作
 paste_local_last=粘贴本地最新数据

--- a/app/src/desktopMain/resources/i18n/zh_hant.properties
+++ b/app/src/desktopMain/resources/i18n/zh_hant.properties
@@ -257,6 +257,7 @@ pairing_v3_session_expired=配對工作階段已過期
 pairing_v3_trusted=已信任
 pairing_v3_unsupported=此裝置不支援安全 PIN 配對。
 pairing_v3_waiting=等待輸入 PIN
+pairing_v3_window_locked=因多次失敗，配對已鎖定。請離開並重新開啟此畫面以恢復。
 paste=貼上資料
 paste_action=粘貼動作
 paste_local_last=貼上本機最新資料

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
@@ -27,6 +27,7 @@ import com.crosspaste.pairing.v3.PakeRole
 import com.crosspaste.pairing.v3.PakeSession
 import com.crosspaste.pairing.v3.Spake2PakeProvider
 import com.crosspaste.pairing.v3.TestPakeProvider
+import com.crosspaste.pairing.v3.WindowOpenSource
 import com.crosspaste.pairing.v3.pairingV3ErrorCodeOf
 import com.crosspaste.test.IntegrationTest
 import com.crosspaste.utils.CryptographyUtils
@@ -43,6 +44,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
@@ -63,6 +65,7 @@ class PairingV3IntegrationTest {
         pairingRateLimiter: PairingRateLimiter = PairingRateLimiter(),
         pakeProvider: PakeProvider = TestPakeProvider(),
         pairingV3Enabled: Boolean = true,
+        acceptanceWindowMaxProofFailures: Int = PairingV3.MAX_ACCEPTOR_PROOF_FAILURES,
     ): TestInstance =
         TestInstance(
             appInstanceId = id,
@@ -71,6 +74,7 @@ class PairingV3IntegrationTest {
             pairingRateLimiter = pairingRateLimiter,
             pakeProvider = pakeProvider,
             pairingV3Enabled = pairingV3Enabled,
+            acceptanceWindowMaxProofFailures = acceptanceWindowMaxProofFailures,
         ).also { instances.add(it) }
 
     @AfterTest
@@ -146,7 +150,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("pairing-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val started = startPairing(b, a)
             val pin = displayedPin(a, b.appInstanceId)
@@ -195,7 +199,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("real-b", pakeProvider = Spake2PakeProvider(OpenSslPakeEcOps.load()))
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val started = startPairing(b, a)
             val result =
@@ -225,7 +229,7 @@ class PairingV3IntegrationTest {
             val initiator = createInstance("generation-create-initiator")
             acceptor.start()
             initiator.start()
-            acceptor.pairingAcceptanceWindow.open()
+            acceptor.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val manual = ManualInitiator(initiator, acceptor)
             manual.buildIntent()
@@ -243,7 +247,7 @@ class PairingV3IntegrationTest {
             val initiator = createInstance("generation-share-initiator")
             acceptor.start()
             initiator.start()
-            acceptor.pairingAcceptanceWindow.open()
+            acceptor.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val manual = ManualInitiator(initiator, acceptor)
             manual.buildIntent()
@@ -277,7 +281,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("disabled-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val result =
                 b.pairingProtocolV3Service.startPairing(a.appInstanceId, a.appInstanceId, urlFor(a))
@@ -292,7 +296,7 @@ class PairingV3IntegrationTest {
         runBlocking {
             val a = createInstance("valid-a")
             val b = createInstance("valid-b")
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val manual = ManualInitiator(b, a)
             val valid = manual.buildIntent()
@@ -343,7 +347,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("canonical-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val manual = ManualInitiator(b, a)
             val offer = manual.requestOffer(urlFor(a))
@@ -368,7 +372,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("compatible-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val valid = ManualInitiator(b, a).buildIntent()
             val payload =
@@ -397,7 +401,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("wrong-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val started = startPairing(b, a)
             val pin = displayedPin(a, b.appInstanceId)
@@ -428,6 +432,48 @@ class PairingV3IntegrationTest {
             assertTrue(a.secureIO.existCryptPublicKey(b.appInstanceId))
         }
 
+    @Test
+    fun testCumulativeProofFailuresLockTheAcceptanceWindow() =
+        runBlocking {
+            // A tiny budget so one wrong PIN spends it: proves handleProof's failure
+            // funnel spends the window-wide budget, and that the real OpenSSL provider
+            // (whose deriveSharedSecret can throw on an identity-element share) counts
+            // the same way as any other rejected proof.
+            val a =
+                createInstance(
+                    "lockout-a",
+                    pakeProvider = Spake2PakeProvider(OpenSslPakeEcOps.load()),
+                    acceptanceWindowMaxProofFailures = 1,
+                )
+            val b = createInstance("lockout-b", pakeProvider = Spake2PakeProvider(OpenSslPakeEcOps.load()))
+            a.start()
+            b.start()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
+            assertFalse(a.pairingAcceptanceWindow.locked.value)
+
+            val started = startPairing(b, a)
+            val pin = displayedPin(a, b.appInstanceId)
+            val wrongPin = pin.copyOf()
+            wrongPin[5] = if (wrongPin[5] == '9') '0' else wrongPin[5] + 1
+
+            val failed = b.pairingProtocolV3Service.submitPin(started.sessionId, wrongPin, urlFor(a))
+            assertIs<PairingV3PinResult.Refused>(failed)
+            assertEquals(PairingV3ErrorCode.PAIRING_PROOF_INVALID, failed.code)
+
+            // The failed proof spent the (size-1) budget: the window locks and closes,
+            // and a remote showPairingCode can no longer re-open it.
+            awaitCondition(message = "acceptance window locks after the budget is spent") {
+                a.pairingAcceptanceWindow.locked.value
+            }
+            assertFalse(a.pairingAcceptanceWindow.isOpen())
+            assertFalse(a.pairingAcceptanceWindow.open(WindowOpenSource.REMOTE))
+
+            // A local gesture clears the lock and restores acceptance.
+            assertTrue(a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL))
+            assertFalse(a.pairingAcceptanceWindow.locked.value)
+            assertTrue(a.pairingAcceptanceWindow.isOpen())
+        }
+
     // ---- Concurrency, capacity, and restart ----
 
     @Test
@@ -439,7 +485,7 @@ class PairingV3IntegrationTest {
             a.start()
             b.start()
             c.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val startedB = startPairing(b, a)
             val startedC = startPairing(c, a)
@@ -468,7 +514,7 @@ class PairingV3IntegrationTest {
         runBlocking {
             val a = createInstance("cap-a")
             a.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             repeat(PairingV3.DEFAULT_MAX_ACTIVE_INCOMING_SESSIONS) { index ->
                 val initiator = createInstance("cap-init-$index")
@@ -491,7 +537,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("restart-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val first = startPairing(b, a)
             // The initiator lost its state and starts over with a fresh intent
@@ -534,7 +580,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("guard-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             startPairing(b, a)
 
@@ -553,7 +599,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("guard2-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             // The v2 exchange completes BEFORE any v3 session exists
             val exchange = b.syncClientApi.exchangeKeys(a.appInstanceId, 3000L, urlFor(a))
@@ -584,7 +630,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("guard3-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             startPairing(b, a)
 
@@ -606,7 +652,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("rotate-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val started = startPairing(b, a)
             val firstGeneration = started.tokenGeneration
@@ -641,7 +687,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("cancel-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val started = startPairing(b, a)
             assertTrue(b.pairingProtocolV3Service.cancelSession(started.sessionId, urlFor(a)))
@@ -660,7 +706,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("commit-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val manual = ManualInitiator(b, a)
             val offer = manual.requestOffer(urlFor(a))
@@ -691,7 +737,7 @@ class PairingV3IntegrationTest {
             a.start()
             b.start()
             attacker.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val manual = ManualInitiator(b, a)
             val offer = manual.requestOffer(urlFor(a))
@@ -724,7 +770,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("replay-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val manual = ManualInitiator(b, a)
             val offer = manual.requestOffer(urlFor(a))
@@ -746,7 +792,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("tamper-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val manual = ManualInitiator(b, a)
             val offer = manual.requestOffer(urlFor(a))
@@ -774,7 +820,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("rate-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             var limited = false
             repeat(11) {
@@ -799,7 +845,7 @@ class PairingV3IntegrationTest {
             val b = createInstance("refresh-b")
             a.start()
             b.start()
-            a.pairingAcceptanceWindow.open()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
 
             val manual = ManualInitiator(b, a)
             val firstOffer = manual.requestOffer(urlFor(a))

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
@@ -6,6 +6,7 @@ import com.crosspaste.dto.pairing.v3.PairingIntentV3
 import com.crosspaste.dto.pairing.v3.PairingOfferV3
 import com.crosspaste.dto.pairing.v3.PairingProofV3
 import com.crosspaste.dto.pairing.v3.PairingV3ErrorCode
+import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.clientapi.ClientApiResult
 import com.crosspaste.net.clientapi.FailureResult
 import com.crosspaste.net.clientapi.SuccessResult
@@ -446,12 +447,16 @@ class PairingV3IntegrationTest {
                     acceptanceWindowMaxProofFailures = 1,
                 )
             val b = createInstance("lockout-b", pakeProvider = Spake2PakeProvider(OpenSslPakeEcOps.load()))
+            val c = createInstance("lockout-c", pakeProvider = Spake2PakeProvider(OpenSslPakeEcOps.load()))
             a.start()
             b.start()
+            c.start()
             a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
             assertFalse(a.pairingAcceptanceWindow.locked.value)
 
             val started = startPairing(b, a)
+            val prefetched = startPairing(c, a)
+            val prefetchedPin = displayedPin(a, c.appInstanceId)
             val pin = displayedPin(a, b.appInstanceId)
             val wrongPin = pin.copyOf()
             wrongPin[5] = if (wrongPin[5] == '9') '0' else wrongPin[5] + 1
@@ -467,6 +472,18 @@ class PairingV3IntegrationTest {
             }
             assertFalse(a.pairingAcceptanceWindow.isOpen())
             assertFalse(a.pairingAcceptanceWindow.open(WindowOpenSource.REMOTE))
+            val remoteReopen = b.syncClientApi.showPairingCode(urlFor(a))
+            assertIs<FailureResult>(remoteReopen)
+            assertEquals(
+                StandardErrorCode.REMOTE_SHOW_PAIRING_CODE_LOCKED.getCode(),
+                remoteReopen.exception.getErrorCode().code,
+            )
+
+            // C already holds a valid offer from before the lock. The global proof
+            // permit still rejects it, so active sessions cannot overshoot the budget.
+            val blocked = c.pairingProtocolV3Service.submitPin(prefetched.sessionId, prefetchedPin, urlFor(a))
+            assertIs<PairingV3PinResult.Refused>(blocked)
+            assertEquals(PairingV3ErrorCode.PAIRING_DISABLED, blocked.code)
 
             // A local gesture clears the lock and restores acceptance.
             assertTrue(a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL))

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
@@ -46,6 +46,7 @@ class TestInstance(
     pairingRateLimiter: PairingRateLimiter = PairingRateLimiter(),
     pakeProvider: PakeProvider = TestPakeProvider(),
     pairingV3Enabled: Boolean = true,
+    acceptanceWindowMaxProofFailures: Int = PairingV3.MAX_ACCEPTOR_PROOF_FAILURES,
 ) {
     companion object {
         val platform: Platform = getPlatformUtils().platform
@@ -90,7 +91,7 @@ class TestInstance(
 
     val pairingSessionStore = PairingSessionStore()
 
-    val pairingAcceptanceWindow = PairingAcceptanceWindow()
+    val pairingAcceptanceWindow = PairingAcceptanceWindow(maxProofFailures = acceptanceWindowMaxProofFailures)
 
     val pairingReceiptCache = PairingReceiptCache()
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestServerModule.kt
@@ -11,6 +11,7 @@ import com.crosspaste.net.routing.pairingV3Routing
 import com.crosspaste.net.routing.syncRouting
 import com.crosspaste.pairing.v3.PairingProtocolV3Service
 import com.crosspaste.pairing.v3.PairingVersionCoordinator
+import com.crosspaste.pairing.v3.WindowOpenSource
 import com.crosspaste.secure.SecureKeyPairSerializer
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.MarketingNearbyDeviceManager
@@ -71,7 +72,7 @@ class TestServerModule(
                     { appInstanceId ->
                         pairingProtocolV3Service?.hasActiveSession(appInstanceId) ?: false
                     },
-                    { pairingProtocolV3Service?.acceptanceWindow?.open() },
+                    { pairingProtocolV3Service?.acceptanceWindow?.open(WindowOpenSource.REMOTE) ?: true },
                 )
                 pairingProtocolV3Service?.let { service ->
                     pairingV3Routing(

--- a/app/src/desktopTest/kotlin/com/crosspaste/pairing/v3/PairingAcceptanceWindowTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/pairing/v3/PairingAcceptanceWindowTest.kt
@@ -3,27 +3,95 @@ package com.crosspaste.pairing.v3
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.minutes
 
 class PairingAcceptanceWindowTest {
 
     private var now = 0L
 
+    private fun window(maxProofFailures: Int = PairingV3.MAX_ACCEPTOR_PROOF_FAILURES) =
+        PairingAcceptanceWindow(maxProofFailures = maxProofFailures, nowEpochMillis = { now })
+
     @Test
     fun testWindowLifecycle() {
-        val window = PairingAcceptanceWindow(nowEpochMillis = { now })
+        val window = window()
 
         assertFalse(window.isOpen())
 
-        window.open(5.minutes)
+        assertTrue(window.open(WindowOpenSource.LOCAL))
         assertTrue(window.isOpen())
 
         now += 5 * 60 * 1000L
         assertFalse(window.isOpen())
 
-        window.open(5.minutes)
+        assertTrue(window.open(WindowOpenSource.REMOTE))
         assertTrue(window.isOpen())
         window.close()
+        assertFalse(window.isOpen())
+    }
+
+    @Test
+    fun failureBudgetLocksTheWindowAndBlocksRemoteReopen() {
+        val window = window(maxProofFailures = 3)
+        assertTrue(window.open(WindowOpenSource.REMOTE))
+
+        // Below the budget, the window stays usable.
+        assertFalse(window.recordProofFailure())
+        assertFalse(window.recordProofFailure())
+        assertTrue(window.isOpen())
+
+        // The failure that spends the budget locks and closes the window.
+        assertTrue(window.recordProofFailure())
+        assertTrue(window.locked.value)
+        assertFalse(window.isOpen())
+
+        // A remote request cannot re-open a locked window.
+        assertFalse(window.open(WindowOpenSource.REMOTE))
+        assertFalse(window.isOpen())
+    }
+
+    @Test
+    fun localOpenClearsTheLockAndResetsTheBudget() {
+        val window = window(maxProofFailures = 2)
+        window.open(WindowOpenSource.REMOTE)
+        window.recordProofFailure()
+        assertTrue(window.recordProofFailure())
+        assertTrue(window.locked.value)
+
+        // A local gesture (Add Device screen) clears the lock and gives a fresh budget.
+        assertTrue(window.open(WindowOpenSource.LOCAL))
+        assertFalse(window.locked.value)
+        assertTrue(window.isOpen())
+
+        // The budget is genuinely reset: it takes the full count again to re-lock.
+        assertFalse(window.recordProofFailure())
+        assertTrue(window.recordProofFailure())
+        assertTrue(window.locked.value)
+    }
+
+    @Test
+    fun extendRenewsWithoutResettingTheBudget() {
+        val window = window(maxProofFailures = 3)
+        window.open(WindowOpenSource.LOCAL)
+        window.recordProofFailure()
+        window.recordProofFailure()
+
+        // Renewal (the on-screen keep-alive loop) must not refill the guess budget:
+        // one more failure still locks.
+        now += 2 * 60 * 1000L
+        window.extend()
+        assertTrue(window.isOpen())
+        assertTrue(window.recordProofFailure())
+        assertTrue(window.locked.value)
+    }
+
+    @Test
+    fun extendIsANoOpWhileLocked() {
+        val window = window(maxProofFailures = 1)
+        window.open(WindowOpenSource.REMOTE)
+        assertTrue(window.recordProofFailure())
+        assertFalse(window.isOpen())
+
+        window.extend()
         assertFalse(window.isOpen())
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/pairing/v3/PairingAcceptanceWindowTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/pairing/v3/PairingAcceptanceWindowTest.kt
@@ -1,7 +1,13 @@
 package com.crosspaste.pairing.v3
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class PairingAcceptanceWindowTest {
@@ -10,6 +16,9 @@ class PairingAcceptanceWindowTest {
 
     private fun window(maxProofFailures: Int = PairingV3.MAX_ACCEPTOR_PROOF_FAILURES) =
         PairingAcceptanceWindow(maxProofFailures = maxProofFailures, nowEpochMillis = { now })
+
+    private fun failProof(window: PairingAcceptanceWindow): Boolean =
+        assertNotNull(window.tryBeginProofAttempt()).recordFailure()
 
     @Test
     fun testWindowLifecycle() {
@@ -35,12 +44,12 @@ class PairingAcceptanceWindowTest {
         assertTrue(window.open(WindowOpenSource.REMOTE))
 
         // Below the budget, the window stays usable.
-        assertFalse(window.recordProofFailure())
-        assertFalse(window.recordProofFailure())
+        assertFalse(failProof(window))
+        assertFalse(failProof(window))
         assertTrue(window.isOpen())
 
         // The failure that spends the budget locks and closes the window.
-        assertTrue(window.recordProofFailure())
+        assertTrue(failProof(window))
         assertTrue(window.locked.value)
         assertFalse(window.isOpen())
 
@@ -53,8 +62,8 @@ class PairingAcceptanceWindowTest {
     fun localOpenClearsTheLockAndResetsTheBudget() {
         val window = window(maxProofFailures = 2)
         window.open(WindowOpenSource.REMOTE)
-        window.recordProofFailure()
-        assertTrue(window.recordProofFailure())
+        failProof(window)
+        assertTrue(failProof(window))
         assertTrue(window.locked.value)
 
         // A local gesture (Add Device screen) clears the lock and gives a fresh budget.
@@ -63,8 +72,8 @@ class PairingAcceptanceWindowTest {
         assertTrue(window.isOpen())
 
         // The budget is genuinely reset: it takes the full count again to re-lock.
-        assertFalse(window.recordProofFailure())
-        assertTrue(window.recordProofFailure())
+        assertFalse(failProof(window))
+        assertTrue(failProof(window))
         assertTrue(window.locked.value)
     }
 
@@ -72,15 +81,15 @@ class PairingAcceptanceWindowTest {
     fun extendRenewsWithoutResettingTheBudget() {
         val window = window(maxProofFailures = 3)
         window.open(WindowOpenSource.LOCAL)
-        window.recordProofFailure()
-        window.recordProofFailure()
+        failProof(window)
+        failProof(window)
 
         // Renewal (the on-screen keep-alive loop) must not refill the guess budget:
         // one more failure still locks.
         now += 2 * 60 * 1000L
         window.extend()
         assertTrue(window.isOpen())
-        assertTrue(window.recordProofFailure())
+        assertTrue(failProof(window))
         assertTrue(window.locked.value)
     }
 
@@ -88,10 +97,50 @@ class PairingAcceptanceWindowTest {
     fun extendIsANoOpWhileLocked() {
         val window = window(maxProofFailures = 1)
         window.open(WindowOpenSource.REMOTE)
-        assertTrue(window.recordProofFailure())
+        assertTrue(failProof(window))
         assertFalse(window.isOpen())
 
         window.extend()
         assertFalse(window.isOpen())
     }
+
+    @Test
+    fun inFlightProofsReserveTheRemainingFailureBudget() {
+        val window = window(maxProofFailures = 2)
+        window.open(WindowOpenSource.LOCAL)
+
+        val first = assertNotNull(window.tryBeginProofAttempt())
+        val second = assertNotNull(window.tryBeginProofAttempt())
+        assertNull(window.tryBeginProofAttempt())
+
+        assertFalse(first.recordFailure())
+        assertNull(window.tryBeginProofAttempt())
+
+        second.release()
+        assertNotNull(window.tryBeginProofAttempt()).release()
+    }
+
+    @Test
+    fun concurrentRemoteRenewalsCannotReopenALockedWindow() =
+        runBlocking {
+            repeat(100) {
+                val window = window(maxProofFailures = 1)
+                window.open(WindowOpenSource.REMOTE)
+                val attempt = assertNotNull(window.tryBeginProofAttempt())
+
+                listOf(
+                    launch(Dispatchers.Default) {
+                        repeat(100) { window.open(WindowOpenSource.REMOTE) }
+                    },
+                    launch(Dispatchers.Default) {
+                        repeat(100) { window.extend() }
+                    },
+                    launch(Dispatchers.Default) { attempt.recordFailure() },
+                ).joinAll()
+
+                assertTrue(window.locked.value)
+                assertFalse(window.isOpen())
+                assertFalse(window.open(WindowOpenSource.REMOTE))
+            }
+        }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/GeneralSyncHandlerTest.kt
@@ -602,10 +602,11 @@ class GeneralSyncHandlerTest {
                 val event = emitter.events.filterIsInstance<SyncEvent.ShowPairingCode>().single()
                 assertFalse(request.isCompleted)
 
-                event.completionSignal.complete(true)
+                event.completionSignal.complete(ShowPairingCodeResult.SHOWN)
                 runCurrent()
 
                 assertTrue(request.isCompleted)
+                assertEquals(ShowPairingCodeResult.SHOWN, request.await())
             } finally {
                 childScope.cancel()
             }
@@ -622,7 +623,7 @@ class GeneralSyncHandlerTest {
             emitter.events.clear()
 
             try {
-                val request = async { runCatching { handler.showPairingCode() } }
+                val request = async { handler.showPairingCode() }
                 runCurrent()
 
                 assertFalse(request.isCompleted)
@@ -631,7 +632,7 @@ class GeneralSyncHandlerTest {
                 runCurrent()
 
                 assertTrue(request.isCompleted)
-                assertTrue(request.await().isFailure)
+                assertEquals(ShowPairingCodeResult.UNAVAILABLE, request.await())
             } finally {
                 childScope.cancel()
             }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncDeviceManagerTest.kt
@@ -3,9 +3,11 @@ package com.crosspaste.sync
 import com.crosspaste.db.sync.SyncRuntimeInfo
 import com.crosspaste.db.sync.SyncRuntimeInfoDao
 import com.crosspaste.db.sync.SyncState
+import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.clientapi.ConnectionRefused
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.net.clientapi.SyncClientApi
+import com.crosspaste.net.clientapi.createFailureResult
 import com.crosspaste.net.ws.WsSessionManager
 import com.crosspaste.secure.SecureStore
 import com.crosspaste.sync.SyncTestFixtures.createConnectedSyncRuntimeInfo
@@ -18,7 +20,6 @@ import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SyncDeviceManagerTest {
@@ -329,21 +330,21 @@ class SyncDeviceManagerTest {
     // ========== showPairingCode ==========
 
     @Test
-    fun showPairingCode_unverifiedAndSuccess_returnsTrue() =
+    fun showPairingCode_unverifiedAndSuccess_returnsShown() =
         runTest {
             val deps = TestDeps()
             val manager = deps.createManager()
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
             coEvery { deps.syncClientApi.showPairingCode(any()) } returns SuccessResult(true)
 
-            assertTrue(manager.showPairingCode(syncRuntimeInfo))
+            assertEquals(ShowPairingCodeResult.SHOWN, manager.showPairingCode(syncRuntimeInfo))
 
             coVerify(exactly = 1) { deps.syncClientApi.showPairingCode(any()) }
             coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
         }
 
     @Test
-    fun showPairingCode_unverifiedAndFails_returnsFalseAndDisconnects() =
+    fun showPairingCode_unverifiedAndFails_returnsUnavailableAndDisconnects() =
         runTest {
             val deps = TestDeps()
             val manager = deps.createManager()
@@ -352,19 +353,34 @@ class SyncDeviceManagerTest {
             val capturedInfo = slot<SyncRuntimeInfo>()
             coEvery { deps.syncRuntimeInfoDao.updateConnectInfo(capture(capturedInfo)) } returns "test-app-1"
 
-            assertFalse(manager.showPairingCode(syncRuntimeInfo))
+            assertEquals(ShowPairingCodeResult.UNAVAILABLE, manager.showPairingCode(syncRuntimeInfo))
 
             assertEquals(SyncState.DISCONNECTED, capturedInfo.captured.connectState)
         }
 
     @Test
-    fun showPairingCode_notUnverified_returnsFalseWithoutRequest() =
+    fun showPairingCode_policyRejectionDoesNotDisconnect() =
+        runTest {
+            val deps = TestDeps()
+            val manager = deps.createManager()
+            val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
+            coEvery {
+                deps.syncClientApi.showPairingCode(any())
+            } returns createFailureResult(StandardErrorCode.REMOTE_SHOW_PAIRING_CODE_LOCKED, "locked")
+
+            assertEquals(ShowPairingCodeResult.NOT_ACCEPTING, manager.showPairingCode(syncRuntimeInfo))
+
+            coVerify(exactly = 0) { deps.syncRuntimeInfoDao.updateConnectInfo(any()) }
+        }
+
+    @Test
+    fun showPairingCode_notUnverified_returnsUnavailableWithoutRequest() =
         runTest {
             val deps = TestDeps()
             val manager = deps.createManager()
             val syncRuntimeInfo = createConnectedSyncRuntimeInfo()
 
-            assertFalse(manager.showPairingCode(syncRuntimeInfo))
+            assertEquals(ShowPairingCodeResult.UNAVAILABLE, manager.showPairingCode(syncRuntimeInfo))
 
             coVerify(exactly = 0) { deps.syncClientApi.showPairingCode(any()) }
         }

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/SyncResolverTest.kt
@@ -45,7 +45,6 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -1709,31 +1708,35 @@ class SyncResolverTest {
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
             val event = SyncEvent.ShowPairingCode(syncRuntimeInfo)
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.syncDeviceManager.showPairingCode(syncRuntimeInfo) } returns true
+            coEvery {
+                deps.syncDeviceManager.showPairingCode(syncRuntimeInfo)
+            } returns ShowPairingCodeResult.SHOWN
 
             resolver.emitEvent(event)
 
             coVerify(exactly = 1) { deps.syncDeviceManager.showPairingCode(syncRuntimeInfo) }
-            assertTrue(event.completionSignal.await())
+            assertEquals(ShowPairingCodeResult.SHOWN, event.completionSignal.await())
         }
 
     @Test
-    fun showPairingCode_reportsFailureWhenRemoteWindowWasNotOpened() =
+    fun showPairingCode_reportsNotAcceptingWhenRemoteWindowWasNotOpened() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
             val syncRuntimeInfo = createUnverifiedSyncRuntimeInfo()
             val event = SyncEvent.ShowPairingCode(syncRuntimeInfo)
             deps.stubDbRead(syncRuntimeInfo)
-            coEvery { deps.syncDeviceManager.showPairingCode(syncRuntimeInfo) } returns false
+            coEvery {
+                deps.syncDeviceManager.showPairingCode(syncRuntimeInfo)
+            } returns ShowPairingCodeResult.NOT_ACCEPTING
 
             resolver.emitEvent(event)
 
-            assertFalse(event.completionSignal.await())
+            assertEquals(ShowPairingCodeResult.NOT_ACCEPTING, event.completionSignal.await())
         }
 
     @Test
-    fun showPairingCode_resolverCancellationCompletesFalseWithoutCancellingCaller() =
+    fun showPairingCode_resolverCancellationCompletesUnavailableWithoutCancellingCaller() =
         runTest {
             val deps = TestDeps()
             val resolver = deps.createResolver()
@@ -1748,7 +1751,7 @@ class SyncResolverTest {
                 resolver.emitEvent(event)
             }
 
-            assertFalse(event.completionSignal.await())
+            assertEquals(ShowPairingCodeResult.UNAVAILABLE, event.completionSignal.await())
         }
 
     @Test
@@ -1765,7 +1768,7 @@ class SyncResolverTest {
             resolver.emitEvent(event)
 
             coVerify(exactly = 0) { deps.syncDeviceManager.showPairingCode(any()) }
-            assertFalse(event.completionSignal.await())
+            assertEquals(ShowPairingCodeResult.UNAVAILABLE, event.completionSignal.await())
         }
 
     private fun extensionPlatform(): Platform =

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3UiControllerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3UiControllerTest.kt
@@ -9,10 +9,12 @@ import com.crosspaste.pairing.v3.PairingSessionUiState
 import com.crosspaste.pairing.v3.PairingV3PinResult
 import com.crosspaste.pairing.v3.PairingV3StartResult
 import com.crosspaste.pairing.v3.PakeRole
+import com.crosspaste.sync.ShowPairingCodeResult
 import com.crosspaste.sync.SyncHandler
 import com.crosspaste.sync.SyncManager
 import com.crosspaste.sync.SyncTestFixtures.createUnverifiedSyncRuntimeInfo
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
@@ -39,7 +41,7 @@ class PairingV3UiControllerTest {
             every { syncManager.getSyncHandler(peerAppInstanceId) } returns syncHandler
             every { syncHandler.currentSyncRuntimeInfo } returns syncRuntimeInfo
             coEvery { syncHandler.getConnectHostAddress() } returns "192.168.1.10"
-            coEvery { syncHandler.showPairingCode() } returns Unit
+            coEvery { syncHandler.showPairingCode() } returns ShowPairingCodeResult.SHOWN
             every { pairingProtocolV3Service.uiSessionsFlow } returns MutableStateFlow(emptyList())
             every { pairingProtocolV3Service.acceptanceWindow } returns PairingAcceptanceWindow()
             coEvery {
@@ -61,6 +63,40 @@ class PairingV3UiControllerTest {
                     toUrl = any(),
                 )
             }
+        }
+
+    @Test
+    fun remotePairingWindowRejectionIsPresentedAsNotAccepting() =
+        runTest {
+            val peerAppInstanceId = "locked-peer"
+            val syncRuntimeInfo =
+                createUnverifiedSyncRuntimeInfo(
+                    appInstanceId = peerAppInstanceId,
+                    hostAddress = "192.168.1.11",
+                )
+            val syncHandler = mockk<SyncHandler>()
+            val syncManager = mockk<SyncManager>()
+            val pairingProtocolV3Service = mockk<PairingProtocolV3Service>()
+
+            every { syncManager.getSyncHandler(peerAppInstanceId) } returns syncHandler
+            every { syncHandler.currentSyncRuntimeInfo } returns syncRuntimeInfo
+            coEvery { syncHandler.getConnectHostAddress() } returns "192.168.1.11"
+            coEvery { syncHandler.showPairingCode() } returns ShowPairingCodeResult.NOT_ACCEPTING
+            every { pairingProtocolV3Service.uiSessionsFlow } returns MutableStateFlow(emptyList())
+            every { pairingProtocolV3Service.acceptanceWindow } returns PairingAcceptanceWindow()
+
+            val result =
+                DefaultPairingV3UiController(pairingProtocolV3Service, syncManager)
+                    .startPairing(peerAppInstanceId)
+
+            assertEquals(
+                PairingV3UiResult.Error(
+                    PairingV3UiError.NOT_ACCEPTING,
+                    PairingV3Recovery.RETRY_START,
+                ),
+                result,
+            )
+            coVerify(exactly = 0) { pairingProtocolV3Service.startPairing(any(), any(), any()) }
         }
 
     @Test

--- a/core/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingV3.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingV3.kt
@@ -67,4 +67,17 @@ object PairingV3 {
 
     /** Hard protocol rule, not tunable: one failed proof invalidates the generation. */
     const val MAX_PROOF_ATTEMPTS_PER_GENERATION: Int = 1
+
+    /**
+     * Cumulative proof-failure budget for one acceptance-window session, across all
+     * peers and generations. `MAX_PROOF_ATTEMPTS_PER_GENERATION` caps guesses per
+     * PIN, but a failed proof rotates a fresh PIN immediately, so on its own it puts
+     * no ceiling on the *total* number of online guesses — the sliding-window rate
+     * limiter only bounds their rate. This budget is that ceiling: once it is spent
+     * the acceptor closes and locks its window, and only a local user gesture
+     * (re-entering the Add Device screen) resets it, so an unattended remote attacker
+     * cannot keep guessing the 6-digit PIN indefinitely. A legitimate user mistypes a
+     * handful of times at most, well under this bound.
+     */
+    const val MAX_ACCEPTOR_PROOF_FAILURES: Int = 10
 }

--- a/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
+++ b/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
@@ -9,8 +9,8 @@ import com.sun.jna.Pointer
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 /**
- * How [OpenSslPakeEcOps.load] resolves the libcrypto to bind (unless an
- * explicit override is set, which always wins for troubleshooting).
+ * How [OpenSslPakeEcOps.load] resolves the libcrypto to bind. Explicit overrides
+ * apply only to [Environment]; [Bundled] always uses its reviewed packaged library.
  *
  * The whole process uses exactly one resolution: the first successful [load]
  * pins it, and a later call with a different resolution throws instead of
@@ -56,10 +56,11 @@ sealed interface LibCryptoResolution {
  * `BN_clear_free`, which zeroes them before freeing — unlike the immutable
  * JVM `BigInteger` copies the BouncyCastle backend left behind for the GC.
  *
- * libcrypto is resolved from the `crosspaste.libcrypto.path` system property
- * or `CROSSPASTE_LIBCRYPTO_PATH` environment variable first; without an
- * override the [LibCryptoResolution] passed to [load] decides the candidates.
- * [load] fails fast with a [PakeException] when no candidate can be loaded.
+ * In [LibCryptoResolution.Environment], libcrypto is resolved from the
+ * `crosspaste.libcrypto.path` system property or `CROSSPASTE_LIBCRYPTO_PATH`
+ * environment variable first. [LibCryptoResolution.Bundled] ignores overrides and
+ * loads only its packaged path. [load] fails fast with a [PakeException] when no
+ * accepted candidate can be loaded.
  */
 class OpenSslPakeEcOps private constructor(
     private val lib: LibCrypto,

--- a/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
+++ b/core/src/desktopMain/kotlin/com/crosspaste/pairing/v3/OpenSslPakeEcOps.kt
@@ -187,7 +187,11 @@ class OpenSslPakeEcOps private constructor(
         try {
             return block(point)
         } finally {
-            lib.EC_POINT_free(point)
+            // clear_free, not free: intermediate points include secret group
+            // elements (w·M, K, peerShare−w·M) whose coordinates would otherwise
+            // survive in freed heap. ADR D5 requires K be non-recoverable; this
+            // matches the BN_clear_free discipline used for secret scalars.
+            lib.EC_POINT_clear_free(point)
         }
     }
 
@@ -320,6 +324,7 @@ class OpenSslPakeEcOps private constructor(
                 "EC_GROUP_get0_order",
                 "EC_POINT_new",
                 "EC_POINT_free",
+                "EC_POINT_clear_free",
                 "EC_POINT_mul",
                 "EC_POINT_add",
                 "EC_POINT_invert",
@@ -376,7 +381,6 @@ class OpenSslPakeEcOps private constructor(
             }
 
         internal fun loadLibCrypto(resolution: LibCryptoResolution): Pair<LibCrypto, String> {
-            val override = overridePath()
             val candidates = libraryCandidates(resolution)
             val failures = mutableListOf<String>()
             for (candidate in candidates) {
@@ -394,36 +398,52 @@ class OpenSslPakeEcOps private constructor(
                 }
             }
             val remedy =
-                when {
-                    override != null ->
-                        "The explicit libcrypto override failed to load; fix it, or remove " +
-                            "crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH to restore the default resolution."
-                    resolution is LibCryptoResolution.Bundled ->
+                when (resolution) {
+                    is LibCryptoResolution.Bundled ->
                         "The bundled libcrypto is missing or unloadable; reinstalling the application should restore it."
-                    else ->
-                        "Install OpenSSL 3 (e.g. brew install openssl@3) or point " +
-                            "crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH at a libcrypto with the full symbol set."
+                    LibCryptoResolution.Environment ->
+                        if (overridePath() != null) {
+                            "The explicit libcrypto override failed to load; fix it, or remove " +
+                                "crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH to restore the default resolution."
+                        } else {
+                            "Install OpenSSL 3 (e.g. brew install openssl@3) or point " +
+                                "crosspaste.libcrypto.path / CROSSPASTE_LIBCRYPTO_PATH at a libcrypto with the full symbol set."
+                        }
                 }
             throw PakeException("OpenSSL 3 libcrypto not found; tried ${failures.joinToString()}. $remedy")
         }
 
-        internal fun libraryCandidates(resolution: LibCryptoResolution): List<String> {
-            overridePath()?.let { return listOf(it) }
-            return when (resolution) {
-                is LibCryptoResolution.Bundled -> listOf(resolution.path)
-                LibCryptoResolution.Environment ->
-                    when {
-                        Platform.isMac() ->
-                            listOf(
-                                "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib",
-                                "/usr/local/opt/openssl@3/lib/libcrypto.3.dylib",
-                                "crypto",
-                            )
-                        Platform.isWindows() -> listOf("libcrypto-3-x64", "libcrypto-3", "libcrypto")
-                        else -> listOf("libcrypto.so.3", "crypto")
+        internal fun libraryCandidates(resolution: LibCryptoResolution): List<String> =
+            when (resolution) {
+                // Bundled = production/beta: resolve ONLY the packaged library. An
+                // override is deliberately NOT honoured here — a shipped build binding
+                // an attacker-set libcrypto would void the reviewed constant-time
+                // premise. If one is set (troubleshooting habit, stale env var), warn
+                // that it is ignored rather than silently switching libraries.
+                is LibCryptoResolution.Bundled -> {
+                    overridePath()?.let { override ->
+                        logger.warn {
+                            "ignoring libcrypto override '$override' in a bundled build; " +
+                                "using the packaged library at ${resolution.path}"
+                        }
                     }
+                    listOf(resolution.path)
+                }
+                LibCryptoResolution.Environment ->
+                    overridePath()?.let { listOf(it) } ?: platformEnvironmentCandidates()
             }
-        }
+
+        private fun platformEnvironmentCandidates(): List<String> =
+            when {
+                Platform.isMac() ->
+                    listOf(
+                        "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib",
+                        "/usr/local/opt/openssl@3/lib/libcrypto.3.dylib",
+                        "crypto",
+                    )
+                Platform.isWindows() -> listOf("libcrypto-3-x64", "libcrypto-3", "libcrypto")
+                else -> listOf("libcrypto.so.3", "crypto")
+            }
 
         private fun overridePath(): String? =
             System.getProperty("crosspaste.libcrypto.path")
@@ -458,6 +478,8 @@ internal interface LibCrypto : Library {
     fun EC_POINT_new(group: Pointer): Pointer?
 
     fun EC_POINT_free(point: Pointer)
+
+    fun EC_POINT_clear_free(point: Pointer)
 
     fun EC_POINT_mul(
         group: Pointer,

--- a/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/OpenSslLibraryResolutionTest.kt
+++ b/core/src/desktopTest/kotlin/com/crosspaste/pairing/v3/OpenSslLibraryResolutionTest.kt
@@ -58,10 +58,17 @@ class OpenSslLibraryResolutionTest {
     }
 
     @Test
-    fun explicitOverrideWinsOverTheBundledPath() {
+    fun explicitOverrideAppliesToEnvironmentButIsIgnoredWhenBundled() {
         withOverrideProperty("/tmp/custom-libcrypto.so") {
+            // Environment (dev/test): the override is honoured for troubleshooting.
             assertEquals(
                 listOf("/tmp/custom-libcrypto.so"),
+                OpenSslPakeEcOps.libraryCandidates(LibCryptoResolution.Environment),
+            )
+            // Bundled (production/beta): the override is deliberately ignored — a
+            // shipped build must never bind an attacker-set libcrypto.
+            assertEquals(
+                listOf(bundled.path),
                 OpenSslPakeEcOps.libraryCandidates(bundled),
             )
         }
@@ -92,17 +99,32 @@ class OpenSslLibraryResolutionTest {
     }
 
     @Test
-    fun failedOverrideRemedyPointsAtTheOverride() {
+    fun failedOverrideRemedyPointsAtTheOverrideInEnvironment() {
+        withOverrideProperty("/nonexistent/override-libcrypto.so") {
+            val exception =
+                assertFailsWith<PakeException> {
+                    OpenSslPakeEcOps.loadLibCrypto(LibCryptoResolution.Environment)
+                }
+            val message = exception.message.orEmpty()
+            // Environment override failed to load: the remedy points at the override.
+            assertTrue("override" in message, "remedy must call out the override: $message")
+            assertFalse("reinstalling" in message, "remedy must not suggest a reinstall: $message")
+        }
+    }
+
+    @Test
+    fun bundledRemedyIgnoresOverrideAndSuggestsReinstall() {
         withOverrideProperty("/nonexistent/override-libcrypto.so") {
             val exception =
                 assertFailsWith<PakeException> {
                     OpenSslPakeEcOps.loadLibCrypto(bundled)
                 }
             val message = exception.message.orEmpty()
-            // The bundled library was never tried, so the remedy must point at
-            // the override instead of suggesting a reinstall.
-            assertTrue("override" in message, "remedy must call out the override: $message")
-            assertFalse("reinstalling" in message, "remedy must not suggest a reinstall: $message")
+            // A bundled build ignores the override entirely, so its failure must not
+            // steer the user toward fixing an override the build never consulted.
+            assertTrue(bundled.path in message, "failure must name the bundled candidate: $message")
+            assertTrue("reinstalling" in message, "bundled remedy should suggest a reinstall: $message")
+            assertFalse("override" in message, "bundled remedy must not mention the override: $message")
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/crosspaste/exception/StandardErrorCode.kt
+++ b/shared/src/commonMain/kotlin/com/crosspaste/exception/StandardErrorCode.kt
@@ -46,6 +46,7 @@ enum class StandardErrorCode(
     SYNC_PASTE_NOT_FOUND_DATA(3002, ErrorType.EXTERNAL_ERROR),
 
     REMOTE_SHOW_PAIRING_CODE_DISABLED(3100, ErrorType.USER_ERROR),
+    REMOTE_SHOW_PAIRING_CODE_LOCKED(3101, ErrorType.USER_ERROR),
 
     // Pairing v3 wire errors (ai/docs/PAIRING_PROTOCOL_V3.md §15). Responses must not
     // disclose whether a guessed PIN was close or which sub-proof failed: proof-stage


### PR DESCRIPTION
Closes #4866

## Summary

Hardens the pairing v3 acceptor against online PIN guessing and closes two secret-hygiene gaps in the OpenSSL backend, ahead of the independent security review (rollout plan step C).

### Cumulative, lockable acceptance window (`PairingAcceptanceWindow`)

- Proof failures now accumulate across peers and token generations. Spending the budget (`PairingV3.MAX_ACCEPTOR_PROOF_FAILURES`) closes **and locks** the window.
- Only a **local** Add Device gesture (`WindowOpenSource.LOCAL`) clears the lock and resets the budget; remote `showPairingCode` opens and on-screen renewals (`extend`) never refill it, so an attacker cannot launder guesses through window renewal.
- The window state is a single atomic `WindowState` (open-until / failures / in-flight / locked); the `StateFlow`s are observational projections for Compose only — authorization never reads them.

### Concurrency-safe reservation scheme

- `handleProof` must reserve a `ProofAttempt` before doing any cryptographic work. In-flight reservations and recorded failures jointly consume the ceiling, so N parallel sessions cannot overshoot the last remaining guess.
- Failed proofs convert the reservation into a counted failure; successful proofs and requests rejected before cryptographic verification release it.
- Once locked, proofs are refused with `PAIRING_DISABLED` — including sessions whose offer was obtained before the lock.

### Surfacing the locked state

- The acceptor pairing screen shows the locked state instead of a seemingly usable pairing code.
- `/sync/showPairingCode` returns distinct error codes (`REMOTE_SHOW_PAIRING_CODE_DISABLED` 3100 / `REMOTE_SHOW_PAIRING_CODE_LOCKED` 3101). The initiator maps them to a tri-state `ShowPairingCodeResult`; policy refusals present as "not accepting pairing requests" (new `pairing_v3_not_accepting` string, 10 locales) and no longer tear the peer down to `DISCONNECTED`.

### OpenSSL backend secret hygiene

- Secret EC points (shared-secret and `w*N` subtraction intermediates) are now zeroized before being freed, matching the existing `BN_clear_free` treatment of scalars.
- `LibCryptoResolution.Bundled` (production/beta) ignores the `crosspaste.libcrypto.path` / `CROSSPASTE_LIBCRYPTO_PATH` override and loads only the reviewed packaged library; overrides remain honored in `Environment` resolution for troubleshooting.

## Testing

- `./gradlew app:desktopTest` (fast tier) — green, including new `PairingAcceptanceWindowTest` reservation and concurrency-stress cases (100-iteration race of remote opens/extends against a locking failure).
- `./gradlew app:desktopTest -PintegrationTests --tests "com.crosspaste.net.PairingV3IntegrationTest"` — 26/26 green, including the extended lockout scenario: a third instance holding a pre-lock offer is refused with `PAIRING_DISABLED`, and a remote reopen attempt fails with `REMOTE_SHOW_PAIRING_CODE_LOCKED`.
- `core:desktopTest` covers bundled-override rejection in `OpenSslLibraryResolutionTest`.

## Notes

- Production remains inert: `PAIRING_VERSION` is still 2 and the double clamp from #4667 is untouched; this only hardens the code path that step D will enable.