### PR TITLE
:memo: add mcpservers.org listing badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
    [![Download](https://img.shields.io/badge/Download-v2.2.0-2cbe4e?logo=download&link=https://crosspaste.com/en/download)](https://crosspaste.com/en/download)
    [![AGPL-3.0](https://img.shields.io/badge/License-AGPL%20v3-2cbe4e.svg)](https://github.com/CrossPaste/crosspaste-desktop/blob/main/LICENSE)
    [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CrossPaste/crosspaste-desktop)
+   [![Listed on mcpservers.org](https://mcpservers.org/badge.svg)](https://mcpservers.org/servers/crosspaste/crosspaste-desktop)
 
    <a href="https://github.com/sponsors/CrossPaste"><img src="https://img.shields.io/badge/sponsor-30363D?style=social&logo=GitHub-Sponsors&logoColor=#white" height="30px"></a>
    <img src="https://img.shields.io/github/stars/CrossPaste/crosspaste-desktop?style=social" height="30px">

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@
    ![OS](https://img.shields.io/badge/OS-Windows%20%7C%20macOS%20%7C%20Linux-2cbe4e)
    [![Download](https://img.shields.io/badge/Download-v2.2.0-2cbe4e?logo=download&link=https://crosspaste.com/en/download)](https://crosspaste.com/en/download)
    [![AGPL-3.0](https://img.shields.io/badge/License-AGPL%20v3-2cbe4e.svg)](https://github.com/CrossPaste/crosspaste-desktop/blob/main/LICENSE)
-   [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CrossPaste/crosspaste-desktop)
    [![Listed on mcpservers.org](https://mcpservers.org/badge.svg)](https://mcpservers.org/servers/crosspaste/crosspaste-desktop)
+   [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CrossPaste/crosspaste-desktop)
 
    <a href="https://github.com/sponsors/CrossPaste"><img src="https://img.shields.io/badge/sponsor-30363D?style=social&logo=GitHub-Sponsors&logoColor=#white" height="30px"></a>
    <img src="https://img.shields.io/github/stars/CrossPaste/crosspaste-desktop?style=social" height="30px">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,8 +29,8 @@
    ![OS](https://img.shields.io/badge/OS-Windows%20%7C%20macOS%20%7C%20Linux-2cbe4e)
    [![Download](https://img.shields.io/badge/Download-v2.2.0-2cbe4e?logo=download&link=https://crosspaste.com/download)](https://crosspaste.com/download)
    [![AGPL-3.0](https://img.shields.io/badge/License-AGPL%20v3-2cbe4e.svg)](https://github.com/CrossPaste/crosspaste-desktop/blob/main/LICENSE)
-   [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CrossPaste/crosspaste-desktop)
    [![Listed on mcpservers.org](https://mcpservers.org/badge.svg)](https://mcpservers.org/servers/crosspaste/crosspaste-desktop)
+   [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CrossPaste/crosspaste-desktop)
 
    <a href="https://github.com/sponsors/CrossPaste"><img src="https://img.shields.io/badge/sponsor-30363D?style=social&logo=GitHub-Sponsors&logoColor=#white" height="30px"></a>
    <img src="https://img.shields.io/github/stars/CrossPaste/crosspaste-desktop?style=social" height="30px">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,6 +30,7 @@
    [![Download](https://img.shields.io/badge/Download-v2.2.0-2cbe4e?logo=download&link=https://crosspaste.com/download)](https://crosspaste.com/download)
    [![AGPL-3.0](https://img.shields.io/badge/License-AGPL%20v3-2cbe4e.svg)](https://github.com/CrossPaste/crosspaste-desktop/blob/main/LICENSE)
    [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CrossPaste/crosspaste-desktop)
+   [![Listed on mcpservers.org](https://mcpservers.org/badge.svg)](https://mcpservers.org/servers/crosspaste/crosspaste-desktop)
 
    <a href="https://github.com/sponsors/CrossPaste"><img src="https://img.shields.io/badge/sponsor-30363D?style=social&logo=GitHub-Sponsors&logoColor=#white" height="30px"></a>
    <img src="https://img.shields.io/github/stars/CrossPaste/crosspaste-desktop?style=social" height="30px">


### PR DESCRIPTION
## Summary

- CrossPaste's MCP server has been approved and listed on mcpservers.org.
- Add the "Listed on mcpservers.org" badge to both `README.md` and `README.zh-CN.md`, next to the DeepWiki badge, linking to https://mcpservers.org/servers/crosspaste/crosspaste-desktop.

Both the badge image and the listing page were verified to resolve (HTTP 200).