### PR TITLE
:bug: keep the Windows network warning dismissal across restarts

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkProfileService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkProfileService.kt
@@ -102,11 +102,12 @@ class DesktopNetworkProfileService(
     /**
      * Publishes a real detection result and reconciles it with the persisted dismissal.
      *
-     * Only a detected state may invalidate the stored fingerprint: the `NOT_APPLICABLE`
-     * placeholder the flow starts with and the `UNKNOWN` of a failed probe are not
-     * network states the user could have dismissed, so comparing against them would
-     * wipe every dismissal on startup and re-open the dialog for the same blocking
-     * state after each restart.
+     * Only a conclusive detection may invalidate the stored fingerprint. The
+     * `NOT_APPLICABLE` placeholder the flow starts with, and the `UNKNOWN` / `null`
+     * that `WindowsNetworkApi.query()` returns when a COM, profile or firewall query
+     * fails, are not network states the user could have dismissed. Treating them as a
+     * change would wipe the dismissal on startup or on a transient firewall read
+     * failure and re-open the dialog once the same blocking state is read back.
      *
      * The dialog is surfaced synchronously here rather than from a `combine` over
      * `_diagnosis` and [isWarningDismissed]: those two flows update independently, so
@@ -118,7 +119,7 @@ class DesktopNetworkProfileService(
         val stored = configManager.getCurrentConfig().networkBlockingDismissedFingerprint
         // The user fixed the network or moved to a different blocking state: forget the
         // dismissal so the next blocking event surfaces a fresh warning.
-        if (stored.isNotEmpty() && stored != fingerprint) {
+        if (diagnosis.isConclusive() && stored.isNotEmpty() && stored != fingerprint) {
             configManager.updateConfig("networkBlockingDismissedFingerprint", "")
         }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkProfileService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopNetworkProfileService.kt
@@ -20,9 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -34,6 +32,7 @@ class DesktopNetworkProfileService(
     private val platform: Platform,
     private val userAttentionService: UserAttentionService,
     private val scope: CoroutineScope = namedScope(ioDispatcher, "DesktopNetworkProfileService"),
+    private val detect: () -> NetworkDiagnosis = ::queryWindowsDiagnosis,
 ) : NetworkProfileService {
 
     private val logger = KotlinLogging.logger {}
@@ -68,27 +67,6 @@ class DesktopNetworkProfileService(
                 ) { runDetection() }
             }
         }
-
-        // When the diagnosis fingerprint diverges from the stored dismissed fingerprint
-        // (e.g. user fixed the network, or moved to a different blocking state), forget
-        // the dismissal so the next blocking event surfaces a fresh warning.
-        _diagnosis
-            .onEach { current ->
-                val stored = configManager.getCurrentConfig().networkBlockingDismissedFingerprint
-                if (stored.isNotEmpty() && stored != current.fingerprint()) {
-                    configManager.updateConfig("networkBlockingDismissedFingerprint", "")
-                }
-            }.launchIn(scope)
-
-        // Auto-surface the dialog the first time a new blocking state is detected.
-        combine(_diagnosis, isWarningDismissed) { current, dismissed ->
-            current.isLikelyBlocking() && !dismissed
-        }.distinctUntilChanged()
-            .onEach { shouldShow ->
-                if (shouldShow) {
-                    _isWarningDialogVisible.value = true
-                }
-            }.launchIn(scope)
     }
 
     override suspend fun refresh() {
@@ -111,14 +89,46 @@ class DesktopNetworkProfileService(
     }
 
     private fun runDetection() {
-        runCatching {
-            val snapshot = WindowsNetworkApi.query()
-            val diagnosis = NetworkDiagnosis(snapshot.profile, snapshot.mDnsAllowed)
-            logger.info { "Network diagnosis: $diagnosis" }
-            _diagnosis.value = diagnosis
-        }.onFailure { e ->
-            logger.warn(e) { "Failed to run Windows network diagnosis" }
-            _diagnosis.value = NetworkDiagnosis(NetworkProfile.UNKNOWN, mDnsAllowed = null)
+        runCatching { detect() }
+            .onSuccess { diagnosis ->
+                logger.info { "Network diagnosis: $diagnosis" }
+                publishDetected(diagnosis)
+            }.onFailure { e ->
+                logger.warn(e) { "Failed to run Windows network diagnosis" }
+                _diagnosis.value = NetworkDiagnosis(NetworkProfile.UNKNOWN, mDnsAllowed = null)
+            }
+    }
+
+    /**
+     * Publishes a real detection result and reconciles it with the persisted dismissal.
+     *
+     * Only a detected state may invalidate the stored fingerprint: the `NOT_APPLICABLE`
+     * placeholder the flow starts with and the `UNKNOWN` of a failed probe are not
+     * network states the user could have dismissed, so comparing against them would
+     * wipe every dismissal on startup and re-open the dialog for the same blocking
+     * state after each restart.
+     *
+     * The dialog is surfaced synchronously here rather than from a `combine` over
+     * `_diagnosis` and [isWarningDismissed]: those two flows update independently, so
+     * the combine could observe the new blocking diagnosis together with a stale
+     * `dismissed = false` and pop the dialog for a state the user already dismissed.
+     */
+    private fun publishDetected(diagnosis: NetworkDiagnosis) {
+        val fingerprint = diagnosis.fingerprint()
+        val stored = configManager.getCurrentConfig().networkBlockingDismissedFingerprint
+        // The user fixed the network or moved to a different blocking state: forget the
+        // dismissal so the next blocking event surfaces a fresh warning.
+        if (stored.isNotEmpty() && stored != fingerprint) {
+            configManager.updateConfig("networkBlockingDismissedFingerprint", "")
+        }
+
+        val previous = _diagnosis.value
+        _diagnosis.value = diagnosis
+
+        // Auto-surface the dialog the first time a new blocking state is detected.
+        val isNewState = previous.fingerprint() != fingerprint
+        if (diagnosis.isLikelyBlocking() && isNewState && stored != fingerprint) {
+            _isWarningDialogVisible.value = true
         }
     }
 
@@ -151,6 +161,11 @@ class DesktopNetworkProfileService(
     }
 
     companion object {
+        private fun queryWindowsDiagnosis(): NetworkDiagnosis {
+            val snapshot = WindowsNetworkApi.query()
+            return NetworkDiagnosis(snapshot.profile, snapshot.mDnsAllowed)
+        }
+
         private const val OPEN_NETWORK_SETTINGS_COMMAND =
             "control.exe /name Microsoft.NetworkAndSharingCenter /page Advanced"
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/NetworkProfileService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/NetworkProfileService.kt
@@ -38,6 +38,14 @@ data class NetworkDiagnosis(
             -> false
         }
 
+    // A detection that actually established the network state. `WindowsNetworkApi.query()`
+    // never throws: a COM, profile or firewall failure is absorbed into UNKNOWN / null, so
+    // an inconclusive result is a failed probe, not a network change.
+    fun isConclusive(): Boolean =
+        profile != NetworkProfile.UNKNOWN &&
+            profile != NetworkProfile.NOT_APPLICABLE &&
+            mDnsAllowed != null
+
     fun fingerprint(): String = "${profile.name}|$mDnsAllowed"
 
     companion object {

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkProfileServiceDismissalTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkProfileServiceDismissalTest.kt
@@ -121,6 +121,48 @@ class DesktopNetworkProfileServiceDismissalTest {
         }
 
     @Test
+    fun `absorbed probe failure returning UNKNOWN does not clear the dismissal`() =
+        runTest {
+            // WindowsNetworkApi.query() never throws; a COM failure comes back as UNKNOWN|null.
+            val unknown = NetworkDiagnosis(NetworkProfile.UNKNOWN, mDnsAllowed = null)
+            val configManager = newConfigManager(storedFingerprint = publicBlocking.fingerprint())
+            val job = Job()
+            val service = newService(configManager, CoroutineScope(coroutineContext + job)) { unknown }
+
+            service.refresh()
+            advanceUntilIdle()
+
+            assertEquals(unknown, service.diagnosis.value)
+            assertEquals(publicBlocking.fingerprint(), storedFingerprint(configManager))
+            assertFalse(service.isWarningDialogVisible.value)
+            job.cancel()
+        }
+
+    @Test
+    fun `transient firewall read failure keeps the dismissal until the same state is read back`() =
+        runTest {
+            val configManager = newConfigManager(storedFingerprint = publicBlocking.fingerprint())
+            var next = NetworkDiagnosis(NetworkProfile.PUBLIC, mDnsAllowed = null)
+            val job = Job()
+            val service = newService(configManager, CoroutineScope(coroutineContext + job)) { next }
+
+            // Profile resolved but the firewall rules could not be enumerated.
+            service.refresh()
+            advanceUntilIdle()
+            assertEquals(publicBlocking.fingerprint(), storedFingerprint(configManager))
+            assertFalse(service.isWarningDialogVisible.value)
+
+            // Firewall query recovers and reports the very state the user dismissed.
+            next = publicBlocking
+            service.refresh()
+            advanceUntilIdle()
+            assertEquals(publicBlocking.fingerprint(), storedFingerprint(configManager))
+            assertTrue(service.isWarningDismissed.value)
+            assertFalse(service.isWarningDialogVisible.value)
+            job.cancel()
+        }
+
+    @Test
     fun `dismissing persists the fingerprint and repeated detections stay quiet`() =
         runTest {
             val configManager = newConfigManager()

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkProfileServiceDismissalTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopNetworkProfileServiceDismissalTest.kt
@@ -1,0 +1,146 @@
+package com.crosspaste.net
+
+import com.crosspaste.config.DesktopConfigManager
+import com.crosspaste.headless.HeadlessUserAttentionService
+import com.crosspaste.notification.NotificationManager
+import com.crosspaste.platform.Platform
+import com.crosspaste.presist.OneFilePersist
+import com.crosspaste.utils.DesktopLocaleUtils
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toOkioPath
+import java.nio.file.Files
+import kotlin.coroutines.coroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The persisted dismissal of the Windows network warning must survive a restart when
+ * the next detection reports the same blocking state, and only a real detection may
+ * invalidate it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DesktopNetworkProfileServiceDismissalTest {
+
+    private val publicBlocking = NetworkDiagnosis(NetworkProfile.PUBLIC, mDnsAllowed = false)
+    private val privateBlocking = NetworkDiagnosis(NetworkProfile.PRIVATE, mDnsAllowed = false)
+
+    private val windows = Platform(Platform.WINDOWS, "x86_64", 64, "11")
+
+    private fun newConfigManager(storedFingerprint: String = ""): DesktopConfigManager {
+        val configDir = Files.createTempDirectory("netProfileConfig").toOkioPath()
+        configDir.toFile().deleteOnExit()
+        val configManager =
+            DesktopConfigManager(
+                OneFilePersist(configDir.resolve("appConfig.json")),
+                DesktopLocaleUtils,
+            )
+        if (storedFingerprint.isNotEmpty()) {
+            configManager.updateConfig("networkBlockingDismissedFingerprint", storedFingerprint)
+        }
+        return configManager
+    }
+
+    private fun newService(
+        configManager: DesktopConfigManager,
+        scope: CoroutineScope,
+        detect: () -> NetworkDiagnosis,
+    ): DesktopNetworkProfileService =
+        DesktopNetworkProfileService(
+            configManager = configManager,
+            notificationManager = mockk<NotificationManager>(relaxed = true),
+            platform = windows,
+            userAttentionService = HeadlessUserAttentionService(),
+            scope = scope,
+            detect = detect,
+        )
+
+    private fun storedFingerprint(configManager: DesktopConfigManager): String =
+        configManager.getCurrentConfig().networkBlockingDismissedFingerprint
+
+    @Test
+    fun `same blocking state after restart keeps the dismissal and stays quiet`() =
+        runTest {
+            val configManager = newConfigManager(storedFingerprint = publicBlocking.fingerprint())
+            val job = Job()
+            val service = newService(configManager, CoroutineScope(coroutineContext + job)) { publicBlocking }
+
+            // Construction alone (placeholder NOT_APPLICABLE) must not touch the dismissal.
+            advanceUntilIdle()
+            assertEquals(publicBlocking.fingerprint(), storedFingerprint(configManager))
+
+            service.refresh()
+            advanceUntilIdle()
+
+            assertEquals(publicBlocking, service.diagnosis.value)
+            assertEquals(publicBlocking.fingerprint(), storedFingerprint(configManager))
+            assertTrue(service.isWarningDismissed.value)
+            assertFalse(service.isWarningDialogVisible.value)
+            job.cancel()
+        }
+
+    @Test
+    fun `different blocking state clears the dismissal and surfaces the dialog`() =
+        runTest {
+            val configManager = newConfigManager(storedFingerprint = publicBlocking.fingerprint())
+            val job = Job()
+            val service = newService(configManager, CoroutineScope(coroutineContext + job)) { privateBlocking }
+
+            service.refresh()
+            advanceUntilIdle()
+
+            assertEquals("", storedFingerprint(configManager))
+            assertFalse(service.isWarningDismissed.value)
+            assertTrue(service.isWarningDialogVisible.value)
+            job.cancel()
+        }
+
+    @Test
+    fun `failed detection does not clear the dismissal`() =
+        runTest {
+            val configManager = newConfigManager(storedFingerprint = publicBlocking.fingerprint())
+            val job = Job()
+            val service =
+                newService(configManager, CoroutineScope(coroutineContext + job)) {
+                    error("COM enumeration failed")
+                }
+
+            service.refresh()
+            advanceUntilIdle()
+
+            assertEquals(NetworkProfile.UNKNOWN, service.diagnosis.value.profile)
+            assertEquals(publicBlocking.fingerprint(), storedFingerprint(configManager))
+            assertFalse(service.isWarningDialogVisible.value)
+            job.cancel()
+        }
+
+    @Test
+    fun `dismissing persists the fingerprint and repeated detections stay quiet`() =
+        runTest {
+            val configManager = newConfigManager()
+            val job = Job()
+            val service = newService(configManager, CoroutineScope(coroutineContext + job)) { publicBlocking }
+
+            service.refresh()
+            advanceUntilIdle()
+            assertTrue(service.isWarningDialogVisible.value)
+
+            service.dismissWarning()
+            advanceUntilIdle()
+            assertEquals(publicBlocking.fingerprint(), storedFingerprint(configManager))
+            assertFalse(service.isWarningDialogVisible.value)
+
+            // The 60s poll re-detecting the same state must not reopen the dialog.
+            service.refresh()
+            advanceUntilIdle()
+            assertFalse(service.isWarningDialogVisible.value)
+            assertTrue(service.isWarningDismissed.value)
+            job.cancel()
+        }
+}


### PR DESCRIPTION
Closes #4925.

## What

- `DesktopNetworkProfileService` no longer invalidates the stored dismissal from a collector on the diagnosis `StateFlow`. The stored fingerprint is reconciled only when a **conclusive** detection result is published: a different fingerprint clears it, the same one keeps it.
- `NetworkDiagnosis.isConclusive()` defines conclusive as a known profile with a non-null `mDnsAllowed`. `WindowsNetworkApi.query()` never throws; a COM, profile or firewall failure is absorbed into `UNKNOWN` or `mDnsAllowed = null`. Those results, like the `NOT_APPLICABLE` placeholder, are failed probes rather than network changes and leave the dismissal untouched. Previously a transient firewall read failure (`PUBLIC|null`) wiped a `PUBLIC|false` dismissal and the warning reopened once the same state was read back.
- The warning dialog is surfaced synchronously in that same publish step ("blocking, fingerprint differs from the previous diagnosis, not dismissed") instead of a `combine` over `_diagnosis` and `isWarningDismissed`. Those two flows update independently, so the combine could see a new blocking diagnosis with a stale `dismissed = false` and reopen the dialog for a state the user already dismissed. Behavior is otherwise unchanged: the 60s poll re-detecting the same state stays quiet, a state change after a fix surfaces a fresh warning.
- The Windows probe is injected as a `detect` function with the existing `WindowsNetworkApi.query()` as default, so the reconciliation runs in tests off Windows.

## Tests

New fast-tier `DesktopNetworkProfileServiceDismissalTest`:
- same blocking state after restart keeps the dismissal and does not open the dialog
- a different conclusive blocking state clears it and surfaces the dialog
- `UNKNOWN|null` returned normally (absorbed COM failure) leaves the dismissal alone
- `PUBLIC|null` (firewall enumeration failed) keeps the dismissal, and the following `PUBLIC|false` read-back stays quiet
- a thrown detection leaves the dismissal alone
- dismiss followed by repeated identical detections stays quiet