### PR TITLE
Declare Glama MCP directory maintainers

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["guiyanakuang"]
+}


### PR DESCRIPTION
Adds a root-level `glama.json` declaring the maintainers of the CrossPaste MCP server listing on Glama.

Because this repository belongs to the CrossPaste organization, Glama requires the maintainers to be declared in the repository before the listing can be claimed via GitHub authentication. Claiming the listing is a prerequisite for creating a Glama release, which in turn enables the tool-definition quality scoring that the awesome-mcp-servers submission (punkpeye/awesome-mcp-servers#13605) depends on.

The file follows the schema at https://glama.ai/mcp/schemas/server.json and has no effect on the application build.