### PR TITLE
Acknowledge received pastes only after they are durable

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/DefaultServerModule.kt
@@ -36,8 +36,6 @@ import com.crosspaste.sync.PendingKeyExchangeStore
 import com.crosspaste.sync.PushSessionManager
 import com.crosspaste.utils.failResponse
 import com.crosspaste.utils.getJsonUtils
-import com.crosspaste.utils.ioDispatcher
-import com.crosspaste.utils.namedScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
@@ -46,8 +44,6 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 
 open class DefaultServerModule(
     private val appControl: AppControl,
@@ -114,12 +110,6 @@ open class DefaultServerModule(
                     "Received request: ${call.request.httpMethod.value} ${call.request.uri} ${call.request.contentType()}"
                 }
             }
-            val pasteRoutingScope =
-                namedScope(
-                    ioDispatcher,
-                    "DefaultServerModule.pasteRoutingScope",
-                    SupervisorJob(coroutineContext[Job]),
-                )
             routing {
                 syncRouting(
                     appInfo,
@@ -152,7 +142,6 @@ open class DefaultServerModule(
                     pasteboardService,
                     pasteReleaseService,
                     pastePullService,
-                    pasteRoutingScope,
                     pushSessionManager,
                     syncRoutingApi,
                 )

--- a/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PasteClientApi.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/clientapi/PasteClientApi.kt
@@ -27,6 +27,7 @@ class PasteClientApi(
             pasteClient.post(
                 message = pasteData,
                 messageType = typeInfo<PasteData>(),
+                timeout = SEND_PASTE_TIMEOUT_MS,
                 headersBuilder = {
                     append("targetAppInstanceId", targetAppInstanceId)
                     if (configManager.getCurrentConfig().enableEncryptSync) {
@@ -63,5 +64,11 @@ class PasteClientApi(
         } else {
             SuccessResult()
         }
+    }
+
+    private companion object {
+        // The receiver persists the paste before ACK, so this must cover its
+        // database and file-metadata preparation rather than only LAN latency.
+        const val SEND_PASTE_TIMEOUT_MS = 10_000L
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PasteRouting.kt
@@ -23,8 +23,7 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
 
 private val logger: KLogger = KotlinLogging.logger("PasteRouting")
 
@@ -34,7 +33,6 @@ fun Routing.pasteRouting(
     pasteboardService: PasteboardService,
     pasteReleaseService: PasteReleaseService,
     pastePullService: PastePullService,
-    pasteRoutingScope: CoroutineScope,
     pushSessionManager: PushSessionManager,
     syncRoutingApi: SyncRoutingApi,
 ) {
@@ -46,7 +44,6 @@ fun Routing.pasteRouting(
             pasteboardService,
             pasteReleaseService,
             pastePullService,
-            pasteRoutingScope,
             pushSessionManager,
             syncRoutingApi,
         )
@@ -60,7 +57,6 @@ private suspend fun handleSyncPaste(
     pasteboardService: PasteboardService,
     pasteReleaseService: PasteReleaseService,
     pastePullService: PastePullService,
-    pasteRoutingScope: CoroutineScope,
     pushSessionManager: PushSessionManager,
     syncRoutingApi: SyncRoutingApi,
 ) {
@@ -106,7 +102,6 @@ private suspend fun handleSyncPaste(
             appControl,
             pasteboardService,
             pastePullService,
-            pasteRoutingScope,
         )
     }
 }
@@ -232,15 +227,23 @@ private suspend fun handlePullSync(
     appControl: AppControl,
     pasteboardService: PasteboardService,
     pastePullService: PastePullService,
-    pasteRoutingScope: CoroutineScope,
 ) {
-    pasteRoutingScope.launch {
-        pasteboardService
-            .tryWriteRemotePasteboard(pasteData)
-            .onSuccess {
-                pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
-            }
+    val ingestResult = pasteboardService.tryWriteRemotePasteboard(pasteData)
+    if (ingestResult.isFailure) {
+        val cause = ingestResult.exceptionOrNull()
+        if (cause is CancellationException) throw cause
+        logger.warn(cause) { "sync handler ($appInstanceId) failed to persist received paste" }
+        failResponse(
+            call,
+            StandardErrorCode.SYNC_PASTE_ERROR.toErrorCode(),
+        )
+        return
     }
+
+    // ACK only after the paste is durable (or deliberately discarded by the
+    // receiver's size/metadata policy). Cursor and operation accounting must
+    // not advance for an actual ingest failure.
+    pastePullService.updateMaxCreateTime(appInstanceId, pasteData.createTime)
     logger.debug { "sync handler ($appInstanceId) receive pasteData: $pasteData" }
     appControl.completeReceiveOperation()
     successResponse(call)

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PullRouting.kt
@@ -119,7 +119,7 @@ fun Routing.pullRouting(
             }
 
             val createTime = call.request.queryParameters["createTime"]?.toLongOrNull()
-            val limit = (call.request.queryParameters["limit"]?.toLongOrNull() ?: 10L).coerceAtMost(50L)
+            val limit = normalizePasteBatchLimit(call.request.queryParameters["limit"])
 
             val recentPasteData =
                 if (createTime != null) {
@@ -160,6 +160,12 @@ fun Routing.pullRouting(
         }
     }
 }
+
+internal fun normalizePasteBatchLimit(rawLimit: String?): Long =
+    (rawLimit?.toLongOrNull() ?: DEFAULT_PASTE_BATCH_LIMIT).coerceIn(1L, MAX_PASTE_BATCH_LIMIT)
+
+private const val DEFAULT_PASTE_BATCH_LIMIT = 10L
+private const val MAX_PASTE_BATCH_LIMIT = 50L
 
 internal class EncodedPasteBatch(
     val json: String,

--- a/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/net/routing/PushRouting.kt
@@ -6,6 +6,7 @@ import com.crosspaste.dto.push.PushHeaders
 import com.crosspaste.exception.StandardErrorCode
 import com.crosspaste.path.UserDataPathProvider
 import com.crosspaste.presist.FileTransferResourceLimits
+import com.crosspaste.sync.PushCompletionResult
 import com.crosspaste.sync.PushSession
 import com.crosspaste.sync.PushSessionManager
 import com.crosspaste.utils.FileUtils
@@ -101,7 +102,7 @@ private suspend fun handleFilePushChunk(
     // Fast-path idempotency: drain the body and ack without writing.
     if (session.isReceived(headers.chunkIndex)) {
         call.receiveChannel().discard()
-        successResponse(call)
+        finishReceivedChunk(call, pushSessionManager, session)
         return
     }
 
@@ -137,16 +138,10 @@ private suspend fun finishChunkPush(
     headers: PushChunkHeaders,
 ) {
     val markResult = session.markReceived(headers.chunkIndex)
-    if (markResult == PushSession.MarkResult.Accepted) {
-        // Auto-finalize the moment the last chunk lands — don't wait for
-        // /complete (the client may never send it, e.g. Share Extension
-        // crash) or for the sweep poll (90s of latency).
-        pushSessionManager.tryFinalizeIfComplete(headers.pasteId)
-    }
     when (markResult) {
         PushSession.MarkResult.Accepted,
         PushSession.MarkResult.AlreadyReceived,
-        -> successResponse(call)
+        -> finishReceivedChunk(call, pushSessionManager, session)
 
         PushSession.MarkResult.OutOfRange ->
             failResponse(
@@ -154,6 +149,31 @@ private suspend fun finishChunkPush(
                 StandardErrorCode.OUT_RANGE_CHUNK_INDEX.toErrorCode(),
                 "chunk index ${headers.chunkIndex} out of range",
             )
+    }
+}
+
+private suspend fun finishReceivedChunk(
+    call: ApplicationCall,
+    pushSessionManager: PushSessionManager,
+    session: PushSession,
+) {
+    if (!session.isComplete) {
+        successResponse(call)
+        return
+    }
+
+    // The last chunk is not acknowledged until LOADING -> LOADED and its
+    // follow-up tasks have been persisted. A retry of the same chunk waits on
+    // the same per-session finalize lock.
+    when (val result = pushSessionManager.finalizeIfComplete(session)) {
+        PushCompletionResult.Complete -> successResponse(call)
+        is PushCompletionResult.Incomplete -> successResponse(call)
+        PushCompletionResult.NotFound ->
+            failResponse(call, StandardErrorCode.NOT_FOUND_PUSH_SESSION.toErrorCode())
+        is PushCompletionResult.Failed -> {
+            logger.warn(result.cause) { "push chunk: finalization failed pasteId=${session.pasteId}" }
+            failResponse(call, StandardErrorCode.PUSH_COMPLETE_FAIL.toErrorCode())
+        }
     }
 }
 
@@ -172,34 +192,24 @@ private suspend fun handleCompletePush(
         return
     }
 
-    val session = pushSessionManager.get(pasteId, token, fromAppInstanceId)
-    if (session == null) {
-        // Session is gone — almost always because auto-finalize on the last
-        // chunk already ran. Return success so the client doesn't retry.
-        // Wrong pasteId/token leaks nothing exploitable (the peer is already
-        // authenticated via secureStore; pasteIds are not secret).
-        logger.debug { "push complete: pasteId=$pasteId session absent (likely auto-finalized)" }
-        successResponse(call, PushCompleteResponse(emptyList()))
-        return
-    }
-
-    val missing = session.missingChunks()
-    if (missing.isNotEmpty()) {
-        logger.debug {
-            "push complete: pasteId=$pasteId missing ${missing.size}/${session.chunkCount} chunks"
+    when (val result = pushSessionManager.complete(pasteId, token, fromAppInstanceId)) {
+        PushCompletionResult.Complete -> {
+            logger.info { "push complete: pasteId=$pasteId durably finalized" }
+            successResponse(call, PushCompleteResponse(emptyList()))
         }
-        successResponse(call, PushCompleteResponse(missing))
-        return
+        is PushCompletionResult.Incomplete -> {
+            logger.debug { "push complete: pasteId=$pasteId missing ${result.missingChunks.size} chunks" }
+            successResponse(call, PushCompleteResponse(result.missingChunks))
+        }
+        PushCompletionResult.NotFound -> {
+            logger.debug { "push complete: session not found pasteId=$pasteId from=$fromAppInstanceId" }
+            failResponse(call, StandardErrorCode.NOT_FOUND_PUSH_SESSION.toErrorCode())
+        }
+        is PushCompletionResult.Failed -> {
+            logger.warn(result.cause) { "push complete: finalization failed pasteId=$pasteId" }
+            failResponse(call, StandardErrorCode.PUSH_COMPLETE_FAIL.toErrorCode())
+        }
     }
-
-    // Defensive: auto-finalize should have caught this already, but races
-    // happen. tryFinalize is idempotent — returns false if someone got here first.
-    if (pushSessionManager.tryFinalize(pasteId)) {
-        logger.info { "push complete: pasteId=$pasteId finalized via /complete" }
-    } else {
-        logger.info { "push complete: pasteId=$pasteId already finalized" }
-    }
-    successResponse(call, PushCompleteResponse(emptyList()))
 }
 
 private suspend fun handleIconPush(

--- a/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/paste/PasteReleaseService.kt
@@ -490,15 +490,18 @@ class PasteReleaseService(
         withContext(ioDispatcher) {
             runCatching {
                 taskSubmitter.submit {
-                    database
-                        .transactionWithResult {
-                            database.pasteDatabaseQueries.updatePasteDataState(PasteState.LOADED.toLong(), id)
-                            pasteDao.getNoDeletePasteDataBlock(id)
-                        }?.let {
-                            markDeleteSameHash(id, it.pasteType, it.hash)
-                            addRelaySyncTask(id, it.appInstanceId)
-                            tryWritePasteboard(it)
-                        }
+                    val pasteData =
+                        database
+                            .transactionWithResult {
+                                val storedPasteData =
+                                    pasteDao.getNoDeletePasteDataBlock(id)
+                                        ?: error("Unable to finalize missing pasteId=$id")
+                                database.pasteDatabaseQueries.updatePasteDataState(PasteState.LOADED.toLong(), id)
+                                storedPasteData.copy(pasteState = PasteState.LOADED)
+                            }
+                    markDeleteSameHash(id, pasteData.pasteType, pasteData.hash)
+                    addRelaySyncTask(id, pasteData.appInstanceId)
+                    tryWritePasteboard(pasteData)
                 }
             }.onFailure { e ->
                 logger.error(e) { "Release remote paste data with file failed" }

--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
@@ -1,6 +1,7 @@
 package com.crosspaste.sync
 
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.PasteState
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.presist.FilesIndex
 import com.crosspaste.utils.DateUtils.nowEpochMilliseconds
@@ -17,6 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.concurrent.Volatile
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.ExperimentalUuidApi
@@ -66,6 +68,9 @@ class PushSession(
 
     @Volatile private var lastActivityBacking: Long = createdAt
     private val lock = Mutex()
+    private val finalizeLock = Mutex()
+
+    @Volatile private var finalized = false
 
     val receivedCount: Int get() = receivedCountBacking
     val lastActivity: Long get() = lastActivityBacking
@@ -93,11 +98,35 @@ class PushSession(
     // Lockless read — snapshot may include a chunk that's about to be marked received.
     fun missingChunks(): List<Int> = (0 until chunkCount).filter { !received[it] }
 
+    internal suspend fun finalize(block: suspend () -> Result<Unit?>): Result<Unit?> =
+        finalizeLock.withLock {
+            if (finalized) {
+                return@withLock Result.success(Unit)
+            }
+            block().onSuccess {
+                finalized = true
+            }
+        }
+
     enum class MarkResult {
         Accepted,
         AlreadyReceived,
         OutOfRange,
     }
+}
+
+internal sealed interface PushCompletionResult {
+    data object Complete : PushCompletionResult
+
+    data class Incomplete(
+        val missingChunks: List<Int>,
+    ) : PushCompletionResult
+
+    data object NotFound : PushCompletionResult
+
+    data class Failed(
+        val cause: Throwable,
+    ) : PushCompletionResult
 }
 
 class PushSessionManager(
@@ -221,45 +250,80 @@ class PushSessionManager(
 
     fun peek(pasteId: Long): PushSession? = sessions[pasteId]
 
-    /**
-     * Atomically claims and finalizes the session. Returns true when this caller
-     * owned the claim — caller can treat the finalize as scheduled. Returns
-     * false when the session is already gone (auto-finalize on last chunk, a
-     * concurrent /complete, or sweep). Idempotent across paths.
-     *
-     * Finalize is fire-and-forget on the manager's [scope]: file state flips
-     * LOADING → LOADED and a write to the local pasteboard is queued.
-     */
-    fun tryFinalize(pasteId: Long): Boolean {
-        if (sessions.remove(pasteId) == null) return false
-        releaseSlot()
-        scope.launch {
-            runCatching {
-                pasteboardService.tryWriteRemotePasteboardWithFile(pasteId)
-            }.onFailure { e ->
-                logger.warn(e) { "PushSession finalize failed: pasteId=$pasteId" }
-            }
+    /** Finalizes one complete session exactly once and only then releases its slot. */
+    internal suspend fun finalizeIfComplete(session: PushSession): PushCompletionResult {
+        if (!session.isComplete) {
+            return PushCompletionResult.Incomplete(session.missingChunks())
         }
-        return true
+
+        if (sessions[session.pasteId] !== session) {
+            return durableCompletionResult(session.pasteId, session.fromAppInstanceId)
+        }
+
+        val result =
+            session.finalize {
+                pasteboardService.tryWriteRemotePasteboardWithFile(session.pasteId)
+            }
+        result.exceptionOrNull()?.let { cause ->
+            if (cause is CancellationException) throw cause
+            logger.warn(cause) { "PushSession finalize failed: pasteId=${session.pasteId}" }
+            return PushCompletionResult.Failed(cause)
+        }
+
+        if (sessions.remove(session.pasteId, session)) {
+            releaseSlot()
+        }
+        return PushCompletionResult.Complete
     }
 
     /**
-     * Primary finalization trigger — called by the chunk handler right after
-     * [PushSession.markReceived]. When the chunk just landed completes the set,
-     * the file is ready for the pasteboard NOW, not 90s later when sweep runs.
+     * Returns the authoritative completion state for `/complete`. An active
+     * session still requires its token; once it is gone, only a durable LOADED
+     * row belonging to the authenticated sender qualifies as idempotent success.
      */
-    fun tryFinalizeIfComplete(pasteId: Long): Boolean {
-        val session = sessions[pasteId] ?: return false
-        if (!session.isComplete) return false
-        return tryFinalize(pasteId)
+    internal suspend fun complete(
+        pasteId: Long,
+        token: String,
+        fromAppInstanceId: String,
+    ): PushCompletionResult {
+        val session = sessions[pasteId] ?: return durableCompletionResult(pasteId, fromAppInstanceId)
+        if (session.token != token || session.fromAppInstanceId != fromAppInstanceId) {
+            return PushCompletionResult.NotFound
+        }
+        val missing = session.missingChunks()
+        if (missing.isNotEmpty()) {
+            return PushCompletionResult.Incomplete(missing)
+        }
+        return finalizeIfComplete(session)
     }
+
+    private suspend fun durableCompletionResult(
+        pasteId: Long,
+        fromAppInstanceId: String,
+    ): PushCompletionResult =
+        try {
+            val pasteData = pasteDao.getNoDeletePasteData(pasteId)
+            if (
+                pasteData?.pasteState == PasteState.LOADED &&
+                pasteData.appInstanceId == fromAppInstanceId
+            ) {
+                PushCompletionResult.Complete
+            } else {
+                PushCompletionResult.NotFound
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "PushSession durable completion lookup failed: pasteId=$pasteId" }
+            PushCompletionResult.Failed(e)
+        }
 
     /**
      * Visible for testing. Last-resort cleanup for sessions that timed out.
      * The orphan-complete branch (all chunks arrived but no finalize ran) is a
-     * safety net — [tryFinalizeIfComplete] normally handles it the moment the
-     * last chunk arrives. Sweep only catches it if that path failed (e.g.
-     * scope cancelled during shutdown, finalize launch dropped).
+     * safety net — [finalizeIfComplete] normally handles it when the last
+     * chunk arrives. Sweep retries finalization once, then discards a session
+     * whose failure would otherwise hold capacity forever.
      */
     suspend fun sweepExpired() {
         val now = nowEpochMilliseconds()
@@ -271,22 +335,37 @@ class PushSessionManager(
         for (id in expiredIds) {
             val session = sessions[id] ?: continue
             if (session.isComplete) {
-                if (tryFinalize(id)) {
-                    logger.info { "PushSession sweep salvaged orphan-complete: pasteId=$id" }
+                when (finalizeIfComplete(session)) {
+                    PushCompletionResult.Complete ->
+                        logger.info { "PushSession sweep finalized orphan-complete: pasteId=$id" }
+                    is PushCompletionResult.Failed ->
+                        discardExpiredSession(session, "finalization failed")
+                    is PushCompletionResult.Incomplete ->
+                        discardExpiredSession(session, "incomplete finalization state")
+                    PushCompletionResult.NotFound -> Unit
                 }
             } else {
-                val removed = sessions.remove(id) ?: continue
-                releaseSlot()
-                runCatching {
-                    pasteDao.markDeletePasteData(id)
-                }.onFailure { e ->
-                    logger.warn(e) { "PushSession expire: markDeletePasteData($id) failed" }
-                }
-                logger.info {
-                    "PushSession expired and discarded: pasteId=$id " +
-                        "(${removed.receivedCount}/${removed.chunkCount} chunks received)"
-                }
+                discardExpiredSession(session, "incomplete upload")
             }
+        }
+    }
+
+    private suspend fun discardExpiredSession(
+        session: PushSession,
+        reason: String,
+    ) {
+        if (!sessions.remove(session.pasteId, session)) return
+        releaseSlot()
+        try {
+            pasteDao.markDeletePasteData(session.pasteId).getOrThrow()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "PushSession expire: markDeletePasteData(${session.pasteId}) failed" }
+        }
+        logger.info {
+            "PushSession expired and discarded: pasteId=${session.pasteId} reason=$reason " +
+                "(${session.receivedCount}/${session.chunkCount} chunks received)"
         }
     }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PasteRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PasteRoutingTest.kt
@@ -30,8 +30,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -73,12 +71,13 @@ class PasteRoutingTest {
 
     private fun withPasteRouting(
         pasteboardService: PasteboardService,
+        appControl: AppControl =
+            mockk(relaxed = true) {
+                coEvery { isReceiveEnabled() } returns true
+            },
+        pastePullService: PastePullService = mockk(relaxed = true),
         block: suspend ApplicationTestBuilder.() -> Unit,
     ) = testApplication {
-        val appControl =
-            mockk<AppControl>(relaxed = true) {
-                coEvery { isReceiveEnabled() } returns true
-            }
         val syncHandler =
             mockk<SyncHandler> {
                 every { currentSyncRuntimeInfo } returns
@@ -98,8 +97,7 @@ class PasteRoutingTest {
                     localAppInfo,
                     pasteboardService,
                     mockk<PasteReleaseService>(),
-                    mockk<PastePullService>(relaxed = true),
-                    CoroutineScope(Dispatchers.Unconfined),
+                    pastePullService,
                     mockk<PushSessionManager>(),
                     syncRoutingApi,
                 )
@@ -141,12 +139,40 @@ class PasteRoutingTest {
     @Test
     fun `paste targeting our identity is accepted`() {
         val pasteboardService = mockk<PasteboardService>(relaxed = true)
+        val appControl =
+            mockk<AppControl>(relaxed = true) {
+                coEvery { isReceiveEnabled() } returns true
+            }
+        val pastePullService = mockk<PastePullService>(relaxed = true)
         coEvery { pasteboardService.tryWriteRemotePasteboard(any()) } returns Result.success(Unit)
-        withPasteRouting(pasteboardService) {
+        withPasteRouting(pasteboardService, appControl, pastePullService) {
             val response = postSyncPaste(targetAppInstanceId = "local-instance")
 
             assertEquals(HttpStatusCode.OK, response.status)
             coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboard(any()) }
+            coVerify(exactly = 1) { pastePullService.updateMaxCreateTime("remote-peer", any()) }
+            coVerify(exactly = 1) { appControl.completeReceiveOperation() }
+        }
+    }
+
+    @Test
+    fun `paste persistence failure is rejected without advancing cursor`() {
+        val pasteboardService = mockk<PasteboardService>(relaxed = true)
+        val appControl =
+            mockk<AppControl>(relaxed = true) {
+                coEvery { isReceiveEnabled() } returns true
+            }
+        val pastePullService = mockk<PastePullService>(relaxed = true)
+        coEvery { pasteboardService.tryWriteRemotePasteboard(any()) } returns
+            Result.failure(IllegalStateException("database unavailable"))
+
+        withPasteRouting(pasteboardService, appControl, pastePullService) {
+            val response = postSyncPaste(targetAppInstanceId = "local-instance")
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboard(any()) }
+            coVerify(exactly = 0) { pastePullService.updateMaxCreateTime(any(), any()) }
+            coVerify(exactly = 0) { appControl.completeReceiveOperation() }
         }
     }
 

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PullRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PullRoutingTest.kt
@@ -15,6 +15,17 @@ class PullRoutingTest {
     private val pasteDataListSerializer = ListSerializer(PasteData.serializer())
 
     @Test
+    fun `paste batch limit defaults and stays within protocol bounds`() {
+        assertEquals(10L, normalizePasteBatchLimit(null))
+        assertEquals(10L, normalizePasteBatchLimit("invalid"))
+        assertEquals(1L, normalizePasteBatchLimit("-1"))
+        assertEquals(1L, normalizePasteBatchLimit("0"))
+        assertEquals(1L, normalizePasteBatchLimit("1"))
+        assertEquals(50L, normalizePasteBatchLimit("50"))
+        assertEquals(50L, normalizePasteBatchLimit("51"))
+    }
+
+    @Test
     fun `paste batch keeps newest prefix within encoded byte limit`() {
         val pastes = listOf(pasteData("first"), pasteData("second"), pasteData("third"))
         val firstTwoSize = encodedSize(pastes.take(2))

--- a/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PushRoutingTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/net/routing/PushRoutingTest.kt
@@ -1,0 +1,180 @@
+package com.crosspaste.net.routing
+
+import com.crosspaste.app.AppInfo
+import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.dto.push.PushCompleteResponse
+import com.crosspaste.dto.push.PushHeaders
+import com.crosspaste.exception.StandardErrorCode
+import com.crosspaste.net.clientapi.FailResponse
+import com.crosspaste.paste.PasteCollection
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteState
+import com.crosspaste.paste.PasteType
+import com.crosspaste.paste.PasteboardService
+import com.crosspaste.path.UserDataPathProvider
+import com.crosspaste.presist.FilesIndexBuilder
+import com.crosspaste.sync.PushSessionManager
+import com.crosspaste.sync.SyncHandler
+import com.crosspaste.utils.HEADER_APP_INSTANCE_ID
+import com.crosspaste.utils.HEADER_TARGET_APP_INSTANCE_ID
+import com.crosspaste.utils.getJsonUtils
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import okio.Path.Companion.toOkioPath
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class PushRoutingTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val json = getJsonUtils().JSON
+    private val localAppInfo =
+        AppInfo(
+            appInstanceId = "local-instance",
+            appVersion = "1.0.0",
+            appRevision = "test",
+            userName = "tester",
+        )
+
+    @Test
+    fun `last chunk returns push complete failure when durable finalization fails`() {
+        val pasteDao = mockk<PasteDao>(relaxed = true)
+        val pasteboardService = mockk<PasteboardService>()
+        coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(41L) } returns
+            Result.failure(IllegalStateException("database unavailable"))
+        val manager = newManager(pasteDao, pasteboardService)
+        val targetFile = File(tempDir, "chunk.bin")
+        val filesIndex =
+            FilesIndexBuilder(chunkSize = 1)
+                .apply {
+                    addFile(targetFile.toOkioPath(), size = 1)
+                }.build()
+        val session = assertNotNull(manager.create(41L, "remote-peer", filesIndex))
+
+        withPushRouting(manager, connectedRoutingApi()) {
+            val response =
+                client.post("/sync/file/push") {
+                    pushHeaders(41L, session.token)
+                    header(PushHeaders.CHUNK_INDEX, "0")
+                    contentType(ContentType.Application.OctetStream)
+                    setBody(byteArrayOf(7))
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            assertEquals(
+                StandardErrorCode.PUSH_COMPLETE_FAIL.getCode(),
+                json.decodeFromString<FailResponse>(response.bodyAsText()).errorCode,
+            )
+            assertEquals(1, manager.activeCount(), "failed finalization must stay retryable")
+            coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(41L) }
+        }
+    }
+
+    @Test
+    fun `complete uses durable loaded paste after in-memory session is gone`() {
+        val pasteDao = mockk<PasteDao>()
+        coEvery { pasteDao.getNoDeletePasteData(42L) } returns storedPaste(42L, "remote-peer")
+        val manager = newManager(pasteDao, mockk(relaxed = true))
+
+        withPushRouting(manager, mockk(relaxed = true)) {
+            val response =
+                client.post("/sync/paste/push/complete") {
+                    pushHeaders(42L, "expired-token")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(
+                PushCompleteResponse(emptyList()),
+                json.decodeFromString<PushCompleteResponse>(response.bodyAsText()),
+            )
+        }
+    }
+
+    private fun withPushRouting(
+        manager: PushSessionManager,
+        syncRoutingApi: SyncRoutingApi,
+        block: suspend ApplicationTestBuilder.() -> Unit,
+    ) = testApplication {
+        application {
+            install(ContentNegotiation) {
+                json(json)
+            }
+            routing {
+                pushRouting(
+                    appInfo = localAppInfo,
+                    pushSessionManager = manager,
+                    syncRoutingApi = syncRoutingApi,
+                    userDataPathProvider = mockk<UserDataPathProvider>(relaxed = true),
+                )
+            }
+        }
+        try {
+            block()
+        } finally {
+            manager.close()
+        }
+    }
+
+    private fun connectedRoutingApi(): SyncRoutingApi {
+        val syncHandler = mockk<SyncHandler>(relaxed = true)
+        return mockk {
+            every { getSyncHandler("remote-peer") } returns syncHandler
+        }
+    }
+
+    private fun io.ktor.client.request.HttpRequestBuilder.pushHeaders(
+        pasteId: Long,
+        token: String,
+    ) {
+        header(HEADER_APP_INSTANCE_ID, "remote-peer")
+        header(HEADER_TARGET_APP_INSTANCE_ID, localAppInfo.appInstanceId)
+        header(PushHeaders.PASTE_ID, pasteId.toString())
+        header(PushHeaders.SESSION_TOKEN, token)
+    }
+
+    private fun newManager(
+        pasteDao: PasteDao,
+        pasteboardService: PasteboardService,
+    ): PushSessionManager =
+        PushSessionManager(
+            pasteDao = pasteDao,
+            pasteboardService = pasteboardService,
+            scope = CoroutineScope(Job()),
+        )
+
+    private fun storedPaste(
+        id: Long,
+        appInstanceId: String,
+    ): PasteData =
+        PasteData(
+            id = id,
+            appInstanceId = appInstanceId,
+            pasteCollection = PasteCollection(emptyList()),
+            pasteType = PasteType.TEXT_TYPE.type,
+            size = 4,
+            hash = "hash-$id",
+            pasteState = PasteState.LOADED,
+        )
+}

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
@@ -1,6 +1,10 @@
 package com.crosspaste.sync
 
 import com.crosspaste.db.paste.PasteDao
+import com.crosspaste.paste.PasteCollection
+import com.crosspaste.paste.PasteData
+import com.crosspaste.paste.PasteState
+import com.crosspaste.paste.PasteType
 import com.crosspaste.paste.PasteboardService
 import com.crosspaste.presist.FilesIndex
 import io.mockk.coEvery
@@ -94,19 +98,28 @@ class PushSessionManagerTest {
         runBlocking {
             val pasteDao = mockk<PasteDao>(relaxed = true)
             coEvery { pasteDao.markDeletePasteData(any()) } returns Result.success(Unit)
-            val (mgr) = newManager(maxActive = 1, sessionTtl = 10.milliseconds, pasteDao = pasteDao)
+            val pasteboardService = mockk<PasteboardService>(relaxed = true)
+            coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(any()) } returns Result.success(Unit)
+            val (mgr) =
+                newManager(
+                    maxActive = 1,
+                    sessionTtl = 10.milliseconds,
+                    pasteDao = pasteDao,
+                    pasteboardService = pasteboardService,
+                )
 
             val preparation = assertNotNull(mgr.tryReserve())
             assertNull(mgr.tryReserve())
             preparation.release()
             assertNotNull(mgr.tryReserve()).release()
 
-            mgr.create(1L, "mobile", fakeFilesIndex(1))!!
+            val session = mgr.create(1L, "mobile", fakeFilesIndex(1))!!
             assertNull(mgr.tryReserve())
             assertNull(mgr.create(2L, "mobile", fakeFilesIndex(1)))
 
             // Finalize frees the slot.
-            assertTrue(mgr.tryFinalize(1L))
+            session.markReceived(0)
+            assertEquals(PushCompletionResult.Complete, mgr.finalizeIfComplete(session))
             assertNotNull(mgr.tryReserve()).release()
 
             // Sweep-expiry of an incomplete session frees the slot too.
@@ -202,60 +215,128 @@ class PushSessionManagerTest {
         }
 
     @Test
-    fun tryFinalize_removesSessionAndQueuesPasteboardWrite() =
+    fun finalizeIfComplete_waitsForPasteboardWriteBeforeRemovingSession() =
         runBlocking {
             val pasteboardService = mockk<PasteboardService>(relaxed = true)
             coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(any()) } returns Result.success(Unit)
             val (mgr) = newManager(pasteboardService = pasteboardService)
-            mgr.create(1L, "mobile", fakeFilesIndex(2))!!
+            val session = mgr.create(1L, "mobile", fakeFilesIndex(2))!!
+            session.markReceived(0)
+            session.markReceived(1)
             assertEquals(1, mgr.activeCount())
 
-            assertTrue(mgr.tryFinalize(1L), "tryFinalize returns true when caller claims removal")
+            assertEquals(PushCompletionResult.Complete, mgr.finalizeIfComplete(session))
             assertEquals(0, mgr.activeCount())
             assertNull(mgr.peek(1L))
-            assertFalse(mgr.tryFinalize(1L), "second call returns false — session already gone")
 
-            // Finalize is launched on the manager's scope; let it run.
-            delay(50.milliseconds)
             coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(1L) }
             mgr.close()
         }
 
     @Test
-    fun tryFinalizeIfComplete_triggersOnLastChunk() =
+    fun finalizeIfComplete_runsOnlyAfterLastChunk() =
         runBlocking {
             val pasteboardService = mockk<PasteboardService>(relaxed = true)
             coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(any()) } returns Result.success(Unit)
             val (mgr) = newManager(pasteboardService = pasteboardService)
             val session = mgr.create(5L, "mobile", fakeFilesIndex(2))!!
 
-            // First chunk: not yet complete — tryFinalizeIfComplete is a no-op.
             assertEquals(PushSession.MarkResult.Accepted, session.markReceived(0))
-            assertFalse(mgr.tryFinalizeIfComplete(5L))
+            assertEquals(
+                PushCompletionResult.Incomplete(listOf(1)),
+                mgr.finalizeIfComplete(session),
+            )
             assertEquals(1, mgr.activeCount())
 
-            // Last chunk: session becomes complete — tryFinalizeIfComplete fires.
             assertEquals(PushSession.MarkResult.Accepted, session.markReceived(1))
-            assertTrue(mgr.tryFinalizeIfComplete(5L))
+            assertEquals(PushCompletionResult.Complete, mgr.finalizeIfComplete(session))
             assertEquals(0, mgr.activeCount())
 
-            delay(50.milliseconds)
             coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(5L) }
             mgr.close()
         }
 
     @Test
-    fun tryFinalizeIfComplete_isNoopForIncompleteOrAbsent() =
+    fun complete_reportsIncompleteAndRejectsAbsentSession() =
         runBlocking {
             val pasteboardService = mockk<PasteboardService>(relaxed = true)
             val (mgr) = newManager(pasteboardService = pasteboardService)
             val session = mgr.create(9L, "mobile", fakeFilesIndex(3))!!
             session.markReceived(0)
 
-            assertFalse(mgr.tryFinalizeIfComplete(9L), "not complete yet")
-            assertFalse(mgr.tryFinalizeIfComplete(404L), "no session for this id")
+            assertEquals(
+                PushCompletionResult.Incomplete(listOf(1, 2)),
+                mgr.complete(9L, session.token, "mobile"),
+            )
+            assertEquals(
+                PushCompletionResult.NotFound,
+                mgr.complete(404L, "missing-token", "mobile"),
+            )
             assertEquals(1, mgr.activeCount())
             coVerify(exactly = 0) { pasteboardService.tryWriteRemotePasteboardWithFile(any()) }
+            mgr.close()
+        }
+
+    @Test
+    fun finalizeIfComplete_retainsSessionAfterFailureAndAllowsRetry() =
+        runBlocking {
+            val pasteboardService = mockk<PasteboardService>()
+            val failure = IllegalStateException("persist failed")
+            coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(11L) } returnsMany
+                listOf(Result.failure(failure), Result.success(Unit))
+            val (mgr) = newManager(pasteboardService = pasteboardService)
+            val session = mgr.create(11L, "mobile", fakeFilesIndex(1))!!
+            session.markReceived(0)
+
+            val first = mgr.finalizeIfComplete(session)
+            assertTrue(first is PushCompletionResult.Failed)
+            assertSame(failure, first.cause)
+            assertSame(session, mgr.peek(11L))
+            assertEquals(1, mgr.activeCount())
+
+            assertEquals(PushCompletionResult.Complete, mgr.finalizeIfComplete(session))
+            assertNull(mgr.peek(11L))
+            assertEquals(0, mgr.activeCount())
+            coVerify(exactly = 2) { pasteboardService.tryWriteRemotePasteboardWithFile(11L) }
+            mgr.close()
+        }
+
+    @Test
+    fun concurrentFinalization_runsDurableTransitionOnce() =
+        runBlocking {
+            val pasteboardService = mockk<PasteboardService>()
+            coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(12L) } coAnswers {
+                delay(20.milliseconds)
+                Result.success(Unit)
+            }
+            val (mgr) = newManager(pasteboardService = pasteboardService)
+            val session = mgr.create(12L, "mobile", fakeFilesIndex(1))!!
+            session.markReceived(0)
+
+            val results =
+                listOf(
+                    async { mgr.finalizeIfComplete(session) },
+                    async { mgr.finalizeIfComplete(session) },
+                ).awaitAll()
+
+            assertEquals(listOf(PushCompletionResult.Complete, PushCompletionResult.Complete), results)
+            coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(12L) }
+            assertEquals(0, mgr.activeCount())
+            mgr.close()
+        }
+
+    @Test
+    fun complete_acceptsOnlyDurableLoadedPasteFromAuthenticatedSender() =
+        runBlocking {
+            val pasteDao = mockk<PasteDao>()
+            coEvery { pasteDao.getNoDeletePasteData(21L) } returns storedPaste(21L, "mobile", PasteState.LOADED)
+            coEvery { pasteDao.getNoDeletePasteData(22L) } returns storedPaste(22L, "mobile", PasteState.LOADING)
+            coEvery { pasteDao.getNoDeletePasteData(23L) } returns storedPaste(23L, "other", PasteState.LOADED)
+            val (mgr) = newManager(pasteDao = pasteDao)
+
+            assertEquals(PushCompletionResult.Complete, mgr.complete(21L, "expired-token", "mobile"))
+            assertEquals(PushCompletionResult.NotFound, mgr.complete(22L, "expired-token", "mobile"))
+            assertEquals(PushCompletionResult.NotFound, mgr.complete(23L, "expired-token", "mobile"))
             mgr.close()
         }
 
@@ -307,14 +388,39 @@ class PushSessionManagerTest {
 
             delay(50.milliseconds)
             mgr.sweepExpired()
-            // Finalize is fire-and-forget on the manager scope; wait for it.
-            delay(50.milliseconds)
 
             assertEquals(0, mgr.activeCount())
             val finalizedId = slot<Long>()
             coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(capture(finalizedId)) }
             assertEquals(77L, finalizedId.captured)
             coVerify(exactly = 0) { pasteDao.markDeletePasteData(any()) }
+            mgr.close()
+        }
+
+    @Test
+    fun sweepExpired_discardsCompleteSessionWhenFinalizationStillFails() =
+        runBlocking {
+            val failure = IllegalStateException("permanent finalize failure")
+            val pasteDao = mockk<PasteDao>()
+            coEvery { pasteDao.markDeletePasteData(78L) } returns Result.success(Unit)
+            val pasteboardService = mockk<PasteboardService>()
+            coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(78L) } returns Result.failure(failure)
+            val (mgr) =
+                newManager(
+                    sessionTtl = 10.milliseconds,
+                    pasteDao = pasteDao,
+                    pasteboardService = pasteboardService,
+                )
+            val session = mgr.create(78L, "mobile", fakeFilesIndex(1))!!
+            session.markReceived(0)
+
+            delay(50.milliseconds)
+            mgr.sweepExpired()
+
+            assertNull(mgr.peek(78L))
+            assertEquals(0, mgr.activeCount())
+            coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(78L) }
+            coVerify(exactly = 1) { pasteDao.markDeletePasteData(78L) }
             mgr.close()
         }
 
@@ -327,4 +433,19 @@ class PushSessionManagerTest {
             assertEquals(1, mgr.activeCount())
             mgr.close()
         }
+
+    private fun storedPaste(
+        id: Long,
+        appInstanceId: String,
+        state: Int,
+    ): PasteData =
+        PasteData(
+            id = id,
+            appInstanceId = appInstanceId,
+            pasteCollection = PasteCollection(emptyList()),
+            pasteType = PasteType.TEXT_TYPE.type,
+            size = 4,
+            hash = "hash-$id",
+            pasteState = state,
+        )
 }


### PR DESCRIPTION
Closes #4936

## Summary

Both desktop receive paths acknowledged a paste before it was persisted, so a local failure was invisible to the sender and the paste was silently lost. This PR moves the ACK behind the durable write on both paths and makes `/complete` authoritative.

### Pull mode (`/sync/paste`)
- `handlePullSync` runs `tryWriteRemotePasteboard` inline instead of on a fire-and-forget scope. The pull cursor and `completeReceiveOperation()` advance only after the write succeeds (or the receiver deliberately discarded the paste by policy).
- On failure it returns `SYNC_PASTE_ERROR`, which the sender's sync task treats as retriable. The error message is not echoed to the peer.
- The `/sync/paste` client timeout goes from 3s to 10s to cover the receiver's persistence work.
- `DefaultServerModule` no longer creates a `pasteRoutingScope`; `pasteRouting` drops the `CoroutineScope` parameter.

### Push mode (`/sync/file/push`, `/sync/paste/push/complete`)
- `PushSession.finalize` serializes finalization under a per-session lock and records success in a `finalized` flag, so concurrent last-chunk retries, `/complete`, and the sweep run the LOADING -> LOADED transition exactly once.
- `PushSessionManager.finalizeIfComplete` waits for `tryWriteRemotePasteboardWithFile` and releases the capacity slot only after it succeeded. The last chunk is acknowledged only when finalization is durable; a failure returns `PUSH_COMPLETE_FAIL` and keeps the session.
- `PushSessionManager.complete` replaces the old "session absent means success" shortcut: an active session still requires its token; once the session is gone, only a durable LOADED row owned by the authenticated sender returns `Complete`, anything else returns `NOT_FOUND_PUSH_SESSION`.
- `sweepExpired` retries finalization once for an expired complete session; if it still fails, the session is discarded and the LOADING row is marked deleted so a permanently failing session cannot pin a capacity slot forever.
- `releaseRemotePasteDataWithFile` fails instead of silently no-oping when the LOADING row is missing, and reads the row before flipping its state so the pasteboard write sees consistent data.

### Misc
- `/pull/paste` `limit` is clamped to `1..50` via `normalizePasteBatchLimit`.

## Tests
- `PushSessionManagerTest`: finalize waits for the write before removing the session, retains the session after a failed finalize and allows retry, concurrent finalization runs the durable transition once, `/complete` accepts only a durable LOADED row from the authenticated sender, sweep discards a complete session whose finalization still fails.
- `PushRoutingTest` (new): last chunk returns `PUSH_COMPLETE_FAIL` when finalization fails and keeps the session; `/complete` succeeds via the durable row after the in-memory session is gone.
- `PasteRoutingTest`: persistence failure returns an error without advancing the cursor or the receive counter.
- `PullRoutingTest`: batch limit normalization.

All of `./gradlew ktlintCheck` and the affected fast-tier test classes pass locally.

## Mobile follow-up
- `pasteRouting` signature no longer takes a `CoroutineScope`.
- `/sync/paste/push/complete` returns `NOT_FOUND_PUSH_SESSION` instead of success for an unknown session; the Share Extension client should treat it as a failed push.