### PR TITLE
:bug: bound encrypted HTTP payloads and stop caching processors for unknown peers

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -10,6 +10,7 @@ import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.net.exception.ExceptionHandler
 import com.crosspaste.net.plugin.ServerDecryptionPluginFactory
 import com.crosspaste.net.plugin.ServerEncryptPluginFactory
+import com.crosspaste.net.plugin.isEncryptedPayloadException
 import com.crosspaste.net.routing.SyncRoutingApi
 import com.crosspaste.net.routing.pairingV3Routing
 import com.crosspaste.net.routing.pasteRouting
@@ -38,6 +39,7 @@ import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.*
@@ -85,8 +87,18 @@ open class DefaultServerModule(
             }
             install(StatusPages) {
                 exception(Exception::class) { call, cause ->
-                    logger.error(cause) { "Unhandled exception" }
-                    failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
+                    if (cause.isEncryptedPayloadException()) {
+                        logger.warn { "Rejected oversized encrypted request" }
+                        failResponse(
+                            call,
+                            StandardErrorCode.INVALID_PARAMETER.toErrorCode(),
+                            "Encrypted payload exceeds route limit",
+                            statusOverride = HttpStatusCode.PayloadTooLarge,
+                        )
+                    } else {
+                        logger.error(cause) { "Unhandled exception" }
+                        failResponse(call, StandardErrorCode.UNKNOWN_ERROR.toErrorCode())
+                    }
                 }
                 exceptionHandler.handler()()
             }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientDecryptPlugin.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ClientDecryptPlugin.kt
@@ -10,9 +10,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.core.*
-import kotlinx.io.IOException
-import kotlinx.io.readByteArray
 
 class ClientDecryptPlugin(
     private val secureStore: SecureStore,
@@ -46,10 +43,7 @@ class ClientDecryptPlugin(
                     val processor = secureStore.getMessageProcessor(appInstanceId)
 
                     if (contentType?.match(ContentType.Application.Json) == true) {
-                        // Note: reads entire JSON response into memory. Acceptable for LAN sync
-                        // where JSON payloads (metadata, device info) are bounded and small.
-                        val bytes = byteReadChannel.readRemaining().readByteArray()
-                        val decrypt = processor.decrypt(bytes)
+                        val decrypt = decryptJsonResponse(byteReadChannel, decrypt = processor::decrypt)
 
                         // Create a new ByteReadChannel to contain the decrypted content
                         val newChannel = ByteReadChannel(decrypt)
@@ -64,25 +58,8 @@ class ClientDecryptPlugin(
                             )
                         proceedWith(DefaultHttpResponse(it.call, responseData))
                     } else if (contentType?.match(ContentType.Application.OctetStream) == true) {
-                        val result =
-                            buildPacket {
-                                while (!byteReadChannel.isClosedForRead) {
-                                    val size =
-                                        try {
-                                            byteReadChannel.readInt()
-                                        } catch (_: IOException) {
-                                            // Channel closed between isClosedForRead check and readInt().
-                                            // All encrypted chunks were already read and decrypted.
-                                            break
-                                        }
-                                    val byteArray = ByteArray(size)
-                                    byteReadChannel.readFully(byteArray, 0, size)
-                                    val decryptByteArray = processor.decrypt(byteArray)
-                                    writeFully(decryptByteArray)
-                                }
-                            }
-
-                        val byteArray = result.readByteArray()
+                        val byteArray =
+                            decryptChunkedResponse(byteReadChannel, decrypt = processor::decrypt)
                         val contentLength = byteArray.size.toString()
                         val newChannel = ByteReadChannel(byteArray)
                         val responseData =

--- a/app/src/commonMain/kotlin/com/crosspaste/net/plugin/EncryptedHttpBody.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/plugin/EncryptedHttpBody.kt
@@ -1,0 +1,116 @@
+package com.crosspaste.net.plugin
+
+import com.crosspaste.net.ws.WS_MAX_FRAME_SIZE
+import com.crosspaste.net.ws.WS_MAX_PAYLOAD_SIZE
+import com.crosspaste.presist.FileTransferResourceLimits
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+import kotlinx.io.IOException
+import kotlinx.io.readByteArray
+
+internal object EncryptedHttpResourceLimits {
+    private const val AES_BLOCK_SIZE: Long = 16
+    private const val MAX_CIPHER_OVERHEAD: Long = AES_BLOCK_SIZE * 2
+
+    const val MAX_JSON_RESPONSE_PLAINTEXT_SIZE: Long = WS_MAX_PAYLOAD_SIZE
+    const val MAX_JSON_RESPONSE_CIPHERTEXT_SIZE: Long =
+        MAX_JSON_RESPONSE_PLAINTEXT_SIZE + MAX_CIPHER_OVERHEAD
+    const val MAX_BINARY_RESPONSE_PLAINTEXT_SIZE: Long = FileTransferResourceLimits.MAX_CHUNK_SIZE
+    const val MAX_BINARY_RECORD_CIPHERTEXT_SIZE: Long =
+        FileTransferResourceLimits.MAX_CHUNK_SIZE + MAX_CIPHER_OVERHEAD
+
+    fun requestCiphertextLimit(path: String): Long =
+        plaintextToCiphertextLimit(
+            when {
+                // Register new routes with bodies larger than a control frame here.
+                path == "/sync/paste" -> WS_MAX_PAYLOAD_SIZE
+                path == "/sync/file/push" -> FileTransferResourceLimits.MAX_CHUNK_SIZE
+                path.startsWith("/sync/icon/push/") -> FileTransferResourceLimits.MAX_ICON_SIZE
+                else -> WS_MAX_FRAME_SIZE
+            },
+        )
+
+    private fun plaintextToCiphertextLimit(plaintextLimit: Long): Long = plaintextLimit + MAX_CIPHER_OVERHEAD
+}
+
+internal class EncryptedPayloadException(
+    message: String,
+) : IOException(message)
+
+internal fun Throwable.isEncryptedPayloadException(): Boolean =
+    generateSequence(this) { current ->
+        current.cause?.takeIf { it !== current }
+    }.take(10).any { it is EncryptedPayloadException }
+
+internal fun validateEncryptedContentLength(
+    contentLength: Long?,
+    maxBytes: Long,
+    description: String,
+) {
+    if (contentLength != null && contentLength > maxBytes) {
+        throw EncryptedPayloadException("$description exceeds $maxBytes bytes")
+    }
+}
+
+internal suspend fun ByteReadChannel.readLimitedByteArray(
+    maxBytes: Long,
+    description: String,
+): ByteArray {
+    require(maxBytes in 0 until Int.MAX_VALUE) { "maxBytes must fit in a ByteArray" }
+    val bytes = readRemaining(maxBytes + 1).readByteArray()
+    if (bytes.size.toLong() > maxBytes) {
+        throw EncryptedPayloadException("$description exceeds $maxBytes bytes")
+    }
+    return bytes
+}
+
+internal suspend fun decryptJsonResponse(
+    channel: ByteReadChannel,
+    maxCiphertextBytes: Long = EncryptedHttpResourceLimits.MAX_JSON_RESPONSE_CIPHERTEXT_SIZE,
+    maxPlaintextBytes: Long = EncryptedHttpResourceLimits.MAX_JSON_RESPONSE_PLAINTEXT_SIZE,
+    decrypt: (ByteArray) -> ByteArray,
+): ByteArray {
+    val encrypted = channel.readLimitedByteArray(maxCiphertextBytes, "encrypted JSON response")
+    val decrypted = decrypt(encrypted)
+    if (decrypted.size.toLong() > maxPlaintextBytes) {
+        throw EncryptedPayloadException("decrypted JSON response exceeds $maxPlaintextBytes bytes")
+    }
+    return decrypted
+}
+
+internal suspend fun decryptChunkedResponse(
+    channel: ByteReadChannel,
+    maxRecordCiphertextBytes: Long = EncryptedHttpResourceLimits.MAX_BINARY_RECORD_CIPHERTEXT_SIZE,
+    maxPlaintextBytes: Long = EncryptedHttpResourceLimits.MAX_BINARY_RESPONSE_PLAINTEXT_SIZE,
+    decrypt: (ByteArray) -> ByteArray,
+): ByteArray =
+    buildPacket {
+        var totalPlaintextBytes = 0L
+        while (true) {
+            val size = channel.readFrameSizeOrNull() ?: break
+            if (size <= 0 || size.toLong() > maxRecordCiphertextBytes) {
+                throw EncryptedPayloadException(
+                    "encrypted binary record size $size is outside 1..$maxRecordCiphertextBytes",
+                )
+            }
+
+            val encrypted = ByteArray(size)
+            channel.readFully(encrypted)
+            val decrypted = decrypt(encrypted)
+            if (decrypted.size.toLong() > maxPlaintextBytes - totalPlaintextBytes) {
+                throw EncryptedPayloadException(
+                    "decrypted binary response exceeds $maxPlaintextBytes bytes",
+                )
+            }
+            totalPlaintextBytes += decrypted.size
+            writeFully(decrypted)
+        }
+    }.readByteArray()
+
+private suspend fun ByteReadChannel.readFrameSizeOrNull(): Int? {
+    if (!awaitContent(1)) return null
+    if (!awaitContent(Int.SIZE_BYTES)) {
+        throw EncryptedPayloadException("truncated encrypted binary record length")
+    }
+    return readInt()
+}

--- a/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ServerDecryptionPluginFactory.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/plugin/ServerDecryptionPluginFactory.kt
@@ -5,8 +5,8 @@ import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.*
 import io.ktor.server.application.hooks.*
+import io.ktor.server.request.*
 import io.ktor.utils.io.*
-import kotlinx.io.readByteArray
 
 class ServerDecryptionPluginFactory(
     private val secureStore: SecureStore,
@@ -28,8 +28,15 @@ class ServerDecryptionPluginFactory(
                         logger.debug { "server decrypt $appInstanceId" }
                         return@on application
                             .writer {
+                                val maxBytes = EncryptedHttpResourceLimits.requestCiphertextLimit(call.request.path())
+                                validateEncryptedContentLength(
+                                    call.request.contentLength(),
+                                    maxBytes,
+                                    "encrypted request",
+                                )
                                 val processor = secureStore.getMessageProcessor(appInstanceId)
-                                val encryptedContent = body.readRemaining().readByteArray()
+                                val encryptedContent =
+                                    body.readLimitedByteArray(maxBytes, "encrypted request")
                                 val decrypted = processor.decrypt(encryptedContent)
                                 channel.writeFully(decrypted, 0, decrypted.size)
                             }.channel

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -6,6 +6,7 @@ import com.crosspaste.dto.push.PushHeaders
 import com.crosspaste.dto.push.PushPrepareResponse
 import com.crosspaste.exception.PasteException
 import com.crosspaste.exception.StandardErrorCode
+import com.crosspaste.net.plugin.isEncryptedPayloadException
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.PasteReleaseService
 import com.crosspaste.paste.PasteboardService
@@ -18,6 +19,7 @@ import com.crosspaste.utils.requireTargetAppInstance
 import com.crosspaste.utils.successResponse
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
@@ -121,14 +123,24 @@ private suspend fun receiveRemotePasteData(
             pasteData.bindAuthenticatedRemoteIdentity(appInstanceId)
         }
     }.onFailure { e ->
-        logger.error(e) { "sync handler ($appInstanceId) receive pasteData error" }
-        val code =
-            if (e is PasteException && e.match(StandardErrorCode.DECRYPT_FAIL)) {
-                StandardErrorCode.DECRYPT_FAIL
-            } else {
-                StandardErrorCode.UNKNOWN_ERROR
-            }
-        failResponse(call, code.toErrorCode())
+        if (e.isEncryptedPayloadException()) {
+            logger.warn { "Rejected oversized paste payload from $appInstanceId" }
+            failResponse(
+                call,
+                StandardErrorCode.INVALID_PARAMETER.toErrorCode(),
+                "Encrypted payload exceeds route limit",
+                statusOverride = HttpStatusCode.PayloadTooLarge,
+            )
+        } else {
+            logger.error(e) { "sync handler ($appInstanceId) receive pasteData error" }
+            val code =
+                if (e is PasteException && e.match(StandardErrorCode.DECRYPT_FAIL)) {
+                    StandardErrorCode.DECRYPT_FAIL
+                } else {
+                    StandardErrorCode.UNKNOWN_ERROR
+                }
+            failResponse(call, code.toErrorCode())
+        }
     }.getOrNull()
 
 internal fun PasteData.bindAuthenticatedRemoteIdentity(appInstanceId: String): PasteData =

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
@@ -4,18 +4,25 @@ import com.crosspaste.app.AppInfo
 import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.dto.pull.PullFileRequest
 import com.crosspaste.exception.StandardErrorCode
+import com.crosspaste.net.plugin.EncryptedHttpResourceLimits
 import com.crosspaste.paste.CacheManager
+import com.crosspaste.paste.PasteData
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getAppInstanceId
 import com.crosspaste.utils.getFileUtils
+import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.requireSyncHandler
 import com.crosspaste.utils.requireTargetAppInstance
 import com.crosspaste.utils.successResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.*
 import io.ktor.server.request.*
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.utils.io.*
+import kotlinx.serialization.encodeToString
+import okio.utf8Size
 
 fun Routing.pullRouting(
     appInfo: AppInfo,
@@ -114,15 +121,18 @@ fun Routing.pullRouting(
             val createTime = call.request.queryParameters["createTime"]?.toLongOrNull()
             val limit = (call.request.queryParameters["limit"]?.toLongOrNull() ?: 10L).coerceAtMost(50L)
 
-            val pasteDataList =
+            val recentPasteData =
                 if (createTime != null) {
                     pasteDao.getRecentPasteDataAfterCreateTime(createTime, limit)
                 } else {
                     pasteDao.getRecentPasteDataByAppInstanceId(limit)
                 }
+            val batch = recentPasteData.encodeJsonArrayWithinLimit()
 
-            logger.debug { "pull pasteBatch by ($fromAppInstanceId): ${pasteDataList.size} items" }
-            successResponse(call, pasteDataList)
+            logger.debug {
+                "pull pasteBatch by ($fromAppInstanceId): ${batch.count}/${recentPasteData.size} items"
+            }
+            call.respondText(batch.json, ContentType.Application.Json, HttpStatusCode.OK)
         }
     }
 
@@ -150,3 +160,46 @@ fun Routing.pullRouting(
         }
     }
 }
+
+internal class EncodedPasteBatch(
+    val json: String,
+    val count: Int,
+)
+
+/**
+ * Encodes the newest-first DAO result as a JSON array, dropping trailing
+ * items so the response stays within the encrypted JSON limit. One item is
+ * always retained so this endpoint preserves the same single-paste
+ * capability as /pull/paste.
+ *
+ * This endpoint has "recent N" semantics, not catch-up semantics: the DAO
+ * already applies DESC + LIMIT, so older items that overflow the limit are
+ * skipped by the client cursor either way. Trimming from the tail keeps the
+ * same behaviour, only with a byte budget instead of a row count.
+ */
+internal fun List<PasteData>.encodeJsonArrayWithinLimit(
+    maxBytes: Long = EncryptedHttpResourceLimits.MAX_JSON_RESPONSE_PLAINTEXT_SIZE,
+): EncodedPasteBatch {
+    val json = getJsonUtils().JSON
+    val builder = StringBuilder("[")
+    var encodedBytes = EMPTY_JSON_ARRAY_SIZE
+    var count = 0
+
+    for (pasteData in this) {
+        val item = json.encodeToString(pasteData)
+        val separatorBytes = if (count == 0) 0L else JSON_ITEM_SEPARATOR_SIZE
+        val itemBytes = separatorBytes + item.utf8Size()
+        if (count > 0 && encodedBytes + itemBytes > maxBytes) {
+            break
+        }
+        if (count > 0) builder.append(',')
+        builder.append(item)
+        encodedBytes += itemBytes
+        count++
+    }
+    builder.append(']')
+    return EncodedPasteBatch(builder.toString(), count)
+}
+
+private const val EMPTY_JSON_ARRAY_SIZE = 2L
+private const val JSON_ITEM_SEPARATOR_SIZE = 1L

--- a/app/src/commonMain/kotlin/com/crosspaste/secure/GeneralSecureStore.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/secure/GeneralSecureStore.kt
@@ -3,67 +3,67 @@ package com.crosspaste.secure
 import com.crosspaste.db.secure.SecureIO
 import com.crosspaste.exception.PasteException
 import com.crosspaste.exception.StandardErrorCode
+import com.crosspaste.utils.StripedMutex
 import io.ktor.util.collections.*
-import kotlinx.coroutines.sync.withLock
 
 class GeneralSecureStore(
     override val secureKeyPair: SecureKeyPair,
     private val secureKeyPairSerializer: SecureKeyPairSerializer,
     private val secureIO: SecureIO,
 ) : SecureStore {
-    private val sessions = ConcurrentMap<String, SecureSession>()
+    private val processors = ConcurrentMap<String, SecureMessageProcessor>()
+    private val peerMutex = StripedMutex()
 
-    private fun getSecureSession(appInstanceId: String): SecureSession =
-        sessions.computeIfAbsent(appInstanceId) {
-            SecureSession()
-        }
+    // @VisibleForTesting
+    internal val cachedProcessorCount: Int
+        get() = processors.size
 
     override suspend fun saveCryptPublicKey(
         appInstanceId: String,
         cryptPublicKey: ByteArray,
     ) {
-        val session = getSecureSession(appInstanceId)
-        session.mutex.withLock {
-            session.processor = null
+        peerMutex.withLock(appInstanceId) {
+            processors.remove(appInstanceId)
             secureIO.saveCryptPublicKey(appInstanceId, cryptPublicKey)
         }
     }
 
-    override suspend fun existCryptPublicKey(appInstanceId: String): Boolean {
-        val session = getSecureSession(appInstanceId)
-        return session.mutex.withLock {
+    override suspend fun existCryptPublicKey(appInstanceId: String): Boolean =
+        peerMutex.withLock(appInstanceId) {
             secureIO.existCryptPublicKey(appInstanceId)
         }
-    }
 
     override suspend fun deleteCryptPublicKey(appInstanceId: String) {
-        val session = getSecureSession(appInstanceId)
-        session.mutex.withLock {
-            session.processor = null
+        peerMutex.withLock(appInstanceId) {
+            processors.remove(appInstanceId)
             secureIO.deleteCryptPublicKey(appInstanceId)
         }
     }
 
     override suspend fun getMessageProcessor(appInstanceId: String): SecureMessageProcessor {
-        val session = getSecureSession(appInstanceId)
-        session.processor?.let { return it }
+        processors[appInstanceId]?.let { return it }
 
-        return session.mutex.withLock {
-            session.processor?.let { return it }
+        // Keep unknown peers out of the striped lock. Known cache misses pay a
+        // second read once, then use the processor cache for subsequent calls.
+        secureIO.serializedPublicKey(appInstanceId) ?: throwMissingKey(appInstanceId)
+
+        return peerMutex.withLock(appInstanceId) {
+            processors[appInstanceId]?.let { return@withLock it }
 
             secureIO.serializedPublicKey(appInstanceId)?.let { publicKey ->
                 val cryptPublicKey = secureKeyPairSerializer.decodeCryptPublicKey(publicKey)
                 val cryptPrivateKey = secureKeyPair.cryptKeyPair.privateKey
 
                 SecureMessageProcessor(cryptPrivateKey, cryptPublicKey).also {
-                    session.processor = it
+                    processors[appInstanceId] = it
                 }
-            } ?: run {
-                throw PasteException(
-                    StandardErrorCode.ENCRYPT_FAIL.toErrorCode(),
-                    "Crypt public key not found by appInstanceId: $appInstanceId",
-                )
-            }
+            } ?: throwMissingKey(appInstanceId)
         }
     }
+
+    private fun throwMissingKey(appInstanceId: String): Nothing =
+        throw PasteException(
+            StandardErrorCode.ENCRYPT_FAIL.toErrorCode(),
+            "Crypt public key not found by appInstanceId: $appInstanceId",
+        )
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/secure/SecureSession.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/secure/SecureSession.kt
@@ -1,9 +1,0 @@
-package com.crosspaste.secure
-
-import kotlinx.coroutines.sync.Mutex
-import kotlin.concurrent.Volatile
-
-data class SecureSession(
-    val mutex: Mutex = Mutex(),
-    @Volatile var processor: SecureMessageProcessor? = null,
-)

--- a/app/src/commonMain/kotlin/com/crosspaste/utils/ResponseUtils.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/utils/ResponseUtils.kt
@@ -50,11 +50,12 @@ suspend inline fun failResponse(
     call: ApplicationCall,
     errorCode: ErrorCode,
     message: String? = null,
+    statusOverride: HttpStatusCode? = null,
 ) {
     val code = errorCode.code
     val type = errorCode.type
     val status =
-        when (type) {
+        statusOverride ?: when (type) {
             ErrorType.EXTERNAL_ERROR -> HttpStatusCode.BadRequest
             ErrorType.INTERNAL_ERROR -> HttpStatusCode.InternalServerError
             ErrorType.USER_ERROR -> HttpStatusCode.UnprocessableEntity

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/plugin/EncryptedHttpBodyTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/plugin/EncryptedHttpBodyTest.kt
@@ -1,0 +1,168 @@
+package com.crosspaste.net.plugin
+
+import com.crosspaste.presist.FileTransferResourceLimits
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.readByteArray
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EncryptedHttpBodyTest {
+
+    @Test
+    fun `request limits follow route payload types`() {
+        val controlLimit = EncryptedHttpResourceLimits.requestCiphertextLimit("/sync/heartbeat")
+        val iconLimit = EncryptedHttpResourceLimits.requestCiphertextLimit("/sync/icon/push/source")
+        val chunkLimit = EncryptedHttpResourceLimits.requestCiphertextLimit("/sync/file/push")
+        val pasteLimit = EncryptedHttpResourceLimits.requestCiphertextLimit("/sync/paste")
+
+        assertTrueAscending(controlLimit, iconLimit, chunkLimit, pasteLimit)
+        assertEquals(controlLimit, EncryptedHttpResourceLimits.requestCiphertextLimit("/pull/file"))
+        assertEquals(
+            FileTransferResourceLimits.MAX_CHUNK_SIZE + 32,
+            chunkLimit,
+        )
+    }
+
+    @Test
+    fun `content length rejects oversized fixed request before reading`() {
+        validateEncryptedContentLength(3, 3, "test body")
+        assertFailsWith<EncryptedPayloadException> {
+            validateEncryptedContentLength(4, 3, "test body")
+        }
+    }
+
+    @Test
+    fun `encrypted payload classifier unwraps transport exceptions`() {
+        val wrapped = IllegalStateException("channel failed", EncryptedPayloadException("too large"))
+
+        assertTrue(wrapped.isEncryptedPayloadException())
+        assertFalse(IllegalStateException("other").isEncryptedPayloadException())
+    }
+
+    @Test
+    fun `limited channel read bounds chunked request at actual bytes`() =
+        runTest {
+            assertContentEquals(
+                byteArrayOf(1, 2, 3),
+                ByteReadChannel(byteArrayOf(1, 2, 3)).readLimitedByteArray(3, "test body"),
+            )
+
+            assertFailsWith<EncryptedPayloadException> {
+                ByteReadChannel(byteArrayOf(1, 2, 3, 4)).readLimitedByteArray(3, "test body")
+            }
+        }
+
+    @Test
+    fun `JSON response checks ciphertext and decrypted limits`() =
+        runTest {
+            assertFailsWith<EncryptedPayloadException> {
+                decryptJsonResponse(
+                    channel = ByteReadChannel(byteArrayOf(1, 2, 3, 4)),
+                    maxCiphertextBytes = 3,
+                    maxPlaintextBytes = 10,
+                    decrypt = { it },
+                )
+            }
+
+            assertFailsWith<EncryptedPayloadException> {
+                decryptJsonResponse(
+                    channel = ByteReadChannel(byteArrayOf(1)),
+                    maxCiphertextBytes = 3,
+                    maxPlaintextBytes = 3,
+                    decrypt = { ByteArray(4) },
+                )
+            }
+        }
+
+    @Test
+    fun `chunked response rejects invalid record size before allocation`() =
+        runTest {
+            assertFailsWith<EncryptedPayloadException> {
+                decryptChunkedResponse(
+                    channel = ByteReadChannel(framePrefix(-1)),
+                    maxRecordCiphertextBytes = 8,
+                    maxPlaintextBytes = 8,
+                    decrypt = { it },
+                )
+            }
+
+            assertFailsWith<EncryptedPayloadException> {
+                decryptChunkedResponse(
+                    channel = ByteReadChannel(framePrefix(9)),
+                    maxRecordCiphertextBytes = 8,
+                    maxPlaintextBytes = 8,
+                    decrypt = { it },
+                )
+            }
+        }
+
+    @Test
+    fun `chunked response rejects partial length prefix`() =
+        runTest {
+            assertFailsWith<EncryptedPayloadException> {
+                decryptChunkedResponse(
+                    channel = ByteReadChannel(byteArrayOf(0, 0, 0)),
+                    maxRecordCiphertextBytes = 8,
+                    maxPlaintextBytes = 8,
+                    decrypt = { it },
+                )
+            }
+        }
+
+    @Test
+    fun `chunked response enforces cumulative plaintext limit`() =
+        runTest {
+            val channel = ByteReadChannel(chunked(byteArrayOf(1, 2, 3), byteArrayOf(4, 5, 6)))
+
+            assertFailsWith<EncryptedPayloadException> {
+                decryptChunkedResponse(
+                    channel = channel,
+                    maxRecordCiphertextBytes = 8,
+                    maxPlaintextBytes = 5,
+                    decrypt = { it },
+                )
+            }
+        }
+
+    @Test
+    fun `chunked response preserves valid records`() =
+        runTest {
+            val result =
+                decryptChunkedResponse(
+                    channel = ByteReadChannel(chunked(byteArrayOf(1, 2), byteArrayOf(3, 4))),
+                    maxRecordCiphertextBytes = 2,
+                    maxPlaintextBytes = 4,
+                    decrypt = { it },
+                )
+
+            assertContentEquals(byteArrayOf(1, 2, 3, 4), result)
+        }
+
+    private fun framePrefix(size: Int): ByteArray =
+        buildPacket {
+            writeInt(size)
+        }.readByteArray()
+
+    private fun chunked(vararg records: ByteArray): ByteArray =
+        buildPacket {
+            records.forEach { record ->
+                writeInt(record.size)
+                writeFully(record)
+            }
+        }.readByteArray()
+
+    private fun assertTrueAscending(vararg values: Long) {
+        for (index in 0 until values.lastIndex) {
+            assertTrue(
+                values[index] < values[index + 1],
+                "${values[index]} must be smaller than ${values[index + 1]}",
+            )
+        }
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PullRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PullRoutingTest.kt
@@ -1,0 +1,75 @@
+package com.crosspaste.net.routing
+
+import com.crosspaste.paste.PasteCollection
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteType
+import com.crosspaste.utils.getJsonUtils
+import kotlinx.serialization.builtins.ListSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PullRoutingTest {
+
+    private val json = getJsonUtils().JSON
+    private val pasteDataListSerializer = ListSerializer(PasteData.serializer())
+
+    @Test
+    fun `paste batch keeps newest prefix within encoded byte limit`() {
+        val pastes = listOf(pasteData("first"), pasteData("second"), pasteData("third"))
+        val firstTwoSize = encodedSize(pastes.take(2))
+
+        val batch = pastes.encodeJsonArrayWithinLimit(firstTwoSize)
+
+        assertEquals(2, batch.count)
+        assertEquals(listOf("first", "second"), decodeSources(batch))
+        assertEquals(
+            firstTwoSize,
+            batch.json
+                .encodeToByteArray()
+                .size
+                .toLong(),
+        )
+    }
+
+    @Test
+    fun `paste batch does not skip oversized middle item`() {
+        val pastes = listOf(pasteData("first"), pasteData("x".repeat(100)), pasteData("third"))
+        val firstSize = encodedSize(pastes.take(1))
+
+        val batch = pastes.encodeJsonArrayWithinLimit(firstSize)
+
+        assertEquals(listOf("first"), decodeSources(batch))
+    }
+
+    @Test
+    fun `paste batch keeps one item when it exceeds batch limit`() {
+        val first = pasteData("x".repeat(100))
+
+        val batch = listOf(first, pasteData("second")).encodeJsonArrayWithinLimit(2)
+
+        assertEquals(listOf(first.source), decodeSources(batch))
+        assertTrue(batch.json.encodeToByteArray().size > 2)
+    }
+
+    private fun encodedSize(pasteData: List<PasteData>): Long =
+        json
+            .encodeToString(pasteDataListSerializer, pasteData)
+            .encodeToByteArray()
+            .size
+            .toLong()
+
+    // createTime is not serialized, so compare by source instead of whole objects.
+    private fun decodeSources(batch: EncodedPasteBatch): List<String> =
+        json.decodeFromString(pasteDataListSerializer, batch.json).map { it.source.orEmpty() }
+
+    private fun pasteData(source: String): PasteData =
+        PasteData(
+            appInstanceId = "local",
+            pasteCollection = PasteCollection(emptyList()),
+            pasteType = PasteType.TEXT_TYPE.type,
+            source = source,
+            size = source.length.toLong(),
+            hash = source,
+        )
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/secure/GeneralSecureStoreTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/secure/GeneralSecureStoreTest.kt
@@ -61,9 +61,12 @@ class GeneralSecureStoreTest {
 
             store.saveCryptPublicKey("instance-1", publicKeyBytes)
             assertTrue(store.existCryptPublicKey("instance-1"))
+            store.getMessageProcessor("instance-1")
+            assertEquals(1, store.cachedProcessorCount)
 
             store.deleteCryptPublicKey("instance-1")
             assertFalse(store.existCryptPublicKey("instance-1"))
+            assertEquals(0, store.cachedProcessorCount)
         }
 
     @Test
@@ -90,6 +93,22 @@ class GeneralSecureStoreTest {
         }
 
     @Test
+    fun `unknown instances do not populate processor cache`() =
+        runBlocking {
+            val (store, _) = createStore()
+
+            repeat(1_000) { index ->
+                val appInstanceId = "unknown-$index"
+                assertFalse(store.existCryptPublicKey(appInstanceId))
+                assertFailsWith<PasteException> {
+                    store.getMessageProcessor(appInstanceId)
+                }
+            }
+
+            assertEquals(0, store.cachedProcessorCount)
+        }
+
+    @Test
     fun `getMessageProcessor caches processor on second call`() =
         runBlocking {
             val (store, _) = createStore()
@@ -104,6 +123,24 @@ class GeneralSecureStoreTest {
         }
 
     @Test
+    fun `concurrent first access builds one processor`() =
+        runBlocking {
+            val (store, _) = createStore()
+            val otherKeyPair = generateSecureKeyPair()
+            val publicKeyBytes = serializer.encodeCryptPublicKey(otherKeyPair.cryptKeyPair.publicKey)
+            store.saveCryptPublicKey("instance-1", publicKeyBytes)
+
+            val processors =
+                (1..20)
+                    .map {
+                        async { store.getMessageProcessor("instance-1") }
+                    }.awaitAll()
+
+            assertTrue(processors.all { it === processors.first() })
+            assertEquals(1, store.cachedProcessorCount)
+        }
+
+    @Test
     fun `saveCryptPublicKey invalidates cached processor`() =
         runBlocking {
             val (store, _) = createStore()
@@ -112,9 +149,11 @@ class GeneralSecureStoreTest {
 
             store.saveCryptPublicKey("instance-1", publicKeyBytes)
             val processor1 = store.getMessageProcessor("instance-1")
+            assertEquals(1, store.cachedProcessorCount)
 
             // Save again invalidates
             store.saveCryptPublicKey("instance-1", publicKeyBytes)
+            assertEquals(0, store.cachedProcessorCount)
             val processor2 = store.getMessageProcessor("instance-1")
             assertFalse(processor1 === processor2, "Processor should be re-created after save")
         }


### PR DESCRIPTION
Closes #4921

## Summary

Adds resource limits to the encrypted HTTP sync path and fixes the unbounded per-peer session map in `GeneralSecureStore`.

### Server (`ServerDecryptionPluginFactory`)
- `EncryptedHttpResourceLimits.requestCiphertextLimit(path)` derives a ciphertext ceiling per route from the existing protocol constants: `/sync/paste` → `WS_MAX_PAYLOAD_SIZE`, `/sync/file/push` → `MAX_CHUNK_SIZE`, `/sync/icon/push/*` → `MAX_ICON_SIZE`, everything else → `WS_MAX_FRAME_SIZE`, plus 32 bytes of AES-CBC IV/padding overhead.
- The limit is checked against `Content-Length` before any allocation and again against the bytes actually read (`readLimitedByteArray`) so chunked transfer cannot bypass it.
- Oversized payloads now return `413` with `INVALID_PARAMETER` and a warn-level log, both from the `/sync/paste` handler and the `StatusPages` fallback, instead of an error-level `500`.

### Client (`ClientDecryptPlugin`)
- `decryptJsonResponse` bounds ciphertext and decrypted size (128 MiB, matching the WebSocket payload cap).
- `decryptChunkedResponse` validates each 4-byte record length (1..`MAX_CHUNK_SIZE`+32) before allocating, enforces a cumulative plaintext cap, and fails on a truncated length prefix instead of treating it as EOF.

### `/pull/pasteBatch`
- The batch is encoded once and trimmed to the encrypted JSON byte budget (always keeping at least one item) so a batch of large pastes cannot exceed the client limit. This keeps the endpoint's existing "recent N" semantics (the DAO already applies `DESC` + `LIMIT`).

### `GeneralSecureStore`
- `SecureSession` and its `ConcurrentMap` are replaced by a `StripedMutex` and a `ConcurrentMap<String, SecureMessageProcessor>` that is only written once the peer's public key is found, so unknown `appInstanceId`s no longer grow memory.

## Tests
- `EncryptedHttpBodyTest`: route limits, content-length and channel-read limits, JSON/chunked response limits, truncated prefix, exception classifier.
- `PullRoutingTest`: batch trimming by byte budget.
- `GeneralSecureStoreTest`: unknown peers do not populate the cache, concurrent first access builds one processor, invalidation on save/delete.

All new tests are in the fast tier (`./gradlew app:desktopTest`), total < 0.2s.