### PR TITLE
:bug: harden MCP server lifecycle and surface start failures in settings

### DIFF
--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -63,7 +63,6 @@ import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.vinceglb.filekit.FileKit
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
@@ -230,23 +229,13 @@ class CrossPaste {
                         getManagedService<CliServer>(ManagedService.CLI_SERVER).start()
                     } else {
                         // The GUI tolerates a degraded CLI and keeps running.
-                        ioCoroutineDispatcher.launch {
-                            runCatching {
-                                getManagedService<CliServer>(ManagedService.CLI_SERVER).start()
-                            }.onFailure { logger.warn { "CLI unavailable for this session" } }
+                        startOptionalServiceInBackground("CLI") {
+                            getManagedService<CliServer>(ManagedService.CLI_SERVER).start()
                         }
                     }
                     val mcpServer = getManagedService<McpServer>(ManagedService.MCP_SERVER)
                     if (configManager.getCurrentConfig().enableMcpServer) {
-                        ioCoroutineDispatcher.launch {
-                            try {
-                                mcpServer.start()
-                            } catch (e: CancellationException) {
-                                throw e
-                            } catch (e: Throwable) {
-                                logger.warn(e) { "MCP server unavailable for this session" }
-                            }
-                        }
+                        startOptionalServiceInBackground("MCP server") { mcpServer.start() }
                     }
                     getManagedService<PasteClient>(ManagedService.PASTE_CLIENT)
                     getManagedService<PasteBonjourService>(ManagedService.PASTE_BONJOUR)
@@ -318,6 +307,20 @@ class CrossPaste {
                     exitProcess(1)
                 }
                 exitProcess(0)
+            }
+        }
+
+        /**
+         * Starts a service the GUI can live without. A failure is logged and the
+         * session continues in degraded mode.
+         */
+        private fun startOptionalServiceInBackground(
+            serviceName: String,
+            start: suspend () -> Unit,
+        ) {
+            ioCoroutineDispatcher.launch {
+                runCatching { start() }
+                    .onFailure { e -> logger.warn(e) { "$serviceName unavailable for this session" } }
             }
         }
 

--- a/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/CrossPaste.kt
@@ -63,6 +63,7 @@ import com.crosspaste.utils.ioDispatcher
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.vinceglb.filekit.FileKit
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
@@ -238,7 +239,13 @@ class CrossPaste {
                     val mcpServer = getManagedService<McpServer>(ManagedService.MCP_SERVER)
                     if (configManager.getCurrentConfig().enableMcpServer) {
                         ioCoroutineDispatcher.launch {
-                            mcpServer.start()
+                            try {
+                                mcpServer.start()
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Throwable) {
+                                logger.warn(e) { "MCP server unavailable for this session" }
+                            }
                         }
                     }
                     getManagedService<PasteClient>(ManagedService.PASTE_CLIENT)

--- a/app/src/desktopMain/kotlin/com/crosspaste/mcp/DesktopMcpServer.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/mcp/DesktopMcpServer.kt
@@ -11,79 +11,195 @@ import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
-class DesktopMcpServer(
-    private var mcpPort: Int,
+internal interface McpServerInstance {
+
+    suspend fun start()
+
+    suspend fun stop()
+}
+
+internal fun interface McpServerInstanceFactory {
+
+    fun create(port: Int): McpServerInstance
+}
+
+private class DefaultMcpServerInstanceFactory(
     private val mcpToolProvider: McpToolProvider,
     private val mcpResourceProvider: McpResourceProvider,
+) : McpServerInstanceFactory {
+
+    override fun create(port: Int): McpServerInstance {
+        val mcpServer =
+            Server(
+                serverInfo =
+                    Implementation(
+                        name = "crosspaste-mcp-server",
+                        version = "1.0.0",
+                    ),
+                options =
+                    ServerOptions(
+                        capabilities =
+                            ServerCapabilities(
+                                tools = ServerCapabilities.Tools(listChanged = true),
+                                resources =
+                                    ServerCapabilities.Resources(
+                                        subscribe = false,
+                                        listChanged = true,
+                                    ),
+                            ),
+                    ),
+            )
+
+        mcpToolProvider.registerTools(mcpServer)
+        mcpResourceProvider.registerResources(mcpServer)
+
+        val server =
+            embeddedServer(CIO, host = "127.0.0.1", port = port) {
+                mcp {
+                    mcpServer
+                }
+            }
+        return KtorMcpServerInstance(server)
+    }
+}
+
+private class KtorMcpServerInstance(
+    private val server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>,
+) : McpServerInstance {
+
+    override suspend fun start() {
+        server.startSuspend(wait = false)
+    }
+
+    override suspend fun stop() {
+        server.stopSuspend()
+    }
+}
+
+class DesktopMcpServer internal constructor(
+    private var configuredPort: Int,
+    private val serverFactory: McpServerInstanceFactory,
+    private val lifecycleDispatcher: CoroutineDispatcher,
 ) : McpServer {
 
-    private val logger = KotlinLogging.logger {}
+    constructor(
+        mcpPort: Int,
+        mcpToolProvider: McpToolProvider,
+        mcpResourceProvider: McpResourceProvider,
+    ) : this(
+        configuredPort = mcpPort,
+        serverFactory = DefaultMcpServerInstanceFactory(mcpToolProvider, mcpResourceProvider),
+        lifecycleDispatcher = ioDispatcher,
+    )
 
-    private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
+    private val logger = KotlinLogging.logger {}
+    private val lifecycleMutex = Mutex()
+
+    private var server: McpServerInstance? = null
+
+    @Volatile
     private var actualPort: Int = 0
 
     override suspend fun start() {
-        withContext(ioDispatcher) {
-            runCatching {
-                val port = if (mcpPort > 0) mcpPort else DEFAULT_PORT
-                val mcpServer =
-                    Server(
-                        serverInfo =
-                            Implementation(
-                                name = "crosspaste-mcp-server",
-                                version = "1.0.0",
-                            ),
-                        options =
-                            ServerOptions(
-                                capabilities =
-                                    ServerCapabilities(
-                                        tools = ServerCapabilities.Tools(listChanged = true),
-                                        resources =
-                                            ServerCapabilities.Resources(
-                                                subscribe = false,
-                                                listChanged = true,
-                                            ),
-                                    ),
-                            ),
-                    )
+        runLifecycleOperation {
+            lifecycleMutex.withLock {
+                if (server != null) {
+                    return@withLock
+                }
 
-                mcpToolProvider.registerTools(mcpServer)
-                mcpResourceProvider.registerResources(mcpServer)
-
-                server =
-                    embeddedServer(CIO, host = "127.0.0.1", port = port) {
-                        mcp {
-                            mcpServer
-                        }
-                    }.start(wait = false)
-
+                val port = resolvePort(configuredPort)
+                server = createStartedServer(port)
                 actualPort = port
                 logger.info { "MCP Server started at port $actualPort (WebSocket)" }
-            }.onFailure { e ->
-                logger.error(e) { "Failed to start MCP Server" }
             }
         }
     }
 
     override suspend fun stop() {
-        runCatching {
-            server?.stop()
-            server = null
-            logger.info { "MCP Server stopped" }
-        }.onFailure { e ->
-            logger.error(e) { "Failed to stop MCP Server" }
+        runLifecycleOperation {
+            lifecycleMutex.withLock {
+                stopCurrentServer()
+            }
         }
     }
 
     override suspend fun restart(newPort: Int) {
-        stop()
-        mcpPort = newPort
-        start()
+        runLifecycleOperation {
+            lifecycleMutex.withLock {
+                val port = resolvePort(newPort)
+                val currentServer = server
+                if (currentServer != null && actualPort == port) {
+                    configuredPort = newPort
+                    return@withLock
+                }
+
+                // Keep the working endpoint available until its replacement has bound.
+                val replacement = createStartedServer(port)
+                try {
+                    currentServer?.stop()
+                } catch (e: Throwable) {
+                    withContext(NonCancellable) {
+                        cleanupServer(replacement, "replacement MCP server")
+                    }
+                    throw e
+                }
+
+                server = replacement
+                configuredPort = newPort
+                actualPort = port
+                logger.info { "MCP Server restarted at port $actualPort (WebSocket)" }
+            }
+        }
     }
 
     override fun port(): Int = actualPort
+
+    private suspend fun createStartedServer(port: Int): McpServerInstance {
+        val candidate = serverFactory.create(port)
+        try {
+            candidate.start()
+            return candidate
+        } catch (e: Throwable) {
+            withContext(NonCancellable) {
+                cleanupServer(candidate, "partially started MCP server")
+            }
+            throw e
+        }
+    }
+
+    private suspend fun stopCurrentServer() {
+        val currentServer = server ?: return
+        currentServer.stop()
+        server = null
+        actualPort = 0
+        logger.info { "MCP Server stopped" }
+    }
+
+    private suspend fun cleanupServer(
+        target: McpServerInstance,
+        description: String,
+    ) {
+        runCatching { target.stop() }
+            .onFailure { e -> logger.warn(e) { "Failed to clean up $description" } }
+    }
+
+    private suspend fun runLifecycleOperation(operation: suspend () -> Unit) {
+        withContext(lifecycleDispatcher) {
+            operation()
+        }
+    }
+
+    private fun resolvePort(port: Int): Int {
+        val resolvedPort = if (port > 0) port else DEFAULT_PORT
+        require(resolvedPort in 1..65535) { "Invalid MCP server port: $port" }
+        return resolvedPort
+    }
 
     companion object {
         const val DEFAULT_PORT = 13130

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/mcp/McpContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/mcp/McpContentView.kt
@@ -56,7 +56,10 @@ fun McpContentView() {
     val themeExt = LocalThemeExtState.current
 
     val config by configManager.config.collectAsState()
-    val operationVersion = remember { AtomicLong() }
+    val controller =
+        remember(configManager, mcpServer, notificationManager) {
+            McpServerSettingsController(configManager, mcpServer, notificationManager)
+        }
     var counterResetKey by remember { mutableIntStateOf(0) }
 
     val displayPort =
@@ -83,35 +86,7 @@ fun McpContentView() {
                         ),
                     checked = config.enableMcpServer,
                 ) { enabled ->
-                    val requestVersion = operationVersion.incrementAndGet()
-                    val previousEnabled = config.enableMcpServer
-                    configManager.updateConfig("enableMcpServer", enabled)
-                    if (configManager.getCurrentConfig().enableMcpServer != enabled) {
-                        return@SettingListSwitchItem
-                    }
-                    ioCoroutineDispatcher.launch {
-                        if (
-                            requestVersion != operationVersion.get() ||
-                            configManager.getCurrentConfig().enableMcpServer != enabled
-                        ) {
-                            return@launch
-                        }
-                        val succeeded =
-                            runMcpServerOperation(notificationManager) {
-                                if (enabled) {
-                                    mcpServer.restart(displayPort)
-                                } else {
-                                    mcpServer.stop()
-                                }
-                            }
-                        if (
-                            !succeeded &&
-                            requestVersion == operationVersion.get() &&
-                            configManager.getCurrentConfig().enableMcpServer == enabled
-                        ) {
-                            configManager.updateConfig("enableMcpServer", previousEnabled)
-                        }
-                    }
+                    controller.setEnabled(enabled, displayPort)
                 }
                 HorizontalDivider(modifier = Modifier.padding(start = xxxxLarge))
                 SettingListItem(
@@ -122,49 +97,15 @@ fun McpContentView() {
                             iconColor = themeExt.indigoIconColor,
                         ),
                     trailingContent = {
+                        // Remount the counter only when a failed port change was rolled
+                        // back, so normal typing keeps focus while the field still snaps
+                        // back to the port the server is actually bound to.
                         key(counterResetKey) {
                             Counter(
                                 defaultValue = displayPort.toLong(),
                                 rule = { it in 1024..65535 },
                             ) { newPort ->
-                                val requestVersion = operationVersion.incrementAndGet()
-                                val requestedPort = newPort.toInt()
-                                configManager.updateConfig("mcpServerPort", requestedPort)
-                                val currentConfig = configManager.getCurrentConfig()
-                                if (currentConfig.mcpServerPort != requestedPort || !currentConfig.enableMcpServer) {
-                                    return@Counter
-                                }
-                                ioCoroutineDispatcher.launch {
-                                    val latestConfig = configManager.getCurrentConfig()
-                                    if (
-                                        requestVersion != operationVersion.get() ||
-                                        !latestConfig.enableMcpServer ||
-                                        latestConfig.mcpServerPort != requestedPort
-                                    ) {
-                                        return@launch
-                                    }
-                                    val succeeded =
-                                        runMcpServerOperation(notificationManager) {
-                                            mcpServer.restart(requestedPort)
-                                        }
-                                    if (
-                                        !succeeded &&
-                                        requestVersion == operationVersion.get() &&
-                                        configManager.getCurrentConfig().enableMcpServer &&
-                                        configManager.getCurrentConfig().mcpServerPort == requestedPort
-                                    ) {
-                                        val actualPort = mcpServer.port()
-                                        withContext(mainDispatcher) {
-                                            if (
-                                                requestVersion == operationVersion.get() &&
-                                                configManager.getCurrentConfig().mcpServerPort == requestedPort
-                                            ) {
-                                                configManager.updateConfig("mcpServerPort", actualPort)
-                                                counterResetKey++
-                                            }
-                                        }
-                                    }
-                                }
+                                controller.setPort(newPort.toInt()) { counterResetKey++ }
                             }
                         }
                     },
@@ -208,19 +149,96 @@ fun McpContentView() {
     }
 }
 
-private suspend fun runMcpServerOperation(
-    notificationManager: NotificationManager,
-    operation: suspend () -> Unit,
-): Boolean =
-    try {
-        operation()
-        true
-    } catch (e: CancellationException) {
-        throw e
-    } catch (_: Throwable) {
-        notificationManager.sendNotification(
-            title = { it.getText("mcp_server_update_failed") },
-            messageType = MessageType.Error,
-        )
-        false
+/**
+ * Applies MCP settings changes to the running server. The config is committed
+ * first, the server operation runs on the app-level IO scope so leaving the
+ * settings page cannot drop it, and a failed operation rolls the config back to
+ * the last working state. Superseded requests are dropped by version.
+ */
+private class McpServerSettingsController(
+    private val configManager: DesktopConfigManager,
+    private val mcpServer: McpServer,
+    private val notificationManager: NotificationManager,
+) {
+
+    private val operationVersion = AtomicLong()
+
+    fun setEnabled(
+        enabled: Boolean,
+        port: Int,
+    ) {
+        val requestVersion = operationVersion.incrementAndGet()
+        val previousEnabled = configManager.getCurrentConfig().enableMcpServer
+        configManager.updateConfig("enableMcpServer", enabled)
+        if (configManager.getCurrentConfig().enableMcpServer != enabled) {
+            return
+        }
+        ioCoroutineDispatcher.launch {
+            if (!isCurrent(requestVersion) || configManager.getCurrentConfig().enableMcpServer != enabled) {
+                return@launch
+            }
+            val succeeded =
+                runServerOperation {
+                    if (enabled) {
+                        mcpServer.restart(port)
+                    } else {
+                        mcpServer.stop()
+                    }
+                }
+            if (!succeeded &&
+                isCurrent(requestVersion) &&
+                configManager.getCurrentConfig().enableMcpServer == enabled
+            ) {
+                configManager.updateConfig("enableMcpServer", previousEnabled)
+            }
+        }
     }
+
+    fun setPort(
+        requestedPort: Int,
+        onRolledBack: () -> Unit,
+    ) {
+        val requestVersion = operationVersion.incrementAndGet()
+        configManager.updateConfig("mcpServerPort", requestedPort)
+        if (!portRequestStillApplies(requestedPort)) {
+            return
+        }
+        ioCoroutineDispatcher.launch {
+            if (!isCurrent(requestVersion) || !portRequestStillApplies(requestedPort)) {
+                return@launch
+            }
+            val succeeded = runServerOperation { mcpServer.restart(requestedPort) }
+            if (succeeded || !isCurrent(requestVersion) || !portRequestStillApplies(requestedPort)) {
+                return@launch
+            }
+            val actualPort = mcpServer.port()
+            withContext(mainDispatcher) {
+                if (isCurrent(requestVersion) && configManager.getCurrentConfig().mcpServerPort == requestedPort) {
+                    configManager.updateConfig("mcpServerPort", actualPort)
+                    onRolledBack()
+                }
+            }
+        }
+    }
+
+    private fun isCurrent(requestVersion: Long): Boolean = requestVersion == operationVersion.get()
+
+    private fun portRequestStillApplies(requestedPort: Int): Boolean {
+        val config = configManager.getCurrentConfig()
+        return config.enableMcpServer && config.mcpServerPort == requestedPort
+    }
+
+    private suspend fun runServerOperation(operation: suspend () -> Unit): Boolean =
+        try {
+            operation()
+            true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            notificationManager.sendNotification(
+                title = { it.getText("mcp_server_update_failed") },
+                messageType = MessageType.Error,
+            )
+            false
+        }
+}

--- a/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/mcp/McpContentView.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/ui/extension/mcp/McpContentView.kt
@@ -13,7 +13,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import com.composables.icons.materialsymbols.MaterialSymbols
@@ -34,10 +37,15 @@ import com.crosspaste.ui.settings.SettingSectionCard
 import com.crosspaste.ui.theme.AppUISize.medium
 import com.crosspaste.ui.theme.AppUISize.tiny
 import com.crosspaste.ui.theme.AppUISize.xxxxLarge
+import com.crosspaste.utils.GlobalCoroutineScope.ioCoroutineDispatcher
+import com.crosspaste.utils.mainDispatcher
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
+import java.util.concurrent.atomic.AtomicLong
 
 @Composable
 fun McpContentView() {
@@ -48,7 +56,8 @@ fun McpContentView() {
     val themeExt = LocalThemeExtState.current
 
     val config by configManager.config.collectAsState()
-    val scope = rememberCoroutineScope()
+    val operationVersion = remember { AtomicLong() }
+    var counterResetKey by remember { mutableIntStateOf(0) }
 
     val displayPort =
         if (config.mcpServerPort > 0) {
@@ -74,12 +83,33 @@ fun McpContentView() {
                         ),
                     checked = config.enableMcpServer,
                 ) { enabled ->
+                    val requestVersion = operationVersion.incrementAndGet()
+                    val previousEnabled = config.enableMcpServer
                     configManager.updateConfig("enableMcpServer", enabled)
-                    scope.launch {
-                        if (enabled) {
-                            mcpServer.restart(displayPort)
-                        } else {
-                            mcpServer.stop()
+                    if (configManager.getCurrentConfig().enableMcpServer != enabled) {
+                        return@SettingListSwitchItem
+                    }
+                    ioCoroutineDispatcher.launch {
+                        if (
+                            requestVersion != operationVersion.get() ||
+                            configManager.getCurrentConfig().enableMcpServer != enabled
+                        ) {
+                            return@launch
+                        }
+                        val succeeded =
+                            runMcpServerOperation(notificationManager) {
+                                if (enabled) {
+                                    mcpServer.restart(displayPort)
+                                } else {
+                                    mcpServer.stop()
+                                }
+                            }
+                        if (
+                            !succeeded &&
+                            requestVersion == operationVersion.get() &&
+                            configManager.getCurrentConfig().enableMcpServer == enabled
+                        ) {
+                            configManager.updateConfig("enableMcpServer", previousEnabled)
                         }
                     }
                 }
@@ -92,14 +122,48 @@ fun McpContentView() {
                             iconColor = themeExt.indigoIconColor,
                         ),
                     trailingContent = {
-                        Counter(
-                            defaultValue = displayPort.toLong(),
-                            rule = { it in 1024..65535 },
-                        ) { newPort ->
-                            configManager.updateConfig("mcpServerPort", newPort.toInt())
-                            if (config.enableMcpServer) {
-                                scope.launch {
-                                    mcpServer.restart(newPort.toInt())
+                        key(counterResetKey) {
+                            Counter(
+                                defaultValue = displayPort.toLong(),
+                                rule = { it in 1024..65535 },
+                            ) { newPort ->
+                                val requestVersion = operationVersion.incrementAndGet()
+                                val requestedPort = newPort.toInt()
+                                configManager.updateConfig("mcpServerPort", requestedPort)
+                                val currentConfig = configManager.getCurrentConfig()
+                                if (currentConfig.mcpServerPort != requestedPort || !currentConfig.enableMcpServer) {
+                                    return@Counter
+                                }
+                                ioCoroutineDispatcher.launch {
+                                    val latestConfig = configManager.getCurrentConfig()
+                                    if (
+                                        requestVersion != operationVersion.get() ||
+                                        !latestConfig.enableMcpServer ||
+                                        latestConfig.mcpServerPort != requestedPort
+                                    ) {
+                                        return@launch
+                                    }
+                                    val succeeded =
+                                        runMcpServerOperation(notificationManager) {
+                                            mcpServer.restart(requestedPort)
+                                        }
+                                    if (
+                                        !succeeded &&
+                                        requestVersion == operationVersion.get() &&
+                                        configManager.getCurrentConfig().enableMcpServer &&
+                                        configManager.getCurrentConfig().mcpServerPort == requestedPort
+                                    ) {
+                                        val actualPort = mcpServer.port()
+                                        withContext(mainDispatcher) {
+                                            if (
+                                                requestVersion == operationVersion.get() &&
+                                                configManager.getCurrentConfig().mcpServerPort == requestedPort
+                                            ) {
+                                                configManager.updateConfig("mcpServerPort", actualPort)
+                                                counterResetKey++
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -143,3 +207,20 @@ fun McpContentView() {
         }
     }
 }
+
+private suspend fun runMcpServerOperation(
+    notificationManager: NotificationManager,
+    operation: suspend () -> Unit,
+): Boolean =
+    try {
+        operation()
+        true
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: Throwable) {
+        notificationManager.sendNotification(
+            title = { it.getText("mcp_server_update_failed") },
+            messageType = MessageType.Error,
+        )
+        false
+    }

--- a/app/src/desktopMain/resources/i18n/de.properties
+++ b/app/src/desktopMain/resources/i18n/de.properties
@@ -172,6 +172,7 @@ mcp_config_copied=Konfiguration in die Zwischenablage kopiert
 mcp_copy_config=Konfiguration kopieren
 mcp_server=MCP-Server
 mcp_server_port=Server-Port
+mcp_server_update_failed=MCP-Server konnte nicht aktualisiert werden
 mcp_settings=MCP-Einstellungen
 mcp_settings_desc=Model Context Protocol Server-Einstellungen
 menu=Menü

--- a/app/src/desktopMain/resources/i18n/en.properties
+++ b/app/src/desktopMain/resources/i18n/en.properties
@@ -172,6 +172,7 @@ mcp_config_copied=Configuration copied to clipboard
 mcp_copy_config=Copy Config
 mcp_server=MCP Server
 mcp_server_port=Server Port
+mcp_server_update_failed=Failed to update MCP server
 mcp_settings=MCP Settings
 mcp_settings_desc=Model Context Protocol server settings
 menu=Menu

--- a/app/src/desktopMain/resources/i18n/es.properties
+++ b/app/src/desktopMain/resources/i18n/es.properties
@@ -172,6 +172,7 @@ mcp_config_copied=Configuración copiada al portapapeles
 mcp_copy_config=Copiar configuración
 mcp_server=Servidor MCP
 mcp_server_port=Puerto del servidor
+mcp_server_update_failed=No se pudo actualizar el servidor MCP
 mcp_settings=Configuración MCP
 mcp_settings_desc=Configuración del servidor Model Context Protocol
 menu=Menú

--- a/app/src/desktopMain/resources/i18n/fa.properties
+++ b/app/src/desktopMain/resources/i18n/fa.properties
@@ -172,6 +172,7 @@ mcp_config_copied=پیکربندی در کلیپ‌بورد کپی شد
 mcp_copy_config=کپی پیکربندی
 mcp_server=سرور MCP
 mcp_server_port=پورت سرور
+mcp_server_update_failed=به‌روزرسانی سرور MCP ناموفق بود
 mcp_settings=تنظیمات MCP
 mcp_settings_desc=تنظیمات سرور Model Context Protocol
 menu=منو

--- a/app/src/desktopMain/resources/i18n/fr.properties
+++ b/app/src/desktopMain/resources/i18n/fr.properties
@@ -172,6 +172,7 @@ mcp_config_copied=Configuration copiée dans le presse-papiers
 mcp_copy_config=Copier la configuration
 mcp_server=Serveur MCP
 mcp_server_port=Port du serveur
+mcp_server_update_failed=Échec de la mise à jour du serveur MCP
 mcp_settings=Paramètres MCP
 mcp_settings_desc=Paramètres du serveur Model Context Protocol
 menu=Menu

--- a/app/src/desktopMain/resources/i18n/ja.properties
+++ b/app/src/desktopMain/resources/i18n/ja.properties
@@ -172,6 +172,7 @@ mcp_config_copied=設定がクリップボードにコピーされました
 mcp_copy_config=設定をコピー
 mcp_server=MCPサーバー
 mcp_server_port=サーバーポート
+mcp_server_update_failed=MCPサーバーの更新に失敗しました
 mcp_settings=MCP設定
 mcp_settings_desc=Model Context Protocolサーバー設定
 menu=メニュー

--- a/app/src/desktopMain/resources/i18n/ko.properties
+++ b/app/src/desktopMain/resources/i18n/ko.properties
@@ -172,6 +172,7 @@ mcp_config_copied=구성이 클립보드에 복사되었습니다
 mcp_copy_config=구성 복사
 mcp_server=MCP 서버
 mcp_server_port=서버 포트
+mcp_server_update_failed=MCP 서버를 업데이트하지 못했습니다
 mcp_settings=MCP 설정
 mcp_settings_desc=Model Context Protocol 서버 설정
 menu=메뉴

--- a/app/src/desktopMain/resources/i18n/pt.properties
+++ b/app/src/desktopMain/resources/i18n/pt.properties
@@ -172,6 +172,7 @@ mcp_config_copied=Configuração copiada para a área de transferência
 mcp_copy_config=Copiar configuração
 mcp_server=Servidor MCP
 mcp_server_port=Porta do servidor
+mcp_server_update_failed=Falha ao atualizar o servidor MCP
 mcp_settings=Configurações MCP
 mcp_settings_desc=Configurações do servidor Model Context Protocol
 menu=Menu

--- a/app/src/desktopMain/resources/i18n/zh.properties
+++ b/app/src/desktopMain/resources/i18n/zh.properties
@@ -172,6 +172,7 @@ mcp_config_copied=配置已复制到剪贴板
 mcp_copy_config=复制配置
 mcp_server=MCP 服务器
 mcp_server_port=服务器端口
+mcp_server_update_failed=更新 MCP 服务器失败
 mcp_settings=MCP 设置
 mcp_settings_desc=Model Context Protocol 服务器设置
 menu=菜单

--- a/app/src/desktopMain/resources/i18n/zh_hant.properties
+++ b/app/src/desktopMain/resources/i18n/zh_hant.properties
@@ -172,6 +172,7 @@ mcp_config_copied=配置已複製到剪貼簿
 mcp_copy_config=複製配置
 mcp_server=MCP 伺服器
 mcp_server_port=伺服器連接埠
+mcp_server_update_failed=更新 MCP 伺服器失敗
 mcp_settings=MCP 設定
 mcp_settings_desc=Model Context Protocol 伺服器設定
 menu=選單

--- a/app/src/desktopTest/kotlin/com/crosspaste/mcp/DesktopMcpServerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/mcp/DesktopMcpServerTest.kt
@@ -1,0 +1,285 @@
+package com.crosspaste.mcp
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DesktopMcpServerTest {
+
+    @Test
+    fun `start is idempotent and stop clears the published port`() =
+        runTest {
+            val factory = RecordingMcpServerFactory()
+            val server = createServer(factory)
+
+            server.start()
+            server.start()
+
+            assertEquals(DesktopMcpServer.DEFAULT_PORT, server.port())
+            assertEquals(listOf("create:13130", "start:13130"), factory.events)
+
+            server.stop()
+
+            assertEquals(0, server.port())
+            assertEquals(listOf("create:13130", "start:13130", "stop:13130"), factory.events)
+        }
+
+    @Test
+    fun `failed replacement keeps the existing listener and port`() =
+        runTest {
+            val factory = RecordingMcpServerFactory(failStartPorts = setOf(13131))
+            val server = createServer(factory)
+            server.start()
+
+            assertFailsWith<IllegalStateException> {
+                server.restart(13131)
+            }
+
+            assertEquals(DesktopMcpServer.DEFAULT_PORT, server.port())
+            assertEquals(
+                0,
+                factory.instances
+                    .getValue(13130)
+                    .single()
+                    .stopCount,
+            )
+            assertEquals(
+                1,
+                factory.instances
+                    .getValue(13131)
+                    .single()
+                    .stopCount,
+            )
+        }
+
+    @Test
+    fun `failed initial start cleans the candidate and does not publish a port`() =
+        runTest {
+            val factory = RecordingMcpServerFactory(failStartPorts = setOf(13130))
+            val server = createServer(factory)
+
+            assertFailsWith<IllegalStateException> {
+                server.start()
+            }
+
+            assertEquals(0, server.port())
+            assertEquals(
+                1,
+                factory.instances
+                    .getValue(13130)
+                    .single()
+                    .stopCount,
+            )
+        }
+
+    @Test
+    fun `restart binds replacement before stopping current listener`() =
+        runTest {
+            val factory = RecordingMcpServerFactory()
+            val server = createServer(factory)
+            server.start()
+
+            server.restart(13131)
+
+            assertEquals(13131, server.port())
+            assertEquals(
+                listOf("create:13130", "start:13130", "create:13131", "start:13131", "stop:13130"),
+                factory.events,
+            )
+        }
+
+    @Test
+    fun `stop waits for an in-flight start and closes the started listener`() =
+        runTest {
+            val startEntered = CompletableDeferred<Unit>()
+            val allowStart = CompletableDeferred<Unit>()
+            val factory =
+                RecordingMcpServerFactory(
+                    beforeStart = { port ->
+                        if (port == DesktopMcpServer.DEFAULT_PORT) {
+                            startEntered.complete(Unit)
+                            allowStart.await()
+                        }
+                    },
+                )
+            val server = createServer(factory)
+
+            val startJob = launch { server.start() }
+            startEntered.await()
+            val stopJob = launch { server.stop() }
+            runCurrent()
+
+            assertEquals(
+                0,
+                factory.instances
+                    .getValue(13130)
+                    .single()
+                    .stopCount,
+            )
+
+            allowStart.complete(Unit)
+            startJob.join()
+            stopJob.join()
+
+            assertEquals(0, server.port())
+            assertEquals(
+                1,
+                factory.instances
+                    .getValue(13130)
+                    .single()
+                    .stopCount,
+            )
+        }
+
+    @Test
+    fun `concurrent restarts are serialized in request order`() =
+        runTest {
+            val replacementStartEntered = CompletableDeferred<Unit>()
+            val allowReplacementStart = CompletableDeferred<Unit>()
+            val factory =
+                RecordingMcpServerFactory(
+                    beforeStart = { port ->
+                        if (port == 13131) {
+                            replacementStartEntered.complete(Unit)
+                            allowReplacementStart.await()
+                        }
+                    },
+                )
+            val server = createServer(factory)
+            server.start()
+
+            val firstRestart = launch { server.restart(13131) }
+            replacementStartEntered.await()
+            val secondRestart = launch { server.restart(13132) }
+            runCurrent()
+
+            allowReplacementStart.complete(Unit)
+            firstRestart.join()
+            secondRestart.join()
+
+            assertEquals(13132, server.port())
+            assertEquals(
+                1,
+                factory.instances
+                    .getValue(13130)
+                    .single()
+                    .stopCount,
+            )
+            assertEquals(
+                1,
+                factory.instances
+                    .getValue(13131)
+                    .single()
+                    .stopCount,
+            )
+            assertEquals(
+                0,
+                factory.instances
+                    .getValue(13132)
+                    .single()
+                    .stopCount,
+            )
+        }
+
+    @Test
+    fun `stop queued behind restart closes the replacement`() =
+        runTest {
+            val replacementStartEntered = CompletableDeferred<Unit>()
+            val allowReplacementStart = CompletableDeferred<Unit>()
+            val factory =
+                RecordingMcpServerFactory(
+                    beforeStart = { port ->
+                        if (port == 13131) {
+                            replacementStartEntered.complete(Unit)
+                            allowReplacementStart.await()
+                        }
+                    },
+                )
+            val server = createServer(factory)
+            server.start()
+
+            val restartJob = launch { server.restart(13131) }
+            replacementStartEntered.await()
+            val stopJob = launch { server.stop() }
+            runCurrent()
+
+            allowReplacementStart.complete(Unit)
+            restartJob.join()
+            stopJob.join()
+
+            assertEquals(0, server.port())
+            assertEquals(
+                1,
+                factory.instances
+                    .getValue(13130)
+                    .single()
+                    .stopCount,
+            )
+            assertEquals(
+                1,
+                factory.instances
+                    .getValue(13131)
+                    .single()
+                    .stopCount,
+            )
+        }
+
+    private fun kotlinx.coroutines.test.TestScope.createServer(factory: McpServerInstanceFactory): DesktopMcpServer =
+        DesktopMcpServer(
+            configuredPort = 0,
+            serverFactory = factory,
+            lifecycleDispatcher = StandardTestDispatcher(testScheduler),
+        )
+}
+
+private class RecordingMcpServerFactory(
+    private val failStartPorts: Set<Int> = emptySet(),
+    private val beforeStart: suspend (Int) -> Unit = {},
+) : McpServerInstanceFactory {
+
+    val events = mutableListOf<String>()
+    val instances = mutableMapOf<Int, MutableList<RecordingMcpServerInstance>>()
+
+    override fun create(port: Int): McpServerInstance {
+        events += "create:$port"
+        return RecordingMcpServerInstance(
+            port = port,
+            events = events,
+            failStart = port in failStartPorts,
+            beforeStart = beforeStart,
+        ).also { instance ->
+            instances.getOrPut(port) { mutableListOf() } += instance
+        }
+    }
+}
+
+private class RecordingMcpServerInstance(
+    private val port: Int,
+    private val events: MutableList<String>,
+    private val failStart: Boolean,
+    private val beforeStart: suspend (Int) -> Unit,
+) : McpServerInstance {
+
+    var stopCount = 0
+        private set
+
+    override suspend fun start() {
+        events += "start:$port"
+        beforeStart(port)
+        if (failStart) {
+            throw IllegalStateException("Port $port is unavailable")
+        }
+    }
+
+    override suspend fun stop() {
+        events += "stop:$port"
+        stopCount++
+    }
+}


### PR DESCRIPTION
Closes #4930

## Summary

- `DesktopMcpServer`: serialize `start` / `stop` / `restart` behind a mutex and make `start` idempotent. `restart` now creates and binds the replacement listener before stopping the current one, so a port that cannot be bound leaves the working endpoint untouched. A candidate that fails to start is cleaned up under `NonCancellable`. Failures propagate to the caller instead of being swallowed.
- Ktor engine calls use `startSuspend` / `stopSuspend` instead of the blocking variants.
- Settings view (`McpContentView`): lifecycle operations run on the app-level IO scope rather than the composable scope so navigating away cannot drop a pending operation. A request-version counter drops superseded requests. On failure the view shows an error notification and rolls the config back to the last working state (the toggle reverts; the port reverts to the port the server is actually bound to, and the `Counter` is remounted only in that case so normal typing keeps focus).
- App startup catches an MCP start failure, logs it, and continues.
- New `mcp_server_update_failed` string in all locales.

## Tests

`DesktopMcpServerTest` (fast tier, virtual time, fake listener factory) covers: idempotent start / stop clearing the port, failed replacement keeping the existing listener, failed initial start cleaning the candidate, replacement bound before the old listener stops, stop waiting for an in-flight start, concurrent restarts serialized in request order, and stop queued behind a restart closing the replacement.

Verified `./gradlew ktlintCheck` and `./gradlew app:desktopTest --tests "com.crosspaste.mcp.DesktopMcpServerTest"` (7/7 pass).