### PR TITLE
:bug: settle push session finalize and expiry discard under one terminal lock

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/sync/PushSessionManager.kt
@@ -68,9 +68,15 @@ class PushSession(
 
     @Volatile private var lastActivityBacking: Long = createdAt
     private val lock = Mutex()
-    private val finalizeLock = Mutex()
+
+    // Terminal state ([finalized] / [discarded]) is decided under [terminalLock]
+    // so a finalize retry and an expiry discard can never both "win": whichever
+    // acquires the lock first settles the session and the other observes it.
+    private val terminalLock = Mutex()
 
     @Volatile private var finalized = false
+
+    @Volatile private var discarded = false
 
     val receivedCount: Int get() = receivedCountBacking
     val lastActivity: Long get() = lastActivityBacking
@@ -98,14 +104,43 @@ class PushSession(
     // Lockless read — snapshot may include a chunk that's about to be marked received.
     fun missingChunks(): List<Int> = (0 until chunkCount).filter { !received[it] }
 
-    internal suspend fun finalize(block: suspend () -> Result<Unit?>): Result<Unit?> =
-        finalizeLock.withLock {
+    /**
+     * Runs [block] at most once to durably finalize the session. Returns
+     * [PushCompletionResult.Complete] once finalized, [PushCompletionResult.NotFound]
+     * if the session was discarded before finalization succeeded, and
+     * [PushCompletionResult.Failed] when [block] fails (the caller may retry).
+     */
+    internal suspend fun finalize(block: suspend () -> Result<Unit?>): PushCompletionResult =
+        terminalLock.withLock {
             if (finalized) {
-                return@withLock Result.success(Unit)
+                return@withLock PushCompletionResult.Complete
             }
-            block().onSuccess {
-                finalized = true
+            if (discarded) {
+                return@withLock PushCompletionResult.NotFound
             }
+            block().fold(
+                onSuccess = {
+                    finalized = true
+                    PushCompletionResult.Complete
+                },
+                onFailure = { PushCompletionResult.Failed(it) },
+            )
+        }
+
+    /**
+     * Marks the session discarded and runs [block] under the same lock as
+     * [finalize]. Returns false without running [block] when the session was
+     * already finalized or discarded, so a durably committed paste is never
+     * deleted by expiry cleanup.
+     */
+    internal suspend fun discard(block: suspend () -> Unit): Boolean =
+        terminalLock.withLock {
+            if (finalized || discarded) {
+                return@withLock false
+            }
+            discarded = true
+            block()
+            true
         }
 
     enum class MarkResult {
@@ -264,16 +299,21 @@ class PushSessionManager(
             session.finalize {
                 pasteboardService.tryWriteRemotePasteboardWithFile(session.pasteId)
             }
-        result.exceptionOrNull()?.let { cause ->
-            if (cause is CancellationException) throw cause
-            logger.warn(cause) { "PushSession finalize failed: pasteId=${session.pasteId}" }
-            return PushCompletionResult.Failed(cause)
+        when (result) {
+            is PushCompletionResult.Failed -> {
+                if (result.cause is CancellationException) throw result.cause
+                logger.warn(result.cause) { "PushSession finalize failed: pasteId=${session.pasteId}" }
+            }
+            PushCompletionResult.Complete -> {
+                if (sessions.remove(session.pasteId, session)) {
+                    releaseSlot()
+                }
+            }
+            // Discarded while this caller waited for the terminal lock; its row
+            // is already marked deleted, so the sender must not see success.
+            PushCompletionResult.NotFound, is PushCompletionResult.Incomplete -> Unit
         }
-
-        if (sessions.remove(session.pasteId, session)) {
-            releaseSlot()
-        }
-        return PushCompletionResult.Complete
+        return result
     }
 
     /**
@@ -323,7 +363,9 @@ class PushSessionManager(
      * The orphan-complete branch (all chunks arrived but no finalize ran) is a
      * safety net — [finalizeIfComplete] normally handles it when the last
      * chunk arrives. Sweep retries finalization once, then discards a session
-     * whose failure would otherwise hold capacity forever.
+     * whose failure would otherwise hold capacity forever. Discard and
+     * finalize share the session's terminal lock, so a concurrent request
+     * retry that commits LOADED can never be deleted by this cleanup.
      */
     suspend fun sweepExpired() {
         val now = nowEpochMilliseconds()
@@ -354,15 +396,25 @@ class PushSessionManager(
         session: PushSession,
         reason: String,
     ) {
-        if (!sessions.remove(session.pasteId, session)) return
-        releaseSlot()
-        try {
-            pasteDao.markDeletePasteData(session.pasteId).getOrThrow()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            logger.warn(e) { "PushSession expire: markDeletePasteData(${session.pasteId}) failed" }
-        }
+        val discarded =
+            session.discard {
+                // The row is marked deleted while the session is still visible
+                // and its slot still held, so an in-flight request that already
+                // resolved this session waits on the terminal lock and then
+                // observes the discard instead of a stale success.
+                try {
+                    pasteDao.markDeletePasteData(session.pasteId).getOrThrow()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.warn(e) { "PushSession expire: markDeletePasteData(${session.pasteId}) failed" }
+                } finally {
+                    if (sessions.remove(session.pasteId, session)) {
+                        releaseSlot()
+                    }
+                }
+            }
+        if (!discarded) return
         logger.info {
             "PushSession expired and discarded: pasteId=${session.pasteId} reason=$reason " +
                 "(${session.receivedCount}/${session.chunkCount} chunks received)"

--- a/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/sync/PushSessionManagerTest.kt
@@ -12,13 +12,16 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -421,6 +424,99 @@ class PushSessionManagerTest {
             assertEquals(0, mgr.activeCount())
             coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(78L) }
             coVerify(exactly = 1) { pasteDao.markDeletePasteData(78L) }
+            mgr.close()
+        }
+
+    @Test
+    fun sweepExpired_doesNotDeleteRowCommittedByConcurrentFinalizeRetry() =
+        runBlocking {
+            // Sweep's finalize attempt fails while a request retry is already
+            // waiting on the terminal lock. The retry wins the lock next (the
+            // mutex is fair), commits LOADED, and sweep's discard must then be
+            // a no-op instead of deleting the durable row.
+            val sweepFinalizeGate = CompletableDeferred<Unit>()
+            val finalizeCalls =
+                java.util.concurrent.atomic
+                    .AtomicInteger(0)
+            val pasteDao = mockk<PasteDao>()
+            coEvery { pasteDao.markDeletePasteData(79L) } returns Result.success(Unit)
+            val pasteboardService = mockk<PasteboardService>()
+            coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(79L) } coAnswers {
+                if (finalizeCalls.incrementAndGet() == 1) {
+                    sweepFinalizeGate.await()
+                    Result.failure(IllegalStateException("transient finalize failure"))
+                } else {
+                    Result.success(Unit)
+                }
+            }
+            val (mgr) =
+                newManager(
+                    maxActive = 1,
+                    sessionTtl = 10.milliseconds,
+                    pasteDao = pasteDao,
+                    pasteboardService = pasteboardService,
+                )
+            val session = mgr.create(79L, "mobile", fakeFilesIndex(1))!!
+            session.markReceived(0)
+            delay(50.milliseconds)
+
+            val sweep = launch { mgr.sweepExpired() }
+            yield() // sweep now holds the terminal lock inside its finalize attempt
+            val retry = async { mgr.complete(79L, session.token, "mobile") }
+            yield() // retry passed the session lookup and is queued on the lock
+            sweepFinalizeGate.complete(Unit)
+            sweep.join()
+
+            assertEquals(PushCompletionResult.Complete, retry.await())
+            assertNull(mgr.peek(79L))
+            assertEquals(0, mgr.activeCount())
+            coVerify(exactly = 2) { pasteboardService.tryWriteRemotePasteboardWithFile(79L) }
+            coVerify(exactly = 0) { pasteDao.markDeletePasteData(any()) }
+            assertNotNull(mgr.create(80L, "mobile", fakeFilesIndex(1)), "slot must be released exactly once")
+            mgr.close()
+        }
+
+    @Test
+    fun sweepExpired_discardOwnsTerminalStateBeforeWaitingRetry() =
+        runBlocking {
+            // Sweep's finalize fails and its discard takes the terminal lock
+            // first. A request that resolved the session before the discard
+            // finished must observe NotFound, not retry finalization and
+            // report a success the deletion would immediately undo.
+            val discardGate = CompletableDeferred<Unit>()
+            val pasteDao = mockk<PasteDao>()
+            coEvery { pasteDao.markDeletePasteData(81L) } coAnswers {
+                discardGate.await()
+                Result.success(Unit)
+            }
+            val pasteboardService = mockk<PasteboardService>()
+            coEvery { pasteboardService.tryWriteRemotePasteboardWithFile(81L) } returns
+                Result.failure(IllegalStateException("permanent finalize failure"))
+            val (mgr) =
+                newManager(
+                    maxActive = 1,
+                    sessionTtl = 10.milliseconds,
+                    pasteDao = pasteDao,
+                    pasteboardService = pasteboardService,
+                )
+            val session = mgr.create(81L, "mobile", fakeFilesIndex(1))!!
+            session.markReceived(0)
+            delay(50.milliseconds)
+
+            val sweep = launch { mgr.sweepExpired() }
+            yield() // finalize failed; discard holds the terminal lock and is marking the row deleted
+            assertNotNull(mgr.peek(81L), "session stays visible until the row is marked deleted")
+            val retry = async { mgr.complete(81L, session.token, "mobile") }
+            yield() // retry resolved the live session and is queued on the terminal lock
+            discardGate.complete(Unit)
+            sweep.join()
+
+            assertEquals(PushCompletionResult.NotFound, retry.await())
+            assertNull(mgr.peek(81L))
+            assertEquals(0, mgr.activeCount())
+            coVerify(exactly = 1) { pasteboardService.tryWriteRemotePasteboardWithFile(81L) }
+            coVerify(exactly = 1) { pasteDao.markDeletePasteData(81L) }
+            assertNotNull(mgr.create(82L, "mobile", fakeFilesIndex(1)), "slot must be released exactly once")
             mgr.close()
         }
 


### PR DESCRIPTION
Fixes #4944

## Problem

`PushSession.finalize` only guarded the finalization callback, while `discardExpiredSession` removed the session and called `markDeletePasteData` outside any per-session lock. When sweep's finalize retry failed, a concurrent `/complete` (or repeated last chunk) that had already resolved the session could take the lock, commit `LOADED`, and return `Complete`, after which sweep's delete marked that durable row deleted. The sender saw success and stopped retrying.

## Change

- `PushSession` now has one terminal lock shared by `finalize` and a new `discard`. Terminal state (`finalized` / `discarded`) is decided inside it.
- `finalize` returns `Complete`, `NotFound` (session discarded while the caller waited), or `Failed`. `discard` returns false without running its block once the session is finalized or already discarded.
- `discardExpiredSession` marks the row deleted while the session is still in the map and its slot still held, then removes it and releases the slot in `finally`. An in-flight request therefore waits on the terminal lock and observes the discard instead of retrying finalization.
- `finalizeIfComplete` propagates the session outcome instead of returning `Complete` unconditionally.
- Persistently failing expired sessions still release capacity exactly once.

## Tests

Two regression tests in `PushSessionManagerTest` drive the interleaving deterministically with `CompletableDeferred` gates and `yield()` under `runBlocking`, relying on `Mutex` FIFO handoff:

- sweep finalize fails, concurrent retry succeeds: row stays `LOADED`, no delete task, retry gets `Complete`, slot released once.
- discard takes the terminal lock first: the waiting retry gets `NotFound`, finalization is not retried, slot released once.

Both fail on `main` and pass with this change. Fast-tier suite: 1763 tests, 0 failures. `ktlintCheck` clean.

## Follow-up

Mobile carries a copy of `PushSessionManager`; sync this file after merge.
