### PR TITLE
:arrow_up: Bump ComposeNativeTray from 1.3.3 to 2.1.3 for Compose 1.12 support

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/tray/NonMacTrayView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/tray/NonMacTrayView.kt
@@ -18,7 +18,7 @@ import com.crosspaste.platform.Platform
 import com.crosspaste.ui.LocalExitApplication
 import com.crosspaste.ui.base.MenuHelper
 import com.crosspaste.utils.GlobalCoroutineScope.mainCoroutineDispatcher
-import com.kdroid.composetray.tray.api.Tray
+import dev.nucleusframework.composenativetray.tray.api.Tray
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ ph-css = "8.2.1"
 richeditor = "1.1.0"
 semver = "3.1.0"
 sqldelight = "2.3.2"
-native-tray = "1.3.3"
+native-tray = "2.1.3"
 tesseract-platform = "5.5.1-1.5.12"
 turbine = "1.2.1"
 webp-imageio = "0.11.0"
@@ -130,7 +130,7 @@ semver = { module = "io.github.z4kn4fein:semver", version.ref = "semver" }
 sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqlite-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-coroutines-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
-native-tray = { module = "io.github.kdroidfilter:composenativetray-jvm", version.ref = "native-tray" }
+native-tray = { module = "dev.nucleusframework:composenativetray-jvm", version.ref = "native-tray" }
 tesseract-platform = { module = "org.bytedeco:tesseract-platform", version.ref = "tesseract-platform" }
 webp-imageio = { module = "com.github.usefulness:webp-imageio", version.ref = "webp-imageio" }
 yaml = { module = "org.yaml:snakeyaml", version.ref = "yaml" }


### PR DESCRIPTION
## Why

The 2.2.0.2539 draft build crashes on startup on Linux. Root cause: ComposeNativeTray was upgraded past our pinned version under new Maven coordinates, and the version we pin is incompatible with Compose Multiplatform 1.12.

- The project moved from `io.github.kdroidfilter:composenativetray` to `dev.nucleusframework:composenativetray` at v2.0.0 (the GitHub repo was transferred to NucleusFramework; the old repo 301-redirects there). The old coordinates are frozen at 1.3.3, which is why the Compose 1.12 dependency audit concluded there was nothing to upgrade.
- v2.1.1 explicitly fixes a `NoSuchMethodError` on `Image.encodeToData` under Compose Multiplatform 1.12 — the tray icon rendering path that crashes at startup on Linux (and would equally affect the Windows tray). macOS is unaffected because it uses our native Swift tray instead of this library.

## What

- Switch the version catalog to `dev.nucleusframework:composenativetray-jvm:2.1.3` (latest; built against Compose 1.12.0).
- Update the import in `NonMacTrayView.kt` to the renamed package (`dev.nucleusframework.composenativetray.tray.api.Tray`). The `Tray` composable signature and the `Item`/`Divider` menu DSL are unchanged, so no other code changes are needed.

## Notes

- 2.1.0 split the library in two; we depend only on the core tray artifact, which does not pull in the heavier windowing backend. New transitive deps are limited to the maintainer's small `nucleus.core-runtime` and `nucleus.darkmode-detector`.
- 2.x bundles its JNI natives inside the jar (1.3.3 did not). Its loader tries `System.loadLibrary` (java.library.path) before classpath extraction, which is compatible with Conveyor's `extract-native-libraries = true`. To be confirmed on real machines during release-build verification on Linux/Windows.

## Verification

- `./gradlew ktlintCheck app:desktopTest` green locally.
- Packaged-app tray behavior on Linux/Windows will be verified against the rebuilt release draft.