### PR TITLE
:whale: add Glama stdio Dockerfile for the MCP server

### DIFF
--- a/glama/Dockerfile
+++ b/glama/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1
+# CrossPaste MCP server over stdio, for Glama's introspection checks.
+#
+# CrossPaste is a desktop clipboard manager; its MCP server is built into the
+# app and speaks SSE on 127.0.0.1:13130. This image runs the app's headless
+# daemon (no display needed) and bridges its SSE endpoint to stdio with
+# mcp-remote, so the container behaves like a plain stdio MCP server.
+# Self-contained: no build context files are needed.
+
+FROM node:22-bookworm-slim
+
+ARG CROSSPASTE_VERSION=2.2.0
+ARG CROSSPASTE_BUILD=2544
+ARG TARGETARCH
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+      libfreetype6 fontconfig \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) arch=amd64 ;; \
+      arm64) arch=aarch64 ;; \
+      *) echo "unsupported arch ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/crosspaste.tar.gz \
+      "https://github.com/CrossPaste/crosspaste-desktop/releases/download/${CROSSPASTE_VERSION}.${CROSSPASTE_BUILD}/crosspaste-${CROSSPASTE_VERSION}-${CROSSPASTE_BUILD}-linux-${arch}.tar.gz"; \
+    mkdir -p /opt/crosspaste; \
+    tar -xzf /tmp/crosspaste.tar.gz -C /opt/crosspaste --strip-components=1; \
+    rm /tmp/crosspaste.tar.gz
+
+RUN npm install -g mcp-remote@0.8.3
+
+RUN useradd -m -u 1987 mcp
+
+# Start the headless daemon with the MCP server enabled, wait for its SSE
+# endpoint, then bridge it to stdio. Daemon output goes to stderr so stdout
+# stays clean for the MCP protocol.
+COPY <<'EOF' /usr/local/bin/entrypoint.sh
+#!/bin/sh
+set -eu
+
+PORT=13130
+DATA_DIR="$HOME/.local/share/.crosspaste"
+
+mkdir -p "$DATA_DIR"
+if [ ! -f "$DATA_DIR/appConfig.json" ]; then
+  printf '{"language":"en","enableMcpServer":true,"mcpServerPort":%s}\n' "$PORT" > "$DATA_DIR/appConfig.json"
+fi
+
+/opt/crosspaste/bin/crosspaste --headless 1>&2 &
+DAEMON_PID=$!
+
+# The SSE endpoint never closes, so a timed-out request that already got a
+# 200 counts as ready.
+i=0
+until [ "$(curl -s -m 2 -o /dev/null -w '%{http_code}' -H 'Accept: text/event-stream' "http://127.0.0.1:${PORT}/" 2>/dev/null)" = "200" ]; do
+  i=$((i + 1))
+  if [ "$i" -ge 120 ]; then
+    echo "crosspaste MCP endpoint did not come up on port ${PORT}" >&2
+    kill "$DAEMON_PID" 2>/dev/null || true
+    exit 1
+  fi
+  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+    echo "crosspaste daemon exited during startup" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+trap 'kill "$DAEMON_PID" 2>/dev/null || true' EXIT INT TERM
+exec mcp-remote "http://127.0.0.1:${PORT}/" --transport sse-only --allow-http
+EOF
+RUN chmod 755 /usr/local/bin/entrypoint.sh
+
+USER mcp
+WORKDIR /home/mcp
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/glama/mcp_stdio_probe.py
+++ b/glama/mcp_stdio_probe.py
@@ -1,17 +1,34 @@
 #!/usr/bin/env python3
 """Minimal MCP stdio client: runs a command, sends initialize + tools/list, prints results."""
-import json, subprocess, sys, threading, time
+import json
+import subprocess
+import sys
+import threading
+import time
 
 cmd = sys.argv[1:]
-p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
+p = subprocess.Popen(
+    cmd,
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+    bufsize=1,
+)
+
 
 def drain_stderr():
     for line in p.stderr:
         sys.stderr.write("[stderr] " + line)
+
+
 threading.Thread(target=drain_stderr, daemon=True).start()
 
+
 def send(obj):
-    p.stdin.write(json.dumps(obj) + "\n"); p.stdin.flush()
+    p.stdin.write(json.dumps(obj) + "\n")
+    p.stdin.flush()
+
 
 def recv(timeout=120):
     deadline = time.time() + timeout
@@ -20,27 +37,41 @@ def recv(timeout=120):
         if not line:
             if p.poll() is not None:
                 raise SystemExit(f"process exited with {p.returncode}")
-            time.sleep(0.1); continue
+            time.sleep(0.1)
+            continue
         line = line.strip()
-        if not line: continue
+        if not line:
+            continue
         try:
             return json.loads(line)
         except json.JSONDecodeError:
             sys.stderr.write("[stdout-noise] " + line + "\n")
     raise SystemExit("timeout waiting for response")
 
-send({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}})
+
+send({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "probe", "version": "0"},
+    },
+})
 init = recv()
-print("initialize ->", json.dumps(init.get("result", init), indent=None)[:400])
-send({"jsonrpc":"2.0","method":"notifications/initialized"})
-send({"jsonrpc":"2.0","id":2,"method":"tools/list"})
+print("initialize ->", json.dumps(init.get("result", init))[:400])
+send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+send({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
 tools = recv()
 names = [t["name"] for t in tools.get("result", {}).get("tools", [])]
 print("tools/list ->", names)
-send({"jsonrpc":"2.0","id":3,"method":"resources/list"})
+send({"jsonrpc": "2.0", "id": 3, "method": "resources/list"})
 res = recv()
 print("resources/list ->", [r["name"] for r in res.get("result", {}).get("resources", [])])
 p.stdin.close()
-try: p.wait(timeout=10)
-except subprocess.TimeoutExpired: p.kill()
+try:
+    p.wait(timeout=10)
+except subprocess.TimeoutExpired:
+    p.kill()
 sys.exit(0 if names else 1)

--- a/glama/mcp_stdio_probe.py
+++ b/glama/mcp_stdio_probe.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Minimal MCP stdio client: runs a command, sends initialize + tools/list, prints results."""
+import json, subprocess, sys, threading, time
+
+cmd = sys.argv[1:]
+p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
+
+def drain_stderr():
+    for line in p.stderr:
+        sys.stderr.write("[stderr] " + line)
+threading.Thread(target=drain_stderr, daemon=True).start()
+
+def send(obj):
+    p.stdin.write(json.dumps(obj) + "\n"); p.stdin.flush()
+
+def recv(timeout=120):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        line = p.stdout.readline()
+        if not line:
+            if p.poll() is not None:
+                raise SystemExit(f"process exited with {p.returncode}")
+            time.sleep(0.1); continue
+        line = line.strip()
+        if not line: continue
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            sys.stderr.write("[stdout-noise] " + line + "\n")
+    raise SystemExit("timeout waiting for response")
+
+send({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}})
+init = recv()
+print("initialize ->", json.dumps(init.get("result", init), indent=None)[:400])
+send({"jsonrpc":"2.0","method":"notifications/initialized"})
+send({"jsonrpc":"2.0","id":2,"method":"tools/list"})
+tools = recv()
+names = [t["name"] for t in tools.get("result", {}).get("tools", [])]
+print("tools/list ->", names)
+send({"jsonrpc":"2.0","id":3,"method":"resources/list"})
+res = recv()
+print("resources/list ->", [r["name"] for r in res.get("result", {}).get("resources", [])])
+p.stdin.close()
+try: p.wait(timeout=10)
+except subprocess.TimeoutExpired: p.kill()
+sys.exit(0 if names else 1)


### PR DESCRIPTION
## Why

Glama (and the awesome-mcp-servers list, which now requires a Glama badge) only runs stdio servers built from a Dockerfile. CrossPaste's MCP server is embedded in the desktop app as an SSE endpoint on `127.0.0.1:13130`, so there was no stdio form to submit.

## What

`glama/Dockerfile` is a self-contained image that:

- downloads the Linux release tarball (bundled JRE, version pinned via `CROSSPASTE_VERSION` / `CROSSPASTE_BUILD` build args)
- seeds `appConfig.json` with the MCP server enabled and starts the app with `--headless`
- waits for the SSE endpoint, then bridges it to stdio with `mcp-remote --transport sse-only`

`glama/mcp_stdio_probe.py` is a small stdio client used to verify the image.

## Verified

Built and probed for both `linux/amd64` and `linux/arm64`: `initialize`, `tools/list` (5 tools) and `resources/list` (2 resources) all respond.

```
docker build -t crosspaste-mcp glama
python3 glama/mcp_stdio_probe.py docker run --rm -i crosspaste-mcp
```

No application code changes.