### PR TITLE
:arrow_up: Bump gradle-wrapper from 9.7.0 to 9.7.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Closes #4888

Upgrades the Gradle wrapper distribution from 9.7.0 to 9.7.1, a patch release fixing several 9.7.0 regressions (`BaseExecSpec` streams API conformance, test-failure diff formatting, ANTLR leaking into the kapt classpath, a breaking change to `Transformer` implementations, and Ant `taskdef` classpath isolation).

Release notes: https://docs.gradle.org/9.7.1/release-notes.html

Verified locally: `./gradlew --version` resolves and runs on 9.7.1.