### PR TITLE
Extract the Glama MCP entrypoint script from the Dockerfile

### DIFF
--- a/glama/Dockerfile
+++ b/glama/Dockerfile
@@ -4,8 +4,8 @@
 # CrossPaste is a desktop clipboard manager; its MCP server is built into the
 # app and speaks SSE on 127.0.0.1:13130. This image runs the app's headless
 # daemon (no display needed) and bridges its SSE endpoint to stdio with
-# mcp-remote, so the container behaves like a plain stdio MCP server.
-# Self-contained: no build context files are needed.
+# supergateway, so the container behaves like a plain stdio MCP server.
+# Build from the repository root: docker build -f glama/Dockerfile .
 
 FROM node:22-bookworm-slim
 
@@ -30,48 +30,11 @@ RUN set -eux; \
     tar -xzf /tmp/crosspaste.tar.gz -C /opt/crosspaste --strip-components=1; \
     rm /tmp/crosspaste.tar.gz
 
-RUN npm install -g mcp-remote@0.8.3
+RUN npm install -g supergateway@3.4.3
 
 RUN useradd -m -u 1987 mcp
 
-# Start the headless daemon with the MCP server enabled, wait for its SSE
-# endpoint, then bridge it to stdio. Daemon output goes to stderr so stdout
-# stays clean for the MCP protocol.
-COPY <<'EOF' /usr/local/bin/entrypoint.sh
-#!/bin/sh
-set -eu
-
-PORT=13130
-DATA_DIR="$HOME/.local/share/.crosspaste"
-
-mkdir -p "$DATA_DIR"
-if [ ! -f "$DATA_DIR/appConfig.json" ]; then
-  printf '{"language":"en","enableMcpServer":true,"mcpServerPort":%s}\n' "$PORT" > "$DATA_DIR/appConfig.json"
-fi
-
-/opt/crosspaste/bin/crosspaste --headless 1>&2 &
-DAEMON_PID=$!
-
-# The SSE endpoint never closes, so a timed-out request that already got a
-# 200 counts as ready.
-i=0
-until [ "$(curl -s -m 2 -o /dev/null -w '%{http_code}' -H 'Accept: text/event-stream' "http://127.0.0.1:${PORT}/" 2>/dev/null)" = "200" ]; do
-  i=$((i + 1))
-  if [ "$i" -ge 120 ]; then
-    echo "crosspaste MCP endpoint did not come up on port ${PORT}" >&2
-    kill "$DAEMON_PID" 2>/dev/null || true
-    exit 1
-  fi
-  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
-    echo "crosspaste daemon exited during startup" >&2
-    exit 1
-  fi
-  sleep 1
-done
-
-trap 'kill "$DAEMON_PID" 2>/dev/null || true' EXIT INT TERM
-exec mcp-remote "http://127.0.0.1:${PORT}/" --transport sse-only --allow-http
-EOF
+COPY glama/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 
 USER mcp

--- a/glama/entrypoint.sh
+++ b/glama/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Starts the CrossPaste headless daemon with the MCP server enabled, waits for
+# its SSE endpoint, then bridges it to stdio with supergateway. Used by
+# glama/Dockerfile and by the Glama-hosted build (CMD ["sh", "glama/entrypoint.sh"]).
+# Daemon output goes to stderr so stdout stays clean for the MCP protocol.
+set -eu
+
+PORT=13130
+DATA_DIR="$HOME/.local/share/.crosspaste"
+
+mkdir -p "$DATA_DIR"
+if [ ! -f "$DATA_DIR/appConfig.json" ]; then
+  printf '{"language":"en","enableMcpServer":true,"mcpServerPort":%s}\n' "$PORT" > "$DATA_DIR/appConfig.json"
+fi
+
+/opt/crosspaste/bin/crosspaste --headless 1>&2 &
+DAEMON_PID=$!
+
+# The SSE endpoint never closes, so a timed-out request that already got a
+# 200 counts as ready.
+i=0
+until [ "$(curl -s -m 2 -o /dev/null -w '%{http_code}' -H 'Accept: text/event-stream' "http://127.0.0.1:${PORT}/" 2>/dev/null)" = "200" ]; do
+  i=$((i + 1))
+  if [ "$i" -ge 120 ]; then
+    echo "crosspaste MCP endpoint did not come up on port ${PORT}" >&2
+    kill "$DAEMON_PID" 2>/dev/null || true
+    exit 1
+  fi
+  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+    echo "crosspaste daemon exited during startup" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+trap 'kill "$DAEMON_PID" 2>/dev/null || true' EXIT INT TERM
+exec supergateway --sse "http://127.0.0.1:${PORT}/"

--- a/glama/mcp_stdio_probe.py
+++ b/glama/mcp_stdio_probe.py
@@ -30,7 +30,8 @@ def send(obj):
     p.stdin.flush()
 
 
-def recv(timeout=120):
+def recv(expected_id, timeout=120):
+    """Return the response whose id matches; notifications and other messages are skipped."""
     deadline = time.time() + timeout
     while time.time() < deadline:
         line = p.stdout.readline()
@@ -43,10 +44,14 @@ def recv(timeout=120):
         if not line:
             continue
         try:
-            return json.loads(line)
+            msg = json.loads(line)
         except json.JSONDecodeError:
             sys.stderr.write("[stdout-noise] " + line + "\n")
-    raise SystemExit("timeout waiting for response")
+            continue
+        if msg.get("id") == expected_id:
+            return msg
+        sys.stderr.write("[skipped] " + line + "\n")
+    raise SystemExit(f"timeout waiting for response id={expected_id}")
 
 
 send({
@@ -59,15 +64,15 @@ send({
         "clientInfo": {"name": "probe", "version": "0"},
     },
 })
-init = recv()
+init = recv(1)
 print("initialize ->", json.dumps(init.get("result", init))[:400])
 send({"jsonrpc": "2.0", "method": "notifications/initialized"})
 send({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
-tools = recv()
+tools = recv(2)
 names = [t["name"] for t in tools.get("result", {}).get("tools", [])]
 print("tools/list ->", names)
 send({"jsonrpc": "2.0", "id": 3, "method": "resources/list"})
-res = recv()
+res = recv(3)
 print("resources/list ->", [r["name"] for r in res.get("result", {}).get("resources", [])])
 p.stdin.close()
 try:


### PR DESCRIPTION
Glama's hosted build does not accept a raw Dockerfile. Its admin form clones the repository into the image and only takes a list of build steps plus a CMD, so the daemon-plus-bridge script that lived inside a `COPY <<'EOF'` heredoc in `glama/Dockerfile` was unreachable from that flow.

Changes:

- Move the script to `glama/entrypoint.sh` so the Glama build can start it with `["sh", "glama/entrypoint.sh"]`, and make `glama/Dockerfile` copy the same file.
- Bridge the daemon's SSE endpoint to stdio with `supergateway --sse` instead of `mcp-remote`. Glama's form rejects any build step mentioning `mcp-remote` (it treats it as proxying to an external endpoint), and supergateway does the same local bridging.
- Make `glama/mcp_stdio_probe.py` match responses by JSON-RPC id. supergateway forwards the `notifications/initialized` notification to stdout, which the id-naive reader mistook for the `tools/list` reply and reported an empty tool list.

Verified locally with an image mirroring Glama's generated Dockerfile (`debian:trixie-slim`, Node via NodeSource, `mcp-proxy`, repository checked out into `/app`, the same build steps configured on Glama): the probe gets `initialize`, `tools/list` (5 tools) and `resources/list` (2 resources) over stdio, and the `mcp-proxy` wrapper answers `initialize` on port 8080.

Build with `docker build -f glama/Dockerfile .` from the repository root now that the Dockerfile needs the script in its build context.