### PR TITLE
Prepare shared device UI for mobile: platform display name, two-line names, neutral section headers, extracted nearby actions

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/base/SectionHeader.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/base/SectionHeader.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
@@ -25,6 +26,7 @@ fun SectionHeader(
     text: String,
     backgroundColor: Color = MaterialTheme.colorScheme.surface,
     topPadding: Dp = 0.dp,
+    titleColor: Color = Color.Unspecified,
     trailingContent: @Composable (() -> Unit)? = null,
 ) {
     val copywriter = koinInject<GlobalCopywriter>()
@@ -43,7 +45,7 @@ fun SectionHeader(
             Text(
                 text = copywriter.getText(text),
                 style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary,
+                color = titleColor.takeOrElse { MaterialTheme.colorScheme.primary },
                 fontWeight = FontWeight.SemiBold,
                 letterSpacing = TextUnit.Unspecified,
             )

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/CurrentDeviceDialog.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/CurrentDeviceDialog.kt
@@ -58,7 +58,7 @@ fun CurrentDeviceDialog(onDismiss: () -> Unit) {
             "user_name" to appInfo.userName,
             "app_version" to appInfo.displayVersion(),
             "device_id" to deviceUtils.getDeviceId(),
-            "os" to "${platform.name} ${platform.version}",
+            "os" to "${platform.displayName()} ${platform.version}",
             "arch" to platform.arch,
             "port" to if (port <= 0) copywriter.getText("unknown") else port.toString(),
         )

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceRowContent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceRowContent.kt
@@ -105,7 +105,7 @@ fun PlatformScope.DeviceRowContent(
                 }
 
                 Text(
-                    text = "${platform.name} ${platform.version}",
+                    text = "${platform.displayName()} ${platform.version}",
                     fontSize = 12.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceRowContent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceRowContent.kt
@@ -98,7 +98,7 @@ fun PlatformScope.DeviceRowContent(
                         text = getDeviceDisplayName(),
                         fontSize = 15.sp,
                         fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
+                        maxLines = style.nameMaxLines,
                         overflow = TextOverflow.Ellipsis,
                         color = style.titleColor,
                     )

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/MyDevicesSection.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/MyDevicesSection.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import com.crosspaste.db.sync.SyncRuntimeInfo
@@ -49,6 +50,7 @@ fun LazyListScope.myDevicesSection(
     onOfflineExpandedChange: (Boolean) -> Unit,
     deviceScopeFactory: DeviceScopeFactory,
     headerTopPadding: Dp = zero,
+    headerTitleColor: Color = Color.Unspecified,
 ) {
     val onlineDevices = deviceGroups.online
     val offlineDevices = deviceGroups.offline
@@ -58,6 +60,7 @@ fun LazyListScope.myDevicesSection(
             SectionHeader(
                 text = "my_devices",
                 topPadding = headerTopPadding,
+                titleColor = headerTitleColor,
                 trailingContent =
                     if (offlineDevices.isNotEmpty()) {
                         {

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/NearbyDeviceActions.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/NearbyDeviceActions.kt
@@ -44,15 +44,7 @@ fun SyncScope.NearbyDeviceActions() {
                     contentColor = MaterialTheme.colorScheme.onErrorContainer,
                 ),
         ) {
-            nearbyDeviceManager.blockDevice(syncInfo)
-            // The row vanishes on block; say where it went so the blacklist is findable.
-            val deviceName = getDeviceDisplayName()
-            notificationManager.sendNotification(
-                title = { "${it.getText("device_blocked")}: $deviceName" },
-                message = { it.getText("device_blocked_desc") },
-                messageType = MessageType.Info,
-                duration = 5000,
-            )
+            blockNearbyDevice(nearbyDeviceManager, notificationManager)
         }
 
         GeneralIconButton(
@@ -64,9 +56,39 @@ fun SyncScope.NearbyDeviceActions() {
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                 ),
         ) {
-            if (appControl.isDeviceConnectionEnabled(syncManager.getSyncHandlers().size + 1)) {
-                syncManager.updateSyncInfo(syncInfo)
-            }
+            pairNearbyDevice(appControl, syncManager)
         }
+    }
+}
+
+/**
+ * Block the nearby device and tell the user where it went, since the row
+ * vanishes on block and the blacklist should stay findable. Plain function so
+ * non-button entry points (e.g. a swipe menu) can trigger the same action.
+ */
+fun SyncScope.blockNearbyDevice(
+    nearbyDeviceManager: NearbyDeviceManager,
+    notificationManager: NotificationManager,
+) {
+    nearbyDeviceManager.blockDevice(syncInfo)
+    val deviceName = getDeviceDisplayName()
+    notificationManager.sendNotification(
+        title = { "${it.getText("device_blocked")}: $deviceName" },
+        message = { it.getText("device_blocked_desc") },
+        messageType = MessageType.Info,
+        duration = 5000,
+    )
+}
+
+/**
+ * Pair with the nearby device if the device-connection limit allows one more
+ * connection. Plain function so non-button entry points can trigger it.
+ */
+fun SyncScope.pairNearbyDevice(
+    appControl: AppControl,
+    syncManager: SyncManager,
+) {
+    if (appControl.isDeviceConnectionEnabled(syncManager.getSyncHandlers().size + 1)) {
+        syncManager.updateSyncInfo(syncInfo)
     }
 }

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PlatformScope.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/PlatformScope.kt
@@ -28,6 +28,7 @@ data class DeviceStyle(
     val paddingValues: PaddingValues = PaddingValues(medium),
     val shape: Shape = mediumRoundedCornerShape,
     val isClickable: Boolean = true,
+    val nameMaxLines: Int = 1,
 )
 
 val myDeviceStyle: DeviceStyle

--- a/app/src/desktopTest/kotlin/com/crosspaste/platform/PlatformTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/platform/PlatformTest.kt
@@ -19,6 +19,17 @@ class PlatformTest {
     }
 
     @Test
+    fun testDisplayName() {
+        fun platform(name: String) = Platform(name = name, arch = "arm64", bitMode = 64, version = "1")
+
+        assertEquals("macOS", platform(Platform.MACOS).displayName())
+        assertEquals("Windows", platform(Platform.WINDOWS).displayName())
+        assertEquals("Linux", platform(Platform.LINUX).displayName())
+        assertEquals("iPhone", platform(Platform.IPHONE).displayName())
+        assertEquals("Unknown", platform(Platform.UNKNOWN_OS).displayName())
+    }
+
+    @Test
     fun testWindowsPlatform() {
         runCatching {
             mockkObject(DesktopSystemProperty)
@@ -28,7 +39,6 @@ class PlatformTest {
 
             val platform = getPlatformUtils().platform
             assertEquals("Windows", platform.name)
-            assertEquals("Windows", platform.displayName())
             assertEquals("amd64", platform.arch)
             assertEquals(64, platform.bitMode)
             assertEquals("10", platform.version)
@@ -47,7 +57,6 @@ class PlatformTest {
 
             val platform = getPlatformUtils().platform
             assertEquals("Macos", platform.name)
-            assertEquals("macOS", platform.displayName())
             assertEquals("x86_64", platform.arch)
             assertEquals(64, platform.bitMode)
             assertEquals("10.15.7", platform.version)
@@ -84,7 +93,6 @@ class PlatformTest {
 
             val platform = getPlatformUtils().platform
             assertEquals("Linux", platform.name)
-            assertEquals("Linux", platform.displayName())
             assertEquals("x86_64", platform.arch)
             assertEquals(64, platform.bitMode)
             assertEquals(LinuxPlatform.getOsVersion(), platform.version)

--- a/app/src/desktopTest/kotlin/com/crosspaste/platform/PlatformTest.kt
+++ b/app/src/desktopTest/kotlin/com/crosspaste/platform/PlatformTest.kt
@@ -28,6 +28,7 @@ class PlatformTest {
 
             val platform = getPlatformUtils().platform
             assertEquals("Windows", platform.name)
+            assertEquals("Windows", platform.displayName())
             assertEquals("amd64", platform.arch)
             assertEquals(64, platform.bitMode)
             assertEquals("10", platform.version)
@@ -46,6 +47,7 @@ class PlatformTest {
 
             val platform = getPlatformUtils().platform
             assertEquals("Macos", platform.name)
+            assertEquals("macOS", platform.displayName())
             assertEquals("x86_64", platform.arch)
             assertEquals(64, platform.bitMode)
             assertEquals("10.15.7", platform.version)
@@ -82,6 +84,7 @@ class PlatformTest {
 
             val platform = getPlatformUtils().platform
             assertEquals("Linux", platform.name)
+            assertEquals("Linux", platform.displayName())
             assertEquals("x86_64", platform.arch)
             assertEquals(64, platform.bitMode)
             assertEquals(LinuxPlatform.getOsVersion(), platform.version)

--- a/core/src/commonMain/kotlin/com/crosspaste/platform/Platform.kt
+++ b/core/src/commonMain/kotlin/com/crosspaste/platform/Platform.kt
@@ -28,7 +28,16 @@ data class Platform(
         const val CHROME_EXTENSION = "ChromeExtension"
 
         const val UNKNOWN_OS = "Unknown"
+
+        private const val MACOS_DISPLAY_NAME = "macOS"
     }
+
+    /**
+     * Human-readable platform name for the UI. [name] is a wire value serialized into
+     * SyncInfo/EndpointInfo and compared across versions, so it stays as is; only the
+     * presentation differs (e.g. "Macos" -> "macOS").
+     */
+    fun displayName(): String = if (isMacos()) MACOS_DISPLAY_NAME else name
 
     fun isWindows(): Boolean = name == WINDOWS
 


### PR DESCRIPTION
## Summary

The mobile apps reuse the shared device UI from `app/src/commonMain` and are about to diverge from desktop in layout and gestures (block via a swipe menu, phone-width rows). They must not fork the business logic, so this PR makes the small shared-side extractions and opt-in parameters first. Shared components keep their current defaults; desktop looks and behaves exactly as before.

- **`Platform.displayName()`** (`core`): new helper that returns `macOS` for the macOS platform and `name` for everything else. Used in `DeviceRowContent` (subtitle) and `CurrentDeviceDialog` ("os" row). `Platform.MACOS` stays `"Macos"` on purpose: it is a wire value serialized into `SyncInfo` / `EndpointInfo` and compared across app versions, so changing the constant would make old and new versions stop recognising each other. Non-UI uses (comparisons, logging, serialization) are untouched. `PlatformTest` now asserts `displayName()` for Windows, macOS and Linux.
- **Device name line count as a style parameter**: `DeviceStyle` gains `nameMaxLines: Int = 1` and `DeviceRowContent` uses it for the title (`overflow = Ellipsis` kept). Every existing preset keeps the default, so desktop rows are unchanged; mobile opts in with `myDeviceStyle.copy(nameMaxLines = 2)` so long names such as `Simulator(device=Unknown)` wrap on phone-width rows.
- **`SectionHeader` title colour as an opt-in parameter**: `SectionHeader` gains `titleColor: Color = Color.Unspecified` and resolves it with `titleColor.takeOrElse { colorScheme.primary }`, so the default is still `primary` (SemiBold kept). `myDevicesSection` threads it through as `headerTitleColor: Color = Color.Unspecified`. Desktop callers are untouched; mobile passes `onSurfaceVariant` for its neutral header.
- **Nearby actions extracted from their buttons**: `NearbyDeviceActions()` keeps its current look and now delegates to two plain (non-composable) `SyncScope` extensions in the same file, which mobile can call from a swipe menu:
  - `fun SyncScope.blockNearbyDevice(nearbyDeviceManager: NearbyDeviceManager, notificationManager: NotificationManager)` — block + "device_blocked" toast
  - `fun SyncScope.pairNearbyDevice(appControl: AppControl, syncManager: SyncManager)` — device-connection-limit guard + `updateSyncInfo`

  Koin injection stays inside the composable.

## Verification

- `./gradlew ktlintFormat` / `./gradlew ktlintCheck` clean
- `./gradlew app:desktopTest --tests "*PlatformTest*"`: 5/5 passed (compiles the shared UI module as well)

Closes #4950
