### PR TITLE
:sparkles: surface v3 PINs via crosspaste token with acceptance-window arming

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliApi.kt
@@ -190,16 +190,55 @@ data class CliPairRequestDto(
     val appInstanceId: String,
     /** Best-effort display name; null when the peer is not known locally. */
     val deviceName: String?,
-    /** The 6-digit SAS of THIS peer's key exchange, zero-padded. */
+    /**
+     * The 6-digit pairing code for THIS request: a v2 SAS (zero-padded) or a
+     * v3 PIN, per [credentialType].
+     */
     val token: String,
+    /**
+     * [CliPairCredential.V2_SAS] or [CliPairCredential.V3_PIN]. Defaults keep
+     * both directions of version skew safe: an older CLI ignores the field, an
+     * older app omits it and the newer CLI assumes v2.
+     */
+    val credentialType: String = CliPairCredential.V2_SAS,
+    /** v3 only: epoch millis when the current PIN generation expires. */
+    val pinExpiresAt: Long? = null,
+    /** v3 only: the rotation generation the PIN belongs to. */
+    val tokenGeneration: Long? = null,
 )
+
+object CliPairCredential {
+    const val V2_SAS = "v2-sas"
+    const val V3_PIN = "v3-pin"
+}
+
+/** How a GET /cli/pair/token request asks to arm the v3 acceptance window. */
+enum class CliTokenArm {
+    /** First fetch of a CLI invocation: opens the window, resets the guess budget. */
+    START,
+
+    /** Poll of the same invocation: extends an open window, never resets the budget. */
+    RENEW,
+    ;
+
+    companion object {
+        /** Parses the `arm` query parameter; null for absent or unknown values. */
+        fun fromQuery(value: String?): CliTokenArm? =
+            when (value) {
+                "start" -> START
+                "renew" -> RENEW
+                else -> null
+            }
+    }
+}
 
 @Serializable
 data class CliPairTokenDto(
     /**
-     * One entry per pending v2 key exchange, each carrying its own code —
-     * never a single global token, which under concurrent pairings could
-     * pair one requester's name with another requester's code.
+     * One entry per pending v2 key exchange and per active v3 acceptor session
+     * showing a PIN, each carrying its own code — never a single global token,
+     * which under concurrent pairings could pair one requester's name with
+     * another requester's code.
      */
     val requests: List<CliPairRequestDto>,
 )

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliPairingService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliPairingService.kt
@@ -6,6 +6,8 @@ import com.crosspaste.db.sync.SyncState
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.pairing.v3.PairingCapabilityFlag
+import com.crosspaste.pairing.v3.PairingSessionState
+import com.crosspaste.pairing.v3.PakeRole
 import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.PairingCredentialRefreshResult
 import com.crosspaste.sync.PairingCredentialType
@@ -161,10 +163,58 @@ class CliPairingService(
                             appInstanceId = appInstanceId,
                             deviceName = resolveDeviceName(appInstanceId),
                             token = exchange.sas.toString().padStart(6, '0'),
+                            credentialType = CliPairCredential.V2_SAS,
                         )
                     }
-                },
+                } + v3AcceptorRequests(),
         )
+
+    /**
+     * Active v3 acceptor sessions currently showing a PIN — the same predicate
+     * the on-screen token cards use. Exposing the PIN over the same-user local
+     * CLI socket is the headless equivalent of rendering it on screen: the
+     * socket is unreachable from the network and from other users, and every
+     * server-side defence (acceptance window, rotation, guess budget) is
+     * unchanged.
+     */
+    private fun v3AcceptorRequests(): List<CliPairRequestDto> =
+        pairingV3UiController.sessions.value.mapNotNull { session ->
+            val pin = session.pin
+            if (session.role != PakeRole.ACCEPTOR ||
+                session.state != PairingSessionState.PIN_AVAILABLE ||
+                pin == null
+            ) {
+                return@mapNotNull null
+            }
+            CliPairRequestDto(
+                appInstanceId = session.peerAppInstanceId,
+                deviceName =
+                    session.peerDisplayName.takeIf { it.isNotBlank() }
+                        ?: resolveDeviceName(session.peerAppInstanceId),
+                token = pin,
+                credentialType = CliPairCredential.V3_PIN,
+                pinExpiresAt = session.pinExpiresAt,
+                tokenGeneration = session.tokenGeneration,
+            )
+        }
+
+    /**
+     * Arms the v3 acceptance window on behalf of `crosspaste token --wait`.
+     *
+     * [CliTokenArm.START] is the first fetch of a CLI invocation — a genuine
+     * local gesture (the operator ran a command on this machine), equivalent to
+     * entering the Add Device screen: it opens the window and resets the
+     * proof-failure budget / clears a lock. [CliTokenArm.RENEW] is the poll
+     * loop of the SAME invocation and only extends an open window, so a
+     * long-running `--wait` cannot silently refill an attacker's guess budget
+     * (mirrors the UI renewal loop).
+     */
+    fun armAcceptanceWindow(arm: CliTokenArm) {
+        when (arm) {
+            CliTokenArm.START -> pairingV3UiController.openAcceptanceWindow()
+            CliTokenArm.RENEW -> pairingV3UiController.renewAcceptanceWindow()
+        }
+    }
 
     private fun resolveDeviceName(appInstanceId: String): String? =
         nearbyDeviceManager.nearbySyncInfos.value

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliRouting.kt
@@ -201,6 +201,12 @@ fun Routing.cliRouting(
             }
 
             get("/token") {
+                // `?arm=start|renew` lets `crosspaste token --wait` open/extend the
+                // v3 acceptance window (see CliPairingService.armAcceptanceWindow);
+                // a plain GET stays a pure read.
+                CliTokenArm.fromQuery(call.request.queryParameters["arm"])?.let { arm ->
+                    cliPairingService.armAcceptanceWindow(arm)
+                }
                 call.respond(cliPairingService.pairingToken())
             }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliDtoContractTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliDtoContractTest.kt
@@ -271,7 +271,7 @@ class CliDtoContractTest {
             )
         assertEquals(setOf("requests"), fieldsOf(tokenEncoded))
         assertEquals(
-            setOf("appInstanceId", "deviceName", "token"),
+            setOf("appInstanceId", "deviceName", "token", "credentialType", "pinExpiresAt", "tokenGeneration"),
             fieldsOf(
                 json.encodeToString(
                     CliPairRequestDto.serializer(),

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliPairingServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliPairingServiceTest.kt
@@ -9,6 +9,9 @@ import com.crosspaste.dto.sync.EndpointInfo
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.net.PasteBonjourService
 import com.crosspaste.pairing.v3.PairingCapabilityFlag
+import com.crosspaste.pairing.v3.PairingSessionState
+import com.crosspaste.pairing.v3.PairingSessionUiState
+import com.crosspaste.pairing.v3.PakeRole
 import com.crosspaste.platform.Platform
 import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.sync.PairingCredentialRefreshResult
@@ -73,7 +76,11 @@ class CliPairingServiceTest {
                 every { nearbySyncInfos } returns this@Fixture.nearbySyncInfos
                 every { searching } returns this@Fixture.searching
             }
-        val pairingV3UiController = mockk<PairingV3UiController>()
+        val v3Sessions = MutableStateFlow<List<PairingSessionUiState>>(listOf())
+        val pairingV3UiController =
+            mockk<PairingV3UiController> {
+                every { sessions } returns v3Sessions
+            }
         val pasteBonjourService =
             mockk<PasteBonjourService> {
                 every { refreshAll() } just Runs
@@ -211,6 +218,110 @@ class CliPairingServiceTest {
         val dto = fixture.service.pairingToken()
 
         assertEquals(PEER_NAME, dto.requests.single().deviceName)
+    }
+
+    private fun v3Session(
+        peerAppInstanceId: String = PEER_ID,
+        role: PakeRole = PakeRole.ACCEPTOR,
+        state: PairingSessionState = PairingSessionState.PIN_AVAILABLE,
+        pin: String? = "654321",
+        peerDisplayName: String = PEER_NAME,
+    ): PairingSessionUiState =
+        PairingSessionUiState(
+            sessionId = "session-$peerAppInstanceId",
+            role = role,
+            peerDisplayName = peerDisplayName,
+            peerAppInstanceId = peerAppInstanceId,
+            peerKeyFingerprintDisplay = "abcd1234",
+            pin = pin,
+            pinExpiresAt = 1_000L,
+            tokenGeneration = 3L,
+            state = state,
+            createdAt = 0L,
+        )
+
+    @Test
+    fun `pairingToken includes v3 acceptor sessions showing a PIN`() {
+        val fixture = Fixture()
+        fixture.v3Sessions.value = listOf(v3Session())
+
+        val request =
+            fixture.service
+                .pairingToken()
+                .requests
+                .single()
+
+        assertEquals(PEER_ID, request.appInstanceId)
+        assertEquals(PEER_NAME, request.deviceName)
+        assertEquals("654321", request.token)
+        assertEquals(CliPairCredential.V3_PIN, request.credentialType)
+        assertEquals(1_000L, request.pinExpiresAt)
+        assertEquals(3L, request.tokenGeneration)
+    }
+
+    @Test
+    fun `pairingToken merges v2 exchanges with v3 sessions`() {
+        val fixture = Fixture()
+        fixture.pendingVerifiersFlow.value = setOf("v2-peer")
+        fixture.storeExchange("v2-peer", sas = 42420)
+        fixture.v3Sessions.value = listOf(v3Session())
+
+        val requests =
+            fixture.service
+                .pairingToken()
+                .requests
+                .associateBy { it.appInstanceId }
+
+        assertEquals(setOf("v2-peer", PEER_ID), requests.keys)
+        assertEquals(CliPairCredential.V2_SAS, requests.getValue("v2-peer").credentialType)
+        assertEquals(CliPairCredential.V3_PIN, requests.getValue(PEER_ID).credentialType)
+    }
+
+    @Test
+    fun `pairingToken excludes v3 sessions without a visible PIN`() {
+        val fixture = Fixture()
+        fixture.v3Sessions.value =
+            listOf(
+                v3Session(peerAppInstanceId = "initiator-role", role = PakeRole.INITIATOR),
+                v3Session(peerAppInstanceId = "negotiating", state = PairingSessionState.PAKE_NEGOTIATING),
+                v3Session(peerAppInstanceId = "no-pin", pin = null),
+            )
+
+        assertTrue(
+            fixture.service
+                .pairingToken()
+                .requests
+                .isEmpty(),
+        )
+    }
+
+    @Test
+    fun `pairingToken falls back to the runtime display name for a blank v3 peer name`() {
+        val fixture = Fixture()
+        fixture.runtimeInfos.value = listOf(runtimeInfo(SyncState.UNVERIFIED))
+        fixture.v3Sessions.value = listOf(v3Session(peerDisplayName = ""))
+
+        assertEquals(
+            PEER_NAME,
+            fixture.service
+                .pairingToken()
+                .requests
+                .single()
+                .deviceName,
+        )
+    }
+
+    @Test
+    fun `armAcceptanceWindow maps START to open and RENEW to renew`() {
+        val fixture = Fixture()
+        every { fixture.pairingV3UiController.openAcceptanceWindow() } just Runs
+        every { fixture.pairingV3UiController.renewAcceptanceWindow() } just Runs
+
+        fixture.service.armAcceptanceWindow(CliTokenArm.START)
+        fixture.service.armAcceptanceWindow(CliTokenArm.RENEW)
+
+        verify(exactly = 1) { fixture.pairingV3UiController.openAcceptanceWindow() }
+        verify(exactly = 1) { fixture.pairingV3UiController.renewAcceptanceWindow() }
     }
 
     // endregion

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliRoutingTest.kt
@@ -954,6 +954,24 @@ class CliRoutingTest {
     }
 
     @Test
+    fun `pair token arms the acceptance window only for known arm values`() {
+        val fixture = Fixture()
+        every { fixture.cliPairingService.pairingToken() } returns CliPairTokenDto(requests = listOf())
+        every { fixture.cliPairingService.armAcceptanceWindow(any()) } just Runs
+
+        withCliRouting(fixture) {
+            assertEquals(HttpStatusCode.OK, client.get("/cli/pair/token?arm=start").status)
+            assertEquals(HttpStatusCode.OK, client.get("/cli/pair/token?arm=renew").status)
+            assertEquals(HttpStatusCode.OK, client.get("/cli/pair/token").status)
+            assertEquals(HttpStatusCode.OK, client.get("/cli/pair/token?arm=bogus").status)
+
+            verify(exactly = 1) { fixture.cliPairingService.armAcceptanceWindow(CliTokenArm.START) }
+            verify(exactly = 1) { fixture.cliPairingService.armAcceptanceWindow(CliTokenArm.RENEW) }
+            verify(exactly = 2) { fixture.cliPairingService.armAcceptanceWindow(any()) }
+        }
+    }
+
+    @Test
     fun `pair nearby forwards the refresh flag and returns the device list`() {
         val fixture = Fixture()
         val device =

--- a/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/TokenCommand.kt
+++ b/cli/src/cliNativeMain/kotlin/com/crosspaste/cli/commands/TokenCommand.kt
@@ -26,12 +26,35 @@ internal data class PairRequestSummary(
     val appInstanceId: String,
     val deviceName: String? = null,
     val token: String = "",
+    // "v2-sas" or "v3-pin"; an older app omits it, which means v2.
+    val credentialType: String = CREDENTIAL_V2_SAS,
+    // v3 only: epoch millis when the current PIN generation expires.
+    val pinExpiresAt: Long? = null,
+    // v3 only: the rotation generation the PIN belongs to.
+    val tokenGeneration: Long? = null,
 )
 
 @Serializable
 internal data class PairTokenSnapshot(
     val requests: List<PairRequestSummary> = listOf(),
 )
+
+internal const val CREDENTIAL_V2_SAS = "v2-sas"
+internal const val CREDENTIAL_V3_PIN = "v3-pin"
+
+/** Which acceptance-window arming a token fetch carries (the `arm` query param). */
+internal enum class TokenFetchArm(
+    val query: String?,
+) {
+    /** Plain read: no arming (one-shot `token` without --wait). */
+    NONE(null),
+
+    /** First fetch of a --wait invocation: opens the v3 acceptance window. */
+    START("start"),
+
+    /** Subsequent --wait polls: extends the window without resetting budgets. */
+    RENEW("renew"),
+}
 
 /** How the terminal-facing token flow reports back; injectable for tests. */
 internal class TokenIo(
@@ -48,10 +71,17 @@ internal val TOKEN_POLL_INTERVAL = 500.milliseconds
  * the daemon log). Codes go to stdout alone — `CODE=$(crosspaste token)`
  * works — and all context lines go to stderr.
  *
- * Each request carries its own code (the SAS of that peer's key exchange), so
- * concurrent pairings can never caption one device's name with another's
- * code. A SAS is deterministic for a given device pair, so print-once-and-exit
- * is the whole contract; there is nothing to live-update.
+ * Each request carries its own code (the SAS of that peer's key exchange or
+ * the current v3 PIN of that peer's session), so concurrent pairings can never
+ * caption one device's name with another's code. Print-once-and-exit stays the
+ * contract for both: a SAS is deterministic for a given device pair, and a v3
+ * PIN is read live per invocation — it rotates every 30 seconds, so rerun (or
+ * poll with --json) for the current code.
+ *
+ * `--wait` additionally arms the v3 acceptance window while it runs: invoking
+ * the command is a local operator gesture, the headless equivalent of opening
+ * the Add Device screen. Without it a headless acceptor refuses v3 intents
+ * (PAIRING_DISABLED).
  */
 internal class TokenCommand : CliktCommand(name = "token") {
 
@@ -61,7 +91,9 @@ internal class TokenCommand : CliktCommand(name = "token") {
 
     private val wait by option(
         "--wait",
-        help = "Wait for a pairing request to arrive instead of failing when there is none",
+        help =
+            "Wait for a pairing request to arrive instead of failing when there is none, " +
+                "and accept v3 pairing while waiting",
     ).flag()
 
     private val timeout by option(
@@ -82,7 +114,10 @@ internal class TokenCommand : CliktCommand(name = "token") {
                     deadline = deadline,
                     json = ctx.json,
                     io = TokenIo(stdout = { echo(it) }, stderr = { echo(it, err = true) }),
-                    fetch = { client.getBody("/cli/pair/token", PairTokenSnapshot.serializer()) },
+                    fetch = { arm ->
+                        val query = arm.query?.let { "?arm=$it" } ?: ""
+                        client.getBody("/cli/pair/token$query", PairTokenSnapshot.serializer())
+                    },
                 )
             if (exitCode != 0) {
                 throw ProgramResult(exitCode)
@@ -104,7 +139,7 @@ internal suspend fun executeToken(
     io: TokenIo,
     pollInterval: Duration = TOKEN_POLL_INTERVAL,
     sleep: suspend (Duration) -> Unit = { delay(it) },
-    fetch: suspend () -> PairTokenSnapshot,
+    fetch: suspend (TokenFetchArm) -> PairTokenSnapshot,
 ): Int =
     try {
         executeTokenInner(wait, timeoutSeconds, deadline, json, io, pollInterval, sleep, fetch)
@@ -125,7 +160,7 @@ private suspend fun executeTokenInner(
     io: TokenIo,
     pollInterval: Duration,
     sleep: suspend (Duration) -> Unit,
-    fetch: suspend () -> PairTokenSnapshot,
+    fetch: suspend (TokenFetchArm) -> PairTokenSnapshot,
 ): Int {
     // With --wait the FIRST fetch already counts against the wall-clock
     // budget: it can block for its own HTTP timeout, and a runCli retry can
@@ -133,15 +168,19 @@ private suspend fun executeTokenInner(
     // budget must hold (a late active answer past the deadline is discarded,
     // not reported as success). Without --wait there is no time contract and
     // the single fetch runs unbounded as before.
+    //
+    // Arming follows the invocation shape: the first --wait fetch is the
+    // operator's gesture (opens the v3 acceptance window), the poll loop only
+    // renews it, and a plain read never arms.
     var snapshot =
         if (wait) {
-            fetchWithinDeadline(deadline, fetch) ?: PairTokenSnapshot()
+            fetchWithinDeadline(deadline) { fetch(TokenFetchArm.START) } ?: PairTokenSnapshot()
         } else {
-            fetch()
+            fetch(TokenFetchArm.NONE)
         }
     if (wait && snapshot.requests.isEmpty() && deadline.hasNotPassedNow()) {
         io.stderr("Waiting for a pairing request... (Ctrl-C to stop)")
-        awaitPairingRequests(deadline, pollInterval, sleep, fetch)?.let { snapshot = it }
+        awaitPairingRequests(deadline, pollInterval, sleep) { fetch(TokenFetchArm.RENEW) }?.let { snapshot = it }
     }
     // A timed-out --wait falls through with the empty snapshot, so the JSON
     // contract is uniform: stdout always carries one snapshot and the exit
@@ -165,6 +204,9 @@ private suspend fun executeTokenInner(
             "Enter each code on its initiating device."
         },
     )
+    if (snapshot.requests.any { it.credentialType == CREDENTIAL_V3_PIN }) {
+        io.stderr("Codes rotate every 30 seconds; rerun token for the current code.")
+    }
     return 0
 }
 

--- a/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/TokenCommandTest.kt
+++ b/cli/src/cliNativeTest/kotlin/com/crosspaste/cli/commands/TokenCommandTest.kt
@@ -291,6 +291,123 @@ class TokenCommandTest {
         }
 
     @Test
+    fun waitArmsStartOnTheFirstFetchAndRenewOnPolls() =
+        runTest {
+            val timeSource = TestTimeSource()
+            val recording = RecordingIo()
+            val arms = mutableListOf<TokenFetchArm>()
+            executeToken(
+                wait = true,
+                timeoutSeconds = 600,
+                deadline = timeSource.markNow() + 600.seconds,
+                json = false,
+                io = recording.io,
+                pollInterval = 500.milliseconds,
+                sleep = { timeSource += it },
+            ) { arm ->
+                arms.add(arm)
+                if (arms.size >= 3) PairTokenSnapshot(listOf(request())) else PairTokenSnapshot()
+            }
+            assertEquals(
+                listOf(TokenFetchArm.START, TokenFetchArm.RENEW, TokenFetchArm.RENEW),
+                arms,
+            )
+        }
+
+    @Test
+    fun plainReadNeverArms() =
+        runTest {
+            val recording = RecordingIo()
+            val arms = mutableListOf<TokenFetchArm>()
+            executeToken(
+                wait = false,
+                timeoutSeconds = 600,
+                deadline = farDeadline(),
+                json = false,
+                io = recording.io,
+            ) { arm ->
+                arms.add(arm)
+                PairTokenSnapshot(listOf(request()))
+            }
+            assertEquals(listOf(TokenFetchArm.NONE), arms)
+        }
+
+    @Test
+    fun v3PinPrintsTheCodeWithARotationHint() =
+        runTest {
+            val recording = RecordingIo()
+            val exit =
+                executeToken(
+                    wait = false,
+                    timeoutSeconds = 600,
+                    deadline = farDeadline(),
+                    json = false,
+                    io = recording.io,
+                ) {
+                    PairTokenSnapshot(
+                        listOf(
+                            PairRequestSummary(
+                                appInstanceId = "peer-1",
+                                deviceName = "Laptop",
+                                token = "654321",
+                                credentialType = CREDENTIAL_V3_PIN,
+                                pinExpiresAt = 1_000L,
+                                tokenGeneration = 3L,
+                            ),
+                        ),
+                    )
+                }
+            assertEquals(0, exit)
+            assertEquals(listOf("654321"), recording.out)
+            assertContains(recording.err.last(), "rotate every 30 seconds")
+        }
+
+    @Test
+    fun v2OnlySnapshotPrintsNoRotationHint() =
+        runTest {
+            val recording = RecordingIo()
+            executeToken(
+                wait = false,
+                timeoutSeconds = 600,
+                deadline = farDeadline(),
+                json = false,
+                io = recording.io,
+            ) { PairTokenSnapshot(listOf(request())) }
+            assertTrue(recording.err.none { it.contains("rotate") })
+        }
+
+    @Test
+    fun jsonCarriesTheV3Fields() =
+        runTest {
+            val recording = RecordingIo()
+            val exit =
+                executeToken(
+                    wait = false,
+                    timeoutSeconds = 600,
+                    deadline = farDeadline(),
+                    json = true,
+                    io = recording.io,
+                ) {
+                    PairTokenSnapshot(
+                        listOf(
+                            PairRequestSummary(
+                                appInstanceId = "peer-1",
+                                token = "654321",
+                                credentialType = CREDENTIAL_V3_PIN,
+                                pinExpiresAt = 1_000L,
+                                tokenGeneration = 3L,
+                            ),
+                        ),
+                    )
+                }
+            assertEquals(0, exit)
+            val body = recording.out.single()
+            assertContains(body, "\"credentialType\": \"v3-pin\"")
+            assertContains(body, "\"pinExpiresAt\": 1000")
+            assertContains(body, "\"tokenGeneration\": 3")
+        }
+
+    @Test
     fun requesterLabelSanitizesUntrustedNamesAtTheTerminalBoundary() {
         // Explicit char codes: no literal control bytes in source (project rule)
         val esc = 27.toChar()

--- a/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairV3Scenario.kt
+++ b/e2e/src/desktopMain/kotlin/com/crosspaste/e2e/scenario/PairV3Scenario.kt
@@ -1,12 +1,14 @@
 package com.crosspaste.e2e.scenario
 
 import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.dto.pairing.v3.PairingV3ErrorCode
 import com.crosspaste.e2e.net.NetworkUtils
 import com.crosspaste.e2e.peer.BonjourAdvertiser
 import com.crosspaste.e2e.peer.buildPeerSyncInfo
 import com.crosspaste.net.SyncApi
 import com.crosspaste.net.clientapi.SuccessResult
 import com.crosspaste.pairing.v3.PairingV3PinResult
+import com.crosspaste.pairing.v3.PairingV3RefreshResult
 import com.crosspaste.pairing.v3.PairingV3StartResult
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
@@ -19,6 +21,11 @@ import io.ktor.http.URLBuilder
  */
 class PairV3Scenario : Scenario {
     override val name: String = "pair-v3"
+
+    companion object {
+        /** Total PIN submissions per run; only budget-free expired refusals retry. */
+        private const val MAX_PIN_ATTEMPTS = 3
+    }
 
     override suspend fun run(ctx: ScenarioContext): ScenarioResult {
         val target = resolveOrDiscover(ctx) ?: return ScenarioResult.Fail("Could not resolve target.")
@@ -59,31 +66,68 @@ class PairV3Scenario : Scenario {
             "[pair-v3] Session ready; target signing-key fingerprint " +
                 started.peerKeyFingerprintDisplay,
         )
-        val pin =
-            try {
-                ctx.pinProvider()
-            } catch (e: Exception) {
-                service.cancelSession(started.sessionId, toTarget)
-                throw e
+        // The session's PAKE material binds the generation adopted at start (or
+        // at the last refreshOffer). Prompt latency easily spans the 30s PIN
+        // rotation, so an expired refusal — which the acceptor rejects BEFORE
+        // cryptographic verification, spending no guess budget — is recovered by
+        // adopting the rotated generation and prompting for the fresh PIN, the
+        // same recovery the GUI initiator's REFRESH_OFFER path uses. Wrong-PIN
+        // proof failures DO spend acceptor budget and are never retried.
+        var attempt = 0
+        while (true) {
+            attempt++
+            if (attempt > 1) {
+                when (val refreshed = service.refreshOffer(started.sessionId, toTarget)) {
+                    is PairingV3RefreshResult.Refreshed ->
+                        println(
+                            "[pair-v3] Adopted rotated generation ${refreshed.tokenGeneration}; " +
+                                "enter the PIN currently shown on the target.",
+                        )
+                    is PairingV3RefreshResult.Refused -> {
+                        service.cancelSession(started.sessionId, toTarget)
+                        return ScenarioResult.Fail("Pairing v3 offer refresh refused: ${refreshed.code}")
+                    }
+                    is PairingV3RefreshResult.NetworkError -> {
+                        service.cancelSession(started.sessionId, toTarget)
+                        return ScenarioResult.Fail(
+                            "Pairing v3 offer refresh failed: ${describeFailure(refreshed.failure)}",
+                        )
+                    }
+                }
             }
-        val paired =
-            try {
-                service.submitPin(started.sessionId, pin, toTarget)
-            } finally {
-                pin.fill('\u0000')
-            }
-        when (paired) {
-            is PairingV3PinResult.Paired -> Unit
-            is PairingV3PinResult.Refused -> {
-                service.cancelSession(started.sessionId, toTarget)
-                return ScenarioResult.Fail("Pairing v3 proof/commit refused: ${paired.code}")
-            }
-            is PairingV3PinResult.NetworkError -> {
-                service.cancelSession(started.sessionId, toTarget)
-                return ScenarioResult.Fail(
-                    "Pairing v3 proof/commit failed " +
-                        "(commitPending=${paired.commitPending}): ${describeFailure(paired.failure)}",
-                )
+            val pin =
+                try {
+                    ctx.pinProvider()
+                } catch (e: Exception) {
+                    service.cancelSession(started.sessionId, toTarget)
+                    throw e
+                }
+            val paired =
+                try {
+                    service.submitPin(started.sessionId, pin, toTarget)
+                } finally {
+                    pin.fill('\u0000')
+                }
+            when (paired) {
+                is PairingV3PinResult.Paired -> break
+                is PairingV3PinResult.Refused -> {
+                    if (paired.code == PairingV3ErrorCode.PAIRING_PIN_EXPIRED && attempt < MAX_PIN_ATTEMPTS) {
+                        println(
+                            "[pair-v3] PIN generation expired before the proof landed; " +
+                                "refreshing (attempt ${attempt + 1}/$MAX_PIN_ATTEMPTS).",
+                        )
+                        continue
+                    }
+                    service.cancelSession(started.sessionId, toTarget)
+                    return ScenarioResult.Fail("Pairing v3 proof/commit refused: ${paired.code}")
+                }
+                is PairingV3PinResult.NetworkError -> {
+                    service.cancelSession(started.sessionId, toTarget)
+                    return ScenarioResult.Fail(
+                        "Pairing v3 proof/commit failed " +
+                            "(commitPending=${paired.commitPending}): ${describeFailure(paired.failure)}",
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4892

## What

Makes v3 pairing readable and acceptable without a screen, and teaches the e2e harness the production rotation recovery — together enabling fully automated pair-v3 verification against release builds.

### App: `/cli/pair/token` extended to v3

- `CliPairingService.pairingToken()` now merges active v3 acceptor sessions showing a PIN (the exact predicate of the on-screen token cards: `role == ACCEPTOR && state == PIN_AVAILABLE && pin != null`) into the existing v2 SAS list. v3 entries carry `credentialType: "v3-pin"`, `pinExpiresAt`, and `tokenGeneration` so automation can respect the 30s rotation window.
- `GET /cli/pair/token?arm=start|renew` arms the acceptance window through `PairingV3UiController`: `start` (the first fetch of a `token --wait` invocation) is a genuine local operator gesture and maps to `openAcceptanceWindow()` — opens the window and resets the proof-failure budget, exactly like entering the Add Device screen; `renew` (the poll loop of the same invocation) maps to `renewAcceptanceWindow()` and can never refill the budget, mirroring the UI renewal loop. A plain GET stays a pure read.
- DTO evolution is add-only with defaults (`CliPairRequestDto` gains `credentialType`/`pinExpiresAt`/`tokenGeneration`), so an older CLI ignores the new fields and an older app leaves the newer CLI assuming v2.

### CLI: `crosspaste token`

- Mirror DTO fields; `--wait` sends `arm=start` on its first fetch and `arm=renew` on polls; a plain `token` never arms.
- v3 codes print to stdout under the existing print-once-and-exit contract, with a stderr hint that they rotate every 30 seconds; `--json` passes the v3 fields through for automation.

### e2e: `PairV3Scenario` generation refresh

- On a `PAIRING_PIN_EXPIRED` refusal — which the acceptor rejects BEFORE cryptographic verification, spending no guess budget — the harness now calls `refreshOffer` to adopt the rotated generation and re-prompts for the fresh PIN (3 total submissions max), the same recovery the GUI initiator's `REFRESH_OFFER` path uses. Wrong-PIN proof failures spend acceptor budget and are never retried. This fixes the 4-in-a-row `PAIRING_PIN_EXPIRED` failures seen while verifying 2.2.0.2535: the harness pinned generation 1 forever while human PIN transcription reliably exceeded the 30s window.

## Security posture (unchanged)

The CLI transport is a same-user unix domain socket — unreachable from the network and from other local users, and a same-user process can already read the app's entire data directory, so exposing the PIN there adds no capability an attacker did not have. The endpoint already serves the same class of secret (v2 SAS, #4859). PIN rotation, per-generation attempt caps, the cumulative guess budget (#4867), and the acceptance-window gate all still apply; arming semantics deliberately distinguish the one budget-resetting local gesture from budget-neutral renewals.

## Mobile follow-up

None — all changes live in desktopMain, the native CLI, and the e2e harness; `commonMain` pairing code is untouched.

## Testing

- `CliPairingServiceTest`: v3 sessions included/excluded by role/state/pin, v2+v3 merge, display-name fallback, arm mapping
- `CliRoutingTest`: `arm=start|renew` dispatch, absent/unknown values never arm
- `CliDtoContractTest`: wire-field set updated (add-only)
- `TokenCommandTest` (Kotlin/Native): arm sequencing (`START` then `RENEW`s), plain read never arms, v3 rotation hint, JSON field passthrough — 20/20
- `./gradlew app:desktopTest :cli:cliNativeTest e2e:compileKotlinDesktop` — green