### PR TITLE
:sparkles: add a nameTrailing slot to DeviceRowContent for inline markers after the device name

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceRowContent.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DeviceRowContent.kt
@@ -28,11 +28,18 @@ import com.crosspaste.ui.theme.AppUISize.tiny
 import com.crosspaste.ui.theme.AppUISize.xLarge
 import com.crosspaste.ui.theme.AppUISize.xxxxLarge
 
+/**
+ * [nameTrailing] sits right after the device name on the title line; the name
+ * wraps or ellipsizes first, so the marker keeps its full width. Use it for a
+ * short inline marker (e.g. "this device") that should not compete with
+ * [trailingContent] for the row's end.
+ */
 @Composable
 fun PlatformScope.DeviceRowContent(
     style: DeviceStyle,
     onClick: (() -> Unit)? = null,
     iconTint: Color? = null,
+    nameTrailing: @Composable (() -> Unit)? = null,
     trailingContent: @Composable (() -> Unit)? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -102,6 +109,7 @@ fun PlatformScope.DeviceRowContent(
                         overflow = TextOverflow.Ellipsis,
                         color = style.titleColor,
                     )
+                    nameTrailing?.invoke()
                 }
 
                 Text(


### PR DESCRIPTION
Closes #4954

## What

Adds an optional `nameTrailing: @Composable (() -> Unit)? = null` parameter to `DeviceRowContent`, rendered inside the existing title-line `Row` right after the device name. The name keeps `weight(1f, fill = false)`, so it wraps or ellipsizes before the marker loses width.

## Why

The mobile local-device row currently puts a "THIS DEVICE" tag in the trailing slot next to the pairing-code button. Because the row measures trailing content first, a 411dp phone leaves the name ~106dp and "Google Pixel 8a" wraps. Moving the marker inline after the name frees the trailing slot for the action button only. Mobile will pass a short primary-colored "This device" text here; desktop callers are unchanged.

## Verification

- `./gradlew ktlintFormat` clean. One-parameter addition with a default; existing call sites untouched.