### PR TITLE
:sparkles: let clicks outside the font dropdown pass through instead of being swallowed

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/FontSettingItemView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/settings/FontSettingItemView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -53,6 +54,7 @@ import com.crosspaste.ui.theme.AppUISize.tiny3X
 import com.crosspaste.ui.theme.AppUISize.xxLarge
 import org.koin.compose.koinInject
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun FontSettingItemView() {
     val fontManager = koinInject<FontManager>()
@@ -89,7 +91,13 @@ fun FontSettingItemView() {
                         Popup(
                             alignment = Alignment.TopEnd,
                             onDismissRequest = { expanded = false },
-                            properties = PopupProperties(focusable = true),
+                            properties =
+                                PopupProperties(
+                                    focusable = true,
+                                    // A click outside both dismisses the dropdown and reaches its
+                                    // target, instead of being swallowed by the focusable popup.
+                                    consumePointerInputOutside = false,
+                                ),
                         ) {
                             Surface(
                                 shape = RoundedCornerShape(tiny3X),


### PR DESCRIPTION
## Summary

Adopts the `PopupProperties.consumePointerInputOutside` flag introduced in Compose Multiplatform 1.12.0 (release notes call it `blockPointerInputOutside`; the shipped API name is `consumePointerInputOutside`, marked `@ExperimentalComposeUiApi`).

The font dropdown in settings is a focusable popup, so a click outside it was swallowed: closing the dropdown and then interacting with another setting required two clicks. With `consumePointerInputOutside = false`, a single outside click both dismisses the dropdown and reaches its target.

Deliberately NOT applied to the other focusable popup (the paste-type filter dropdown in the search window, `SearchTrailingIcon`): there the area outside the popup is the paste list, and letting the dismissing click through could accidentally trigger a paste — swallowing the first click is the safe behavior. The in-tree context menu popup is non-focusable and never blocked outside clicks, so it needs no change.

## Verification

- `./gradlew ktlintFormat` — clean
- `./gradlew app:compileKotlinDesktop` + `app:desktopTest` — green