### PR TITLE
:bug: read trust request bodies before taking the per-peer pairing lock (#4871)

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/SyncRouting.kt
@@ -266,6 +266,17 @@ fun Routing.syncRouting(
 
     post("/sync/trust") {
         getAppInstanceId(call)?.let { appInstanceId ->
+            // Read the body BEFORE taking the per-peer lock (same order as the
+            // pairing v3 routes): receive() suspends on client network I/O, and a
+            // peer that dies mid-request would otherwise park this handler inside
+            // the lock indefinitely, starving every later pairing request for the
+            // peer — including v3 /intent, which shares the lock.
+            val trustRequest =
+                runCatching { call.receive(TrustRequest::class) }.getOrElse { e ->
+                    logger.error(e) { "Trust request failed for $appInstanceId" }
+                    failResponse(call, StandardErrorCode.TRUST_FAIL.toErrorCode())
+                    return@let
+                }
             pairingVersionCoordinator.withPeerLock(appInstanceId) {
                 if (hasActivePairingV3Session(appInstanceId)) {
                     logger.warn { "refusing v1 trust during active pairing v3 session for $appInstanceId" }
@@ -273,7 +284,6 @@ fun Routing.syncRouting(
                     return@withPeerLock
                 }
                 runCatching {
-                    val trustRequest = call.receive(TrustRequest::class)
                     val currentTimestamp = nowEpochMilliseconds()
 
                     val receiveSignPublicKey =
@@ -339,6 +349,13 @@ fun Routing.syncRouting(
 
     post("/sync/trust/v2/exchange") {
         getAppInstanceId(call)?.let { appInstanceId ->
+            // Body read stays outside the per-peer lock — see /sync/trust.
+            val request =
+                runCatching { call.receive(KeyExchangeRequest::class) }.getOrElse { e ->
+                    logger.error(e) { "v2 exchange failed for $appInstanceId" }
+                    failResponse(call, StandardErrorCode.EXCHANGE_FAIL.toErrorCode())
+                    return@let
+                }
             pairingVersionCoordinator.withPeerLock(appInstanceId) {
                 if (hasActivePairingV3Session(appInstanceId)) {
                     logger.warn { "refusing v2 exchange during active pairing v3 session for $appInstanceId" }
@@ -346,8 +363,6 @@ fun Routing.syncRouting(
                     return@withPeerLock
                 }
                 runCatching {
-                    val request = call.receive(KeyExchangeRequest::class)
-
                     val receiveSignPublicKey =
                         secureKeyPairSerializer.decodeSignPublicKey(request.signPublicKey)
 
@@ -424,6 +439,13 @@ fun Routing.syncRouting(
 
     post("/sync/trust/v2/confirm") {
         getAppInstanceId(call)?.let { appInstanceId ->
+            // Body read stays outside the per-peer lock — see /sync/trust.
+            val request =
+                runCatching { call.receive(TrustConfirmRequest::class) }.getOrElse { e ->
+                    logger.error(e) { "v2 confirm failed for $appInstanceId" }
+                    failResponse(call, StandardErrorCode.TRUST_FAIL.toErrorCode())
+                    return@let
+                }
             pairingVersionCoordinator.withPeerLock(appInstanceId) {
                 if (hasActivePairingV3Session(appInstanceId)) {
                     releasePendingKeyExchange(appInstanceId)
@@ -432,8 +454,6 @@ fun Routing.syncRouting(
                     return@withPeerLock
                 }
                 runCatching {
-                    val request = call.receive(TrustConfirmRequest::class)
-
                     val pending =
                         when (val lookup = pendingKeyExchangeStore.lookup(appInstanceId)) {
                             is PendingKeyExchangeLookup.Live -> lookup.exchange

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
@@ -264,6 +264,9 @@ class PairingV3IntegrationTest {
             } finally {
                 stalledSocket.close()
             }
+            // Keep the lambda's result Unit: assertNotNull returns its argument, and a
+            // non-Unit expression body makes JUnit 5 silently skip the test method.
+            Unit
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
@@ -223,6 +223,50 @@ class PairingV3IntegrationTest {
         }
 
     @Test
+    fun testStalledTrustBodyDoesNotBlockPairingV3Intent() =
+        runBlocking {
+            val a = createInstance("stall-acceptor")
+            val b = createInstance("stall-initiator")
+            a.start()
+            b.start()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
+
+            // Simulate a peer that died mid-request: a /sync/trust request whose
+            // declared body never arrives. The handler parks in receive(); it must
+            // do so OUTSIDE the per-peer pairing lock, or every later pairing
+            // request from this peer (including v3 /intent) starves behind it.
+            val stalledSocket = java.net.Socket("localhost", a.getPort())
+            stalledSocket.getOutputStream().let { out ->
+                out.write(
+                    (
+                        "POST /sync/trust HTTP/1.1\r\n" +
+                            "Host: localhost\r\n" +
+                            "appInstanceId: ${b.appInstanceId}\r\n" +
+                            "Content-Type: application/json\r\n" +
+                            "Content-Length: 100000\r\n" +
+                            "\r\n"
+                    ).toByteArray(),
+                )
+                out.flush()
+            }
+            // Let the server dispatch the stalled handler into its body read.
+            delay(300)
+
+            try {
+                val started =
+                    kotlinx.coroutines.withTimeoutOrNull(3.seconds) {
+                        startPairing(b, a)
+                    }
+                assertNotNull(
+                    started,
+                    "pairing v3 intent must not be starved by a stalled /sync/trust body read",
+                )
+            } finally {
+                stalledSocket.close()
+            }
+        }
+
+    @Test
     fun testGenerationFailureDuringSessionCreationClearsPin() =
         runBlocking {
             val failingProvider = FailingGenerationPakeProvider(failDuringCreate = true)


### PR DESCRIPTION
Closes #4871

## What

`/sync/trust`, `/sync/trust/v2/exchange`, and `/sync/trust/v2/confirm` now `call.receive(...)` **before** entering `pairingVersionCoordinator.withPeerLock`, matching the order the pairing v3 routes already use (`receivePairingV3OrNull` → `withPeerLock`). Receive failures answer the same error codes as before (`TRUST_FAIL` / `EXCHANGE_FAIL`); the v3-session guard still runs under the lock, so the "legacy trust cannot complete concurrently with v3 session creation" invariant is unchanged.

## Why

`receive()` suspends on client network I/O. A peer that dies mid-request (app restart, or a client 3 s timeout aborting between headers and body) parked the handler **inside the per-peer lock indefinitely**, starving every later pairing request for that peer. In the field this made pairing v3 unusable: `/sync/showPairingCode` (unlocked) succeeded and the acceptor displayed its code, while every `POST /sync/pairing/v3/intent` timed out at exactly +3 s and the initiator showed the "network error" dialog on each retry.

## Tests

- New `PairingV3IntegrationTest.testStalledTrustBodyDoesNotBlockPairingV3Intent`: a raw socket sends a `/sync/trust` request whose declared body never arrives, then a full v3 `startPairing` must still complete. **Verified to fail against the previous routing order** (intent starves behind the stalled handler) and pass with this change.
- Full fast-tier `:app:desktopTest` passes.

https://claude.ai/code/session_019wycxR1g64gXPsgaQeFAaX