### PR TITLE
:bug: fix Coil memory cache limit being overridden to 435 MiB

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/DesktopAppModule.kt
@@ -184,7 +184,6 @@ fun desktopAppModule(
                 .strongReferencesEnabled(true)
                 .weakReferencesEnabled(true)
                 .maxSizeBytes(256L * 1024L * 1024L)
-                .maxSizePercent(get<PlatformContext>(), 0.85)
                 .build()
         }
         single<ThumbnailLoader> { DesktopThumbnailLoader(get(), get()) }


### PR DESCRIPTION
## Summary

Part of #4908 (903 MB physical footprint after ~6 days idle). Independent of #4911, which handles the thread count side.

`DesktopAppModule` built the shared Coil `MemoryCache` with `.maxSizeBytes(256 MiB)` followed by `.maxSizePercent(context, 0.85)`. In Coil 3 the second call replaces the first (`maxSizeBytesFactory` is a single field), and on non-Android targets `totalAvailableMemoryBytes()` is hard-coded to 512 MiB, so the strong-reference LRU was actually 435 MiB. It fills slowly with every thumbnail and preview the user scrolls past, which matches the "grows with uptime, then plateaus" shape in the report. The overriding call is removed so the intended 256 MiB limit applies.

GC tuning flags were part of the first revision of this PR and have been dropped: `-XX:ParallelGCThreads` is a fixed count rather than a cap and `-XX:+UseG1GC` would force G1 onto single-core machines that default to Serial, and the remaining periodic-GC / heap-free-ratio flags need real-machine RSS, pause and CPU measurements before they are worth shipping. They will come back as a separate PR once that A/B exists.

## Test plan

- [x] `app:compileKotlinDesktop`
- [ ] Real-machine: scroll a long image-heavy history to confirm previews still stay cached and responsive
