### PR TITLE
:bug: honor the discovery toggle when resolving interfaces and stop dropping hosts by last octet

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/settings/NetworkSettingsContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/settings/NetworkSettingsContentView.kt
@@ -95,18 +95,19 @@ fun NetworkSettingsContentView(syncExtContent: @Composable () -> Unit = {}) {
                 SettingListSwitchItem(
                     title = "allow_discovery_by_new_devices",
                     icon = IconData(MaterialSymbols.Rounded.Visibility, themeExt.blueIconColor),
-                    checked = useNetworkInterfaces.isNotEmpty(),
+                    checked = config.enableDiscovery,
                 ) { enableDiscovery ->
                     if (enableDiscovery) {
-                        networkInterfaceService.getPreferredNetworkInterface()?.let {
-                            val newUseNetworkInterfaces = listOf(it.name)
-                            val newUseNetworkInterfacesJson =
-                                jsonUtils.JSON.encodeToString(newUseNetworkInterfaces)
-                            configManager.updateConfig(
-                                listOf("useNetworkInterfaces", "enableDiscovery"),
-                                listOf(newUseNetworkInterfacesJson, true),
-                            )
-                        }
+                        // Offline right now: persist the intent with an empty selection and
+                        // let the resolver auto-select once the network comes back.
+                        val newUseNetworkInterfaces =
+                            listOfNotNull(networkInterfaceService.getPreferredNetworkInterface()?.name)
+                        val newUseNetworkInterfacesJson =
+                            jsonUtils.JSON.encodeToString(newUseNetworkInterfaces)
+                        configManager.updateConfig(
+                            listOf("useNetworkInterfaces", "enableDiscovery"),
+                            listOf(newUseNetworkInterfacesJson, true),
+                        )
                     } else {
                         configManager.updateConfig(
                             listOf("useNetworkInterfaces", "enableDiscovery"),
@@ -118,10 +119,10 @@ fun NetworkSettingsContentView(syncExtContent: @Composable () -> Unit = {}) {
                 SettingCheckboxView(
                     count = networkInterfaces.size,
                     getCurrentCheckboxValue = { index ->
-                        config.useNetworkInterfaces.contains(networkInterfaces.map { it.name }[index])
+                        networkInterfaces[index].name in useNetworkInterfaces
                     },
                     onChange = { index, isChecked ->
-                        val currentInterface = networkInterfaces.map { it.name }[index]
+                        val currentInterface = networkInterfaces[index].name
                         val newUseNetworkInterfaces =
                             if (isChecked) {
                                 useNetworkInterfaces + currentInterface

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/AbstractNetworkInterfaceService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/AbstractNetworkInterfaceService.kt
@@ -10,10 +10,6 @@ import java.util.Collections
 abstract class AbstractNetworkInterfaceService : NetworkInterfaceService {
 
     companion object {
-        private const val INVALID_END_OCTET_0 = ".0"
-        private const val INVALID_END_OCTET_1 = ".1"
-        private const val INVALID_END_OCTET_255 = ".255"
-
         // Legacy interface names: letters followed by a trailing numeric index (eth0, wlan0,
         // en1). The captured digits are the interface index. systemd predictable names
         // (enp0s3) have digits embedded mid-name and intentionally do NOT match.
@@ -123,12 +119,6 @@ abstract class AbstractNetworkInterfaceService : NetworkInterfaceService {
 
     protected val preferredNetworkInterfaceInfo = ValueProvider<NetworkInterfaceInfo?>()
 
-    protected fun isValidLocalAddress(hostAddress: String): Boolean =
-        hostAddress.isNotEmpty() &&
-            !hostAddress.endsWith(INVALID_END_OCTET_0) &&
-            !hostAddress.endsWith(INVALID_END_OCTET_1) &&
-            !hostAddress.endsWith(INVALID_END_OCTET_255)
-
     override fun getAllNetworkInterfaceInfo(): List<NetworkInterfaceInfo> =
         Collections
             .list(NetworkInterface.getNetworkInterfaces())
@@ -163,16 +153,13 @@ abstract class AbstractNetworkInterfaceService : NetworkInterfaceService {
             return null
         }
 
+        // Every IPv4 address enumerated on an up, non-loopback interface is a unicast
+        // address this host owns and can bind; no last-octet heuristics. A `.1` host is
+        // the norm when this machine shares a hotspot (192.168.137.1 on Windows,
+        // 192.168.2.1 on macOS), and `.0`/`.255` are ordinary hosts in anything wider
+        // than /24.
         val hostAddress = address.hostAddress ?: return null
         val networkPrefixLength = addr.networkPrefixLength
-
-        if (!isValidLocalAddress(hostAddress)) {
-            logger.debug {
-                "Not a local address, Network interface: $nicName " +
-                    "address: $hostAddress networkPrefixLength: $networkPrefixLength"
-            }
-            return null
-        }
 
         val likelyVirtual = isLikelyVirtual(nicName, macAddress)
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkInterfaceService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkInterfaceService.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.net
 
+import com.crosspaste.config.DesktopAppConfig
 import com.crosspaste.config.DesktopConfigManager
 import com.crosspaste.utils.getJsonUtils
 import com.crosspaste.utils.ioDispatcher
@@ -29,18 +30,19 @@ open class DesktopNetworkInterfaceService(
     @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
     override val networkInterfaces: StateFlow<List<NetworkInterfaceInfo>> =
         combine(
-            // Re-resolve when the user changes the configured interfaces...
+            // Re-resolve when the user changes the discovery toggle or the
+            // configured interfaces...
             configManager.config
-                .map { it.useNetworkInterfaces }
+                .map { it.toDiscoverySelection() }
                 .distinctUntilChanged(),
             // ...or when the OS reports a real network state change. The leading
             // emit drives the initial resolution; debounce collapses flap bursts.
             networkStateMonitor.networkChanges
                 .onStart { emit(Unit) }
                 .debounce(NETWORK_CHANGE_DEBOUNCE),
-        ) { useNetworkInterfacesJson, _ -> useNetworkInterfacesJson }
-            .mapLatest { useNetworkInterfacesJson ->
-                resolveNetworkInterfaceInfos(useNetworkInterfacesJson)
+        ) { selection, _ -> selection }
+            .mapLatest { selection ->
+                resolveNetworkInterfaceInfos(selection)
             }
             // Content-based: only rebuild mDNS when the interface set actually changes.
             .distinctUntilChanged()
@@ -55,7 +57,20 @@ open class DesktopNetworkInterfaceService(
     }
 
     private fun initNetworkInterfaceInfos(): List<NetworkInterfaceInfo> =
-        resolveNetworkInterfaceInfos(configManager.getCurrentConfig().useNetworkInterfaces)
+        resolveNetworkInterfaceInfos(configManager.getCurrentConfig().toDiscoverySelection())
+
+    /**
+     * The two config fields that drive interface resolution, captured together so a
+     * change to either one re-resolves (a CLI `enableDiscovery=false` never touches the
+     * interface list, for example).
+     */
+    private data class DiscoverySelection(
+        val enableDiscovery: Boolean,
+        val useNetworkInterfacesJson: String,
+    )
+
+    private fun DesktopAppConfig.toDiscoverySelection(): DiscoverySelection =
+        DiscoverySelection(enableDiscovery, useNetworkInterfaces)
 
     /**
      * Reads a fresh snapshot of the live interfaces and resolves them against the
@@ -71,16 +86,21 @@ open class DesktopNetworkInterfaceService(
      *    interface: bind to it in-memory so discovery keeps working, but do NOT
      *    persist — the preference must survive the outage so we heal back to it once
      *    it returns (which a later network event re-resolves).
+     *  - Discovery switched off: nothing is bound, regardless of what is online. The
+     *    offline fallback above must never resurrect a discovery the user turned off.
      */
-    private fun resolveNetworkInterfaceInfos(useNetworkInterfacesJson: String): List<NetworkInterfaceInfo> {
+    private fun resolveNetworkInterfaceInfos(selection: DiscoverySelection): List<NetworkInterfaceInfo> {
         // Drop cached provider values so auto-select reflects the current network.
         clearProviderCache()
 
-        val config = configManager.getCurrentConfig()
-        val useNetworkInterfaces =
-            jsonUtils.JSON.decodeFromString<List<String>>(useNetworkInterfacesJson)
+        if (!selection.enableDiscovery) {
+            return emptyList()
+        }
 
-        if (config.enableDiscovery && useNetworkInterfaces.isEmpty()) {
+        val useNetworkInterfaces =
+            jsonUtils.JSON.decodeFromString<List<String>>(selection.useNetworkInterfacesJson)
+
+        if (useNetworkInterfaces.isEmpty()) {
             autoSelectPreferredInterface(persist = true)?.let { return it }
         }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkInterfaceServiceSelfHealingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkInterfaceServiceSelfHealingTest.kt
@@ -210,4 +210,92 @@ class DesktopNetworkInterfaceServiceSelfHealingTest {
 
             job.cancel()
         }
+
+    @Test
+    fun `discovery switched off binds nothing even while the machine is online`() =
+        runTest {
+            val configManager = newConfigManager()
+            // What the settings toggle writes when the user turns discovery off.
+            configManager.updateConfig(
+                listOf("useNetworkInterfaces", "enableDiscovery"),
+                listOf("[]", false),
+            )
+
+            setLiveSnapshot(listOf(en0, en5))
+            val monitor = FakeNetworkStateMonitor()
+            val job = Job()
+            val service = TestableService(configManager, monitor, CoroutineScope(coroutineContext + job))
+            advanceUntilIdle()
+            assertEquals(emptyList(), service.networkInterfaces.value)
+
+            // The offline fallback must not resurrect discovery on a network event...
+            monitor.fireNetworkChange()
+            advanceUntilIdle()
+            assertEquals(emptyList(), service.networkInterfaces.value)
+            // ...nor persist an auto-selected interface behind the user's back.
+            assertEquals("[]", configManager.getCurrentConfig().useNetworkInterfaces)
+
+            job.cancel()
+        }
+
+    @Test
+    fun `toggling only enableDiscovery re-resolves without an interface list change`() =
+        runTest {
+            val configManager = newConfigManager()
+            configManager.updateConfig(
+                "useNetworkInterfaces",
+                jsonUtils.JSON.encodeToString(listOf("en0")),
+            )
+
+            setLiveSnapshot(listOf(en0))
+            val monitor = FakeNetworkStateMonitor()
+            val job = Job()
+            val service = TestableService(configManager, monitor, CoroutineScope(coroutineContext + job))
+            advanceUntilIdle()
+            assertEquals(listOf(en0), service.networkInterfaces.value)
+
+            // CLI-style write: only the boolean changes, the list stays ["en0"].
+            configManager.updateConfig("enableDiscovery", false)
+            advanceUntilIdle()
+            assertEquals(emptyList(), service.networkInterfaces.value)
+
+            configManager.updateConfig("enableDiscovery", true)
+            advanceUntilIdle()
+            assertEquals(listOf(en0), service.networkInterfaces.value)
+
+            job.cancel()
+        }
+
+    @Test
+    fun `discovery enabled while offline auto-selects once the network returns`() =
+        runTest {
+            val configManager = newConfigManager()
+            // Toggle switched on with no interface available: intent persisted, list empty.
+            configManager.updateConfig(
+                listOf("useNetworkInterfaces", "enableDiscovery"),
+                listOf("[]", true),
+            )
+
+            setLiveSnapshot(emptyList())
+            val monitor = FakeNetworkStateMonitor()
+            val job = Job()
+            val service = TestableService(configManager, monitor, CoroutineScope(coroutineContext + job))
+            advanceUntilIdle()
+            assertEquals(emptyList(), service.networkInterfaces.value)
+
+            setLiveSnapshot(listOf(en0))
+            monitor.fireNetworkChange()
+            advanceUntilIdle()
+
+            assertEquals(listOf(en0), service.networkInterfaces.value)
+            // Bootstrap default is persisted so the choice survives the next restart.
+            assertEquals(
+                listOf("en0"),
+                jsonUtils.JSON.decodeFromString<List<String>>(
+                    configManager.getCurrentConfig().useNetworkInterfaces,
+                ),
+            )
+
+            job.cancel()
+        }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/NetworkInterfaceAddressFilterTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/NetworkInterfaceAddressFilterTest.kt
@@ -1,0 +1,57 @@
+package com.crosspaste.net
+
+import io.mockk.every
+import io.mockk.mockk
+import java.net.InetAddress
+import java.net.InterfaceAddress
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Interface enumeration yields unicast addresses this host owns; none of them may be
+ * dropped on a last-octet heuristic. `.1` is the hotspot host address, and `.0`/`.255`
+ * are ordinary hosts once the network is wider than /24.
+ */
+class NetworkInterfaceAddressFilterTest {
+
+    private val service = TestNetworkInterfaceService()
+
+    private fun interfaceAddress(
+        host: String,
+        prefixLength: Short,
+    ): InterfaceAddress =
+        mockk<InterfaceAddress> {
+            every { address } returns InetAddress.getByName(host)
+            every { networkPrefixLength } returns prefixLength
+        }
+
+    @Test
+    fun `ordinary host address is kept`() {
+        val info = service.testProcessAddress(interfaceAddress("192.168.1.100", 24), "en0")
+        assertEquals(NetworkInterfaceInfo("en0", 24, "192.168.1.100"), info)
+    }
+
+    @Test
+    fun `hotspot host address ending in dot 1 is kept`() {
+        val info = service.testProcessAddress(interfaceAddress("192.168.137.1", 24), "wlan1")
+        assertEquals("192.168.137.1", info?.hostAddress)
+    }
+
+    @Test
+    fun `dot 0 and dot 255 hosts inside a slash 16 are kept`() {
+        assertEquals(
+            "10.1.5.0",
+            service.testProcessAddress(interfaceAddress("10.1.5.0", 16), "eth0")?.hostAddress,
+        )
+        assertEquals(
+            "10.1.7.255",
+            service.testProcessAddress(interfaceAddress("10.1.7.255", 16), "eth0")?.hostAddress,
+        )
+    }
+
+    @Test
+    fun `ipv6 addresses are still ignored`() {
+        assertNull(service.testProcessAddress(interfaceAddress("fe80::1", 64), "en0"))
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/TestNetworkInterfaceService.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/TestNetworkInterfaceService.kt
@@ -2,6 +2,7 @@ package com.crosspaste.net
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.net.InterfaceAddress
 
 class TestNetworkInterfaceService(
     private val testNetworkInterfaces: List<NetworkInterfaceInfo> = emptyList(),
@@ -16,4 +17,9 @@ class TestNetworkInterfaceService(
     override fun getPreferredNetworkInterface(): NetworkInterfaceInfo? = testPreferredInterface
 
     fun testSortAddresses(addresses: List<NetworkInterfaceInfo>): List<NetworkInterfaceInfo> = sortAddresses(addresses)
+
+    fun testProcessAddress(
+        addr: InterfaceAddress,
+        nicName: String,
+    ): NetworkInterfaceInfo? = processAddress(addr, nicName)
 }


### PR DESCRIPTION
Closes #4923.

## What

- `DesktopNetworkInterfaceService`: the resolver now consumes a `(enableDiscovery, useNetworkInterfaces)` snapshot and returns an empty selection whenever discovery is off, before any auto-select or offline fallback runs. A change to either field re-resolves, so a CLI `enableDiscovery=false` takes effect immediately.
- `NetworkSettingsContentView`: the toggle is bound to `enableDiscovery`. Switching it on while offline persists `enableDiscovery=true` with an empty list; the resolver auto-selects and persists the bootstrap interface once the network comes back.
- `AbstractNetworkInterfaceService`: removed the `.0`/`.1`/`.255` last-octet filter. Enumerated addresses are unicast addresses this host owns; hotspot hosts sit on `.1`, and `/16` hosts legitimately end in `.0`/`.255`.
- Interface checkboxes compare against the decoded list instead of the raw JSON string, so `en1` no longer shows as selected when `en10` is.

## Tests

`DesktopNetworkInterfaceServiceSelfHealingTest` gains three fast-tier cases: discovery off binds nothing even while online and never persists a fallback; flipping only `enableDiscovery` re-resolves; enabling while offline auto-selects and persists once the network returns. New `NetworkInterfaceAddressFilterTest` covers `.1`, `/16 .0`, `/16 .255`, an ordinary host and IPv6 rejection.