### PR TITLE
:bug: use origin.remoteAddress instead of remoteHost in pairing v3 routes to avoid a blocking reverse DNS lookup

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PairingV3Routing.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PairingV3Routing.kt
@@ -53,7 +53,7 @@ fun Routing.pairingV3Routing(
             pairingVersionCoordinator.withPeerLock(appInstanceId) {
                 // origin.remoteAddress, NOT origin.remoteHost: remoteHost triggers a
                 // reverse DNS lookup that stalls ~3.5s on LANs without PTR records,
-                // blowing the initiator's 3s request timeout (#4868).
+                // blowing the initiator's 3s request timeout (#4874).
                 val remoteAddress = runCatching { call.request.origin.remoteAddress }.getOrNull()
                 when (val result = pairingProtocolV3Service.handleIntent(intent, appInstanceId, remoteAddress)) {
                     is PairingV3ServerResult.Ok -> {
@@ -81,7 +81,7 @@ fun Routing.pairingV3Routing(
                         )
                         return@let
                     }
-            // remoteAddress, not remoteHost — see the intent route (#4868).
+            // remoteAddress, not remoteHost — see the intent route (#4874).
             val remoteAddress = runCatching { call.request.origin.remoteAddress }.getOrNull()
             when (val result = pairingProtocolV3Service.handleProof(proof, appInstanceId, remoteAddress)) {
                 is PairingV3ServerResult.Ok -> successResponse(call, result.value)
@@ -104,7 +104,7 @@ fun Routing.pairingV3Routing(
                     }
             when (val result = pairingProtocolV3Service.handleCommit(commit, appInstanceId)) {
                 is PairingV3ServerResult.Ok -> {
-                    // remoteAddress, not remoteHost — see the intent route (#4868).
+                    // remoteAddress, not remoteHost — see the intent route (#4874).
                     val host = runCatching { call.request.origin.remoteAddress }.getOrNull()
                     logger.info { "pairing v3 commit accepted, trusting $appInstanceId" }
                     // Non-discoverable initiators (browser extension) self-register via

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PairingV3Routing.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PairingV3Routing.kt
@@ -51,7 +51,10 @@ fun Routing.pairingV3Routing(
                         return@let
                     }
             pairingVersionCoordinator.withPeerLock(appInstanceId) {
-                val remoteAddress = runCatching { call.request.origin.remoteHost }.getOrNull()
+                // origin.remoteAddress, NOT origin.remoteHost: remoteHost triggers a
+                // reverse DNS lookup that stalls ~3.5s on LANs without PTR records,
+                // blowing the initiator's 3s request timeout (#4868).
+                val remoteAddress = runCatching { call.request.origin.remoteAddress }.getOrNull()
                 when (val result = pairingProtocolV3Service.handleIntent(intent, appInstanceId, remoteAddress)) {
                     is PairingV3ServerResult.Ok -> {
                         // The v3 takeover consumes the peer's v2 pending exchange;
@@ -78,7 +81,8 @@ fun Routing.pairingV3Routing(
                         )
                         return@let
                     }
-            val remoteAddress = runCatching { call.request.origin.remoteHost }.getOrNull()
+            // remoteAddress, not remoteHost — see the intent route (#4868).
+            val remoteAddress = runCatching { call.request.origin.remoteAddress }.getOrNull()
             when (val result = pairingProtocolV3Service.handleProof(proof, appInstanceId, remoteAddress)) {
                 is PairingV3ServerResult.Ok -> successResponse(call, result.value)
                 is PairingV3ServerResult.Refused ->
@@ -100,7 +104,8 @@ fun Routing.pairingV3Routing(
                     }
             when (val result = pairingProtocolV3Service.handleCommit(commit, appInstanceId)) {
                 is PairingV3ServerResult.Ok -> {
-                    val host = runCatching { call.request.origin.remoteHost }.getOrNull()
+                    // remoteAddress, not remoteHost — see the intent route (#4868).
+                    val host = runCatching { call.request.origin.remoteAddress }.getOrNull()
                     logger.info { "pairing v3 commit accepted, trusting $appInstanceId" }
                     // Non-discoverable initiators (browser extension) self-register via
                     // the crosspaste-sync-info header, mirroring the v2 confirm route;


### PR DESCRIPTION
Closes #4874

## Summary

All three pairing v3 routes (`/sync/pairing/v3/intent`, `/proof`, `/commit`) read the caller address via `call.request.origin.remoteHost`, which performs a reverse DNS lookup on the client IP. On LANs without PTR records the Windows resolver blocks ~3.5 s, so the acceptor's response consistently exceeds the initiator's 3 s request timeout and every pairing attempt fails with `HttpRequestTimeoutException`.

This switches the three routes to `origin.remoteAddress` (plain IP, no DNS), matching the existing usage in `WsRouting`.

## Details

- Stage-timing diagnostics on a Windows acceptor pinpointed the stall: peer lock acquired at +0.6 ms, then a 3.47 s gap on the `remoteHost` line; the actual crypto (SPAKE2 session creation + offer signing) took < 3 ms. Total response time was 3.49 s, just past the 3 s client budget.
- The address is consumed by the pairing rate limiter (`ip:<address>` bucket key) and recorded as the trusted peer address on commit; an IP literal is strictly more correct than a possibly reverse-resolved hostname in both places.
- macOS resolvers fail PTR lookups for private addresses quickly, which is why macOS↔macOS and Docker verification never hit this — it only reproduces on a real Windows peer.

## Verification

- Reproduced the stable timeout on a real Windows 
acceptor, then confirmed pairing v3 completes end to end with this fix applied (manual real-device verification, macOS initiator ↔ Windows acceptor).
- `./gradlew ktlintFormat` and desktop compilation pass.