### PR TITLE
:bug: Show tooltip for clipped paste title and commit title edit on focus loss

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/PasteTooltipAreaView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/PasteTooltipAreaView.kt
@@ -37,12 +37,17 @@ fun PasteTooltipAreaView(
     },
     content: @Composable () -> Unit,
 ) {
+    if (!enabled) {
+        Box(modifier = modifier) {
+            content()
+        }
+        return
+    }
     TooltipArea(
         modifier = modifier,
         delayMillis = delayMillis,
         tooltipPlacement = computeTooltipPlacement(),
         tooltip = {
-            if (!enabled) return@TooltipArea
             Box(
                 modifier =
                     Modifier

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/base/PasteTooltipAreaView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/base/PasteTooltipAreaView.kt
@@ -28,6 +28,7 @@ import com.crosspaste.ui.theme.AppUISize.zero
 fun PasteTooltipAreaView(
     modifier: Modifier = Modifier,
     text: String,
+    enabled: Boolean = true,
     delayMillis: Int = 500,
     computeTooltipPlacement: @Composable () -> TooltipPlacement = {
         TooltipPlacement.CursorPoint(
@@ -41,6 +42,7 @@ fun PasteTooltipAreaView(
         delayMillis = delayMillis,
         tooltipPlacement = computeTooltipPlacement(),
         tooltip = {
+            if (!enabled) return@TooltipArea
             Box(
                 modifier =
                     Modifier

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SidePasteTitleView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SidePasteTitleView.kt
@@ -60,7 +60,6 @@ import com.crosspaste.ui.theme.DesktopAppUIFont
 import com.crosspaste.utils.ColorAccessibility.getBestTextColor
 import com.crosspaste.utils.DateUtils
 import com.crosspaste.utils.RelativeTime
-import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -178,9 +177,19 @@ fun PasteDataScope.SidePasteTitleView() {
 
                         var hadFocus by remember { mutableStateOf(false) }
 
+                        val committer =
+                            remember {
+                                TitleEditCommitter(scope) { name ->
+                                    updatePasteItemHelper
+                                        .updateName(pasteData, name, pasteItem)
+                                        .map { }
+                                }
+                            }
+
                         val completeEditing: () -> Unit = {
-                            if (isEditing) {
-                                if (editedTextValue.text.isBlank()) {
+                            committer.commit(
+                                text = editedTextValue.text,
+                                onRevert = {
                                     // Revert to the original name if empty
                                     editedTextValue =
                                         TextFieldValue(
@@ -188,26 +197,23 @@ fun PasteDataScope.SidePasteTitleView() {
                                             selection = TextRange(pasteboardName.length),
                                         )
                                     isEditing = false
-                                } else {
-                                    // Proceed with update if not empty
-                                    scope.launch {
-                                        updatePasteItemHelper
-                                            .updateName(
-                                                pasteData,
-                                                editedTextValue.text,
-                                                pasteItem,
-                                            ).onSuccess {
-                                                pasteboardName = editedTextValue.text
-                                                isEditing = false
-                                            }.onFailure {
-                                                notificationManager.sendNotification(
-                                                    title = { copywriter.getText("save_failed") },
-                                                    messageType = MessageType.Error,
-                                                )
-                                            }
-                                    }
-                                }
-                            }
+                                },
+                                onSaved = { savedName ->
+                                    pasteboardName = savedName
+                                    editedTextValue =
+                                        TextFieldValue(
+                                            text = savedName,
+                                            selection = TextRange(savedName.length),
+                                        )
+                                    isEditing = false
+                                },
+                                onFailure = {
+                                    notificationManager.sendNotification(
+                                        title = { copywriter.getText("save_failed") },
+                                        messageType = MessageType.Error,
+                                    )
+                                },
+                            )
                         }
 
                         CompositionLocalProvider(LocalTextSelectionColors provides customTextSelectionColors) {
@@ -221,6 +227,7 @@ fun PasteDataScope.SidePasteTitleView() {
                                             if (state.isFocused) {
                                                 hadFocus = true
                                             } else if (hadFocus) {
+                                                hadFocus = false
                                                 // Losing focus (e.g. clicking elsewhere) commits the edit
                                                 completeEditing()
                                             }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SidePasteTitleView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/SidePasteTitleView.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.ui.paste.side.preview
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -32,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
@@ -47,6 +49,7 @@ import com.crosspaste.paste.item.UpdatePasteItemHelper
 import com.crosspaste.ui.LocalDesktopAppSizeValueState
 import com.crosspaste.ui.LocalSearchWindowInfoState
 import com.crosspaste.ui.LocalThemeState
+import com.crosspaste.ui.base.PasteTooltipAreaView
 import com.crosspaste.ui.base.SidePasteTypeIconView
 import com.crosspaste.ui.base.darkSideBarColors
 import com.crosspaste.ui.base.lightSideBarColors
@@ -60,6 +63,7 @@ import com.crosspaste.utils.RelativeTime
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun PasteDataScope.SidePasteTitleView() {
     val copywriter = koinInject<GlobalCopywriter>()
@@ -116,6 +120,8 @@ fun PasteDataScope.SidePasteTitleView() {
 
     var isEditing by remember { mutableStateOf(false) }
 
+    var titleOverflowed by remember(pasteData.id) { mutableStateOf(false) }
+
     val focusRequester = remember { FocusRequester() }
 
     LaunchedEffect(isCurrentThemeDark, pasteData.source) {
@@ -135,105 +141,136 @@ fun PasteDataScope.SidePasteTitleView() {
             }
     }
 
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .height(sideTitleHeight)
-                .background(background)
-                .padding(start = medium),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
+    PasteTooltipAreaView(
+        text = editedTextValue.text,
+        enabled = titleOverflowed && !isEditing,
     ) {
-        Column(
+        Row(
             modifier =
                 Modifier
-                    .weight(1f)
-                    .fillMaxHeight(),
-            verticalArrangement = Arrangement.Center,
+                    .fillMaxWidth()
+                    .height(sideTitleHeight)
+                    .background(background)
+                    .padding(start = medium),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(
-                modifier = Modifier.wrapContentSize().width(IntrinsicSize.Min),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Start,
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                verticalArrangement = Arrangement.Center,
             ) {
-                if (isEditing) {
-                    val customTextSelectionColors =
-                        remember(onBackground) {
-                            TextSelectionColors(
-                                handleColor = onBackground,
-                                backgroundColor = onBackground.copy(alpha = 0.3f),
+                Row(
+                    modifier = Modifier.wrapContentSize().width(IntrinsicSize.Min),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Start,
+                ) {
+                    if (isEditing) {
+                        val customTextSelectionColors =
+                            remember(onBackground) {
+                                TextSelectionColors(
+                                    handleColor = onBackground,
+                                    backgroundColor = onBackground.copy(alpha = 0.3f),
+                                )
+                            }
+
+                        var hadFocus by remember { mutableStateOf(false) }
+
+                        val completeEditing: () -> Unit = {
+                            if (isEditing) {
+                                if (editedTextValue.text.isBlank()) {
+                                    // Revert to the original name if empty
+                                    editedTextValue =
+                                        TextFieldValue(
+                                            text = pasteboardName,
+                                            selection = TextRange(pasteboardName.length),
+                                        )
+                                    isEditing = false
+                                } else {
+                                    // Proceed with update if not empty
+                                    scope.launch {
+                                        updatePasteItemHelper
+                                            .updateName(
+                                                pasteData,
+                                                editedTextValue.text,
+                                                pasteItem,
+                                            ).onSuccess {
+                                                pasteboardName = editedTextValue.text
+                                                isEditing = false
+                                            }.onFailure {
+                                                notificationManager.sendNotification(
+                                                    title = { copywriter.getText("save_failed") },
+                                                    messageType = MessageType.Error,
+                                                )
+                                            }
+                                    }
+                                }
+                            }
+                        }
+
+                        CompositionLocalProvider(LocalTextSelectionColors provides customTextSelectionColors) {
+                            BasicTextField(
+                                value = editedTextValue,
+                                onValueChange = { editedTextValue = it },
+                                modifier =
+                                    Modifier
+                                        .focusRequester(focusRequester)
+                                        .onFocusChanged { state ->
+                                            if (state.isFocused) {
+                                                hadFocus = true
+                                            } else if (hadFocus) {
+                                                // Losing focus (e.g. clicking elsewhere) commits the edit
+                                                completeEditing()
+                                            }
+                                        }.weight(1f, fill = false),
+                                textStyle =
+                                    DesktopAppUIFont.sidePasteTitleTextStyle.copy(
+                                        color = onBackground,
+                                    ),
+                                cursorBrush = SolidColor(onBackground),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                keyboardActions =
+                                    KeyboardActions(
+                                        onDone = { completeEditing() },
+                                    ),
                             )
                         }
 
-                    CompositionLocalProvider(LocalTextSelectionColors provides customTextSelectionColors) {
-                        BasicTextField(
-                            value = editedTextValue,
-                            onValueChange = { editedTextValue = it },
+                        // Autofocus and select all when entering edit mode
+                        LaunchedEffect(Unit) {
+                            focusRequester.requestFocus()
+                            // Set selection to cover the entire text length
+                            editedTextValue =
+                                editedTextValue.copy(
+                                    selection = TextRange(0, editedTextValue.text.length),
+                                )
+                        }
+                    } else {
+                        Text(
                             modifier =
-                                Modifier
-                                    .focusRequester(focusRequester)
-                                    .weight(1f, fill = false),
-                            textStyle =
+                                Modifier.clickable {
+                                    isEditing = true
+                                },
+                            text = editedTextValue.text,
+                            style =
                                 DesktopAppUIFont.sidePasteTitleTextStyle.copy(
                                     color = onBackground,
                                 ),
-                            cursorBrush = SolidColor(onBackground),
-                            singleLine = true,
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                            keyboardActions =
-                                KeyboardActions(
-                                    onDone = {
-                                        if (editedTextValue.text.isBlank()) {
-                                            // Revert to the original name if empty
-                                            editedTextValue =
-                                                TextFieldValue(
-                                                    text = pasteboardName,
-                                                    selection = TextRange(pasteboardName.length),
-                                                )
-                                            isEditing = false
-                                        } else {
-                                            // Proceed with update if not empty
-                                            scope.launch {
-                                                updatePasteItemHelper
-                                                    .updateName(
-                                                        pasteData,
-                                                        editedTextValue.text,
-                                                        pasteItem,
-                                                    ).onSuccess {
-                                                        pasteboardName = editedTextValue.text
-                                                        isEditing = false
-                                                    }.onFailure {
-                                                        notificationManager.sendNotification(
-                                                            title = { copywriter.getText("save_failed") },
-                                                            messageType = MessageType.Error,
-                                                        )
-                                                    }
-                                            }
-                                        }
-                                    },
-                                ),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            onTextLayout = { titleOverflowed = it.hasVisualOverflow },
                         )
                     }
+                }
 
-                    // Autofocus and select all when entering edit mode
-                    LaunchedEffect(Unit) {
-                        focusRequester.requestFocus()
-                        // Set selection to cover the entire text length
-                        editedTextValue =
-                            editedTextValue.copy(
-                                selection = TextRange(0, editedTextValue.text.length),
-                            )
-                    }
-                } else {
+                relativeTime?.let {
                     Text(
-                        modifier =
-                            Modifier.clickable {
-                                isEditing = true
-                            },
-                        text = editedTextValue.text,
+                        text = copywriter.getText(it.unit, it.value?.toString() ?: ""),
                         style =
-                            DesktopAppUIFont.sidePasteTitleTextStyle.copy(
+                            DesktopAppUIFont.sidePasteTimeTextStyle.copy(
                                 color = onBackground,
                             ),
                         maxLines = 1,
@@ -241,21 +278,9 @@ fun PasteDataScope.SidePasteTitleView() {
                     )
                 }
             }
-
-            relativeTime?.let {
-                Text(
-                    text = copywriter.getText(it.unit, it.value?.toString() ?: ""),
-                    style =
-                        DesktopAppUIFont.sidePasteTimeTextStyle.copy(
-                            color = onBackground,
-                        ),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
+            SidePasteTypeIconView(
+                modifier = Modifier.fillMaxHeight().wrapContentWidth(),
+            )
         }
-        SidePasteTypeIconView(
-            modifier = Modifier.fillMaxHeight().wrapContentWidth(),
-        )
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/TitleEditCommitter.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/TitleEditCommitter.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.ui.paste.side.preview
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -28,7 +29,15 @@ class TitleEditCommitter(
             return
         }
         scope.launch {
-            updateName(text)
+            val result =
+                try {
+                    updateName(text)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
+            result
                 .onSuccess {
                     onSaved(text)
                 }.onFailure {

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/TitleEditCommitter.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/paste/side/preview/TitleEditCommitter.kt
@@ -1,0 +1,40 @@
+package com.crosspaste.ui.paste.side.preview
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Serializes commits of a single title-edit session. Enter and focus loss can
+ * both request a commit for the same edit; only the first request runs, and the
+ * committed text is snapshotted at that moment. A failed save unlocks the
+ * session so the user can retry.
+ */
+class TitleEditCommitter(
+    private val scope: CoroutineScope,
+    private val updateName: suspend (String) -> Result<Unit>,
+) {
+    private var committing = false
+
+    fun commit(
+        text: String,
+        onRevert: () -> Unit,
+        onSaved: (String) -> Unit,
+        onFailure: () -> Unit,
+    ) {
+        if (committing) return
+        committing = true
+        if (text.isBlank()) {
+            onRevert()
+            return
+        }
+        scope.launch {
+            updateName(text)
+                .onSuccess {
+                    onSaved(text)
+                }.onFailure {
+                    committing = false
+                    onFailure()
+                }
+        }
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/paste/side/preview/TitleEditCommitterTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/paste/side/preview/TitleEditCommitterTest.kt
@@ -1,12 +1,14 @@
 package com.crosspaste.ui.paste.side.preview
 
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TitleEditCommitterTest {
 
     @Test
@@ -81,6 +83,43 @@ class TitleEditCommitterTest {
 
             assertEquals(1, reverts)
             assertEquals(0, updateCalls)
+        }
+
+    @Test
+    fun thrownExceptionReportsFailureAndUnlocksSessionForRetry() =
+        runTest {
+            var updateCalls = 0
+            var shouldThrow = true
+            val committer =
+                TitleEditCommitter(backgroundScope) {
+                    updateCalls++
+                    if (shouldThrow) {
+                        throw IllegalStateException("db exploded")
+                    }
+                    Result.success(Unit)
+                }
+
+            var savedName: String? = null
+            var failures = 0
+            val commit = {
+                committer.commit(
+                    text = "name",
+                    onRevert = {},
+                    onSaved = { savedName = it },
+                    onFailure = { failures++ },
+                )
+            }
+
+            commit()
+            runCurrent()
+            assertEquals(1, failures)
+            assertNull(savedName)
+
+            shouldThrow = false
+            commit()
+            runCurrent()
+            assertEquals(2, updateCalls)
+            assertEquals("name", savedName)
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/paste/side/preview/TitleEditCommitterTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/paste/side/preview/TitleEditCommitterTest.kt
@@ -1,0 +1,119 @@
+package com.crosspaste.ui.paste.side.preview
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TitleEditCommitterTest {
+
+    @Test
+    fun enterThenImmediateFocusLossCommitsOnlyOnce() =
+        runTest {
+            val gate = CompletableDeferred<Result<Unit>>()
+            var updateCalls = 0
+            var updatedName: String? = null
+            val committer =
+                TitleEditCommitter(backgroundScope) { name ->
+                    updateCalls++
+                    updatedName = name
+                    gate.await()
+                }
+
+            var savedName: String? = null
+            var reverts = 0
+            var failures = 0
+            val commit = { text: String ->
+                committer.commit(
+                    text = text,
+                    onRevert = { reverts++ },
+                    onSaved = { savedName = it },
+                    onFailure = { failures++ },
+                )
+            }
+
+            // Enter starts the save; the update is still in flight...
+            commit("edited name")
+            runCurrent()
+            // ...when focus loss requests a second commit (user typed more meanwhile)
+            commit("edited name typed further")
+            runCurrent()
+
+            assertEquals(1, updateCalls)
+            assertEquals("edited name", updatedName)
+            assertNull(savedName)
+
+            gate.complete(Result.success(Unit))
+            runCurrent()
+
+            // The saved name is the snapshot from the first commit, not the later text
+            assertEquals("edited name", savedName)
+            assertEquals(0, reverts)
+            assertEquals(0, failures)
+        }
+
+    @Test
+    fun blankTextRevertsOnceAndBlocksFollowUpCommit() =
+        runTest {
+            var updateCalls = 0
+            val committer =
+                TitleEditCommitter(backgroundScope) {
+                    updateCalls++
+                    Result.success(Unit)
+                }
+
+            var reverts = 0
+            val commit = {
+                committer.commit(
+                    text = "   ",
+                    onRevert = { reverts++ },
+                    onSaved = {},
+                    onFailure = {},
+                )
+            }
+
+            commit()
+            // Disposal of the edit field fires a focus-loss commit right after
+            commit()
+            runCurrent()
+
+            assertEquals(1, reverts)
+            assertEquals(0, updateCalls)
+        }
+
+    @Test
+    fun failureUnlocksSessionForRetry() =
+        runTest {
+            var updateCalls = 0
+            var result: Result<Unit> = Result.failure(RuntimeException("boom"))
+            val committer =
+                TitleEditCommitter(backgroundScope) {
+                    updateCalls++
+                    result
+                }
+
+            var savedName: String? = null
+            var failures = 0
+            val commit = {
+                committer.commit(
+                    text = "name",
+                    onRevert = {},
+                    onSaved = { savedName = it },
+                    onFailure = { failures++ },
+                )
+            }
+
+            commit()
+            runCurrent()
+            assertEquals(1, failures)
+            assertNull(savedName)
+
+            result = Result.success(Unit)
+            commit()
+            runCurrent()
+            assertEquals(2, updateCalls)
+            assertEquals("name", savedName)
+        }
+}


### PR DESCRIPTION
Closes #4883

## Summary

- **Tooltip for clipped titles**: when a paste item's title is truncated with an ellipsis in the side title bar, hovering anywhere over the title bar for 500ms now shows the full title in a tooltip (via the existing `PasteTooltipAreaView`). Overflow is detected with `onTextLayout`/`hasVisualOverflow`; titles that fit get no tooltip, and none is shown while the title is being edited.
- **`PasteTooltipAreaView` gains an `enabled` parameter** (default `true`, existing callers unaffected). When disabled, no `TooltipArea` is created at all — the content is rendered in a plain `Box`, so no hover handlers, delay tasks, or empty popups run for short titles or during editing. All durable edit/overflow state in `SidePasteTitleView` is hoisted above the wrapper, so the subtree swap on an `enabled` flip (which coincides with entering/leaving edit mode) is safe.
- **Title edit commits on focus loss**: previously the rename field only committed on Enter. Enter (`ImeAction.Done`) and `onFocusChanged` now both go through a small `TitleEditCommitter` that serializes commits per edit session: the committed text is snapshotted synchronously at the first commit request, concurrent Enter/focus-loss requests are ignored while a save is in flight (no double `updateName`, no spurious `save_failed` from a CAS conflict), the UI is reset to the exact committed name on success, and a failed save unlocks the session for retry.

## Testing

- `TitleEditCommitterTest` (fast tier, virtual time) covers the async state machine with a delayable fake updater: Enter followed by an immediate focus loss commits exactly once with the snapshotted text, blank text reverts once and blocks the disposal-triggered follow-up commit, and a failure unlocks the session for retry.
- `./gradlew ktlintFormat` and `app:desktopTest` pass.
- Manually verified in the running app: hovering the title bar shows the full title when clipped; short titles show no tooltip; clicking away while renaming saves the new title.