### PR TITLE
:bug: restart pairing v3 session after a lost proof response

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Results.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Results.kt
@@ -55,8 +55,9 @@ sealed interface PairingV3PinResult {
     /**
      * Transport failure. When [commitPending] is true the local session holds a
      * verified transcript in COMMITTING state and `retryCommit` can complete the
-     * pairing without a new PIN; otherwise the generation was invalidated and the
-     * caller should refresh the offer and ask for the (possibly rotated) PIN again.
+     * pairing without a new PIN. Otherwise the proof response was lost: the
+     * acceptor may or may not have verified the proof, so the session cannot be
+     * proven again and the caller must cancel it and start a fresh one.
      */
     data class NetworkError(
         val failure: ClientApiResult,

--- a/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/pairing/v3/PairingProtocolV3Service.kt
@@ -868,6 +868,10 @@ class PairingProtocolV3Service(
                         PairingKeySchedule.identitySignaturePayload(PakeRole.INITIATOR, transcriptHash)
                     },
             )
+        // Any failure here retires this generation locally. Without a v3 error
+        // code the outcome is ambiguous (the acceptor may have verified the proof
+        // before the response was lost), and the caller restarts with a fresh
+        // session instead of refreshing this one.
         val response =
             when (val sent = pairingV3ClientApi.sendProof(proof, toUrl)) {
                 is SuccessResult -> sent.getResult<PairingProofResponseV3>()
@@ -1038,7 +1042,10 @@ class PairingProtocolV3Service(
     /**
      * Re-fetches the acceptor's current offer by resending the byte-identical
      * intent and adopts its generation (rotated PIN, fresh PAKE share). Used after
-     * `PAIRING_PIN_EXPIRED` or a transport failure during the proof step.
+     * `PAIRING_PIN_EXPIRED` / `PAIRING_PROOF_INVALID`, where the acceptor is known
+     * to have invalidated the generation. Not for a lost proof response: the
+     * acceptor may have accepted that proof, and the byte-identical intent would
+     * then return the same session with no provable generation left.
      */
     suspend fun refreshOffer(
         sessionId: String,

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3TrustDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3TrustDeviceDialog.kt
@@ -442,6 +442,7 @@ internal class PairingV3DialogState(
             PairingV3Recovery.RETRY_COMMIT,
             -> sessionId?.let { launchAction { controller.recover(it) } }
 
+            PairingV3Recovery.RESTART -> sessionId?.let { launchAction { controller.restart(it, appInstanceId) } }
             PairingV3Recovery.NONE -> Unit
         }
     }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PairingV3UiController.kt
@@ -50,6 +50,19 @@ interface PairingV3UiController {
 
     suspend fun recover(sessionId: String): PairingV3UiResult
 
+    /**
+     * Abandons [sessionId] (notifying the peer best-effort) and opens a fresh
+     * session with [peerAppInstanceId]. Used when the current session can no
+     * longer be proven — e.g. the proof was accepted by the acceptor but its
+     * response was lost — so re-fetching the old offer could never succeed.
+     * Idempotent: a retried restart still opens a fresh session after the old
+     * one is gone, which is why the peer is passed explicitly.
+     */
+    suspend fun restart(
+        sessionId: String,
+        peerAppInstanceId: String,
+    ): PairingV3UiResult
+
     suspend fun reject(sessionId: String): Boolean
 
     suspend fun cancel(sessionId: String): Boolean
@@ -85,6 +98,7 @@ enum class PairingV3Recovery {
     RETRY_START,
     REFRESH_OFFER,
     RETRY_COMMIT,
+    RESTART,
 }
 
 sealed interface PairingV3UiResult {
@@ -204,6 +218,14 @@ class DefaultPairingV3UiController(
             }
         }
 
+    override suspend fun restart(
+        sessionId: String,
+        peerAppInstanceId: String,
+    ): PairingV3UiResult {
+        cancel(sessionId)
+        return startPairing(peerAppInstanceId)
+    }
+
     override suspend fun reject(sessionId: String): Boolean =
         withContext(ioDispatcher) { pairingProtocolV3Service.rejectSession(sessionId) }
 
@@ -273,6 +295,10 @@ internal fun PairingV3PinResult.toUiResult(): PairingV3UiResult =
                 recovery = code.pinRecovery(),
             )
 
+        // A lost proof response is ambiguous: the acceptor may already have
+        // verified the proof and moved past the PIN step, in which case a
+        // refreshed offer would only replay the old session and every further
+        // proof against it is refused. Only a fresh session converges both sides.
         is PairingV3PinResult.NetworkError ->
             PairingV3UiResult.Error(
                 reason = PairingV3UiError.NETWORK_FAILURE,
@@ -280,7 +306,7 @@ internal fun PairingV3PinResult.toUiResult(): PairingV3UiResult =
                     if (commitPending) {
                         PairingV3Recovery.RETRY_COMMIT
                     } else {
-                        PairingV3Recovery.REFRESH_OFFER
+                        PairingV3Recovery.RESTART
                     },
             )
     }

--- a/app/src/desktopMain/kotlin/com/crosspaste/cli/CliPairingService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/cli/CliPairingService.kt
@@ -46,7 +46,7 @@ import kotlin.time.Duration.Companion.seconds
  *   for the resolver to reach UNVERIFIED with a resolved host, warm up via
  *   [SyncManager.exchangeKeysForPairing] (makes the peer display its SAS), then
  *   confirm with [SyncManager.trustBySasCode].
- * - v3 PIN: [PairingV3UiController.startPairing] / submitPin / recover, which
+ * - v3 PIN: [PairingV3UiController.startPairing] / submitPin / recover / restart, which
  *   also makes the peer surface its pairing UI (showPairingCode) so a closed
  *   acceptance window opens the same way it does for a GUI initiator.
  *
@@ -91,6 +91,7 @@ class CliPairingService(
     private enum class V3Action {
         SUBMIT_PIN,
         RECOVER,
+        RESTART,
     }
 
     private val sessions = ConcurrentHashMap<String, PairSession>()
@@ -418,17 +419,21 @@ class CliPairingService(
         // COMMITTING. Recover on a fresh timeout scope before claiming the CLI
         // session is retryable; if recovery also hangs, the next submit must
         // retry recovery rather than feed another PIN into an unknown state.
-        if (!setNextV3Action(session, V3Action.RECOVER)) {
+        // A restart that timed out is simply restarted again (it is idempotent).
+        // Re-read the entry: the timed-out steps may have updated it.
+        val current = sessions[session.sessionId] ?: return SubmitOutcome.SessionNotFound
+        val action = if (current.nextV3Action == V3Action.RESTART) V3Action.RESTART else V3Action.RECOVER
+        if (!setNextV3Action(session, action)) {
             return SubmitOutcome.SessionNotFound
         }
         val recovered =
             withTimeoutOrNull(RECOVERY_TIMEOUT) {
-                pairingV3UiController.recover(checkNotNull(session.v3SessionId))
+                runV3Action(current, action, checkNotNull(current.v3SessionId), code)
             }
         return when (recovered) {
             PairingV3UiResult.Paired -> completeV3Pairing(session)
             is PairingV3UiResult.SessionReady -> {
-                if (setNextV3Action(session, V3Action.SUBMIT_PIN)) {
+                if (adoptV3Session(session, recovered.sessionId)) {
                     retryableV3Failure(session, "Pairing timed out; check the connection and try again.")
                 } else {
                     SubmitOutcome.SessionNotFound
@@ -460,32 +465,31 @@ class CliPairingService(
         session: PairSession,
         code: String,
     ): SubmitOutcome {
-        val v3SessionId = checkNotNull(session.v3SessionId)
+        var v3SessionId = checkNotNull(session.v3SessionId)
         var submittedPin = session.nextV3Action == V3Action.SUBMIT_PIN
-        var result =
-            if (submittedPin) {
-                pairingV3UiController.submitPin(v3SessionId, V3Pin(code))
-            } else {
-                pairingV3UiController.recover(v3SessionId)
-            }
+        var result = runV3Action(session, session.nextV3Action, v3SessionId, code)
         if (result is PairingV3UiResult.SessionReady) {
-            if (!setNextV3Action(session, V3Action.SUBMIT_PIN)) {
+            v3SessionId = result.sessionId
+            if (!adoptV3Session(session, v3SessionId)) {
                 return SubmitOutcome.SessionNotFound
             }
             result = pairingV3UiController.submitPin(v3SessionId, V3Pin(code))
             submittedPin = true
         }
-        if (submittedPin && result is PairingV3UiResult.Error && result.recovery.requiresRecovery()) {
-            val originalError = result
-            if (!setNextV3Action(session, V3Action.RECOVER)) {
-                return SubmitOutcome.SessionNotFound
-            }
-            result = pairingV3UiController.recover(v3SessionId)
-            if (result is PairingV3UiResult.SessionReady) {
-                if (!setNextV3Action(session, V3Action.SUBMIT_PIN)) {
+        if (submittedPin && result is PairingV3UiResult.Error) {
+            val recovery = result.recovery.toV3Action()
+            if (recovery != null) {
+                val originalError = result
+                if (!setNextV3Action(session, recovery)) {
                     return SubmitOutcome.SessionNotFound
                 }
-                return retryableV3Failure(session, describeV3Error(originalError.reason))
+                result = runV3Action(session, recovery, v3SessionId, code)
+                if (result is PairingV3UiResult.SessionReady) {
+                    if (!adoptV3Session(session, result.sessionId)) {
+                        return SubmitOutcome.SessionNotFound
+                    }
+                    return retryableV3Failure(session, describeV3Recovery(originalError.reason, recovery))
+                }
             }
         }
         return when (result) {
@@ -503,6 +507,40 @@ class CliPairingService(
                 )
         }
     }
+
+    private suspend fun runV3Action(
+        session: PairSession,
+        action: V3Action,
+        v3SessionId: String,
+        code: String,
+    ): PairingV3UiResult =
+        when (action) {
+            V3Action.SUBMIT_PIN -> pairingV3UiController.submitPin(v3SessionId, V3Pin(code))
+            V3Action.RECOVER -> pairingV3UiController.recover(v3SessionId)
+            V3Action.RESTART -> pairingV3UiController.restart(v3SessionId, session.appInstanceId)
+        }
+
+    /** The next PIN goes to a session that recovery just made ready — possibly a new one after a restart. */
+    private fun adoptV3Session(
+        session: PairSession,
+        v3SessionId: String,
+    ): Boolean =
+        updateSession(session) { current ->
+            current.copy(v3SessionId = v3SessionId, nextV3Action = V3Action.SUBMIT_PIN)
+        }
+
+    private fun describeV3Recovery(
+        reason: PairingV3UiError,
+        action: V3Action,
+    ): String =
+        when (action) {
+            V3Action.RESTART ->
+                "${describeV3Error(reason)} The device now shows a new PIN; enter that one."
+
+            V3Action.SUBMIT_PIN,
+            V3Action.RECOVER,
+            -> describeV3Error(reason)
+        }
 
     private fun completeV3Pairing(session: PairSession): SubmitOutcome {
         sessions.remove(session.sessionId)
@@ -522,9 +560,9 @@ class CliPairingService(
         session: PairSession,
         error: PairingV3UiResult.Error,
     ): SubmitOutcome {
-        val retryable = error.recovery.requiresRecovery()
-        if (retryable) {
-            if (!setNextV3Action(session, V3Action.RECOVER)) {
+        val recovery = error.recovery.toV3Action()
+        if (recovery != null) {
+            if (!setNextV3Action(session, recovery)) {
                 return SubmitOutcome.SessionNotFound
             }
         } else {
@@ -533,14 +571,24 @@ class CliPairingService(
         return SubmitOutcome.Completed(
             CliPairSubmitResultDto(
                 paired = false,
-                retryable = retryable,
+                retryable = recovery != null,
                 message = describeV3Error(error.reason),
             ),
         )
     }
 
-    private fun PairingV3Recovery.requiresRecovery(): Boolean =
-        this == PairingV3Recovery.REFRESH_OFFER || this == PairingV3Recovery.RETRY_COMMIT
+    /** The action the next submit must run before it may feed another PIN, or null if the session is dead. */
+    private fun PairingV3Recovery.toV3Action(): V3Action? =
+        when (this) {
+            PairingV3Recovery.REFRESH_OFFER,
+            PairingV3Recovery.RETRY_COMMIT,
+            -> V3Action.RECOVER
+
+            PairingV3Recovery.RESTART -> V3Action.RESTART
+            PairingV3Recovery.NONE,
+            PairingV3Recovery.RETRY_START,
+            -> null
+        }
 
     private suspend fun awaitPairableState(appInstanceId: String): SyncRuntimeInfo? =
         withTimeoutOrNull(RESOLVE_TIMEOUT) {
@@ -565,16 +613,21 @@ class CliPairingService(
     private fun findRuntimeInfo(appInstanceId: String): SyncRuntimeInfo? =
         syncManager.realTimeSyncRuntimeInfos.value.firstOrNull { it.appInstanceId == appInstanceId }
 
-    // Always writes through to the map: the caller's PairSession is a snapshot
-    // from submit entry and may be stale after an earlier update in the same call.
     private fun setNextV3Action(
         session: PairSession,
         action: V3Action,
+    ): Boolean = updateSession(session) { current -> current.copy(nextV3Action = action) }
+
+    // Always writes through to the map: the caller's PairSession is a snapshot
+    // from submit entry and may be stale after an earlier update in the same call.
+    private fun updateSession(
+        session: PairSession,
+        transform: (PairSession) -> PairSession,
     ): Boolean {
         var updated = false
         sessions.computeIfPresent(session.sessionId) { _, current ->
             updated = true
-            current.copy(nextV3Action = action)
+            transform(current)
         }
         return updated
     }

--- a/app/src/desktopTest/kotlin/com/crosspaste/cli/CliPairingServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/cli/CliPairingServiceTest.kt
@@ -775,6 +775,68 @@ class CliPairingServiceTest {
         }
 
     @Test
+    fun `submit v3 restarts after a lost proof response and adopts the fresh session`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("123456")) } returns
+                PairingV3UiResult.Error(PairingV3UiError.NETWORK_FAILURE, PairingV3Recovery.RESTART)
+            coEvery { fixture.pairingV3UiController.restart("v3-session", PEER_ID) } returns
+                PairingV3UiResult.SessionReady("v3-session-2", 1L, 789L, "AB:CD")
+
+            val first =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "123456"),
+                )
+            assertFalse(first.result.paired)
+            assertTrue(first.result.retryable)
+            assertContains(first.result.message, "new PIN")
+
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session-2", V3Pin("654321")) } returns
+                PairingV3UiResult.Paired
+
+            val second =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "654321"),
+                )
+            assertTrue(second.result.paired)
+            coVerify(exactly = 1) { fixture.pairingV3UiController.restart("v3-session", PEER_ID) }
+            coVerify(exactly = 0) { fixture.pairingV3UiController.recover(any()) }
+        }
+
+    @Test
+    fun `submit v3 retries the restart before accepting another pin when it failed`() =
+        runTest {
+            val fixture = Fixture(localPairingVersion = 3)
+            val session = startedV3Session(fixture)
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session", V3Pin("111111")) } returns
+                PairingV3UiResult.Error(PairingV3UiError.NETWORK_FAILURE, PairingV3Recovery.RESTART)
+            coEvery { fixture.pairingV3UiController.restart("v3-session", PEER_ID) } coAnswers {
+                awaitCancellation()
+            }
+
+            val first =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "111111"),
+                )
+            assertFalse(first.result.paired)
+            assertTrue(first.result.retryable)
+
+            coEvery { fixture.pairingV3UiController.restart("v3-session", PEER_ID) } returns
+                PairingV3UiResult.SessionReady("v3-session-2", 1L, 789L, "AB:CD")
+            coEvery { fixture.pairingV3UiController.submitPin("v3-session-2", V3Pin("123456")) } returns
+                PairingV3UiResult.Paired
+
+            val second =
+                assertIs<CliPairingService.SubmitOutcome.Completed>(
+                    fixture.service.submit(session.sessionId, "123456"),
+                )
+            assertTrue(second.result.paired)
+            // In-flight, once more on the timeout path, once on the next submit.
+            coVerify(exactly = 3) { fixture.pairingV3UiController.restart("v3-session", PEER_ID) }
+        }
+
+    @Test
     fun `concurrent v3 submits are serialized per session`() =
         runTest {
             val fixture = Fixture(localPairingVersion = 3)

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/PairingV3IntegrationTest.kt
@@ -10,7 +10,9 @@ import com.crosspaste.dto.pairing.v3.PairingV3ErrorCode
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.clientapi.ClientApiResult
 import com.crosspaste.net.clientapi.FailureResult
+import com.crosspaste.net.clientapi.PairingV3Transport
 import com.crosspaste.net.clientapi.SuccessResult
+import com.crosspaste.net.clientapi.UnknownError
 import com.crosspaste.pairing.v3.OpenSslPakeEcOps
 import com.crosspaste.pairing.v3.PairingKeySchedule
 import com.crosspaste.pairing.v3.PairingRateLimiter
@@ -47,6 +49,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -76,6 +79,7 @@ class PairingV3IntegrationTest {
         pairingV3Enabled: Boolean = true,
         acceptanceWindowMaxProofFailures: Int = PairingV3.MAX_ACCEPTOR_PROOF_FAILURES,
         pairingTelemetryObserver: PairingV3TelemetryObserver = PairingV3TelemetryObserver.NOOP,
+        pairingV3Transport: (PairingV3Transport) -> PairingV3Transport = { it },
     ): TestInstance =
         TestInstance(
             appInstanceId = id,
@@ -87,6 +91,7 @@ class PairingV3IntegrationTest {
             pairingV3Enabled = pairingV3Enabled,
             acceptanceWindowMaxProofFailures = acceptanceWindowMaxProofFailures,
             pairingTelemetryObserver = pairingTelemetryObserver,
+            pairingV3Transport = pairingV3Transport,
         ).also { instances.add(it) }
 
     @AfterTest
@@ -489,6 +494,57 @@ class PairingV3IntegrationTest {
             val paired = b.pairingProtocolV3Service.submitPin(started.sessionId, freshPin, urlFor(a))
             assertIs<PairingV3PinResult.Paired>(paired)
             assertTrue(a.secureIO.existCryptPublicKey(b.appInstanceId))
+        }
+
+    @Test
+    fun testLostProofResponseIsRecoveredByRestartingTheSession() =
+        runBlocking {
+            val dropProofResponse = AtomicBoolean(false)
+            val a = createInstance("lost-proof-a")
+            val b =
+                createInstance("lost-proof-b") { delegate ->
+                    object : PairingV3Transport by delegate {
+                        override suspend fun sendProof(
+                            proof: PairingProofV3,
+                            toUrl: io.ktor.http.URLBuilder.() -> Unit,
+                        ): ClientApiResult {
+                            // The proof reaches the acceptor; only the response is lost.
+                            val sent = delegate.sendProof(proof, toUrl)
+                            return if (dropProofResponse.get()) UnknownError else sent
+                        }
+                    }
+                }
+            a.start()
+            b.start()
+            a.pairingAcceptanceWindow.open(WindowOpenSource.LOCAL)
+
+            val first = startPairing(b, a)
+            val pin = displayedPin(a, b.appInstanceId)
+            dropProofResponse.set(true)
+            val lost = b.pairingProtocolV3Service.submitPin(first.sessionId, pin, urlFor(a))
+            dropProofResponse.set(false)
+            assertIs<PairingV3PinResult.NetworkError>(lost)
+            assertFalse(lost.commitPending)
+
+            // The acceptor verified the proof and left the PIN step behind
+            awaitCondition(message = "acceptor reaches PEER_CONFIRMED") {
+                acceptorCardFor(a, b.appInstanceId)?.state == PairingSessionState.PEER_CONFIRMED
+            }
+
+            // Refreshing the offer replays the same session, so no further proof can succeed on it
+            b.pairingProtocolV3Service.refreshOffer(first.sessionId, urlFor(a))
+            val replayed = b.pairingProtocolV3Service.submitPin(first.sessionId, pin, urlFor(a))
+            assertIs<PairingV3PinResult.Refused>(replayed)
+
+            // Restart: cancel the dead session and open a fresh one with a new PIN
+            assertTrue(b.pairingProtocolV3Service.cancelSession(first.sessionId, urlFor(a)))
+            val second = startPairing(b, a)
+            assertNotEquals(first.sessionId, second.sessionId)
+            val freshPin = displayedPin(a, b.appInstanceId)
+            val paired = b.pairingProtocolV3Service.submitPin(second.sessionId, freshPin, urlFor(a))
+            assertIs<PairingV3PinResult.Paired>(paired)
+            assertTrue(a.secureIO.existCryptPublicKey(b.appInstanceId))
+            assertTrue(b.secureIO.existCryptPublicKey(a.appInstanceId))
         }
 
     @Test

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestInstance.kt
@@ -8,6 +8,7 @@ import com.crosspaste.config.TestConfigManager
 import com.crosspaste.config.TestReadWritePort
 import com.crosspaste.db.secure.MemorySecureIO
 import com.crosspaste.net.clientapi.PairingV3ClientApi
+import com.crosspaste.net.clientapi.PairingV3Transport
 import com.crosspaste.net.clientapi.SyncClientApi
 import com.crosspaste.net.exception.DesktopExceptionHandler
 import com.crosspaste.net.exception.ExceptionHandler
@@ -50,6 +51,8 @@ class TestInstance(
     pairingV3Enabled: Boolean = true,
     acceptanceWindowMaxProofFailures: Int = PairingV3.MAX_ACCEPTOR_PROOF_FAILURES,
     pairingTelemetryObserver: PairingV3TelemetryObserver = PairingV3TelemetryObserver.NOOP,
+    // Wraps the real HTTP transport so a test can lose or alter individual calls.
+    pairingV3Transport: (PairingV3Transport) -> PairingV3Transport = { it },
 ) {
     companion object {
         val platform: Platform = getPlatformUtils().platform
@@ -105,7 +108,7 @@ class TestInstance(
     val pairingProtocolV3Service =
         PairingProtocolV3Service(
             appInfo = appInfo,
-            pairingV3ClientApi = pairingV3ClientApi,
+            pairingV3ClientApi = pairingV3Transport(pairingV3ClientApi),
             pakeProvider = pakeProvider,
             receiptCache = pairingReceiptCache,
             rateLimiter = pairingRateLimiter,

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3DialogModelTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3DialogModelTest.kt
@@ -87,6 +87,20 @@ class PairingV3DialogModelTest {
     }
 
     @Test
+    fun restartRecoveryWithSessionOffersRetry() {
+        val m =
+            model(
+                uiError = PairingV3UiError.NETWORK_FAILURE,
+                recovery = PairingV3Recovery.RESTART,
+                pinComplete = true,
+            )
+        assertTrue(m.canRetry)
+        assertFalse(m.showConfirm)
+        assertFalse(m.canSubmit)
+        assertTrue(m.inputLocked)
+    }
+
+    @Test
     fun unrecoverableErrorLeavesOnlyCancel() {
         val m =
             model(

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3DialogStateTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3DialogStateTest.kt
@@ -120,4 +120,43 @@ class PairingV3DialogStateTest {
             assertEquals(PairingV3Recovery.REFRESH_OFFER, state.recovery)
             assertTrue(state.recovery != PairingV3Recovery.NONE)
         }
+
+    @Test
+    fun restartRecovery_retryRestartsInsteadOfRefreshing() =
+        runTest {
+            val controller = mockk<PairingV3UiController>()
+            val state =
+                PairingV3DialogState(
+                    appInstanceId = "peer",
+                    controller = controller,
+                    syncManager = mockk<SyncManager>(relaxed = true),
+                    coroutineScope = this,
+                )
+            coEvery { controller.submitPin("session", any()) } returns
+                PairingV3UiResult.Error(
+                    PairingV3UiError.NETWORK_FAILURE,
+                    PairingV3Recovery.RESTART,
+                )
+            coEvery { controller.restart("session", "peer") } returns
+                PairingV3UiResult.SessionReady(
+                    sessionId = "session-2",
+                    tokenGeneration = 1,
+                    pinExpiresAt = 60_000,
+                    peerKeyFingerprintDisplay = "aabbccdd",
+                )
+
+            state.submitPin("session", "123456")
+            runCurrent()
+            assertEquals(PairingV3UiError.NETWORK_FAILURE, state.uiError)
+            assertEquals(PairingV3Recovery.RESTART, state.recovery)
+
+            state.retry("session")
+            runCurrent()
+
+            coVerify(exactly = 1) { controller.restart("session", "peer") }
+            coVerify(exactly = 0) { controller.recover(any()) }
+            assertEquals(null, state.uiError)
+            assertEquals(PairingV3Recovery.NONE, state.recovery)
+            assertFalse(state.isLoading)
+        }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3UiControllerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/ui/devices/PairingV3UiControllerTest.kt
@@ -132,7 +132,9 @@ class PairingV3UiControllerTest {
     }
 
     @Test
-    fun proofNetworkFailureRefreshesOffer() {
+    fun proofNetworkFailureRestartsTheSession() {
+        // The acceptor may already have verified the proof, so the old session
+        // can never be proven again: only a fresh session converges both sides.
         val result =
             PairingV3PinResult
                 .NetworkError(UnknownError, commitPending = false)
@@ -141,11 +143,56 @@ class PairingV3UiControllerTest {
         assertEquals(
             PairingV3UiResult.Error(
                 PairingV3UiError.NETWORK_FAILURE,
-                PairingV3Recovery.REFRESH_OFFER,
+                PairingV3Recovery.RESTART,
             ),
             result,
         )
     }
+
+    @Test
+    fun restartCancelsTheDeadSessionBeforeOpeningAFreshOne() =
+        runTest {
+            val peerAppInstanceId = "dead-app"
+            val syncRuntimeInfo =
+                createUnverifiedSyncRuntimeInfo(
+                    appInstanceId = peerAppInstanceId,
+                    hostAddress = "192.168.1.12",
+                )
+            val syncHandler = mockk<SyncHandler>()
+            val syncManager = mockk<SyncManager>()
+            val pairingProtocolV3Service = mockk<PairingProtocolV3Service>()
+
+            every { syncManager.getSyncHandler(peerAppInstanceId) } returns syncHandler
+            every { syncHandler.currentSyncRuntimeInfo } returns syncRuntimeInfo
+            coEvery { syncHandler.getConnectHostAddress() } returns "192.168.1.12"
+            coEvery { syncHandler.showPairingCode() } returns ShowPairingCodeResult.SHOWN
+            every { pairingProtocolV3Service.uiSessionsFlow } returns
+                MutableStateFlow(listOf(pairingSession("dead", PakeRole.INITIATOR, pin = null)))
+            every { pairingProtocolV3Service.acceptanceWindow } returns PairingAcceptanceWindow()
+            coEvery { pairingProtocolV3Service.cancelSession("dead", any()) } returns true
+            coEvery {
+                pairingProtocolV3Service.startPairing(
+                    targetAppInstanceId = peerAppInstanceId,
+                    targetDisplayName = any(),
+                    toUrl = any(),
+                )
+            } returns PairingV3StartResult.Started("fresh", 1L, 60_000L, "aabbccdd")
+
+            val result =
+                DefaultPairingV3UiController(pairingProtocolV3Service, syncManager)
+                    .restart("dead", peerAppInstanceId)
+
+            assertEquals(PairingV3UiResult.SessionReady("fresh", 1L, 60_000L, "aabbccdd"), result)
+            coVerifyOrder {
+                pairingProtocolV3Service.cancelSession("dead", any())
+                syncHandler.showPairingCode()
+                pairingProtocolV3Service.startPairing(
+                    targetAppInstanceId = peerAppInstanceId,
+                    targetDisplayName = any(),
+                    toUrl = any(),
+                )
+            }
+        }
 
     @Test
     fun commitNetworkFailureRetriesCommitWithoutNewPin() {


### PR DESCRIPTION
Closes #4918

## Summary

A proof POST that fails without a v3 error code (timeout, reset, lost response) is ambiguous: the acceptor may already have verified the proof and moved to `PEER_CONFIRMED`. The initiator currently destroys its PAKE state and offers `REFRESH_OFFER`, which re-sends the byte-identical intent, gets the old offer back, and then has every further proof refused with `PAIRING_INVALID_STATE`. The dialog ends in a dead-end `FAILED`; the CLI session is equally stuck.

This mirrors the web extension's `restartV3Session`: the dead session is cancelled and a fresh intent opens a new one.

## Changes

- `PairingV3Recovery.RESTART` + `PairingV3UiController.restart(sessionId, peerAppInstanceId)`: cancel (best-effort peer notification) then `startPairing`. Idempotent, so a failed restart can be retried.
- `PairingV3PinResult.NetworkError(commitPending = false)` now maps to `RESTART`. `PAIRING_PIN_EXPIRED` / `PAIRING_PROOF_INVALID` keep `REFRESH_OFFER` (the acceptor is known to have invalidated the generation). `commitPending = true` keeps `RETRY_COMMIT`.
- Desktop dialog: Retry runs the restart; the PIN input resets on the new session via the existing `sessionId` keyed effect.
- `CliPairingService`: new `V3Action.RESTART`; recovery results adopt the (possibly new) v3 session id; the user is told the device now shows a new PIN; a restart that times out is retried as a restart rather than a refresh.
- Doc comments on `NetworkError` and `refreshOffer` state when each recovery applies.

## Tests

- New integration test `testLostProofResponseIsRecoveredByRestartingTheSession`: the proof reaches the acceptor, the response is dropped via a transport wrapper on `TestInstance`, the acceptor reaches `PEER_CONFIRMED`, a refreshed proof is refused, and cancel + fresh start pairs successfully.
- Controller, dialog state/model and CLI unit tests for the new recovery path.
- `./gradlew app:desktopTest` (touched classes) and `-PintegrationTests --tests PairingV3IntegrationTest` (33 tests) pass; `ktlintCheck` clean.