### PR TITLE
:hammer: replace Netty server engine with CIO on desktop

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,7 +135,6 @@ kotlin {
             implementation(libs.jna.platform)
             implementation(libs.jnativehook)
             implementation(libs.ktor.server.cio)
-            implementation(libs.ktor.server.netty)
             implementation(libs.logback.classic)
             implementation(libs.mcp.server)
             implementation(libs.metadata.extractor)
@@ -303,7 +302,6 @@ private fun initJvmArgs(
             "-Djava.net.preferIPv4Stack=true",
             "-Djava.net.preferIPv6Addresses=false",
             "-DglobalListener=$globalListener",
-            "-Dio.netty.maxDirectMemory=268435456",
         ),
     )
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopNetworkModule.kt
@@ -83,7 +83,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.websocket.WebSockets
-import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.cio.CIOApplicationEngine
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -174,11 +174,11 @@ fun desktopNetworkModule(
             DesktopPasteServer(
                 get(named("readWritePort")),
                 get(),
-                get<ServerFactory<NettyApplicationEngine, NettyApplicationEngine.Configuration>>(),
+                get<ServerFactory<CIOApplicationEngine, CIOApplicationEngine.Configuration>>(),
                 get(),
             )
         }
-        single<ServerFactory<NettyApplicationEngine, NettyApplicationEngine.Configuration>> {
+        single<ServerFactory<CIOApplicationEngine, CIOApplicationEngine.Configuration>> {
             DesktopServerFactory()
         }
         single<ServerModule> {

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliServer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliServer.kt
@@ -46,7 +46,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * processes are inside the trust boundary — they can already read the
  * database files directly.
  *
- * Runs as an independent CIO server so the Netty sync server stays untouched.
+ * Runs as an independent CIO server so the sync server stays untouched.
  * On successful start it publishes [CliEndpoint] via [CliEndpointFile]; the
  * CLI discovers the socket exclusively through that file.
  */

--- a/app/src/desktopMain/kotlin/com/crosspaste/mcp/DesktopMcpServer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/mcp/DesktopMcpServer.kt
@@ -2,8 +2,10 @@ package com.crosspaste.mcp
 
 import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
+import io.ktor.server.cio.CIO
+import io.ktor.server.cio.CIOApplicationEngine
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
@@ -19,7 +21,7 @@ class DesktopMcpServer(
 
     private val logger = KotlinLogging.logger {}
 
-    private var server: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>? = null
+    private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
     private var actualPort: Int = 0
 
     override suspend fun start() {
@@ -51,7 +53,7 @@ class DesktopMcpServer(
                 mcpResourceProvider.registerResources(mcpServer)
 
                 server =
-                    embeddedServer(Netty, host = "127.0.0.1", port = port) {
+                    embeddedServer(CIO, host = "127.0.0.1", port = port) {
                         mcp {
                             mcpServer
                         }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteServer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteServer.kt
@@ -4,7 +4,7 @@ import com.crosspaste.config.ReadWriteConfig
 import com.crosspaste.net.exception.ExceptionHandler
 import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.cio.CIOApplicationEngine
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
@@ -12,9 +12,9 @@ import kotlin.coroutines.CoroutineContext
 class DesktopPasteServer(
     private val readWritePort: ReadWriteConfig<Int>,
     private val exceptionHandler: ExceptionHandler,
-    serverFactory: ServerFactory<NettyApplicationEngine, NettyApplicationEngine.Configuration>,
+    serverFactory: ServerFactory<CIOApplicationEngine, CIOApplicationEngine.Configuration>,
     serverModule: ServerModule,
-) : PasteServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>(
+) : PasteServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>(
         serverFactory,
         serverModule,
     ) {

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopServerFactory.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopServerFactory.kt
@@ -1,18 +1,11 @@
 package com.crosspaste.net
 
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
-import io.netty.channel.ChannelOption
+import io.ktor.server.cio.CIO
+import io.ktor.server.cio.CIOApplicationEngine
+import io.ktor.server.engine.ApplicationEngineFactory
 
-class DesktopServerFactory : ServerFactory<NettyApplicationEngine, NettyApplicationEngine.Configuration> {
-    override fun getFactory(): ApplicationEngineFactory<NettyApplicationEngine, NettyApplicationEngine.Configuration> =
-        Netty
+class DesktopServerFactory : ServerFactory<CIOApplicationEngine, CIOApplicationEngine.Configuration> {
+    override fun getFactory(): ApplicationEngineFactory<CIOApplicationEngine, CIOApplicationEngine.Configuration> = CIO
 
-    override fun getConfigure(): NettyApplicationEngine.Configuration.() -> Unit =
-        {
-            configureBootstrap = {
-                childOption(ChannelOption.TCP_NODELAY, true)
-                childOption(ChannelOption.SO_KEEPALIVE, true)
-            }
-        }
+    override fun getConfigure(): CIOApplicationEngine.Configuration.() -> Unit = {}
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopPasteServerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopPasteServerTest.kt
@@ -2,7 +2,7 @@ package com.crosspaste.net
 
 import com.crosspaste.config.TestReadWritePort
 import com.crosspaste.net.exception.ExceptionHandler
-import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.cio.CIOApplicationEngine
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -24,8 +24,8 @@ class DesktopPasteServerTest {
             val serverFactory =
                 mockk<
                     ServerFactory<
-                        NettyApplicationEngine,
-                        NettyApplicationEngine.Configuration,
+                        CIOApplicationEngine,
+                        CIOApplicationEngine.Configuration,
                     >,
                 > {
                     every { getFactory() } throws startupFailure

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncIntegrationTest.kt
@@ -207,8 +207,8 @@ class SyncIntegrationTest {
             a.start()
             b.start()
             c.start()
-            // Allow Netty event loops to stabilize after starting 3 servers
-            // in the same JVM to avoid ClosedReadChannelException from resource contention
+            // Let the 3 servers in the same JVM finish binding before pairing
+            // to avoid ClosedReadChannelException from resource contention
             kotlinx.coroutines.delay(200.milliseconds)
 
             // B trusts A

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/SyncTest.kt
@@ -36,7 +36,7 @@ import com.crosspaste.utils.DeviceUtils
 import com.crosspaste.utils.HostAndPort
 import com.crosspaste.utils.buildUrl
 import com.crosspaste.utils.getPlatformUtils
-import io.ktor.server.netty.*
+import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.util.reflect.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -127,14 +127,14 @@ class SyncTest : KoinTest {
                     DesktopPasteServer(
                         get(named("readWritePort")),
                         get(),
-                        get<ServerFactory<NettyApplicationEngine, NettyApplicationEngine.Configuration>>(),
+                        get<ServerFactory<CIOApplicationEngine, CIOApplicationEngine.Configuration>>(),
                         get(),
                     )
                 }
                 single<CommonConfigManager> { TestConfigManager(TestAppConfig()) }
                 single<PendingKeyExchangeStore> { PendingKeyExchangeStore() }
                 single<SyncApi> { SyncApi }
-                single<ServerFactory<NettyApplicationEngine, NettyApplicationEngine.Configuration>> {
+                single<ServerFactory<CIOApplicationEngine, CIOApplicationEngine.Configuration>> {
                     DesktopServerFactory()
                 }
                 single<SyncInfoFactory> { SyncInfoFactory(get(named("serverAppInfo")), get()) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -109,7 +109,6 @@ ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
 ktor-server-compression = { module = "io.ktor:ktor-server-compression", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
-ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }


### PR DESCRIPTION
## Summary

Part of #4908 (thread count growing over long uptime).

The desktop sync server and the local MCP server were the only Netty users in the app. Netty keeps three event loop groups sized for a server host (connection = parallelism/2+1, worker = parallelism/2+1, call = parallelism), starts each event loop thread lazily on first use, and never releases it until shutdown. On an 18-core machine that is up to 38 permanently parked `eventLoopGroupProxy-*` threads that only appear to "grow" over days because they start on demand.

This PR swaps both servers to Ktor's CIO engine and removes the Netty dependency entirely:

- `DesktopServerFactory` / `DesktopPasteServer` / `DesktopNetworkModule` now use `CIOApplicationEngine`.
- `DesktopMcpServer` uses `embeddedServer(CIO, ...)`; the MCP SDK's `mcp {}` plugin is engine agnostic.
- `ktor-server-netty` is dropped from the version catalog and the desktop dependencies, along with the `-Dio.netty.maxDirectMemory` JVM flag. The whole `io.netty:*` 4.2.x stack disappears from the runtime classpath.
- The Netty bootstrap options are gone: Ktor's network layer already sets `TCP_NODELAY` on accepted sockets, and the 30 s WebSocket ping already covers keep-alive.

CIO has no dedicated threads. The selector loop and request handling run on `Dispatchers.IO`, whose idle workers are reclaimed after 60 s, so the server no longer contributes a fixed thread pool at all. The CLI server has been running on CIO since it was introduced, and the `commonMain` routing is engine agnostic (the mobile apps cannot use Netty), so no routing or protocol code changes.

Verified from Ktor 3.5.2 sources that CIO's `connectionIdleTimeoutSeconds` (45 s) only applies while waiting between HTTP responses on a keep-alive connection; after a WebSocket upgrade the pipeline closes its writer channel and hands the connection over, so long-lived sync sockets are unaffected.

## Test plan

- [x] `./gradlew app:desktopTest` (fast tier): 1680 tests, 0 failures
- [x] `./gradlew app:desktopTest -PintegrationTests --tests SyncIntegrationTest` (3 servers, full pairing + sync in one JVM): 15/15
- [x] `DesktopPasteServerTest` port-in-use fallback path still passes
- [x] `app:dependencies --configuration desktopRuntimeClasspath` contains no Netty artifacts
- [x] Real-machine: two devices, large file transfer throughput and a WebSocket sync session idle for more than 45 s
- [x] Real-machine: thread count (`ps -M <pid> | wc -l`) after several hours compared with 2.2.0
