### PR TITLE
:bug: isolate JmDNS lifecycle per interface and bind nearby presence to the discovery source

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopPasteBonjourService.kt
@@ -3,6 +3,7 @@ package com.crosspaste.net
 import com.crosspaste.app.AppInfo
 import com.crosspaste.app.EndpointInfoFactory
 import com.crosspaste.db.sync.HostInfo
+import com.crosspaste.dto.sync.EndpointInfo
 import com.crosspaste.dto.sync.SyncInfo
 import com.crosspaste.sync.NearbyDeviceManager
 import com.crosspaste.utils.DesktopControlUtils.ensureMinExecutionTime
@@ -11,64 +12,112 @@ import com.crosspaste.utils.getDateUtils
 import com.crosspaste.utils.ioDispatcher
 import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.util.collections.*
+import io.ktor.util.collections.ConcurrentMap
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withTimeoutOrNull
 import java.net.InetAddress
-import javax.jmdns.JmDNS
-import javax.jmdns.ServiceEvent
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import javax.jmdns.ServiceInfo
-import javax.jmdns.ServiceListener
-import javax.jmdns.impl.util.ByteWrangler
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
-class DesktopPasteBonjourService(
+class DesktopPasteBonjourService internal constructor(
     private val appInfo: AppInfo,
     private val endpointInfoFactory: EndpointInfoFactory,
     private val nearbyDeviceManager: NearbyDeviceManager,
     private val networkInterfaceService: NetworkInterfaceService,
-    private val scope: CoroutineScope = namedScope(ioDispatcher, "DesktopPasteBonjourService"),
+    private val scope: CoroutineScope,
+    private val jmdnsFactory: JmDnsFactory,
+    private val cleanupDispatcher: CoroutineDispatcher = ioDispatcher,
 ) : PasteBonjourService {
 
+    constructor(
+        appInfo: AppInfo,
+        endpointInfoFactory: EndpointInfoFactory,
+        nearbyDeviceManager: NearbyDeviceManager,
+        networkInterfaceService: NetworkInterfaceService,
+    ) : this(
+        appInfo,
+        endpointInfoFactory,
+        nearbyDeviceManager,
+        networkInterfaceService,
+        namedScope(ioDispatcher, "DesktopPasteBonjourService"),
+        DefaultJmDnsFactory,
+    )
+
+    constructor(
+        appInfo: AppInfo,
+        endpointInfoFactory: EndpointInfoFactory,
+        nearbyDeviceManager: NearbyDeviceManager,
+        networkInterfaceService: NetworkInterfaceService,
+        scope: CoroutineScope,
+    ) : this(
+        appInfo,
+        endpointInfoFactory,
+        nearbyDeviceManager,
+        networkInterfaceService,
+        scope,
+        DefaultJmDnsFactory,
+    )
+
     companion object {
-        private const val SERVICE_TYPE = "_crosspasteService._tcp.local."
+        internal const val SERVICE_TYPE = "_crosspasteService._tcp.local."
 
-        private const val ACTIVE_SCAN_TIMEOUT = 3000L // jmdns.list blocking time
-        private const val INTERFACE_SCAN_INTERVAL = 5000L // Throttle for heavy scan per interface
-        private const val DEVICE_RESOLVE_INTERVAL = 2000L // Throttle for specific device resolution
-        private const val MIN_SEARCH_DURATION = 2000L // Minimum duration for searching
-        private const val CLOSE_TIMEOUT = 10000L // Maximum time to wait for close
-        private const val LIFECYCLE_CLOSE_TIMEOUT = 4000L // Must stay below the app's 5s shutdown budget
+        private const val ACTIVE_SCAN_TIMEOUT = 3000L
+        private const val INTERFACE_SCAN_INTERVAL = 5000L
+        private const val DEVICE_RESOLVE_INTERVAL = 2000L
+        private const val MIN_SEARCH_DURATION = 2000L
+        private const val CLOSE_TIMEOUT = 10000L
+        private const val LIFECYCLE_CLOSE_TIMEOUT = 4000L
+        private const val MAX_SETUP_RETRIES = 3
 
+        private val SETUP_RETRY_DELAY = 2.seconds
         private val dateUtils = getDateUtils()
     }
 
+    private data class ActiveJmDns(
+        val id: Long,
+        val generation: Long,
+        val hostAddress: String,
+        val instance: JmDnsInstance,
+        val listener: DesktopServiceListener,
+    )
+
+    private data class DiscoverySource(
+        val registrationId: Long,
+        val serviceName: String,
+    )
+
     private val logger = KotlinLogging.logger {}
 
-    // CONFLATED, not UNLIMITED: a single close()+setup() rebuild can take seconds
-    // (jmDNS teardown + re-registration), and the event-driven NetworkStateMonitor
-    // can emit several interface snapshots while one rebuild is in flight. We only
-    // ever need to converge on the *latest* snapshot, so collapse intermediate
-    // bursts instead of replaying every transient state (#4509 phase 2 debounce).
+    // A rebuild can take seconds. We only need to converge on the latest snapshot,
+    // so collapse intermediate network-interface changes.
     private val actionChannel = Channel<List<NetworkInterfaceInfo>>(Channel.CONFLATED)
 
-    private val serviceListener = DesktopServiceListener(nearbyDeviceManager)
-
-    private val jmdnsMap: MutableMap<String, JmDNS> = ConcurrentMap()
+    private val stateLock = Any()
+    private val registrations = mutableMapOf<String, ActiveJmDns>()
+    private val presenceBySource = mutableMapOf<DiscoverySource, SyncInfo>()
+    private val generation = AtomicLong(0)
+    private val registrationId = AtomicLong(0)
+    private val refreshAllRunning = AtomicBoolean(false)
 
     private val interfaceScanThrottle: MutableMap<String, Long> = ConcurrentMap()
-
     private val deviceResolveThrottle: MutableMap<String, Long> = ConcurrentMap()
+
+    private var setupRetryJob: Job? = null
 
     init {
         scope.launch {
@@ -79,85 +128,200 @@ class DesktopPasteBonjourService(
 
         scope.launch {
             for (interfaces in actionChannel) {
-                processNetworkChange(interfaces)
+                try {
+                    processNetworkChange(interfaces)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    // Keep the sole rebuild consumer alive so a later network snapshot
+                    // can recover from an unexpected setup failure.
+                    logger.error(e) { "Failed to rebuild Bonjour services" }
+                }
             }
         }
     }
 
     suspend fun processNetworkChange(interfaces: List<NetworkInterfaceInfo>) {
-        // Suspending teardown: the network-change consumer is a single coroutine, so
-        // a blocking close() (runBlocking) here would freeze the consumer's thread for
-        // the whole jmDNS shutdown. Drive it through the suspend path instead so the
-        // dispatcher stays free while interfaces tear down (#4509 phase 2).
-        closeServices()
+        setupRetryJob?.cancel()
+        val currentGeneration = generation.incrementAndGet()
+        closeServices(detachServices())
 
-        setup(interfaces)
-    }
-
-    suspend fun setup(interfaces: List<NetworkInterfaceInfo>) {
-        val hostInfoList = interfaces.map { info -> info.toHostInfo() }
-        val endpointInfo = endpointInfoFactory.createEndpointInfo(hostInfoList)
-        val syncInfo = SyncInfo(appInfo, endpointInfo)
-
-        logger.debug { "Registering service: $syncInfo" }
-
-        val txtRecordDict = TxtRecordUtils.encodeToTxtRecordDict(syncInfo)
-
-        coroutineScope {
-            hostInfoList
-                .map { hostInfo ->
-                    async {
-                        val hostAddress = hostInfo.hostAddress
-                        jmdnsMap.computeIfAbsent(hostAddress) {
-                            val jmDNS = JmDNS.create(InetAddress.getByName(hostAddress))
-                            val serviceInfo =
-                                ServiceInfo.create(
-                                    SERVICE_TYPE,
-                                    "crosspaste@${appInfo.appInstanceId}@${hostAddress.replace(".", "_")}",
-                                    endpointInfo.port,
-                                    0,
-                                    0,
-                                    txtRecordDict,
-                                )
-                            jmDNS.addServiceListener(SERVICE_TYPE, serviceListener)
-                            jmDNS.registerService(serviceInfo)
-                            jmDNS
-                        }
-                    }
-                }.awaitAll()
+        if (interfaces.isNotEmpty()) {
+            setup(interfaces, currentGeneration)
         }
     }
 
-    override fun refreshAll() {
-        scope.launch {
-            nearbyDeviceManager.startSearching()
-            ensureMinExecutionTime(MIN_SEARCH_DURATION) {
-                logger.info { "Manual refresh started..." }
+    private suspend fun setup(
+        interfaces: List<NetworkInterfaceInfo>,
+        currentGeneration: Long,
+    ) {
+        val hostInfoList = interfaces.map { info -> info.toHostInfo() }
+        val endpointInfo = endpointInfoFactory.createEndpointInfo(hostInfoList)
+        val syncInfo = SyncInfo(appInfo, endpointInfo)
+        val txtRecordDict = TxtRecordUtils.encodeToTxtRecordDict(syncInfo)
 
-                coroutineScope {
-                    jmdnsMap
-                        .map { (hostAddress, jmdns) ->
-                            async {
-                                // Force fresh multicast PTR queries by re-registering the listener.
-                                // This resets JmDNS's internal state machine, triggering real
-                                // network broadcasts instead of just searching the local cache.
-                                jmdns.removeServiceListener(SERVICE_TYPE, serviceListener)
-                                jmdns.addServiceListener(SERVICE_TYPE, serviceListener)
+        logger.debug { "Registering service: $syncInfo" }
 
-                                val services = jmdns.list(SERVICE_TYPE, ACTIVE_SCAN_TIMEOUT)
-                                logger.debug { "Interface $hostAddress found ${services.size} services" }
+        val failed = setupInterfaces(interfaces, currentGeneration, endpointInfo, txtRecordDict)
+        scheduleSetupRetry(failed, currentGeneration, endpointInfo, txtRecordDict)
+    }
 
-                                services.forEach { serviceInfo ->
-                                    jmdns.requestServiceInfo(SERVICE_TYPE, serviceInfo.name)
-                                }
-                            }
-                        }.awaitAll()
+    private suspend fun setupInterfaces(
+        interfaces: List<NetworkInterfaceInfo>,
+        currentGeneration: Long,
+        endpointInfo: EndpointInfo,
+        txtRecordDict: Map<String, String>,
+    ): List<NetworkInterfaceInfo> =
+        supervisorScope {
+            interfaces
+                .map { networkInterface ->
+                    async {
+                        networkInterface.takeUnless {
+                            setupInterface(it, currentGeneration, endpointInfo, txtRecordDict)
+                        }
+                    }
+                }.awaitAll()
+                .filterNotNull()
+        }
+
+    private fun setupInterface(
+        networkInterface: NetworkInterfaceInfo,
+        currentGeneration: Long,
+        endpointInfo: EndpointInfo,
+        txtRecordDict: Map<String, String>,
+    ): Boolean {
+        if (generation.get() != currentGeneration) return true
+
+        val hostAddress = networkInterface.hostAddress
+        var instance: JmDnsInstance? = null
+        return try {
+            instance = jmdnsFactory.create(InetAddress.getByName(hostAddress))
+            instance.registerService(
+                ServiceInfo.create(
+                    SERVICE_TYPE,
+                    "crosspaste@${appInfo.appInstanceId}@${hostAddress.replace(".", "_")}",
+                    endpointInfo.port,
+                    0,
+                    0,
+                    txtRecordDict,
+                ),
+            )
+
+            val id = registrationId.incrementAndGet()
+            val listener =
+                DesktopServiceListener(
+                    isActive = { isRegistrationActive(hostAddress, id, currentGeneration) },
+                    onResolved = { serviceName, syncInfo ->
+                        recordResolved(hostAddress, id, currentGeneration, serviceName, syncInfo)
+                    },
+                    onRemoved = { serviceName, appInstanceId ->
+                        recordRemoved(hostAddress, id, currentGeneration, serviceName, appInstanceId)
+                    },
+                )
+            val registration =
+                ActiveJmDns(
+                    id = id,
+                    generation = currentGeneration,
+                    hostAddress = hostAddress,
+                    instance = instance,
+                    listener = listener,
+                )
+
+            val activated =
+                synchronized(stateLock) {
+                    if (generation.get() != currentGeneration || registrations.containsKey(hostAddress)) {
+                        false
+                    } else {
+                        registrations[hostAddress] = registration
+                        try {
+                            instance.addServiceListener(SERVICE_TYPE, listener)
+                            true
+                        } catch (e: Throwable) {
+                            registrations.remove(hostAddress, registration)
+                            throw e
+                        }
+                    }
                 }
-            }.onFailure { e ->
-                logger.error(e) { "Error during manual refreshAll" }
+
+            if (!activated) {
+                closeFailedInstance(instance)
             }
-            nearbyDeviceManager.stopSearching()
-            logger.info { "Manual refresh completed." }
+            true
+        } catch (e: Throwable) {
+            instance?.let(::closeFailedInstance)
+            logger.warn(e) { "Failed to register Bonjour service on $hostAddress" }
+            false
+        }
+    }
+
+    private fun scheduleSetupRetry(
+        initialFailures: List<NetworkInterfaceInfo>,
+        currentGeneration: Long,
+        endpointInfo: EndpointInfo,
+        txtRecordDict: Map<String, String>,
+    ) {
+        if (initialFailures.isEmpty() || generation.get() != currentGeneration) return
+
+        setupRetryJob =
+            scope.launch {
+                var failures = initialFailures
+                repeat(MAX_SETUP_RETRIES) {
+                    delay(SETUP_RETRY_DELAY)
+                    if (generation.get() != currentGeneration) return@launch
+                    failures = setupInterfaces(failures, currentGeneration, endpointInfo, txtRecordDict)
+                    if (failures.isEmpty()) return@launch
+                }
+                logger.warn {
+                    "Bonjour setup still failing on: ${failures.joinToString { it.hostAddress }}"
+                }
+            }
+    }
+
+    override fun refreshAll() {
+        if (!refreshAllRunning.compareAndSet(false, true)) return
+
+        scope.launch {
+            try {
+                nearbyDeviceManager.startSearching()
+                ensureMinExecutionTime(MIN_SEARCH_DURATION) {
+                    logger.info { "Manual refresh started..." }
+                    supervisorScope {
+                        activeRegistrations()
+                            .map { registration ->
+                                async { refreshAllOnInterface(registration) }
+                            }.awaitAll()
+                    }
+                }.getOrThrow()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                logger.error(e) { "Error during manual refreshAll" }
+            } finally {
+                nearbyDeviceManager.stopSearching()
+                refreshAllRunning.set(false)
+                logger.info { "Manual refresh completed." }
+            }
+        }
+    }
+
+    private fun refreshAllOnInterface(registration: ActiveJmDns) {
+        if (!isRegistrationActive(registration)) return
+
+        try {
+            registration.instance.removeServiceListener(SERVICE_TYPE, registration.listener)
+            registration.instance.addServiceListener(SERVICE_TYPE, registration.listener)
+
+            val services = registration.instance.list(SERVICE_TYPE, ACTIVE_SCAN_TIMEOUT)
+            logger.debug {
+                "Interface ${registration.hostAddress} found ${services.size} services"
+            }
+            services.forEach { serviceInfo ->
+                registration.instance.requestServiceInfo(SERVICE_TYPE, serviceInfo.name)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logger.warn(e) { "Failed to refresh Bonjour interface ${registration.hostAddress}" }
         }
     }
 
@@ -165,117 +329,238 @@ class DesktopPasteBonjourService(
         appInstanceId: String,
         hostInfoList: List<HostInfo>,
     ) {
-        // Use the existing scope to avoid blocking the caller
+        // mDNS visibility is determined by active local interfaces. hostInfoList remains
+        // part of the shared API for discovery backends that can target remote addresses.
         scope.launch {
             val currentTime = dateUtils.nowEpochMilliseconds()
-
-            // Run scans in parallel across all interfaces
-            jmdnsMap
-                .map { (hostAddress, jmdns) ->
+            activeRegistrations()
+                .map { registration ->
                     async {
-                        refreshTargetOnInterface(hostAddress, jmdns, appInstanceId, currentTime)
+                        try {
+                            refreshTargetOnInterface(registration, appInstanceId, currentTime)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Throwable) {
+                            logger.warn(e) {
+                                "Failed to refresh $appInstanceId on ${registration.hostAddress}"
+                            }
+                        }
                     }
                 }.awaitAll()
         }
     }
 
     private fun refreshTargetOnInterface(
-        hostAddress: String,
-        jmdns: JmDNS,
+        registration: ActiveJmDns,
         appInstanceId: String,
         currentTime: Long,
     ) {
+        if (!isRegistrationActive(registration)) return
+
         val servicePrefix = "crosspaste@$appInstanceId@"
+        var targetServiceName = cachedServiceName(registration.id, appInstanceId)
 
-        // 1. Try to find from local cache first
-        var targetService = jmdns.list(SERVICE_TYPE).find { it.name.startsWith(servicePrefix) }
-
-        // 2. Atomic check for heavy scan (Interface-level)
-        if (targetService == null) {
-            var performedScan = false
-            interfaceScanThrottle.compute(hostAddress) { _, lastTime ->
-                if (lastTime == null || currentTime - lastTime > INTERFACE_SCAN_INTERVAL) {
-                    performedScan = true
-                    currentTime // Update with current time
-                } else {
-                    lastTime // Keep the old timestamp
-                }
+        if (targetServiceName == null &&
+            tryAcquire(
+                interfaceScanThrottle,
+                registration.hostAddress,
+                currentTime,
+                INTERFACE_SCAN_INTERVAL,
+            )
+        ) {
+            logger.info {
+                "Performing active scan for $appInstanceId on ${registration.hostAddress}"
             }
-
-            if (performedScan) {
-                logger.info { "Performing active scan for $appInstanceId on $hostAddress" }
-                // list(type, timeout) is blocking
-                val freshServices = jmdns.list(SERVICE_TYPE, ACTIVE_SCAN_TIMEOUT)
-                targetService = freshServices.find { it.name.startsWith(servicePrefix) }
-            }
+            targetServiceName =
+                registration.instance
+                    .list(SERVICE_TYPE, ACTIVE_SCAN_TIMEOUT)
+                    .find { it.name.startsWith(servicePrefix) }
+                    ?.name
         }
 
-        // 3. Atomic check for device resolution (Device-level)
-        if (targetService != null) {
-            val deviceKey = "${hostAddress}_$appInstanceId"
-            var shouldResolve = false
-            deviceResolveThrottle.compute(deviceKey) { _, lastTime ->
-                if (lastTime == null || currentTime - lastTime > DEVICE_RESOLVE_INTERVAL) {
-                    shouldResolve = true
-                    currentTime
-                } else {
-                    lastTime
-                }
+        val deviceKey = "${registration.hostAddress}_$appInstanceId"
+        if (targetServiceName != null &&
+            tryAcquire(deviceResolveThrottle, deviceKey, currentTime, DEVICE_RESOLVE_INTERVAL)
+        ) {
+            logger.info {
+                "Requesting service info for $appInstanceId via ${registration.hostAddress}"
             }
+            registration.instance.requestServiceInfo(SERVICE_TYPE, targetServiceName)
+        }
+    }
 
-            if (shouldResolve) {
-                logger.info { "Requesting service info for $appInstanceId via $hostAddress" }
-                jmdns.requestServiceInfo(SERVICE_TYPE, targetService.name)
+    private fun tryAcquire(
+        throttle: MutableMap<String, Long>,
+        key: String,
+        currentTime: Long,
+        interval: Long,
+    ): Boolean {
+        var acquired = false
+        throttle.compute(key) { _, lastTime ->
+            if (lastTime == null || currentTime - lastTime > interval) {
+                acquired = true
+                currentTime
+            } else {
+                lastTime
+            }
+        }
+        return acquired
+    }
+
+    private fun recordResolved(
+        hostAddress: String,
+        id: Long,
+        currentGeneration: Long,
+        serviceName: String,
+        syncInfo: SyncInfo,
+    ) {
+        synchronized(stateLock) {
+            if (!isRegistrationActiveLocked(hostAddress, id, currentGeneration)) return
+
+            val source = DiscoverySource(id, serviceName)
+            val previous = presenceBySource.put(source, syncInfo)
+            if (previous != null &&
+                previous.appInfo.appInstanceId != syncInfo.appInfo.appInstanceId &&
+                presenceBySource.values.none {
+                    it.appInfo.appInstanceId == previous.appInfo.appInstanceId
+                }
+            ) {
+                nearbyDeviceManager.removeDevice(previous.appInfo.appInstanceId)
+            }
+            nearbyDeviceManager.addDevice(syncInfo)
+        }
+    }
+
+    private fun recordRemoved(
+        hostAddress: String,
+        id: Long,
+        currentGeneration: Long,
+        serviceName: String,
+        appInstanceId: String,
+    ) {
+        synchronized(stateLock) {
+            if (!isRegistrationActiveLocked(hostAddress, id, currentGeneration)) return
+
+            val removed = presenceBySource.remove(DiscoverySource(id, serviceName))
+            val removedAppInstanceId = removed?.appInfo?.appInstanceId ?: appInstanceId
+            if (presenceBySource.values.none {
+                    it.appInfo.appInstanceId == removedAppInstanceId
+                }
+            ) {
+                nearbyDeviceManager.removeDevice(removedAppInstanceId)
             }
         }
     }
 
-    /**
-     * Suspending teardown of all registered jmDNS instances. Used on the network-change
-     * hot path ([processNetworkChange]) so a rebuild never blocks the consumer coroutine.
-     * jmDNS unregister/close are themselves blocking calls. [withTimeout] bounds
-     * cooperative work, but cannot interrupt a native/blocking jmDNS call; lifecycle
-     * shutdown therefore also has a hard wait bound in [close].
-     */
-    private suspend fun closeServices() {
-        runCatching {
-            withTimeout(CLOSE_TIMEOUT) {
-                coroutineScope {
-                    jmdnsMap.values
-                        .map { jmDNS ->
-                            async {
-                                jmDNS.unregisterAllServices()
-                                jmDNS.close()
-                            }
-                        }.awaitAll()
-                }
-            }
-            jmdnsMap.clear()
+    private fun cachedServiceName(
+        id: Long,
+        appInstanceId: String,
+    ): String? =
+        synchronized(stateLock) {
+            presenceBySource.entries
+                .firstOrNull { (source, syncInfo) ->
+                    source.registrationId == id &&
+                        syncInfo.appInfo.appInstanceId == appInstanceId
+                }?.key
+                ?.serviceName
+        }
+
+    private fun isRegistrationActive(
+        hostAddress: String,
+        id: Long,
+        currentGeneration: Long,
+    ): Boolean =
+        synchronized(stateLock) {
+            isRegistrationActiveLocked(hostAddress, id, currentGeneration)
+        }
+
+    private fun isRegistrationActive(registration: ActiveJmDns): Boolean =
+        isRegistrationActive(
+            registration.hostAddress,
+            registration.id,
+            registration.generation,
+        )
+
+    private fun isRegistrationActiveLocked(
+        hostAddress: String,
+        id: Long,
+        currentGeneration: Long,
+    ): Boolean = generation.get() == currentGeneration && registrations[hostAddress]?.id == id
+
+    private fun activeRegistrations(): List<ActiveJmDns> =
+        synchronized(stateLock) {
+            registrations.values.toList()
+        }
+
+    private fun detachServices(): List<ActiveJmDns> =
+        synchronized(stateLock) {
+            val detached = registrations.values.toList()
+            registrations.clear()
             interfaceScanThrottle.clear()
             deviceResolveThrottle.clear()
-        }.onFailure { e ->
-            logger.warn(e) { "Error closing Bonjour service" }
+
+            val appInstanceIds =
+                presenceBySource.values
+                    .map { it.appInfo.appInstanceId }
+                    .distinct()
+            presenceBySource.clear()
+            appInstanceIds.forEach(nearbyDeviceManager::removeDevice)
+            detached
+        }
+
+    private suspend fun closeServices(services: List<ActiveJmDns>) {
+        if (services.isEmpty()) return
+
+        // JmDNS close is blocking and ignores coroutine cancellation. Keep it in a
+        // detached cleanup scope so the timeout bounds the rebuild caller's wait;
+        // inactive instances that time out continue closing in the background.
+        val cleanupScope = CoroutineScope(cleanupDispatcher + SupervisorJob())
+        val cleanupJob =
+            cleanupScope.launch {
+                services
+                    .map { registration ->
+                        async {
+                            runCatching { registration.instance.close() }
+                                .onFailure { e ->
+                                    logger.warn(e) {
+                                        "Failed to close Bonjour service on ${registration.hostAddress}"
+                                    }
+                                }
+                        }
+                    }.awaitAll()
+            }
+        cleanupJob.invokeOnCompletion { cleanupScope.cancel() }
+
+        val completed =
+            withTimeoutOrNull(CLOSE_TIMEOUT.milliseconds) {
+                cleanupJob.join()
+                true
+            } ?: false
+        if (!completed) {
+            logger.warn { "Bonjour service close exceeded ${CLOSE_TIMEOUT}ms" }
         }
     }
 
-    /**
-     * Lifecycle teardown (interface contract). The cleanup job is deliberately detached
-     * from the synchronous caller: jmDNS scans and close calls may ignore coroutine
-     * cancellation, so application shutdown waits at most [LIFECYCLE_CLOSE_TIMEOUT] and
-     * then proceeds while the daemon-backed IO cleanup is allowed to finish.
-     */
+    private fun closeFailedInstance(instance: JmDnsInstance) {
+        runCatching { instance.close() }
+            .onFailure { e -> logger.warn(e) { "Failed to close incomplete Bonjour service" } }
+    }
+
     override fun close() {
-        val cleanupScope = CoroutineScope(ioDispatcher + SupervisorJob())
+        scope.cancel()
+        generation.incrementAndGet()
+        val services = detachServices()
+
+        val cleanupScope = CoroutineScope(cleanupDispatcher + SupervisorJob())
         val cleanupJob =
             cleanupScope.launch {
-                scope.coroutineContext.job.cancelAndJoin()
-                closeServices()
+                closeServices(services)
             }
         cleanupJob.invokeOnCompletion { cleanupScope.cancel() }
 
         runBlocking {
             val completed =
-                withTimeoutOrNull(LIFECYCLE_CLOSE_TIMEOUT) {
+                withTimeoutOrNull(LIFECYCLE_CLOSE_TIMEOUT.milliseconds) {
                     cleanupJob.join()
                     true
                 } ?: false
@@ -284,53 +569,6 @@ class DesktopPasteBonjourService(
                     "Bonjour lifecycle cleanup exceeded ${LIFECYCLE_CLOSE_TIMEOUT}ms; continuing shutdown"
                 }
             }
-        }
-    }
-}
-
-class DesktopServiceListener(
-    private val nearbyDeviceManager: NearbyDeviceManager,
-) : ServiceListener {
-
-    private val logger = KotlinLogging.logger {}
-
-    override fun serviceAdded(event: ServiceEvent) {
-        logger.debug { "Service added: " + event.info }
-    }
-
-    override fun serviceRemoved(event: ServiceEvent) {
-        val textBytes = event.info.textBytes
-        if (textBytes == null || textBytes.isEmpty()) {
-            logger.debug { "Service removed with empty textBytes: ${event.info.name}" }
-            return
-        }
-        runCatching {
-            val serviceName = event.info.name
-            if (serviceName.startsWith("crosspaste@")) {
-                logger.debug { "Processing service removed: $serviceName" }
-                serviceName.split("@").takeIf { it.size == 3 }?.let { parts ->
-                    val appInstanceId = parts[1]
-                    nearbyDeviceManager.removeDevice(appInstanceId)
-                }
-            }
-        }.onFailure { e ->
-            logger.debug(e) { "Failed to decode service removed event: ${event.info}" }
-        }
-    }
-
-    override fun serviceResolved(event: ServiceEvent) {
-        val textBytes = event.info.textBytes
-        if (textBytes == null || textBytes.isEmpty()) {
-            logger.debug { "Service resolved with empty textBytes: ${event.info.name}" }
-            return
-        }
-        runCatching {
-            val map: Map<String, ByteArray> = mutableMapOf()
-            ByteWrangler.readProperties(map, textBytes)
-            val syncInfo = TxtRecordUtils.decodeFromTxtRecordDict<SyncInfo>(map)
-            nearbyDeviceManager.addDevice(syncInfo)
-        }.onFailure { e ->
-            logger.debug(e) { "Failed to decode service resolved event: ${event.info}" }
         }
     }
 }

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopServiceListener.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopServiceListener.kt
@@ -1,0 +1,67 @@
+package com.crosspaste.net
+
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.utils.TxtRecordUtils
+import io.github.oshai.kotlinlogging.KotlinLogging
+import javax.jmdns.ServiceEvent
+import javax.jmdns.ServiceListener
+import javax.jmdns.impl.util.ByteWrangler
+
+internal class DesktopServiceListener(
+    private val isActive: () -> Boolean,
+    private val onResolved: (serviceName: String, syncInfo: SyncInfo) -> Unit,
+    private val onRemoved: (serviceName: String, appInstanceId: String) -> Unit,
+) : ServiceListener {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun serviceAdded(event: ServiceEvent) {
+        if (isActive()) {
+            logger.debug { "Service added: " + event.info }
+        }
+    }
+
+    override fun serviceRemoved(event: ServiceEvent) {
+        if (!isActive()) return
+
+        runCatching {
+            val serviceName = event.info.name
+            val appInstanceId = appInstanceIdFromServiceName(serviceName) ?: return
+            logger.debug { "Processing service removed: $serviceName" }
+            onRemoved(serviceName, appInstanceId)
+        }.onFailure { e ->
+            logger.debug(e) { "Failed to process service removed event: ${event.info}" }
+        }
+    }
+
+    override fun serviceResolved(event: ServiceEvent) {
+        if (!isActive()) return
+
+        val textBytes = event.info.textBytes
+        if (textBytes == null || textBytes.isEmpty()) {
+            logger.debug { "Service resolved with empty textBytes: ${event.info.name}" }
+            return
+        }
+        runCatching {
+            val map: Map<String, ByteArray> = mutableMapOf()
+            ByteWrangler.readProperties(map, textBytes)
+            val syncInfo = TxtRecordUtils.decodeFromTxtRecordDict<SyncInfo>(map)
+            if (isActive()) {
+                onResolved(event.info.name, syncInfo)
+            }
+        }.onFailure { e ->
+            logger.debug(e) { "Failed to decode service resolved event: ${event.info}" }
+        }
+    }
+}
+
+internal fun appInstanceIdFromServiceName(serviceName: String): String? {
+    val parts = serviceName.split("@")
+    return parts
+        .takeIf {
+            it.size == 3 &&
+                it[0] == "crosspaste" &&
+                it[1].isNotEmpty() &&
+                it[2].isNotEmpty()
+        }?.get(1)
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/JmDnsInstance.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/JmDnsInstance.kt
@@ -1,0 +1,74 @@
+package com.crosspaste.net
+
+import java.net.InetAddress
+import javax.jmdns.JmDNS
+import javax.jmdns.ServiceInfo
+import javax.jmdns.ServiceListener
+
+internal interface JmDnsInstance {
+
+    fun addServiceListener(
+        type: String,
+        listener: ServiceListener,
+    )
+
+    fun removeServiceListener(
+        type: String,
+        listener: ServiceListener,
+    )
+
+    fun registerService(serviceInfo: ServiceInfo)
+
+    fun list(
+        type: String,
+        timeout: Long,
+    ): List<ServiceInfo>
+
+    fun requestServiceInfo(
+        type: String,
+        name: String,
+    )
+
+    fun close()
+}
+
+internal fun interface JmDnsFactory {
+
+    fun create(address: InetAddress): JmDnsInstance
+}
+
+internal object DefaultJmDnsFactory : JmDnsFactory {
+
+    override fun create(address: InetAddress): JmDnsInstance = DefaultJmDnsInstance(JmDNS.create(address))
+}
+
+private class DefaultJmDnsInstance(
+    private val delegate: JmDNS,
+) : JmDnsInstance {
+
+    override fun addServiceListener(
+        type: String,
+        listener: ServiceListener,
+    ) = delegate.addServiceListener(type, listener)
+
+    override fun removeServiceListener(
+        type: String,
+        listener: ServiceListener,
+    ) = delegate.removeServiceListener(type, listener)
+
+    override fun registerService(serviceInfo: ServiceInfo) = delegate.registerService(serviceInfo)
+
+    override fun list(
+        type: String,
+        timeout: Long,
+    ): List<ServiceInfo> = delegate.list(type, timeout).toList()
+
+    override fun requestServiceInfo(
+        type: String,
+        name: String,
+    ) {
+        delegate.requestServiceInfo(type, name)
+    }
+
+    override fun close() = delegate.close()
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopPasteBonjourServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopPasteBonjourServiceTest.kt
@@ -1,0 +1,423 @@
+package com.crosspaste.net
+
+import com.crosspaste.app.EndpointInfoFactory
+import com.crosspaste.dto.sync.SyncInfo
+import com.crosspaste.sync.NearbyDeviceManager
+import com.crosspaste.sync.SyncTestFixtures
+import com.crosspaste.utils.TxtRecordUtils
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import java.io.IOException
+import java.net.InetAddress
+import javax.jmdns.ServiceEvent
+import javax.jmdns.ServiceInfo
+import javax.jmdns.ServiceListener
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DesktopPasteBonjourServiceTest {
+
+    private val localInterface = NetworkInterfaceInfo("en0", 24, "192.168.1.10")
+    private val secondInterface = NetworkInterfaceInfo("en1", 24, "10.0.0.10")
+
+    @Test
+    fun `setup failure on one interface does not block another and is retried`() =
+        runTest {
+            val factory = RecordingJmDnsFactory()
+            factory.createFailures[localInterface.hostAddress] = 1
+            val fixture = createFixture(factory)
+            runCurrent()
+
+            fixture.service.processNetworkChange(listOf(localInterface, secondInterface))
+
+            assertEquals(1, factory.createAttempts[localInterface.hostAddress])
+            assertNotNull(factory.latest(secondInterface.hostAddress).listener)
+
+            advanceTimeBy(2000)
+            runCurrent()
+
+            assertEquals(2, factory.createAttempts[localInterface.hostAddress])
+            assertNotNull(factory.latest(localInterface.hostAddress).listener)
+        }
+
+    @Test
+    fun `registration failure closes partially created instance`() =
+        runTest {
+            val factory = RecordingJmDnsFactory(failRegistrationFor = setOf(localInterface.hostAddress))
+            val fixture = createFixture(factory)
+            runCurrent()
+
+            fixture.service.processNetworkChange(listOf(localInterface))
+
+            assertTrue(factory.latest(localInterface.hostAddress).closed)
+        }
+
+    @Test
+    fun `close failure never leaves old instance active`() =
+        runTest {
+            val factory = RecordingJmDnsFactory(failCloseFor = setOf(localInterface.hostAddress))
+            val fixture = createFixture(factory)
+            runCurrent()
+            fixture.service.processNetworkChange(listOf(localInterface))
+            val first = factory.latest(localInterface.hostAddress)
+
+            fixture.service.processNetworkChange(listOf(localInterface))
+
+            assertTrue(first.closeAttempted)
+            assertEquals(2, factory.createAttempts[localInterface.hostAddress])
+            assertNotNull(factory.latest(localInterface.hostAddress).listener)
+        }
+
+    @Test
+    fun `removal with empty TXT record still removes valid service name`() {
+        val removed = mutableListOf<Pair<String, String>>()
+        val listener =
+            DesktopServiceListener(
+                isActive = { true },
+                onResolved = { _, _ -> },
+                onRemoved = { serviceName, appInstanceId ->
+                    removed += serviceName to appInstanceId
+                },
+            )
+        val serviceInfo =
+            ServiceInfo.create(
+                DesktopPasteBonjourService.SERVICE_TYPE,
+                "crosspaste@peer-1@192_168_1_20",
+                13129,
+                "",
+            )
+
+        listener.serviceRemoved(serviceEvent(serviceInfo))
+
+        assertEquals(
+            listOf("crosspaste@peer-1@192_168_1_20" to "peer-1"),
+            removed,
+        )
+    }
+
+    @Test
+    fun `malformed service names never remove a device`() {
+        val removed = mutableListOf<String>()
+        val listener =
+            DesktopServiceListener(
+                isActive = { true },
+                onResolved = { _, _ -> },
+                onRemoved = { _, appInstanceId -> removed += appInstanceId },
+            )
+
+        listOf(
+            "other@peer-1@host",
+            "crosspaste@@host",
+            "crosspaste@peer-1@",
+            "crosspaste@peer-1@host@extra",
+        ).forEach { serviceName ->
+            val serviceInfo =
+                ServiceInfo.create(
+                    DesktopPasteBonjourService.SERVICE_TYPE,
+                    serviceName,
+                    13129,
+                    "",
+                )
+            listener.serviceRemoved(serviceEvent(serviceInfo))
+        }
+
+        assertTrue(removed.isEmpty())
+    }
+
+    @Test
+    fun `device remains nearby until all interface sources are removed`() =
+        runTest {
+            val factory = RecordingJmDnsFactory()
+            val fixture = createFixture(factory)
+            runCurrent()
+            fixture.service.processNetworkChange(listOf(localInterface, secondInterface))
+            val syncInfo = SyncTestFixtures.createSyncInfo(appInstanceId = "peer-1")
+
+            val first = factory.latest(localInterface.hostAddress)
+            val second = factory.latest(secondInterface.hostAddress)
+            first.emitResolved(syncInfo, "crosspaste@peer-1@first")
+            second.emitResolved(syncInfo, "crosspaste@peer-1@second")
+
+            first.emitRemoved("crosspaste@peer-1@first")
+            assertTrue("peer-1" in fixture.nearby.devices)
+            assertTrue(fixture.nearby.removedIds.isEmpty())
+
+            second.emitRemoved("crosspaste@peer-1@second")
+            assertFalse("peer-1" in fixture.nearby.devices)
+            assertEquals(listOf("peer-1"), fixture.nearby.removedIds)
+        }
+
+    @Test
+    fun `network rebuild removes old presence and ignores stale callbacks`() =
+        runTest {
+            val factory = RecordingJmDnsFactory()
+            val fixture = createFixture(factory)
+            runCurrent()
+            fixture.service.processNetworkChange(listOf(localInterface))
+            val oldInstance = factory.latest(localInterface.hostAddress)
+            val syncInfo = SyncTestFixtures.createSyncInfo(appInstanceId = "peer-1")
+            oldInstance.emitResolved(syncInfo, "crosspaste@peer-1@old")
+            assertEquals(1, fixture.nearby.addedIds.size)
+
+            fixture.service.processNetworkChange(listOf(secondInterface))
+
+            assertTrue(oldInstance.closed)
+            assertFalse("peer-1" in fixture.nearby.devices)
+            oldInstance.emitResolved(syncInfo, "crosspaste@peer-1@old")
+            assertEquals(1, fixture.nearby.addedIds.size)
+        }
+
+    @Test
+    fun `target refresh uses presence cache and throttles cache misses`() =
+        runTest {
+            val factory = RecordingJmDnsFactory()
+            val fixture = createFixture(factory)
+            runCurrent()
+            fixture.service.processNetworkChange(listOf(localInterface))
+            val instance = factory.latest(localInterface.hostAddress)
+
+            fixture.service.refreshTarget("peer-1", emptyList())
+            runCurrent()
+            fixture.service.refreshTarget("peer-1", emptyList())
+            runCurrent()
+            assertEquals(1, instance.listCalls)
+
+            instance.emitResolved(
+                SyncTestFixtures.createSyncInfo(appInstanceId = "peer-2"),
+                "crosspaste@peer-2@cached",
+            )
+            fixture.service.refreshTarget("peer-2", emptyList())
+            runCurrent()
+
+            assertEquals(1, instance.listCalls)
+            assertEquals(listOf("crosspaste@peer-2@cached"), instance.requestedServices)
+        }
+
+    @Test
+    fun `concurrent manual refresh requests share one scan`() =
+        runTest {
+            val factory = RecordingJmDnsFactory()
+            val fixture = createFixture(factory)
+            runCurrent()
+            fixture.service.processNetworkChange(listOf(localInterface))
+            val instance = factory.latest(localInterface.hostAddress)
+
+            fixture.service.refreshAll()
+            fixture.service.refreshAll()
+            runCurrent()
+
+            assertEquals(1, instance.listCalls)
+            assertEquals(1, fixture.nearby.searchStarts)
+            advanceTimeBy(2000)
+            runCurrent()
+            assertEquals(1, fixture.nearby.searchStops)
+        }
+
+    private fun TestScope.createFixture(factory: RecordingJmDnsFactory): Fixture {
+        val scope = backgroundScope
+        val endpointInfoFactory = mockk<EndpointInfoFactory>()
+        coEvery { endpointInfoFactory.createEndpointInfo(any()) } answers {
+            SyncTestFixtures.createEndpointInfo(hostInfoList = firstArg())
+        }
+        val nearby = RecordingNearbyDeviceManager(scope)
+        val networkInterfaceService = MutableNetworkInterfaceService()
+        val service =
+            DesktopPasteBonjourService(
+                appInfo = SyncTestFixtures.createAppInfo(appInstanceId = "self"),
+                endpointInfoFactory = endpointInfoFactory,
+                nearbyDeviceManager = nearby,
+                networkInterfaceService = networkInterfaceService,
+                scope = scope,
+                jmdnsFactory = factory,
+                cleanupDispatcher = StandardTestDispatcher(testScheduler),
+            )
+        return Fixture(service, nearby)
+    }
+
+    private data class Fixture(
+        val service: DesktopPasteBonjourService,
+        val nearby: RecordingNearbyDeviceManager,
+    )
+
+    private class MutableNetworkInterfaceService : NetworkInterfaceService {
+        override val networkInterfaces = MutableStateFlow<List<NetworkInterfaceInfo>>(emptyList())
+
+        override fun getAllNetworkInterfaceInfo(): List<NetworkInterfaceInfo> = networkInterfaces.value
+
+        override fun getSortedNetworkInterfaceInfo(): List<NetworkInterfaceInfo> = networkInterfaces.value
+
+        override fun getPreferredNetworkInterface(): NetworkInterfaceInfo? = networkInterfaces.value.firstOrNull()
+
+        override fun clearProviderCache() = Unit
+    }
+
+    private class RecordingNearbyDeviceManager(
+        override val nearbyDeviceScope: CoroutineScope,
+    ) : NearbyDeviceManager {
+        private val _nearbySyncInfos = MutableStateFlow<List<SyncInfo>>(emptyList())
+        override val nearbySyncInfos: StateFlow<List<SyncInfo>> = _nearbySyncInfos
+        private val _searching = MutableStateFlow(false)
+        override val searching: StateFlow<Boolean> = _searching
+
+        val devices = mutableMapOf<String, SyncInfo>()
+        val addedIds = mutableListOf<String>()
+        val removedIds = mutableListOf<String>()
+        var searchStarts = 0
+        var searchStops = 0
+
+        override fun addDevice(syncInfo: SyncInfo) {
+            val id = syncInfo.appInfo.appInstanceId
+            devices[id] = syncInfo
+            addedIds += id
+            _nearbySyncInfos.value = devices.values.toList()
+        }
+
+        override fun removeDevice(appInstanceId: String) {
+            devices.remove(appInstanceId)
+            removedIds += appInstanceId
+            _nearbySyncInfos.value = devices.values.toList()
+        }
+
+        override fun startSearching() {
+            searchStarts++
+            _searching.value = true
+        }
+
+        override fun stopSearching() {
+            searchStops++
+            _searching.value = false
+        }
+    }
+
+    private class RecordingJmDnsFactory(
+        private val failRegistrationFor: Set<String> = emptySet(),
+        private val failCloseFor: Set<String> = emptySet(),
+    ) : JmDnsFactory {
+        val createAttempts = mutableMapOf<String, Int>()
+        val createFailures = mutableMapOf<String, Int>()
+        private val instances = mutableMapOf<String, MutableList<RecordingJmDnsInstance>>()
+
+        override fun create(address: InetAddress): JmDnsInstance {
+            val hostAddress = address.hostAddress
+            createAttempts[hostAddress] = createAttempts.getOrDefault(hostAddress, 0) + 1
+            val failuresLeft = createFailures.getOrDefault(hostAddress, 0)
+            if (failuresLeft > 0) {
+                createFailures[hostAddress] = failuresLeft - 1
+                throw IOException("simulated create failure")
+            }
+
+            val instance =
+                RecordingJmDnsInstance(
+                    failRegistration = hostAddress in failRegistrationFor,
+                    failClose = hostAddress in failCloseFor,
+                )
+            instances.getOrPut(hostAddress, ::mutableListOf) += instance
+            return instance
+        }
+
+        fun latest(hostAddress: String): RecordingJmDnsInstance =
+            instances[hostAddress]?.lastOrNull()
+                ?: error("No JmDNS instance for $hostAddress")
+    }
+
+    private class RecordingJmDnsInstance(
+        private val failRegistration: Boolean,
+        private val failClose: Boolean,
+    ) : JmDnsInstance {
+        var listener: ServiceListener? = null
+        var closed = false
+        var closeAttempted = false
+        var listCalls = 0
+        val requestedServices = mutableListOf<String>()
+
+        override fun addServiceListener(
+            type: String,
+            listener: ServiceListener,
+        ) {
+            this.listener = listener
+        }
+
+        override fun removeServiceListener(
+            type: String,
+            listener: ServiceListener,
+        ) {
+            if (this.listener === listener) {
+                this.listener = null
+            }
+        }
+
+        override fun registerService(serviceInfo: ServiceInfo) {
+            if (failRegistration) throw IOException("simulated registration failure")
+        }
+
+        override fun list(
+            type: String,
+            timeout: Long,
+        ): List<ServiceInfo> {
+            listCalls++
+            return emptyList()
+        }
+
+        override fun requestServiceInfo(
+            type: String,
+            name: String,
+        ) {
+            requestedServices += name
+        }
+
+        override fun close() {
+            closeAttempted = true
+            if (failClose) throw IOException("simulated close failure")
+            closed = true
+        }
+
+        fun emitResolved(
+            syncInfo: SyncInfo,
+            serviceName: String,
+        ) {
+            val txtRecord = TxtRecordUtils.encodeToTxtRecordDict(syncInfo)
+            val serviceInfo =
+                ServiceInfo.create(
+                    DesktopPasteBonjourService.SERVICE_TYPE,
+                    serviceName,
+                    syncInfo.endpointInfo.port,
+                    0,
+                    0,
+                    txtRecord,
+                )
+            listener?.serviceResolved(serviceEvent(serviceInfo))
+        }
+
+        fun emitRemoved(serviceName: String) {
+            val serviceInfo =
+                ServiceInfo.create(
+                    DesktopPasteBonjourService.SERVICE_TYPE,
+                    serviceName,
+                    13129,
+                    "",
+                )
+            listener?.serviceRemoved(serviceEvent(serviceInfo))
+        }
+    }
+
+    companion object {
+        private fun serviceEvent(serviceInfo: ServiceInfo): ServiceEvent =
+            mockk {
+                every { info } returns serviceInfo
+            }
+    }
+}


### PR DESCRIPTION
Closes #4928

## Summary

Reworks the JmDNS lifecycle in `DesktopPasteBonjourService` so a single interface failure can no longer kill discovery for the rest of the session, and binds nearby-device presence to the JmDNS instance that discovered it.

- **Per-interface setup with bounded retry.** JmDNS is isolated behind a thin desktop-only `JmDnsInstance` / `JmDnsFactory` adapter. Each interface is created, registered and activated independently; a failure closes only its own half-created instance and is retried up to 3 times (2 s apart), gated on the rebuild generation. The sole network-snapshot consumer logs non-cancellation failures and keeps processing later snapshots.
- **Generation-gated teardown.** A rebuild increments a generation, detaches active instances, throttle state and presence under one lock, then closes the old instances on a detached cleanup scope with a bounded wait. A close that throws or hangs never leaves a stale instance active or reused. `close()` keeps the existing 4 s shutdown budget.
- **Source-aware presence.** Discovered devices are tracked per `(registration id, service name)`. `removeDevice` is called only when the last source for an app id disappears, so a device visible through two interfaces survives losing one. Callbacks from inactive registrations are ignored before and after TXT decoding. A network rebuild or disabling discovery clears the presence it produced.
- **`serviceRemoved` no longer requires TXT data.** Removal strictly parses the `crosspaste@{id}@{host}` name; malformed or foreign names are ignored without side effects.
- **Target refresh uses the presence registry as its cache.** The default 6 s blocking `list()` overload is gone; a cache miss first takes the per-interface scan permit, then performs at most one 3 s bounded `list`. Manual `refreshAll()` is single-flight.

Service registration now happens before the listener is attached; JmDNS replays cached SRV records (and resolves entries that already carry data) when the listener is added, so no discovery is lost during the announce window.

## Behavior note

Every interface-snapshot change now clears the nearby (unpaired) device list until JmDNS re-resolves peers a few seconds later. Paired devices are unaffected.

## Test plan

- New `DesktopPasteBonjourServiceTest` (fast tier, virtual time, fake JmDNS): one interface failing does not block another and is retried; registration failure closes the partial instance; close failure never leaves the old instance active; empty-TXT removal still removes; malformed names never remove; device stays until all sources are gone; rebuild revokes presence and ignores stale callbacks; target refresh hits the cache and throttles misses; concurrent manual refreshes share one scan.
- `./gradlew app:ktlintCheck app:desktopTest --tests "com.crosspaste.net.DesktopPasteBonjourServiceTest"` passes.
