### PR TITLE
:bug: drain sessions in WsSessionManager.closeAll to fix concurrent iteration flake

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ws/WsSessionManager.kt
@@ -80,7 +80,10 @@ class WsSessionManager {
     }
 
     suspend fun closeAll() {
-        sessions.keys.toList().forEach { appInstanceId ->
+        // Drain instead of snapshot-then-iterate: toList() races with concurrent
+        // session registration/removal (NoSuchElementException, see #4884).
+        while (true) {
+            val appInstanceId = sessions.keys.firstOrNull() ?: break
             sessions.remove(appInstanceId)?.let { session ->
                 runCatching { session.close("App shutting down") }
                     .onFailure { e -> logger.warn(e) { "Error closing WS session for $appInstanceId" } }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/ws/WsSessionManagerTest.kt
@@ -185,6 +185,29 @@ class WsSessionManagerTest {
         }
 
     @Test
+    fun closeAll_closesAndUnregistersAllSessions() =
+        runTest {
+            val mgr = WsSessionManager()
+            val innerA: WebSocketSession =
+                mockk(relaxed = true) {
+                    every { coroutineContext } returns Job()
+                }
+            val innerB: WebSocketSession =
+                mockk(relaxed = true) {
+                    every { coroutineContext } returns Job()
+                }
+            mgr.registerSession("A", WsSession(innerA, "remote"))
+            mgr.registerSession("B", WsSession(innerB, "remote"))
+
+            mgr.closeAll()
+
+            assertFalse(mgr.isConnected("A"))
+            assertFalse(mgr.isConnected("B"))
+            coVerify(exactly = 1) { innerA.send(any<Frame.Close>()) }
+            coVerify(exactly = 1) { innerB.send(any<Frame.Close>()) }
+        }
+
+    @Test
     fun sendWithPayloadLimits_legacySessionRejectsAboveSingleFrameLimit() =
         runTest {
             val mgr = WsSessionManager()


### PR DESCRIPTION
Fixes #4884

## Problem

`WsSessionManager.closeAll()` did `sessions.keys.toList()` and iterated the snapshot. Kotlin's `toList()` takes a fast path for `size == 1` that calls `iterator().next()` without a `hasNext()` guard, so if the sole session is concurrently removed (e.g. by the auth handshake finishing during test teardown) between the size check and the iterator creation, `next()` throws `NoSuchElementException`. This surfaced as a 1-in-1729 flake in `WsAuthenticationIntegrationTest` during the 2.2.0.2525 release build.

## Fix

Replace snapshot-then-iterate with a drain loop: repeatedly take `sessions.keys.firstOrNull()` and `remove()` it until the map is empty. Removal drives the loop, so a concurrently added/removed key can never desync an iterator — `firstOrNull()` guards with `hasNext()` and ConcurrentHashMap iterators pre-fetch, so it either returns a captured key or null. Sessions registered mid-shutdown also get closed instead of being skipped by a stale snapshot.

## Testing

- Added `closeAll_closesAndUnregistersAllSessions` to `WsSessionManagerTest` (fast tier)
- `./gradlew app:desktopTest --tests "com.crosspaste.net.ws.WsSessionManagerTest"` — all pass
- `./gradlew app:desktopTest -PintegrationTests --tests "com.crosspaste.net.ws.WsAuthenticationIntegrationTest"` — all pass