### PR TITLE
:hammer: resolve system dark theme directly in composition via dynamic isSystemInDarkTheme

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/theme/CrossPasteTheme.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/theme/CrossPasteTheme.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -21,42 +20,29 @@ object CrossPasteTheme {
     fun Theme(content: @Composable () -> Unit) {
         val themeDetector = koinInject<ThemeDetector>()
 
-        val isSystemInDark = isSystemInDarkTheme()
+        val themeConfig by themeDetector.themeConfig.collectAsState()
 
-        val themeState by themeDetector.themeState.collectAsState()
+        // Dynamic since Compose Multiplatform 1.12: recomposes when the OS theme
+        // changes, and is already correct on the first frame — so the resolved
+        // theme never needs an async correction step.
+        val isSystemInDark = isSystemInDarkTheme()
 
         val userSelectedFont by rememberUserSelectedFont()
 
-        LaunchedEffect(isSystemInDark) {
-            themeDetector.setSystemInDark(isSystemInDark)
-        }
-
-        // Use Compose-detected isSystemInDark directly to avoid theme flash on startup.
-        // DesktopThemeDetector initializes isSystemInDark to false, and the LaunchedEffect
-        // above corrects it asynchronously — but that causes one frame of wrong theme.
-        val effectiveThemeState =
-            remember(themeState, isSystemInDark) {
-                if (themeState.isSystemInDark != isSystemInDark) {
-                    createThemeState(
-                        themeColor = themeState.themeColor,
-                        isFollowSystem = themeState.isFollowSystem,
-                        isUserInDark = themeState.isUserInDark,
-                        isSystemInDark = isSystemInDark,
-                    )
-                } else {
-                    themeState
-                }
+        val themeState =
+            remember(themeConfig, isSystemInDark) {
+                createThemeState(themeConfig, isSystemInDark)
             }
 
-        val themeExt = ThemeExt.buildThemeExt(effectiveThemeState.isCurrentThemeDark)
+        val themeExt = ThemeExt.buildThemeExt(themeState.isCurrentThemeDark)
 
         CompositionLocalProvider(LocalThemeExtState provides themeExt) {
             MaterialTheme(
-                colorScheme = effectiveThemeState.colorScheme,
+                colorScheme = themeState.colorScheme,
                 typography = MaterialTheme.typography.withCustomFonts(userSelectedFont),
             ) {
                 CompositionLocalProvider(
-                    LocalThemeState provides effectiveThemeState,
+                    LocalThemeState provides themeState,
                 ) {
                     content()
                 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/theme/ThemeDetector.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/theme/ThemeDetector.kt
@@ -5,14 +5,26 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface ThemeDetector {
 
-    val themeState: StateFlow<ThemeState>
-
-    fun setSystemInDark(isSystemInDark: Boolean)
+    val themeConfig: StateFlow<ThemeConfig>
 
     fun setThemeConfig(
         isFollowSystem: Boolean,
         isUserInDark: Boolean = false,
     )
+}
+
+/**
+ * User-controlled theme preferences. The system dark-mode value is intentionally
+ * not part of this state: it is read in composition via `isSystemInDarkTheme()`
+ * (dynamic since Compose Multiplatform 1.12) and resolved against this config.
+ */
+data class ThemeConfig(
+    val themeColor: ThemeColor,
+    val isFollowSystem: Boolean,
+    val isUserInDark: Boolean,
+) {
+
+    fun resolveIsDark(isSystemInDark: Boolean): Boolean = if (isFollowSystem) isSystemInDark else isUserInDark
 }
 
 data class ThemeState(
@@ -45,6 +57,17 @@ data class ThemeState(
                 colorScheme = currentColorScheme,
             )
         }
+
+        fun createThemeState(
+            themeConfig: ThemeConfig,
+            isSystemInDark: Boolean,
+        ): ThemeState =
+            createThemeState(
+                themeColor = themeConfig.themeColor,
+                isFollowSystem = themeConfig.isFollowSystem,
+                isUserInDark = themeConfig.isUserInDark,
+                isSystemInDark = isSystemInDark,
+            )
     }
 
     val isCurrentThemeDark: Boolean

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/SearchWindow.kt
@@ -2,6 +2,7 @@ package com.crosspaste.ui
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -50,7 +51,8 @@ fun SearchWindow(windowIcon: Painter?) {
 
     val searchWindowInfo by appWindowManager.searchWindowInfo.collectAsState()
 
-    val themeState by themeDetector.themeState.collectAsState()
+    val themeConfig by themeDetector.themeConfig.collectAsState()
+    val isDarkTheme = themeConfig.resolveIsDark(isSystemInDarkTheme())
 
     val isMac = remember { platform.isMacos() }
     val isWindowsAndSupportBlurEffect =
@@ -130,12 +132,12 @@ fun SearchWindow(windowIcon: Painter?) {
         if (isMac) {
             MacAcrylicEffect(
                 window = this.window,
-                isDark = themeState.isCurrentThemeDark,
+                isDark = isDarkTheme,
             )
         } else if (isWindowsAndSupportBlurEffect) {
             WindowsBlurEffect(
                 window = this.window,
-                isDark = themeState.isCurrentThemeDark,
+                isDark = isDarkTheme,
             )
         }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/theme/DesktopThemeDetector.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/theme/DesktopThemeDetector.kt
@@ -1,67 +1,25 @@
 package com.crosspaste.ui.theme
 
 import com.crosspaste.config.CommonConfigManager
-import com.crosspaste.ui.theme.ThemeState.Companion.createThemeState
-import com.crosspaste.utils.mainDispatcher
-import com.crosspaste.utils.namedScope
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 class DesktopThemeDetector(
     private val configManager: CommonConfigManager,
-    scope: CoroutineScope = namedScope(mainDispatcher, "DesktopThemeDetector"),
 ) : ThemeDetector {
 
-    private data class ThemeConfig(
-        val isFollowSystem: Boolean,
-        val isUserInDark: Boolean,
-    )
-
-    private val initialThemeColor = CrossPasteColor
-    private val initialFollowSystem = configManager.getCurrentConfig().isFollowSystemTheme
-    private val initialIsDarkTheme = configManager.getCurrentConfig().isDarkTheme
-
-    private val _themeColor = MutableStateFlow(initialThemeColor)
-    private val _themeConfig = MutableStateFlow(ThemeConfig(initialFollowSystem, initialIsDarkTheme))
-
-    // Initial system dark mode is false; the actual value is set shortly after
-    // startup when CrossPasteTheme's LaunchedEffect calls setSystemInDark().
-    private val _isSystemInDark = MutableStateFlow(false)
-
-    override val themeState: StateFlow<ThemeState> =
-        combine(
-            _themeColor,
-            _themeConfig.map { it.isFollowSystem },
-            _themeConfig.map { it.isUserInDark },
-            _isSystemInDark,
-        ) { color, follow, user, system ->
-
-            createThemeState(
-                themeColor = color,
-                isFollowSystem = follow,
-                isUserInDark = user,
-                isSystemInDark = system,
-            )
-        }.stateIn(
-            scope,
-            SharingStarted.Eagerly,
-            initialValue =
-                createThemeState(
-                    themeColor = initialThemeColor,
-                    isFollowSystem = initialFollowSystem,
-                    isUserInDark = initialIsDarkTheme,
-                    isSystemInDark = false,
-                ),
+    private val _themeConfig =
+        MutableStateFlow(
+            ThemeConfig(
+                themeColor = CrossPasteColor,
+                isFollowSystem = configManager.getCurrentConfig().isFollowSystemTheme,
+                isUserInDark = configManager.getCurrentConfig().isDarkTheme,
+            ),
         )
 
-    override fun setSystemInDark(isSystemInDark: Boolean) {
-        _isSystemInDark.value = isSystemInDark
-    }
+    override val themeConfig: StateFlow<ThemeConfig> = _themeConfig.asStateFlow()
 
     override fun setThemeConfig(
         isFollowSystem: Boolean,
@@ -69,7 +27,12 @@ class DesktopThemeDetector(
     ) {
         // Atomic update: both values change in a single emission to avoid
         // an intermediate theme state flash from updating them separately.
-        _themeConfig.value = ThemeConfig(isFollowSystem, isUserInDark)
+        _themeConfig.update {
+            it.copy(
+                isFollowSystem = isFollowSystem,
+                isUserInDark = isUserInDark,
+            )
+        }
 
         configManager.updateConfig(
             listOf("isFollowSystemTheme", "isDarkTheme"),

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/theme/DesktopThemeDetectorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/theme/DesktopThemeDetectorTest.kt
@@ -5,23 +5,16 @@ import com.crosspaste.config.CommonConfigManager
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class DesktopThemeDetectorTest {
 
     private fun createDetector(
         isFollowSystemTheme: Boolean = true,
         isDarkTheme: Boolean = false,
-        testScope: TestScope,
     ): Pair<DesktopThemeDetector, CommonConfigManager> {
         val appConfig = mockk<AppConfig>()
         every { appConfig.isFollowSystemTheme } returns isFollowSystemTheme
@@ -31,130 +24,111 @@ class DesktopThemeDetectorTest {
         every { configManager.getCurrentConfig() } returns appConfig
         every { configManager.updateConfig(any<List<String>>(), any<List<Any>>()) } returns Unit
 
-        // Use backgroundScope so the Eagerly-started combine coroutine gets cancelled
-        // automatically when the test finishes, preventing UncompletedCoroutinesError.
-        val detector = DesktopThemeDetector(configManager, testScope.backgroundScope)
+        val detector = DesktopThemeDetector(configManager)
         return detector to configManager
     }
 
     @Test
-    fun `initial state follows config values`() =
-        runTest(UnconfinedTestDispatcher()) {
-            val (detector, _) =
-                createDetector(
-                    isFollowSystemTheme = false,
-                    isDarkTheme = true,
-                    testScope = this,
-                )
-            advanceUntilIdle()
+    fun `initial config follows persisted values`() {
+        val (detector, _) =
+            createDetector(
+                isFollowSystemTheme = false,
+                isDarkTheme = true,
+            )
 
-            val state = detector.themeState.value
-            assertFalse(state.isFollowSystem)
-            assertTrue(state.isUserInDark)
-            // Since followSystem=false and userInDark=true → dark theme
-            assertTrue(state.isCurrentThemeDark)
-            assertEquals(CrossPasteColor.darkColorScheme, state.colorScheme)
-        }
+        val config = detector.themeConfig.value
+        assertFalse(config.isFollowSystem)
+        assertTrue(config.isUserInDark)
+        assertEquals(CrossPasteColor, config.themeColor)
+    }
 
     @Test
-    fun `setSystemInDark updates theme when following system`() =
-        runTest(UnconfinedTestDispatcher()) {
-            val (detector, _) =
-                createDetector(
-                    isFollowSystemTheme = true,
-                    isDarkTheme = false,
-                    testScope = this,
-                )
-            advanceUntilIdle()
+    fun `resolveIsDark uses system value when following system`() {
+        val (detector, _) =
+            createDetector(
+                isFollowSystemTheme = true,
+                isDarkTheme = false,
+            )
 
-            // Initially system dark is false
-            assertFalse(detector.themeState.value.isCurrentThemeDark)
-
-            // System switches to dark
-            detector.setSystemInDark(true)
-            advanceUntilIdle()
-
-            assertTrue(detector.themeState.value.isCurrentThemeDark)
-            assertEquals(CrossPasteColor.darkColorScheme, detector.themeState.value.colorScheme)
-        }
+        val config = detector.themeConfig.value
+        assertFalse(config.resolveIsDark(isSystemInDark = false))
+        assertTrue(config.resolveIsDark(isSystemInDark = true))
+    }
 
     @Test
-    fun `setSystemInDark has no effect when not following system`() =
-        runTest(UnconfinedTestDispatcher()) {
-            val (detector, _) =
-                createDetector(
-                    isFollowSystemTheme = false,
-                    isDarkTheme = false,
-                    testScope = this,
-                )
-            advanceUntilIdle()
+    fun `resolveIsDark ignores system value when not following system`() {
+        val (detector, _) =
+            createDetector(
+                isFollowSystemTheme = false,
+                isDarkTheme = false,
+            )
 
-            detector.setSystemInDark(true)
-            advanceUntilIdle()
-
-            // Still light because user preference is false and not following system
-            assertFalse(detector.themeState.value.isCurrentThemeDark)
-        }
+        val config = detector.themeConfig.value
+        assertFalse(config.resolveIsDark(isSystemInDark = true))
+    }
 
     @Test
-    fun `setThemeConfig persists to config manager`() =
-        runTest(UnconfinedTestDispatcher()) {
-            val (detector, configManager) =
-                createDetector(testScope = this)
-            advanceUntilIdle()
+    fun `setThemeConfig persists to config manager`() {
+        val (detector, configManager) = createDetector()
 
-            detector.setThemeConfig(isFollowSystem = false, isUserInDark = true)
+        detector.setThemeConfig(isFollowSystem = false, isUserInDark = true)
 
-            verify {
-                configManager.updateConfig(
-                    listOf("isFollowSystemTheme", "isDarkTheme"),
-                    listOf(false, true),
-                )
-            }
+        verify {
+            configManager.updateConfig(
+                listOf("isFollowSystemTheme", "isDarkTheme"),
+                listOf(false, true),
+            )
         }
+    }
 
     @Test
-    fun `setThemeConfig updates theme state atomically`() =
-        runTest(UnconfinedTestDispatcher()) {
-            val (detector, _) =
-                createDetector(
-                    isFollowSystemTheme = true,
-                    isDarkTheme = false,
-                    testScope = this,
-                )
-            advanceUntilIdle()
+    fun `setThemeConfig updates config atomically`() {
+        val (detector, _) =
+            createDetector(
+                isFollowSystemTheme = true,
+                isDarkTheme = false,
+            )
 
-            // Switch from follow-system to manual dark mode
-            detector.setThemeConfig(isFollowSystem = false, isUserInDark = true)
-            advanceUntilIdle()
+        detector.setThemeConfig(isFollowSystem = false, isUserInDark = true)
 
-            val state = detector.themeState.value
-            assertFalse(state.isFollowSystem)
-            assertTrue(state.isUserInDark)
-            assertTrue(state.isCurrentThemeDark)
-        }
+        val config = detector.themeConfig.value
+        assertFalse(config.isFollowSystem)
+        assertTrue(config.isUserInDark)
+        assertTrue(config.resolveIsDark(isSystemInDark = false))
+    }
 
     @Test
-    fun `switching from follow-system to manual preserves correct theme`() =
-        runTest(UnconfinedTestDispatcher()) {
-            val (detector, _) =
-                createDetector(
-                    isFollowSystemTheme = true,
-                    isDarkTheme = false,
-                    testScope = this,
-                )
-            advanceUntilIdle()
+    fun `switching from follow-system to manual preserves correct theme`() {
+        val (detector, _) =
+            createDetector(
+                isFollowSystemTheme = true,
+                isDarkTheme = false,
+            )
 
-            // System is in dark mode
-            detector.setSystemInDark(true)
-            advanceUntilIdle()
-            assertTrue(detector.themeState.value.isCurrentThemeDark)
+        // Following system while system is dark → dark
+        assertTrue(detector.themeConfig.value.resolveIsDark(isSystemInDark = true))
 
-            // Switch to manual light mode - should become light despite system being dark
-            detector.setThemeConfig(isFollowSystem = false, isUserInDark = false)
-            advanceUntilIdle()
+        // Switch to manual light mode - should be light despite system being dark
+        detector.setThemeConfig(isFollowSystem = false, isUserInDark = false)
+        assertFalse(detector.themeConfig.value.resolveIsDark(isSystemInDark = true))
+    }
 
-            assertFalse(detector.themeState.value.isCurrentThemeDark)
-            assertEquals(CrossPasteColor.lightColorScheme, detector.themeState.value.colorScheme)
-        }
+    @Test
+    fun `createThemeState resolves color scheme from config and system value`() {
+        val (detector, _) =
+            createDetector(
+                isFollowSystemTheme = true,
+                isDarkTheme = false,
+            )
+
+        val config = detector.themeConfig.value
+
+        val darkState = ThemeState.createThemeState(config, isSystemInDark = true)
+        assertTrue(darkState.isCurrentThemeDark)
+        assertEquals(CrossPasteColor.darkColorScheme, darkState.colorScheme)
+
+        val lightState = ThemeState.createThemeState(config, isSystemInDark = false)
+        assertFalse(lightState.isCurrentThemeDark)
+        assertEquals(CrossPasteColor.lightColorScheme, lightState.colorScheme)
+    }
 }


### PR DESCRIPTION
## Summary

Since Compose Multiplatform 1.12.0 (#4885), `isSystemInDarkTheme()` on desktop is dynamic: it recomposes when the OS theme changes and is already correct on the first frame. This makes the old bridge — `LaunchedEffect` pushing the Compose-detected value into `DesktopThemeDetector`, plus the `effectiveThemeState` override that papered over the one-frame flash from the detector's `false` initial value — unnecessary. This PR removes that machinery and makes composition the single source of truth for system dark mode.

## Changes

- **`ThemeDetector`** now exposes only user-controlled preferences as `themeConfig: StateFlow<ThemeConfig>` (theme color, follow-system flag, manual dark flag). `setSystemInDark()` is removed; `ThemeConfig.resolveIsDark(isSystemInDark)` resolves the effective mode against a system value read in composition.
- **`DesktopThemeDetector`** shrinks to a single `MutableStateFlow` plus config persistence — no coroutine scope, no 4-way `combine`, no eager `stateIn`.
- **`CrossPasteTheme.Theme`** builds `ThemeState` directly from `themeConfig` + `isSystemInDarkTheme()` in a `remember`. The `LaunchedEffect` and the flash-workaround override are gone; the resolved theme is consistent with the OS from the very first frame by construction.
- **`SearchWindow`** (the only raw-flow consumer outside the theme wrapper, feeding `isDark` to the Mac acrylic / Windows blur effects) now resolves the same way; the native blur appearance keeps following live OS theme changes.
- **`ThemeState` / `createThemeState`** keep their shape (a `(ThemeConfig, Boolean)` overload was added), so all `LocalThemeState` consumers are untouched.
- Tests rewritten for the synchronous detector — no `TestScope`/`advanceUntilIdle` needed anymore.

Net: −52 lines, one less state-synchronization path, and the documented startup theme-flash workaround becomes structurally impossible rather than patched over.

## Mobile follow-up

`ThemeDetector`/`ThemeConfig` and `CrossPasteTheme` live in `commonMain`; mobile's `ThemeDetector` implementation needs the same reshaping when this is synced (Android/iOS `isSystemInDarkTheme()` has always been dynamic, so the same pattern applies directly).

## Verification

- `./gradlew ktlintFormat` — clean
- `./gradlew app:desktopTest` — green
- Runtime smoke via `./gradlew app:run`: full startup, no exceptions