### PR TITLE
:bug: unwrap wrapped crypto failures so key mismatch surfaces as DECRYPT_FAIL (#4870)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/exception/ExceptionHandler.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/exception/ExceptionHandler.kt
@@ -29,24 +29,30 @@ abstract class ExceptionHandler {
 
     abstract fun isConnectionRefused(e: Throwable): Boolean
 
+    // Crypto failures rarely surface as the top-level exception: a decrypt that
+    // happens inside a body-transform channel arrives wrapped (e.g. Ktor's
+    // ClosedByteChannelException with the PasteException as its cause), so every
+    // classifier below walks the cause chain instead of matching only `e`.
+    private fun causeChain(e: Throwable): Sequence<Throwable> =
+        generateSequence(e) { current ->
+            current.cause?.takeIf { it !== current }
+        }.take(MAX_CAUSE_DEPTH)
+
     fun isEncryptFail(e: Throwable): Boolean =
-        when (e) {
-            is PasteException -> e.getErrorCode() == StandardErrorCode.ENCRYPT_FAIL.toErrorCode()
-            else -> false
+        causeChain(e).any {
+            it is PasteException && it.getErrorCode() == StandardErrorCode.ENCRYPT_FAIL.toErrorCode()
         }
 
     fun isDecryptFail(e: Throwable): Boolean =
-        when (e) {
-            is PasteException -> {
-                e.getErrorCode() == StandardErrorCode.DECRYPT_FAIL.toErrorCode()
-            }
-
-            is CannotTransformContentToTypeException -> {
-                true
-            }
-
-            else -> {
-                false
+        causeChain(e).any {
+            when (it) {
+                is PasteException -> it.getErrorCode() == StandardErrorCode.DECRYPT_FAIL.toErrorCode()
+                is CannotTransformContentToTypeException -> true
+                else -> false
             }
         }
+
+    companion object {
+        private const val MAX_CAUSE_DEPTH = 10
+    }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/exception/ExceptionHandlerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/exception/ExceptionHandlerTest.kt
@@ -79,4 +79,55 @@ class ExceptionHandlerTest {
     fun `isDecryptFail returns false for null throwable message`() {
         assertFalse(handler.isDecryptFail(RuntimeException()))
     }
+
+    @Test
+    fun `isDecryptFail unwraps DECRYPT_FAIL nested in a transport exception`() {
+        // Server-side decrypt runs inside a Ktor body-transform channel, so the
+        // PasteException surfaces wrapped (ClosedByteChannelException in the field).
+        val wrapped =
+            IllegalStateException(
+                "channel was cancelled",
+                PasteException(StandardErrorCode.DECRYPT_FAIL.toErrorCode(), "bad padding"),
+            )
+        assertTrue(handler.isDecryptFail(wrapped))
+    }
+
+    @Test
+    fun `isDecryptFail unwraps deeply nested CannotTransformContentToTypeException`() {
+        val wrapped =
+            RuntimeException(
+                "outer",
+                IllegalStateException("mid", CannotTransformContentToTypeException(typeOf<String>())),
+            )
+        assertTrue(handler.isDecryptFail(wrapped))
+    }
+
+    @Test
+    fun `isDecryptFail returns false for wrapped unrelated PasteException`() {
+        val wrapped =
+            IllegalStateException(
+                "channel was cancelled",
+                PasteException(StandardErrorCode.UNKNOWN_ERROR.toErrorCode(), "boom"),
+            )
+        assertFalse(handler.isDecryptFail(wrapped))
+    }
+
+    @Test
+    fun `isEncryptFail unwraps ENCRYPT_FAIL nested in a transport exception`() {
+        val wrapped =
+            IllegalStateException(
+                "channel was cancelled",
+                PasteException(StandardErrorCode.ENCRYPT_FAIL.toErrorCode(), "encrypt error"),
+            )
+        assertTrue(handler.isEncryptFail(wrapped))
+    }
+
+    @Test
+    fun `cause chain walk survives cyclic causes`() {
+        val first = RuntimeException("first")
+        val second = RuntimeException("second")
+        first.initCause(second)
+        second.initCause(first)
+        assertFalse(handler.isDecryptFail(first))
+    }
 }


### PR DESCRIPTION
Closes #4870

## What

`ExceptionHandler.isDecryptFail` / `isEncryptFail` now walk the exception cause chain (bounded at depth 10, cycle-safe) instead of matching only the top-level exception.

## Why

Server-side body decryption runs inside the Ktor body-transform writer (`ServerDecryptionPluginFactory`), so a key-mismatch `PasteException(DECRYPT_FAIL)` reaches the route handler wrapped in `io.ktor.utils.io.ClosedByteChannelException`. The top-level-only match classified it as unknown, `/sync/heartbeat/syncInfo` answered `UNKNOWN_ERROR` instead of `DECRYPT_FAIL`, and the peer's `SyncResolver` — which maps only `DECRYPT_FAIL` to `SyncState.UNMATCHED` — showed the device as permanently **offline** instead of **unmatched/re-pair**. Manual refresh could never recover. The same classifier backs the client-side `safeApiCall`, which benefits equally.

## Tests

- New `ExceptionHandlerTest` cases: `DECRYPT_FAIL`/`ENCRYPT_FAIL` nested one and two levels deep, wrapped unrelated `PasteException` still rejected, and cyclic cause chains terminate.
- Full fast-tier `:app:desktopTest` passes.

https://claude.ai/code/session_019wycxR1g64gXPsgaQeFAaX