### PR TITLE
Route SOCKS proxies through OkHttp and cap ResourcesClient response sizes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,6 +134,7 @@ kotlin {
             implementation(libs.jna)
             implementation(libs.jna.platform)
             implementation(libs.jnativehook)
+            implementation(libs.ktor.client.okhttp)
             implementation(libs.ktor.server.cio)
             implementation(libs.logback.classic)
             implementation(libs.mcp.server)

--- a/app/src/commonMain/kotlin/com/crosspaste/app/CrossPasteWebService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/app/CrossPasteWebService.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.app
 
+import com.crosspaste.net.ResourceRequestLimits
 import com.crosspaste.net.ResourcesClient
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.util.collections.ConcurrentMap
@@ -36,7 +37,7 @@ class CrossPasteWebService(
         runCatching {
             val metaUrl = "${appUrls.homeUrl}/api/meta.json"
             resourcesClient
-                .request(metaUrl)
+                .request(metaUrl, ResourceRequestLimits.METADATA)
                 .getOrNull()
                 ?.let { response ->
                     val text = response.getBodyAsText()

--- a/app/src/commonMain/kotlin/com/crosspaste/net/AbstractResourcesClient.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/AbstractResourcesClient.kt
@@ -2,28 +2,32 @@ package com.crosspaste.net
 
 import com.crosspaste.app.AppFileType
 import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.utils.FileUtils
 import com.crosspaste.utils.getFileUtils
 import io.github.oshai.kotlinlogging.KLogger
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.onDownload
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.prepareRequest
-import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.contentLength
+import io.ktor.http.contentType
 import io.ktor.http.isSuccess
+import io.ktor.utils.io.readRemaining
+import kotlinx.io.readByteArray
 import okio.Path
 import kotlin.coroutines.cancellation.CancellationException
 
 abstract class AbstractResourcesClient(
     val userDataPathProvider: UserDataPathProvider,
+    protected val fileUtils: FileUtils = getFileUtils(),
 ) : ResourcesClient {
-
-    companion object {
-        val fileUtils = getFileUtils()
-    }
 
     abstract val logger: KLogger
 
     abstract fun getHttpClient(): HttpClient
+
+    protected open fun configureRequest(builder: HttpRequestBuilder) {}
 
     private fun getTempFilePath(): Path =
         userDataPathProvider.resolve(
@@ -48,44 +52,65 @@ abstract class AbstractResourcesClient(
                 if (response.status.isSuccess()) {
                     shouldShowProgress = true
                     val tempFilePath = getTempFilePath()
-                    runCatching {
-                        val channel = response.bodyAsChannel()
-                        fileUtils.writeFile(tempFilePath, channel)
-                        fileUtils.moveFile(tempFilePath, path)
-                    }.onSuccess {
-                        listener.onSuccess()
-                    }.onFailure { error ->
+                    val downloadResult =
                         runCatching {
-                            if (fileUtils.existFile(tempFilePath)) {
-                                fileUtils.deleteFile(tempFilePath)
-                            }
-                        }.onFailure { e ->
-                            logger.warn(e) { "Failed to delete temp file: $tempFilePath" }
+                            val channel = response.bodyAsChannel()
+                            fileUtils.writeFile(tempFilePath, channel)
+                            fileUtils.moveFile(tempFilePath, path).getOrThrow()
                         }
-                        runCatching {
-                            if (fileUtils.existFile(path)) {
-                                fileUtils.deleteFile(path)
-                            }
-                        }.onFailure { e ->
-                            logger.warn(e) { "Failed to delete target file: $path" }
+                    downloadResult
+                        .onSuccess {
+                            listener.onSuccess()
+                        }.onFailure { error ->
+                            deleteTempFile(tempFilePath)
+                            listener.onFailure(response.status, error)
+                            if (error is CancellationException) throw error
                         }
-                        listener.onFailure(response.status, error)
-                    }
                 } else {
                     listener.onFailure(response.status, null)
                 }
             }
     }
 
-    override suspend fun request(url: String): Result<ClientResponse> =
+    private fun deleteTempFile(tempFilePath: Path) {
+        if (!fileUtils.existFile(tempFilePath)) return
+        fileUtils.deleteFile(tempFilePath).onFailure { error ->
+            logger.warn(error) { "Failed to delete temp file: $tempFilePath" }
+        }
+    }
+
+    override suspend fun request(
+        url: String,
+        maxBytes: Long,
+    ): Result<ClientResponse> =
         runCatching {
-            val response = clientRequest(url, getHttpClient())
-            if (response.status.isSuccess()) {
-                ClientResponse(response)
-            } else {
-                logger.warn { "Failed to fetch data from $url, status code: ${response.status.value}" }
-                throw kotlin.Exception("HTTP error: ${response.status.value}")
+            require(maxBytes in 0 until Int.MAX_VALUE) {
+                "maxBytes must be non-negative and fit in a ByteArray"
             }
+            getHttpClient()
+                .prepareRequest(url) {
+                    configureRequest(this)
+                }.execute { response ->
+                    if (!response.status.isSuccess()) {
+                        logger.warn { "Failed to fetch data from $url, status code: ${response.status.value}" }
+                        throw kotlin.Exception("HTTP error: ${response.status.value}")
+                    }
+
+                    val contentLength = response.contentLength()
+                    if (contentLength != null && contentLength > maxBytes) {
+                        throw ResourceResponseTooLargeException(maxBytes)
+                    }
+
+                    val body =
+                        response
+                            .bodyAsChannel()
+                            .readRemaining(maxBytes + 1)
+                            .readByteArray()
+                    if (body.size.toLong() > maxBytes) {
+                        throw ResourceResponseTooLargeException(maxBytes)
+                    }
+                    ClientResponse(body, response.contentType())
+                }
         }.onFailure { e ->
             // Network/TLS failures (e.g. SunCertPathBuilderException behind a
             // TLS-intercepting proxy) must surface as Result.failure, not propagate:
@@ -94,9 +119,4 @@ abstract class AbstractResourcesClient(
             if (e is CancellationException) throw e
             logger.warn(e) { "Failed to request $url" }
         }
-
-    abstract suspend fun clientRequest(
-        url: String,
-        client: HttpClient,
-    ): HttpResponse
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/ResourcesClient.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/ResourcesClient.kt
@@ -1,18 +1,20 @@
 package com.crosspaste.net
 
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsChannel
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentLength
-import io.ktor.http.contentType
-import io.ktor.utils.io.*
+import io.ktor.http.charset
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.charsets.decode
+import kotlinx.io.Buffer
 import okio.Path
 
 interface ResourcesClient {
 
-    suspend fun request(url: String): Result<ClientResponse>
+    suspend fun request(
+        url: String,
+        maxBytes: Long,
+    ): Result<ClientResponse>
 
     suspend fun download(
         url: String,
@@ -23,18 +25,38 @@ interface ResourcesClient {
     fun close() {}
 }
 
-class ClientResponse(
-    private val response: HttpResponse,
+class ClientResponse internal constructor(
+    private val body: ByteArray,
+    private val contentType: ContentType?,
 ) {
 
-    suspend fun getBody(): ByteReadChannel = response.bodyAsChannel()
+    suspend fun getBody(): ByteReadChannel = ByteReadChannel(body)
 
-    suspend fun getBodyAsText(): String = response.bodyAsText()
+    suspend fun getBodyAsText(): String {
+        val source = Buffer().apply { write(body) }
+        return (contentType?.charset() ?: Charsets.UTF_8).newDecoder().decode(source)
+    }
 
-    fun getContentLength(): Long = response.contentLength() ?: -1L
+    fun getContentLength(): Long = body.size.toLong()
 
-    fun getContentType(): ContentType? = response.contentType()
+    fun getContentType(): ContentType? = contentType
 }
+
+object ResourceRequestLimits {
+
+    /** Small JSON, properties and checksum documents controlled by CrossPaste. */
+    const val METADATA: Long = 1024L * 1024
+
+    /** HTML parsed for a URL preview. */
+    const val HTML: Long = 8L * 1024 * 1024
+
+    /** Encoded favicon or Open Graph image bytes, before image decoding. */
+    const val IMAGE: Long = 16L * 1024 * 1024
+}
+
+class ResourceResponseTooLargeException(
+    val maxBytes: Long,
+) : IllegalArgumentException("Resource response exceeds $maxBytes bytes")
 
 interface DownloadProgressListener {
 

--- a/app/src/commonMain/kotlin/com/crosspaste/rendering/OpenGraphService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/rendering/OpenGraphService.kt
@@ -5,6 +5,7 @@ import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.image.GenerateImageService
 import com.crosspaste.image.ImageHandler
 import com.crosspaste.net.ClientResponse
+import com.crosspaste.net.ResourceRequestLimits
 import com.crosspaste.net.ResourcesClient
 import com.crosspaste.paste.PasteData
 import com.crosspaste.paste.item.UpdatePasteItemHelper
@@ -49,7 +50,7 @@ class OpenGraphService<Image>(
             if (fileUtils.existFile(openGraphImage)) {
                 logger.info { "Open graph image file exists" }
             } else {
-                resourcesClient.request(urlPasteItem.url).onSuccess { response ->
+                resourcesClient.request(urlPasteItem.url, ResourceRequestLimits.HTML).onSuccess { response ->
                     response.getContentType()?.let { contentType ->
                         if (contentType.match(ContentType.Text.Html) ||
                             contentType.match(ContentType.Application.Xml)
@@ -138,7 +139,7 @@ class OpenGraphService<Image>(
             ).mapNotNull { it() }.firstOrNull { it.isNotBlank() }
 
         ogImage?.let { imageUrl ->
-            resourcesClient.request(imageUrl).onSuccess { imageResponse ->
+            resourcesClient.request(imageUrl, ResourceRequestLimits.IMAGE).onSuccess { imageResponse ->
                 imageHandler.readImage(imageResponse.getBody())?.also { image ->
                     if (imageHandler.writeImage(image, "png", openGraphImage)) {
                         val currentUrlItem =

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/UpdateMetadataFetcher.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/UpdateMetadataFetcher.kt
@@ -1,5 +1,6 @@
 package com.crosspaste.app
 
+import com.crosspaste.net.ResourceRequestLimits
 import com.crosspaste.net.ResourcesClient
 import com.crosspaste.utils.getJsonUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -56,7 +57,7 @@ class UpdateMetadataFetcher(
             ?: versionApiUrl?.let { fetchFromVersionApi(it) }
 
     private suspend fun fetchFromMetadataProperties(url: String): ReleaseMetadata? =
-        resourcesClient.request(url).getOrNull()?.let { response ->
+        resourcesClient.request(url, ResourceRequestLimits.METADATA).getOrNull()?.let { response ->
             runCatching {
                 val properties = Properties()
                 properties.load(StringReader(response.getBodyAsText()))
@@ -68,7 +69,7 @@ class UpdateMetadataFetcher(
         }
 
     private suspend fun fetchFromVersionApi(url: String): ReleaseMetadata? =
-        resourcesClient.request(url).getOrNull()?.let { response ->
+        resourcesClient.request(url, ResourceRequestLimits.METADATA).getOrNull()?.let { response ->
             runCatching {
                 val api =
                     getJsonUtils().JSON.decodeFromString<DesktopVersionApi>(response.getBodyAsText())

--- a/app/src/desktopMain/kotlin/com/crosspaste/app/WindowsZipUpdater.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/app/WindowsZipUpdater.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.app
 
 import com.crosspaste.net.DownloadProgressListener
+import com.crosspaste.net.ResourceRequestLimits
 import com.crosspaste.net.ResourcesClient
 import com.crosspaste.path.AppPathProvider
 import com.crosspaste.platform.Platform
@@ -398,7 +399,7 @@ class WindowsZipUpdater(
                         runCatching {
                             val text =
                                 resourcesClient
-                                    .request(base + "checksum.txt")
+                                    .request(base + "checksum.txt", ResourceRequestLimits.METADATA)
                                     .getOrThrow()
                                     .getBodyAsText()
                             base to text

--- a/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopFaviconLoader.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/image/DesktopFaviconLoader.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.image
 
 import com.crosspaste.config.CommonConfigManager
+import com.crosspaste.net.ResourceRequestLimits
 import com.crosspaste.net.ResourcesClient
 import com.crosspaste.path.UserDataPathProvider
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -20,7 +21,7 @@ class DesktopFaviconLoader(
         url: String,
         path: Path,
     ): Path? =
-        resourcesClient.request(url).getOrNull()?.let { response ->
+        resourcesClient.request(url, ResourceRequestLimits.IMAGE).getOrNull()?.let { response ->
             FileOutputStream(path.toFile()).use { output ->
                 response.getBody().toInputStream().use { input ->
                     input.copyTo(output)

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopResourcesClient.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopResourcesClient.kt
@@ -5,12 +5,13 @@ import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.ui.extension.ProxyType
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.client.*
-import io.ktor.client.engine.*
-import io.ktor.client.engine.cio.*
-import io.ktor.client.engine.okhttp.*
-import io.ktor.client.plugins.*
-import io.ktor.client.plugins.logging.*
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.ProxyBuilder
+import io.ktor.client.engine.http
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.http.headers
 import io.ktor.util.collections.*
@@ -30,35 +31,27 @@ class DesktopResourcesClient(
             clientLogger: KLogger,
             proxyConfig: Proxy? = null,
         ): HttpClient =
-            if (proxyConfig?.type == ProxyType.SOCKS) {
-                HttpClient(OkHttp) {
-                    configureClient(clientLogger)
-                    engine {
-                        proxy = ProxyBuilder.socks(proxyConfig.host, proxyConfig.port)
-                    }
-                }
-            } else {
-                HttpClient(CIO) {
-                    configureClient(clientLogger)
-                    engine {
-                        proxyConfig?.let {
-                            proxy = ProxyBuilder.http("http://${proxyConfig.host}:${proxyConfig.port}")
+            HttpClient(OkHttp) {
+                followRedirects = true
+                install(Logging) {
+                    logger =
+                        object : Logger {
+                            override fun log(message: String) {
+                                clientLogger.info { message }
+                            }
                         }
+                }
+                engine {
+                    proxyConfig?.let {
+                        proxy =
+                            if (it.type == ProxyType.SOCKS) {
+                                ProxyBuilder.socks(it.host, it.port)
+                            } else {
+                                ProxyBuilder.http("http://${it.host}:${it.port}")
+                            }
                     }
                 }
             }
-
-        private fun HttpClientConfig<*>.configureClient(clientLogger: KLogger) {
-            followRedirects = true
-            install(Logging) {
-                logger =
-                    object : Logger {
-                        override fun log(message: String) {
-                            clientLogger.info { message }
-                        }
-                    }
-            }
-        }
     }
 
     override val logger = KotlinLogging.logger {}

--- a/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopResourcesClient.kt
+++ b/app/src/desktopMain/kotlin/com/crosspaste/net/DesktopResourcesClient.kt
@@ -8,16 +8,17 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.logging.*
-import io.ktor.client.request.request
-import io.ktor.client.statement.*
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.http.headers
 import io.ktor.util.collections.*
 
 class DesktopResourcesClient(
     val configManager: DesktopConfigManager,
     userDataPathProvider: UserDataPathProvider,
+    private val clientFactory: (KLogger, Proxy?) -> HttpClient = ::createClient,
 ) : AbstractResourcesClient(userDataPathProvider) {
 
     companion object {
@@ -29,32 +30,40 @@ class DesktopResourcesClient(
             clientLogger: KLogger,
             proxyConfig: Proxy? = null,
         ): HttpClient =
-            HttpClient(CIO) {
-                followRedirects = true
-                engine {
-                    proxyConfig?.let {
-                        proxy =
-                            if (proxyConfig.type == ProxyType.HTTP) {
-                                ProxyBuilder.http("http://${proxyConfig.host}:${proxyConfig.port}")
-                            } else {
-                                ProxyBuilder.socks(proxyConfig.host, proxyConfig.port)
-                            }
+            if (proxyConfig?.type == ProxyType.SOCKS) {
+                HttpClient(OkHttp) {
+                    configureClient(clientLogger)
+                    engine {
+                        proxy = ProxyBuilder.socks(proxyConfig.host, proxyConfig.port)
                     }
                 }
-                install(Logging, configure = {
-                    logger =
-                        object : Logger {
-                            override fun log(message: String) {
-                                clientLogger.info { message }
-                            }
+            } else {
+                HttpClient(CIO) {
+                    configureClient(clientLogger)
+                    engine {
+                        proxyConfig?.let {
+                            proxy = ProxyBuilder.http("http://${proxyConfig.host}:${proxyConfig.port}")
                         }
-                })
+                    }
+                }
             }
+
+        private fun HttpClientConfig<*>.configureClient(clientLogger: KLogger) {
+            followRedirects = true
+            install(Logging) {
+                logger =
+                    object : Logger {
+                        override fun log(message: String) {
+                            clientLogger.info { message }
+                        }
+                    }
+            }
+        }
     }
 
     override val logger = KotlinLogging.logger {}
 
-    private val noProxyClient = createClient(logger)
+    private val noProxyClient = clientFactory(logger, null)
 
     private val proxyClientMap: ConcurrentMap<Proxy, HttpClient> = ConcurrentMap()
 
@@ -72,17 +81,14 @@ class DesktopResourcesClient(
     override fun getHttpClient(): HttpClient {
         val proxy = getProxy()
         return proxy?.let {
-            proxyClientMap.getOrPut(proxy) {
-                createClient(logger, proxy)
+            proxyClientMap.computeIfAbsent(proxy) {
+                clientFactory(logger, proxy)
             }
         } ?: noProxyClient
     }
 
-    override suspend fun clientRequest(
-        url: String,
-        client: HttpClient,
-    ): HttpResponse =
-        client.request(url) {
+    override fun configureRequest(builder: HttpRequestBuilder) {
+        builder.apply {
             headers {
                 append("User-Agent", DEFAULT_USER_AGENT)
                 append("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
@@ -93,6 +99,7 @@ class DesktopResourcesClient(
                 requestTimeoutMillis = 5000L
             }
         }
+    }
 
     override fun close() {
         noProxyClient.close()

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/UpdateMetadataFetcherTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/UpdateMetadataFetcherTest.kt
@@ -7,8 +7,11 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import io.ktor.http.isSuccess
+import io.ktor.utils.io.toByteArray
 import kotlinx.coroutines.runBlocking
 import okio.Path
 import kotlin.test.Test
@@ -138,10 +141,15 @@ private class RoutingResourcesClient(
     private val client: HttpClient,
 ) : ResourcesClient {
 
-    override suspend fun request(url: String): Result<ClientResponse> {
+    override suspend fun request(
+        url: String,
+        maxBytes: Long,
+    ): Result<ClientResponse> {
         val response = client.get(url)
         return if (response.status.isSuccess()) {
-            Result.success(ClientResponse(response))
+            val body = response.bodyAsChannel().toByteArray()
+            require(body.size.toLong() <= maxBytes)
+            Result.success(ClientResponse(body, response.contentType()))
         } else {
             Result.failure(IllegalStateException("HTTP ${response.status.value}"))
         }

--- a/app/src/desktopTest/kotlin/com/crosspaste/app/WindowsZipUpdaterDownloadTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/app/WindowsZipUpdaterDownloadTest.kt
@@ -12,7 +12,9 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentLength
+import io.ktor.http.contentType
 import io.ktor.http.isSuccess
+import io.ktor.utils.io.toByteArray
 import io.mockk.mockk
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -159,10 +161,15 @@ private class MockResourcesClient(
     private val client: HttpClient,
 ) : ResourcesClient {
 
-    override suspend fun request(url: String): Result<ClientResponse> {
+    override suspend fun request(
+        url: String,
+        maxBytes: Long,
+    ): Result<ClientResponse> {
         val response = client.get(url)
         return if (response.status.isSuccess()) {
-            Result.success(ClientResponse(response))
+            val body = response.bodyAsChannel().toByteArray()
+            require(body.size.toLong() <= maxBytes)
+            Result.success(ClientResponse(body, response.contentType()))
         } else {
             Result.failure(IllegalStateException("HTTP ${response.status.value}"))
         }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/AbstractResourcesClientTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/AbstractResourcesClientTest.kt
@@ -1,18 +1,29 @@
 package com.crosspaste.net
 
+import com.crosspaste.app.AppFileType
+import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.utils.FileUtils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
-import io.ktor.client.request.get
-import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
+import okio.Path.Companion.toPath
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -24,20 +35,15 @@ import kotlin.test.assertTrue
  */
 class AbstractResourcesClientTest {
 
-    /** Drives [clientRequest] from a lambda so each test can throw or respond at will. */
     private class FakeResourcesClient(
         private val httpClient: HttpClient,
-        private val onRequest: suspend (String, HttpClient) -> HttpResponse,
-    ) : AbstractResourcesClient(mockk(relaxed = true)) {
+        userDataPathProvider: UserDataPathProvider = mockk(relaxed = true),
+        fileUtils: FileUtils = mockk(relaxed = true),
+    ) : AbstractResourcesClient(userDataPathProvider, fileUtils) {
 
         override val logger = KotlinLogging.logger {}
 
         override fun getHttpClient(): HttpClient = httpClient
-
-        override suspend fun clientRequest(
-            url: String,
-            client: HttpClient,
-        ): HttpResponse = onRequest(url, client)
     }
 
     private fun mockClient(status: HttpStatusCode = HttpStatusCode.OK): HttpClient =
@@ -47,22 +53,21 @@ class AbstractResourcesClientTest {
     fun `network exception surfaces as failure instead of throwing`() =
         runBlocking {
             val boom = IllegalStateException("unable to find valid certification path to requested target")
-            val client = FakeResourcesClient(mockClient()) { _, _ -> throw boom }
+            val client = FakeResourcesClient(HttpClient(MockEngine { throw boom }))
 
-            val result = client.request("https://example.test/meta.json")
+            val result = client.request("https://example.test/meta.json", ResourceRequestLimits.METADATA)
 
             assertTrue(result.isFailure)
-            assertSame(boom, result.exceptionOrNull())
+            assertEquals(boom.message, result.exceptionOrNull()?.message)
         }
 
     @Test
     fun `cancellation is re-thrown, not captured into the result`() =
         runBlocking {
-            val client =
-                FakeResourcesClient(mockClient()) { _, _ -> throw CancellationException("scope cancelled") }
+            val client = FakeResourcesClient(HttpClient(MockEngine { throw CancellationException("scope cancelled") }))
 
             assertFailsWith<CancellationException> {
-                client.request("https://example.test/meta.json")
+                client.request("https://example.test/meta.json", ResourceRequestLimits.METADATA)
             }
             Unit
         }
@@ -70,10 +75,9 @@ class AbstractResourcesClientTest {
     @Test
     fun `non-success status returns failure`() =
         runBlocking {
-            val client =
-                FakeResourcesClient(mockClient(HttpStatusCode.InternalServerError)) { url, http -> http.get(url) }
+            val client = FakeResourcesClient(mockClient(HttpStatusCode.InternalServerError))
 
-            val result = client.request("https://example.test/meta.json")
+            val result = client.request("https://example.test/meta.json", ResourceRequestLimits.METADATA)
 
             assertTrue(result.isFailure)
         }
@@ -81,11 +85,166 @@ class AbstractResourcesClientTest {
     @Test
     fun `success status returns success`() =
         runBlocking {
-            val client =
-                FakeResourcesClient(mockClient(HttpStatusCode.OK)) { url, http -> http.get(url) }
+            val client = FakeResourcesClient(mockClient(HttpStatusCode.OK))
 
-            val result = client.request("https://example.test/meta.json")
+            val result = client.request("https://example.test/meta.json", ResourceRequestLimits.METADATA)
 
             assertTrue(result.isSuccess)
+            assertEquals("body", result.getOrThrow().getBodyAsText())
         }
+
+    @Test
+    fun `text response honors the declared charset`() =
+        runBlocking {
+            val client =
+                FakeResourcesClient(
+                    HttpClient(
+                        MockEngine {
+                            respond(
+                                content = ByteReadChannel(byteArrayOf(0xE9.toByte())),
+                                headers = headersOf(HttpHeaders.ContentType, "text/plain; charset=ISO-8859-1"),
+                            )
+                        },
+                    ),
+                )
+
+            val response =
+                client
+                    .request("https://example.test/text", ResourceRequestLimits.METADATA)
+                    .getOrThrow()
+
+            assertEquals("é", response.getBodyAsText())
+        }
+
+    @Test
+    fun `declared content length above limit returns failure`() =
+        runBlocking {
+            val client =
+                FakeResourcesClient(
+                    HttpClient(
+                        MockEngine {
+                            respond(
+                                content = "body",
+                                headers = headersOf(HttpHeaders.ContentLength, "5"),
+                            )
+                        },
+                    ),
+                )
+
+            val result = client.request("https://example.test/meta.json", maxBytes = 4)
+
+            assertTrue(result.exceptionOrNull() is ResourceResponseTooLargeException)
+        }
+
+    @Test
+    fun `streamed body above limit returns failure without content length`() =
+        runBlocking {
+            val client = FakeResourcesClient(mockClient())
+
+            val result = client.request("https://example.test/meta.json", maxBytes = 3)
+
+            assertTrue(result.exceptionOrNull() is ResourceResponseTooLargeException)
+        }
+
+    @Test
+    fun `download write failure preserves existing target and cleans temp file`() =
+        runBlocking {
+            val target = "/target/module.bin".toPath()
+            val temp = "/temp/download.tmp".toPath()
+            val boom = IllegalStateException("write failed")
+            val fileUtils = mockk<FileUtils>()
+            val listener = mockk<DownloadProgressListener>(relaxed = true)
+            val client = downloadClient(fileUtils, temp)
+            coEvery { fileUtils.writeFile(temp, any<ByteReadChannel>()) } throws boom
+            every { fileUtils.existFile(temp) } returns true
+            every { fileUtils.deleteFile(temp) } returns Result.success(Unit)
+
+            client.download("https://example.test/module.bin", target, listener)
+
+            verify { listener.onFailure(HttpStatusCode.OK, boom) }
+            coVerify(exactly = 0) { fileUtils.moveFile(any(), any()) }
+            verify { fileUtils.deleteFile(temp) }
+            verify(exactly = 0) { fileUtils.deleteFile(target) }
+        }
+
+    @Test
+    fun `download move failure is reported and preserves existing target`() =
+        runBlocking {
+            val target = "/target/module.bin".toPath()
+            val temp = "/temp/download.tmp".toPath()
+            val boom = IllegalStateException("move failed")
+            val fileUtils = mockk<FileUtils>()
+            val listener = mockk<DownloadProgressListener>(relaxed = true)
+            val client = downloadClient(fileUtils, temp)
+            coEvery { fileUtils.writeFile(temp, any<ByteReadChannel>()) } just Runs
+            every { fileUtils.moveFile(temp, target) } returns Result.failure(boom)
+            every { fileUtils.existFile(temp) } returns true
+            every { fileUtils.deleteFile(temp) } returns Result.success(Unit)
+
+            client.download("https://example.test/module.bin", target, listener)
+
+            verify { listener.onFailure(HttpStatusCode.OK, boom) }
+            verify(exactly = 0) { listener.onSuccess() }
+            verify { fileUtils.deleteFile(temp) }
+            verify(exactly = 0) { fileUtils.deleteFile(target) }
+        }
+
+    @Test
+    fun `download success is reported only after atomic move`() =
+        runBlocking {
+            val target = "/target/module.bin".toPath()
+            val temp = "/temp/download.tmp".toPath()
+            val fileUtils = mockk<FileUtils>()
+            val listener = mockk<DownloadProgressListener>(relaxed = true)
+            val client = downloadClient(fileUtils, temp)
+            coEvery { fileUtils.writeFile(temp, any<ByteReadChannel>()) } just Runs
+            every { fileUtils.moveFile(temp, target) } returns Result.success(Unit)
+
+            client.download("https://example.test/module.bin", target, listener)
+
+            verify { fileUtils.moveFile(temp, target) }
+            verify { listener.onSuccess() }
+            verify(exactly = 0) { listener.onFailure(any(), any()) }
+        }
+
+    @Test
+    fun `download cancellation cleans temp file and propagates`() =
+        runBlocking {
+            val target = "/target/module.bin".toPath()
+            val temp = "/temp/download.tmp".toPath()
+            val cancellation = CancellationException("cancelled")
+            val fileUtils = mockk<FileUtils>()
+            val listener = mockk<DownloadProgressListener>(relaxed = true)
+            val client = downloadClient(fileUtils, temp)
+            coEvery { fileUtils.writeFile(temp, any<ByteReadChannel>()) } throws cancellation
+            every { fileUtils.existFile(temp) } returns true
+            every { fileUtils.deleteFile(temp) } returns Result.success(Unit)
+
+            assertFailsWith<CancellationException> {
+                client.download("https://example.test/module.bin", target, listener)
+            }
+
+            verify { listener.onFailure(HttpStatusCode.OK, cancellation) }
+            verify { fileUtils.deleteFile(temp) }
+            verify(exactly = 0) { fileUtils.deleteFile(target) }
+        }
+
+    private fun downloadClient(
+        fileUtils: FileUtils,
+        temp: okio.Path,
+    ): FakeResourcesClient {
+        every { fileUtils.createRandomFileName() } returns temp.name
+        val pathProvider = mockk<UserDataPathProvider>()
+        every {
+            pathProvider.resolve(
+                fileName = temp.name,
+                appFileType = AppFileType.TEMP,
+            )
+        } returns temp
+        return FakeResourcesClient(
+            httpClient = mockClient(),
+            userDataPathProvider = pathProvider,
+            fileUtils = fileUtils,
+        )
+    }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopResourcesClientTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopResourcesClientTest.kt
@@ -1,0 +1,167 @@
+package com.crosspaste.net
+
+import com.crosspaste.config.DesktopAppConfig
+import com.crosspaste.config.DesktopConfigManager
+import com.crosspaste.ui.extension.ProxyType
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.SocketException
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class DesktopResourcesClientTest {
+
+    @Test
+    fun `manual SOCKS client performs a SOCKS handshake`() {
+        FakeSocksServer().use { proxy ->
+            val client =
+                DesktopResourcesClient.createClient(
+                    KotlinLogging.logger {},
+                    Proxy(ProxyType.SOCKS, "127.0.0.1", proxy.port),
+                )
+            try {
+                val body =
+                    runBlocking {
+                        client.get("http://crosspaste-socks-test.invalid/resource").bodyAsText()
+                    }
+
+                assertEquals("ok", body)
+                assertEquals("crosspaste-socks-test.invalid", proxy.awaitRequestedHost())
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent first requests create one client per proxy`() =
+        runBlocking {
+            val configManager = mockk<DesktopConfigManager>()
+            every { configManager.getCurrentConfig() } returns
+                DesktopAppConfig(
+                    language = "en",
+                    useManualProxy = true,
+                    proxyType = ProxyType.HTTP,
+                    proxyHost = "proxy.test",
+                    proxyPort = "8080",
+                )
+
+            val createCount = AtomicInteger()
+            val client =
+                DesktopResourcesClient(
+                    configManager = configManager,
+                    userDataPathProvider = mockk(relaxed = true),
+                    clientFactory = { _, _ ->
+                        createCount.incrementAndGet()
+                        repeat(100_000) { Thread.onSpinWait() }
+                        mockk(relaxed = true)
+                    },
+                )
+
+            val clients =
+                List(64) {
+                    async(Dispatchers.Default) {
+                        client.getHttpClient()
+                    }
+                }.awaitAll()
+
+            assertEquals(2, createCount.get(), "one base client and one proxy client should be created")
+            assertEquals(1, clients.toSet().size)
+            client.close()
+        }
+
+    private class FakeSocksServer : AutoCloseable {
+
+        private val server = ServerSocket(0, 1, InetAddress.getLoopbackAddress())
+        private val requestedHost = AtomicReference<String>()
+        private val failure = AtomicReference<Throwable>()
+
+        val port: Int = server.localPort
+
+        private val worker =
+            thread(name = "fake-socks-server", isDaemon = true) {
+                try {
+                    server.accept().use { socket ->
+                        val input = DataInputStream(BufferedInputStream(socket.getInputStream()))
+                        val output = BufferedOutputStream(socket.getOutputStream())
+
+                        assertEquals(5, input.readUnsignedByte())
+                        val methodCount = input.readUnsignedByte()
+                        repeat(methodCount) { input.readUnsignedByte() }
+                        output.write(byteArrayOf(5, 0))
+                        output.flush()
+
+                        assertEquals(5, input.readUnsignedByte())
+                        assertEquals(1, input.readUnsignedByte())
+                        assertEquals(0, input.readUnsignedByte())
+                        val host = readAddress(input)
+                        input.readUnsignedShort()
+                        requestedHost.set(host)
+
+                        output.write(byteArrayOf(5, 0, 0, 1, 127, 0, 0, 1, 0, 0))
+                        output.flush()
+                        readHttpHeaders(input)
+                        output.write(
+                            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+                                .toByteArray(StandardCharsets.US_ASCII),
+                        )
+                        output.flush()
+                    }
+                } catch (e: SocketException) {
+                    if (!server.isClosed) failure.set(e)
+                } catch (e: Throwable) {
+                    failure.set(e)
+                }
+            }
+
+        fun awaitRequestedHost(): String {
+            failure.get()?.let { throw AssertionError("Fake SOCKS server failed", it) }
+            return assertNotNull(requestedHost.get())
+        }
+
+        private fun readAddress(input: DataInputStream): String =
+            when (val addressType = input.readUnsignedByte()) {
+                1 -> InetAddress.getByAddress(ByteArray(4).also(input::readFully)).hostAddress
+                3 -> {
+                    val length = input.readUnsignedByte()
+                    String(ByteArray(length).also(input::readFully), StandardCharsets.US_ASCII)
+                }
+                4 -> InetAddress.getByAddress(ByteArray(16).also(input::readFully)).hostAddress
+                else -> error("Unsupported SOCKS address type: $addressType")
+            }
+
+        private fun readHttpHeaders(input: DataInputStream) {
+            var matched = 0
+            var count = 0
+            val terminator = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte(), '\r'.code.toByte(), '\n'.code.toByte())
+            while (matched < terminator.size) {
+                check(count++ < 16 * 1024) { "HTTP headers exceed test limit" }
+                val byte = input.readByte()
+                matched = if (byte == terminator[matched]) matched + 1 else 0
+            }
+        }
+
+        override fun close() {
+            server.close()
+            worker.join(5_000)
+            failure.get()?.let { throw AssertionError("Fake SOCKS server failed", it) }
+        }
+    }
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopResourcesClientTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/DesktopResourcesClientTest.kt
@@ -51,6 +51,31 @@ class DesktopResourcesClientTest {
     }
 
     @Test
+    fun `manual HTTP client sends the absolute request target to the proxy`() {
+        FakeHttpProxyServer().use { proxy ->
+            val client =
+                DesktopResourcesClient.createClient(
+                    KotlinLogging.logger {},
+                    Proxy(ProxyType.HTTP, "127.0.0.1", proxy.port),
+                )
+            try {
+                val body =
+                    runBlocking {
+                        client.get("http://crosspaste-http-proxy-test.invalid/resource").bodyAsText()
+                    }
+
+                assertEquals("ok", body)
+                assertEquals(
+                    "GET http://crosspaste-http-proxy-test.invalid/resource HTTP/1.1",
+                    proxy.awaitRequestLine(),
+                )
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    @Test
     fun `concurrent first requests create one client per proxy`() =
         runBlocking {
             val configManager = mockk<DesktopConfigManager>()
@@ -86,6 +111,47 @@ class DesktopResourcesClientTest {
             assertEquals(1, clients.toSet().size)
             client.close()
         }
+
+    private class FakeHttpProxyServer : AutoCloseable {
+
+        private val server = ServerSocket(0, 1, InetAddress.getLoopbackAddress())
+        private val requestLine = AtomicReference<String>()
+        private val failure = AtomicReference<Throwable>()
+
+        val port: Int = server.localPort
+
+        private val worker =
+            thread(name = "fake-http-proxy-server", isDaemon = true) {
+                try {
+                    server.accept().use { socket ->
+                        val input = DataInputStream(BufferedInputStream(socket.getInputStream()))
+                        val output = BufferedOutputStream(socket.getOutputStream())
+                        val headers = readHttpHeaders(input)
+                        requestLine.set(headers.lineSequence().first())
+                        output.write(
+                            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+                                .toByteArray(StandardCharsets.US_ASCII),
+                        )
+                        output.flush()
+                    }
+                } catch (e: SocketException) {
+                    if (!server.isClosed) failure.set(e)
+                } catch (e: Throwable) {
+                    failure.set(e)
+                }
+            }
+
+        fun awaitRequestLine(): String {
+            failure.get()?.let { throw AssertionError("Fake HTTP proxy server failed", it) }
+            return assertNotNull(requestLine.get())
+        }
+
+        override fun close() {
+            server.close()
+            worker.join(5_000)
+            failure.get()?.let { throw AssertionError("Fake HTTP proxy server failed", it) }
+        }
+    }
 
     private class FakeSocksServer : AutoCloseable {
 
@@ -147,21 +213,26 @@ class DesktopResourcesClientTest {
                 else -> error("Unsupported SOCKS address type: $addressType")
             }
 
-        private fun readHttpHeaders(input: DataInputStream) {
-            var matched = 0
-            var count = 0
-            val terminator = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte(), '\r'.code.toByte(), '\n'.code.toByte())
-            while (matched < terminator.size) {
-                check(count++ < 16 * 1024) { "HTTP headers exceed test limit" }
-                val byte = input.readByte()
-                matched = if (byte == terminator[matched]) matched + 1 else 0
-            }
-        }
-
         override fun close() {
             server.close()
             worker.join(5_000)
             failure.get()?.let { throw AssertionError("Fake SOCKS server failed", it) }
+        }
+    }
+
+    private companion object {
+
+        fun readHttpHeaders(input: DataInputStream): String {
+            val bytes = java.io.ByteArrayOutputStream()
+            var matched = 0
+            val terminator = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte(), '\r'.code.toByte(), '\n'.code.toByte())
+            while (matched < terminator.size) {
+                check(bytes.size() < 16 * 1024) { "HTTP headers exceed test limit" }
+                val byte = input.readByte()
+                bytes.write(byte.toInt())
+                matched = if (byte == terminator[matched]) matched + 1 else 0
+            }
+            return bytes.toString(StandardCharsets.US_ASCII)
         }
     }
 }

--- a/app/src/desktopTest/kotlin/com/crosspaste/rendering/OpenGraphServiceTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/rendering/OpenGraphServiceTest.kt
@@ -6,6 +6,7 @@ import com.crosspaste.db.paste.PasteDao
 import com.crosspaste.image.GenerateImageService
 import com.crosspaste.image.ImageHandler
 import com.crosspaste.net.ClientResponse
+import com.crosspaste.net.ResourceRequestLimits
 import com.crosspaste.net.ResourcesClient
 import com.crosspaste.paste.PasteCollection
 import com.crosspaste.paste.PasteData
@@ -111,8 +112,12 @@ class OpenGraphServiceTest {
             coEvery { pageResponse.getBody() } returns
                 ByteReadChannel("""<meta property="og:image" content="$imageUrl">""")
             coEvery { imageResponse.getBody() } returns ByteReadChannel(byteArrayOf(1, 2, 3))
-            coEvery { resourcesClient.request(oldItem.url) } returns Result.success(pageResponse)
-            coEvery { resourcesClient.request(imageUrl) } returns Result.success(imageResponse)
+            coEvery {
+                resourcesClient.request(oldItem.url, ResourceRequestLimits.HTML)
+            } returns Result.success(pageResponse)
+            coEvery {
+                resourcesClient.request(imageUrl, ResourceRequestLimits.IMAGE)
+            } returns Result.success(imageResponse)
             coEvery { imageHandler.readImage(any<ByteReadChannel>()) } returns Any()
             coEvery { imageHandler.writeImage(any(), "png", capture(writtenPath)) } returns true
             coEvery { pasteDao.getNoDeletePasteData(oldPasteData.id) } returns currentPasteData

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,6 +99,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
 ktor-io = { module = "io.ktor:ktor-io", version.ref = "ktor" }
 ktor-network = { module = "io.ktor:ktor-network", version.ref = "ktor" }


### PR DESCRIPTION
Closes #4932

## Summary

- **SOCKS proxy actually works, one engine on desktop.** Ktor CIO 3.5.x treats a SOCKS `ProxyConfig` as `null` and connects directly. `DesktopResourcesClient.createClient` now builds every client on the OkHttp engine (new `ktor-client-okhttp` dependency), which handles both HTTP and SOCKS proxies through `java.net.Proxy`. CIO remains the engine for the LAN sync client (`PasteClient`, shared with mobile) and the WebSocket connector, which never go through the user's proxy. Per-proxy clients are created via `computeIfAbsent` so concurrent first requests share one instance.
- **Bounded `request()` bodies.** `ResourcesClient.request(url, maxBytes)` rejects responses whose `Content-Length` exceeds the limit and otherwise streams at most `maxBytes + 1` bytes before failing with `ResourceResponseTooLargeException`. Call sites use `ResourceRequestLimits.METADATA` (1 MiB: meta.json, update properties, version API, checksum), `HTML` (8 MiB: URL preview page) and `IMAGE` (16 MiB: favicon, Open Graph image).
- **`ClientResponse` is now a buffered value.** It holds the body bytes and content type, so `getBody()` can be called more than once and `getBodyAsText()` decodes with the declared charset (UTF-8 fallback). The `HttpResponse` no longer leaks past the client.
- **`download()` failure path.** The existing target file is preserved on failure (temp file + `atomicMove` already guarantees no partial target), the temp file is cleaned up, and `CancellationException` is re-thrown instead of being swallowed by `runCatching`.

## Tests

- `AbstractResourcesClientTest`: charset decoding, Content-Length and streamed over-limit failures, download write/move failure, success only after atomic move, cancellation cleanup and propagation.
- `DesktopResourcesClientTest`: real SOCKS5 handshake against a loopback fake proxy (asserts the remote hostname is sent to the proxy), a fake HTTP proxy asserting the absolute request target is sent, and concurrent `getHttpClient()` creating exactly one client per proxy.
- Existing `OpenGraphServiceTest`, `UpdateMetadataFetcherTest`, `WindowsZipUpdaterDownloadTest` updated for the new signature.

All classes pass in the fast tier (each under 0.5 s).

## Notes

- Release packaging goes through Conveyor with plain runtime jars, so no ProGuard rules are needed for OkHttp.
- OkHttp transparently negotiates gzip and strips `Content-Length` on decompressed responses; the streamed byte check covers that case.
- Mobile follow-up: `AbstractResourcesClient.clientRequest` is replaced by the `configureRequest` hook, `request` gains `maxBytes`, and `ClientResponse` has an internal constructor. The mobile copies of `commonMain` need the matching subclass and call-site updates.