### PR TITLE
:heavy_minus_sign: remove unused kotter entry from the version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,6 @@ kotlinx-serialization = "1.11.0"
 kotlinx-uuid = "0.1.7"
 ksoup = "0.2.6"
 ktlint = "14.2.0"
-kotter = "1.4.0"
 ktor = "3.5.2"
 lifecycle = "2.11.0"
 logback = "1.6.3"
@@ -89,7 +88,6 @@ koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging", version.ref = "kotlin-logging" }
-kotter = { module = "com.varabyte.kotter:kotter", version.ref = "kotter" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }


### PR DESCRIPTION
## Summary

Remove the `kotter` version and library entries from `gradle/libs.versions.toml`. Nothing in the repository consumes them: no `build.gradle.kts` references `libs.kotter`, and no source file imports `com.varabyte`.

## Background

The entries were added in #3950 when the native CLI was first planned, presumably as a candidate TUI library, but the CLI ended up building its interactive views (`pick`, `watch`, `edit`) on Clikt 5's bundled mordant raw-mode support plus hand-written rendering and inline image protocols. Since then Dependabot has bumped the dead entry twice (#4478, #4685) with no effect on any artifact.

Introducing kotter is also not a viable option going forward: its 1.4.0 release publishes native variants for linuxX64, macosX64, macosArm64 and mingwX64 only, with no linuxArm64 target, which the CLI builds.

## Verification

- `./gradlew help` configures successfully with the trimmed catalog.