### PR TITLE
:bug: stop pushing pastes to stale disconnected sync rows

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -136,6 +136,7 @@ open class DefaultServerModule(
                 )
                 pasteRouting(
                     appControl,
+                    appInfo,
                     pasteboardService,
                     pasteReleaseService,
                     pastePullService,

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.net.routing
 
 import com.crosspaste.app.AppControl
+import com.crosspaste.app.AppInfo
 import com.crosspaste.dto.push.PushHeaders
 import com.crosspaste.dto.push.PushPrepareResponse
 import com.crosspaste.exception.PasteException
@@ -13,6 +14,7 @@ import com.crosspaste.sync.PushSessionManager
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
 import com.crosspaste.utils.requireSyncHandler
+import com.crosspaste.utils.requireTargetAppInstance
 import com.crosspaste.utils.successResponse
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -26,6 +28,7 @@ private val logger: KLogger = KotlinLogging.logger("PasteRouting")
 
 fun Routing.pasteRouting(
     appControl: AppControl,
+    appInfo: AppInfo,
     pasteboardService: PasteboardService,
     pasteReleaseService: PasteReleaseService,
     pastePullService: PastePullService,
@@ -37,6 +40,7 @@ fun Routing.pasteRouting(
         handleSyncPaste(
             call,
             appControl,
+            appInfo,
             pasteboardService,
             pasteReleaseService,
             pastePullService,
@@ -50,6 +54,7 @@ fun Routing.pasteRouting(
 private suspend fun handleSyncPaste(
     call: ApplicationCall,
     appControl: AppControl,
+    appInfo: AppInfo,
     pasteboardService: PasteboardService,
     pasteReleaseService: PasteReleaseService,
     pastePullService: PastePullService,
@@ -58,6 +63,13 @@ private suspend fun handleSyncPaste(
     syncRoutingApi: SyncRoutingApi,
 ) {
     val appInstanceId = getAppInstanceId(call) ?: return
+
+    // Reject pastes addressed to a different identity. A sender pushing through a
+    // stale SyncRuntimeInfo row (peer reinstalled and changed appInstanceId, same
+    // address — #4894) targets the old id; storing it would duplicate every paste
+    // once per stale row.
+    if (!requireTargetAppInstance(call, appInfo)) return
+
     val syncHandler = requireSyncHandler(call, syncRoutingApi, appInstanceId) ?: return
 
     if (!syncHandler.currentSyncRuntimeInfo.allowReceive) {

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -382,23 +382,25 @@ class SyncPasteTaskExecutor(
         return if (fails.isEmpty()) {
             SuccessPasteTaskResult(jsonUtils.JSON.encodeToString(syncExtraInfo))
         } else {
-            // If any of the failures is due to non-retriable errors, do not retry
-            val noNeedRetry =
-                fails.values.any {
-                    it.exception.match(StandardErrorCode.SYNC_NOT_ALLOW_RECEIVE_BY_APP) ||
-                        it.exception.match(StandardErrorCode.SYNC_NOT_ALLOW_SEND_BY_APP) ||
-                        it.exception.match(StandardErrorCode.DECRYPT_FAIL) ||
-                        it.exception.match(StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID)
-                }
+            // Retry decisions are per target: a non-retriable failure (e.g. a stale
+            // row's NOT_MATCH_APP_INSTANCE_ID) only drops its own target from
+            // syncFails, so transient failures on other targets still get retried.
+            val retriableFails = fails.filterValues { !isNonRetriable(it) }
 
-            syncExtraInfo.syncFails.addAll(fails.keys)
+            syncExtraInfo.syncFails.addAll(retriableFails.keys)
             TaskUtils.createFailurePasteTaskResult(
                 logger = logger,
-                retryHandler = { !noNeedRetry && syncExtraInfo.executionHistories.size < 3 },
+                retryHandler = { retriableFails.isNotEmpty() && syncExtraInfo.executionHistories.size < 3 },
                 startTime = startTime,
                 fails = fails.values,
                 extraInfo = syncExtraInfo,
             )
         }
     }
+
+    private fun isNonRetriable(failure: FailureResult): Boolean =
+        failure.exception.match(StandardErrorCode.SYNC_NOT_ALLOW_RECEIVE_BY_APP) ||
+            failure.exception.match(StandardErrorCode.SYNC_NOT_ALLOW_SEND_BY_APP) ||
+            failure.exception.match(StandardErrorCode.DECRYPT_FAIL) ||
+            failure.exception.match(StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID)
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/task/SyncPasteTaskExecutor.kt
@@ -5,6 +5,7 @@ import com.crosspaste.app.AppInfo
 import com.crosspaste.config.AppConfig
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.sync.SyncState
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.SyncExtraInfo
 import com.crosspaste.db.task.TaskType
@@ -122,10 +123,15 @@ class SyncPasteTaskExecutor(
         return deferredResults.associate { it.await() }
     }
 
+    // Only CONNECTED handlers are eligible: a stale row left behind by a peer whose
+    // appInstanceId changed keeps the last known address, so pushing to DISCONNECTED
+    // handlers delivers duplicates to whoever now owns that address (#4894). A peer
+    // that reconnects catches up via the pull cursor.
     private suspend fun getEligibleSyncHandlers(syncExtraInfo: SyncExtraInfo): Map<String, SyncHandler> =
         if (syncExtraInfo.appInstanceId == appInfo.appInstanceId) {
             syncManager.getSyncHandlers().filter { (key, handler) ->
                 handler.currentSyncRuntimeInfo.allowSend &&
+                    handler.currentSyncRuntimeInfo.connectState == SyncState.CONNECTED &&
                     handler.currentVersionRelation == VersionRelation.EQUAL_TO &&
                     (
                         syncExtraInfo.targetAppInstanceIds?.contains(key) != false
@@ -139,6 +145,7 @@ class SyncPasteTaskExecutor(
                         if (key != syncExtraInfo.appInstanceId) {
                             val isEligible =
                                 handler.currentSyncRuntimeInfo.allowSend &&
+                                    handler.currentSyncRuntimeInfo.connectState == SyncState.CONNECTED &&
                                     handler.currentVersionRelation == VersionRelation.EQUAL_TO &&
                                     (syncExtraInfo.syncFails.isEmpty() || syncExtraInfo.syncFails.contains(key))
                             if (!isEligible) {
@@ -380,7 +387,8 @@ class SyncPasteTaskExecutor(
                 fails.values.any {
                     it.exception.match(StandardErrorCode.SYNC_NOT_ALLOW_RECEIVE_BY_APP) ||
                         it.exception.match(StandardErrorCode.SYNC_NOT_ALLOW_SEND_BY_APP) ||
-                        it.exception.match(StandardErrorCode.DECRYPT_FAIL)
+                        it.exception.match(StandardErrorCode.DECRYPT_FAIL) ||
+                        it.exception.match(StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID)
                 }
 
             syncExtraInfo.syncFails.addAll(fails.keys)

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PasteRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PasteRoutingTest.kt
@@ -1,8 +1,37 @@
 package com.crosspaste.net.routing
 
+import com.crosspaste.app.AppControl
+import com.crosspaste.app.AppInfo
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteType
+import com.crosspaste.paste.PasteboardService
+import com.crosspaste.sync.PastePullService
+import com.crosspaste.sync.PushSessionManager
+import com.crosspaste.sync.SyncHandler
+import com.crosspaste.sync.SyncTestFixtures.createConnectedSyncRuntimeInfo
+import com.crosspaste.utils.HEADER_APP_INSTANCE_ID
+import com.crosspaste.utils.HEADER_TARGET_APP_INSTANCE_ID
+import com.crosspaste.utils.getJsonUtils
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -28,6 +57,97 @@ class PasteRoutingTest {
 
         assertEquals("authenticated-peer", bound.appInstanceId)
         assertTrue(bound.remote)
+    }
+
+    // ========== /sync/paste target identity validation (#4894) ==========
+
+    private val jsonUtils = getJsonUtils()
+
+    private val localAppInfo =
+        AppInfo(
+            appInstanceId = "local-instance",
+            appVersion = "1.0.0",
+            appRevision = "abc",
+            userName = "tester",
+        )
+
+    private fun withPasteRouting(
+        pasteboardService: PasteboardService,
+        block: suspend ApplicationTestBuilder.() -> Unit,
+    ) = testApplication {
+        val appControl =
+            mockk<AppControl>(relaxed = true) {
+                coEvery { isReceiveEnabled() } returns true
+            }
+        val syncHandler =
+            mockk<SyncHandler> {
+                every { currentSyncRuntimeInfo } returns
+                    createConnectedSyncRuntimeInfo(appInstanceId = "remote-peer")
+            }
+        val syncRoutingApi =
+            mockk<SyncRoutingApi> {
+                every { getSyncHandler("remote-peer") } returns syncHandler
+            }
+        application {
+            install(ContentNegotiation) {
+                json(jsonUtils.JSON)
+            }
+            routing {
+                pasteRouting(
+                    appControl,
+                    localAppInfo,
+                    pasteboardService,
+                    mockk<PasteReleaseService>(),
+                    mockk<PastePullService>(relaxed = true),
+                    CoroutineScope(Dispatchers.Unconfined),
+                    mockk<PushSessionManager>(),
+                    syncRoutingApi,
+                )
+            }
+        }
+        block()
+    }
+
+    private suspend fun ApplicationTestBuilder.postSyncPaste(targetAppInstanceId: String?) =
+        client.post("/sync/paste") {
+            header(HEADER_APP_INSTANCE_ID, "remote-peer")
+            targetAppInstanceId?.let { header(HEADER_TARGET_APP_INSTANCE_ID, it) }
+            contentType(ContentType.Application.Json)
+            setBody(jsonUtils.JSON.encodeToString(createPasteData(appInstanceId = "remote-peer")))
+        }
+
+    @Test
+    fun `paste targeting a stale identity is rejected without touching the pasteboard`() {
+        val pasteboardService = mockk<PasteboardService>(relaxed = true)
+        withPasteRouting(pasteboardService) {
+            val response = postSyncPaste(targetAppInstanceId = "stale-old-identity")
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            coVerify(exactly = 0) { pasteboardService.tryWriteRemotePasteboard(any()) }
+        }
+    }
+
+    @Test
+    fun `paste without target header is rejected`() {
+        val pasteboardService = mockk<PasteboardService>(relaxed = true)
+        withPasteRouting(pasteboardService) {
+            val response = postSyncPaste(targetAppInstanceId = null)
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            coVerify(exactly = 0) { pasteboardService.tryWriteRemotePasteboard(any()) }
+        }
+    }
+
+    @Test
+    fun `paste targeting our identity is accepted`() {
+        val pasteboardService = mockk<PasteboardService>(relaxed = true)
+        coEvery { pasteboardService.tryWriteRemotePasteboard(any()) } returns Result.success(Unit)
+        withPasteRouting(pasteboardService) {
+            val response = postSyncPaste(targetAppInstanceId = "local-instance")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboard(any()) }
+        }
     }
 
     private fun createPasteData(appInstanceId: String): PasteData =

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
@@ -5,6 +5,7 @@ import com.crosspaste.app.AppInfo
 import com.crosspaste.config.AppConfig
 import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.db.sync.SyncState
 import com.crosspaste.db.task.PasteTask
 import com.crosspaste.db.task.SyncExtraInfo
 import com.crosspaste.db.task.TaskType
@@ -137,13 +138,14 @@ class SyncPasteTaskExecutorTest {
         allowSend: Boolean = true,
         versionRelation: VersionRelation = VersionRelation.EQUAL_TO,
         connectHostAddress: String? = "192.168.1.100",
+        connectState: Int = SyncState.CONNECTED,
     ): SyncHandler {
         val handler = mockk<SyncHandler>(relaxed = true)
         val syncRuntimeInfo =
             createConnectedSyncRuntimeInfo(
                 appInstanceId = appInstanceId,
                 hostAddress = connectHostAddress ?: "192.168.1.100",
-            ).copy(allowSend = allowSend)
+            ).copy(allowSend = allowSend, connectState = connectState)
         every { handler.currentSyncRuntimeInfo } returns syncRuntimeInfo
         every { handler.currentVersionRelation } returns versionRelation
         coEvery { handler.getConnectHostAddress() } returns connectHostAddress
@@ -259,6 +261,31 @@ class SyncPasteTaskExecutorTest {
 
             assertTrue(result is SuccessPasteTaskResult)
             coVerify(exactly = 1) { deps.pasteClientApi.sendPaste(any(), eq("remote-1"), any()) }
+        }
+
+    @Test
+    fun doExecuteTask_localPaste_filtersDisconnectedHandler() =
+        runTest {
+            // #4894: a stale row left by a reinstalled peer keeps the last known
+            // address but stays DISCONNECTED — it must not receive pushes
+            val deps = TestDeps()
+            val executor = deps.createExecutor()
+            val task = createPasteTask()
+            val pasteData = createMockPasteData()
+
+            val handlerConnected = createMockSyncHandler("remote-1")
+            val handlerStale = createMockSyncHandler("remote-2", connectState = SyncState.DISCONNECTED)
+
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns
+                mapOf("remote-1" to handlerConnected, "remote-2" to handlerStale)
+            coEvery { deps.pasteClientApi.sendPaste(any(), any(), any()) } returns SuccessResult()
+
+            val result = executor.doExecuteTask(task)
+
+            assertTrue(result is SuccessPasteTaskResult)
+            coVerify(exactly = 1) { deps.pasteClientApi.sendPaste(any(), eq("remote-1"), any()) }
+            coVerify(exactly = 0) { deps.pasteClientApi.sendPaste(any(), eq("remote-2"), any()) }
         }
 
     // ========== C. Sync execution ==========

--- a/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/task/SyncPasteTaskExecutorTest.kt
@@ -7,6 +7,7 @@ import com.crosspaste.config.CommonConfigManager
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.db.sync.SyncState
 import com.crosspaste.db.task.PasteTask
+import com.crosspaste.db.task.PasteTaskExtraInfo
 import com.crosspaste.db.task.SyncExtraInfo
 import com.crosspaste.db.task.TaskType
 import com.crosspaste.exception.PasteException
@@ -39,6 +40,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SyncPasteTaskExecutorTest {
@@ -420,6 +422,79 @@ class SyncPasteTaskExecutorTest {
 
             val failResult = result as FailurePasteTaskResult
             assertTrue(failResult.needRetry)
+        }
+
+    @Test
+    fun doExecuteTask_mismatchAndTransientFailure_retriesOnlyTransientTarget() =
+        runTest {
+            // A stale target's NOT_MATCH_APP_INSTANCE_ID must not cancel the retry
+            // of another target that failed transiently (#4894 review follow-up)
+            val deps = TestDeps()
+            val executor = deps.createExecutor()
+            val task = createPasteTask()
+            val pasteData = createMockPasteData()
+
+            val staleHandler = createMockSyncHandler("stale-target")
+            val transientHandler = createMockSyncHandler("transient-target")
+
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns
+                mapOf("stale-target" to staleHandler, "transient-target" to transientHandler)
+            coEvery { deps.pasteClientApi.sendPaste(any(), eq("stale-target"), any()) } returns
+                FailureResult(
+                    PasteException(
+                        StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID.toErrorCode(),
+                        "stale identity",
+                    ),
+                )
+            coEvery { deps.pasteClientApi.sendPaste(any(), eq("transient-target"), any()) } returns
+                FailureResult(
+                    PasteException(
+                        StandardErrorCode.UNKNOWN_ERROR.toErrorCode(),
+                        "transient error",
+                    ),
+                )
+
+            val result = executor.doExecuteTask(task)
+
+            val failResult = result as FailurePasteTaskResult
+            assertTrue(failResult.needRetry)
+            val newExtraInfo =
+                jsonUtils.JSON.decodeFromString<PasteTaskExtraInfo>(
+                    failResult.newExtraInfo,
+                ) as SyncExtraInfo
+            assertEquals(setOf("transient-target"), newExtraInfo.syncFails)
+        }
+
+    @Test
+    fun doExecuteTask_allFailuresNonRetriable_noRetryAndEmptySyncFails() =
+        runTest {
+            val deps = TestDeps()
+            val executor = deps.createExecutor()
+            val task = createPasteTask()
+            val pasteData = createMockPasteData()
+
+            val staleHandler = createMockSyncHandler("stale-target")
+
+            coEvery { deps.pasteDao.getNoDeletePasteData(any()) } returns pasteData
+            coEvery { deps.syncManager.getSyncHandlers() } returns mapOf("stale-target" to staleHandler)
+            coEvery { deps.pasteClientApi.sendPaste(any(), eq("stale-target"), any()) } returns
+                FailureResult(
+                    PasteException(
+                        StandardErrorCode.NOT_MATCH_APP_INSTANCE_ID.toErrorCode(),
+                        "stale identity",
+                    ),
+                )
+
+            val result = executor.doExecuteTask(task)
+
+            val failResult = result as FailurePasteTaskResult
+            assertTrue(!failResult.needRetry)
+            val newExtraInfo =
+                jsonUtils.JSON.decodeFromString<PasteTaskExtraInfo>(
+                    failResult.newExtraInfo,
+                ) as SyncExtraInfo
+            assertTrue(newExtraInfo.syncFails.isEmpty())
         }
 
     @Test


### PR DESCRIPTION
Fixes #4894

When a paired peer comes back with a new `appInstanceId`, its old `SyncRuntimeInfo` rows survive with the same address and `allowSend`, and every copy is pushed once per stale row — the receiver gets the same paste N times.

## Changes

**Sender: only CONNECTED handlers are eligible for push.** `SyncPasteTaskExecutor.getEligibleSyncHandlers` now requires `connectState == SyncState.CONNECTED` in both the local-paste and relay branches. A stale row stays DISCONNECTED (its heartbeat fails on the identity check), so it no longer receives pushes; a genuinely disconnected peer catches up via the pull cursor on reconnect, same as before. Extension handlers keep their `connectState` maintained by the WebSocket probe, so the extension path is unaffected.

**Receiver: `/sync/paste` validates the target identity.** The route now runs `requireTargetAppInstance` before accepting the body, mirroring what `/sync/heartbeat`, the push chunk routes and the pull routes already do — `/sync/paste` was the only sync endpoint missing it. A push addressed to a stale (old) identity is rejected with `NOT_MATCH_APP_INSTANCE_ID` instead of being stored. Both HTTP callers (`PasteClientApi.sendPaste`, `PushClientApi.preparePush`) already send the header; the WebSocket path already validates it at session open.

**Retry decisions are per target, not task-wide.** Previously one non-retriable failure (`fails.values.any { ... }`) cancelled the retry for every target in the batch — a stale row's `NOT_MATCH_APP_INSTANCE_ID` (or a `DECRYPT_FAIL`) would permanently stop the retry of another target that only failed transiently. `processResults` now splits failures: non-retriable targets are dropped from `syncFails`, transient ones are kept, and the task retries as long as any transient failure remains. `NOT_MATCH_APP_INSTANCE_ID` joins the non-retriable set — a changed peer identity never resolves by retrying.

## Tests

- `SyncPasteTaskExecutorTest`: a DISCONNECTED handler no longer receives `sendPaste` while a CONNECTED one still does; a mismatch + transient failure pair retries only the transient target; all-non-retriable failures yield no retry and empty `syncFails`.
- `PasteRoutingTest`: `/sync/paste` rejects a stale/missing `targetAppInstanceId` with 400 without touching the pasteboard, and accepts a matching one.
- Full suite green including the integration tier (`app:desktopTest -PintegrationTests`).

## Not in this PR

Superseding stale rows themselves (issue suggestion 2) is deliberately left out: auto-replacing a trusted row keyed by `deviceId` turned out to be infeasible — `deviceId` derives from the same machine identifier as `appInstanceId`, so there is no reliable signal that a new identity is the old device (see #4896, closed). Stale rows are inert after this PR; manual removal covers cleanup.
