### PR TITLE
:sparkles: show the local device as the first row of my devices on desktop

### DIFF
--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/DevicesContentView.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,12 +30,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.rounded.Add
-import com.composables.icons.materialsymbols.rounded.Devices
 import com.composables.icons.materialsymbols.rounded.Refresh
 import com.crosspaste.i18n.GlobalCopywriter
 import com.crosspaste.net.PasteBonjourService
@@ -54,7 +51,6 @@ import com.crosspaste.ui.theme.AppUISize.tiny3X
 import com.crosspaste.ui.theme.AppUISize.tiny5X
 import com.crosspaste.ui.theme.AppUISize.titanic
 import com.crosspaste.ui.theme.AppUISize.xxLarge
-import com.crosspaste.ui.theme.AppUISize.zero
 import org.koin.compose.koinInject
 
 @Composable
@@ -71,7 +67,6 @@ fun DevicesContentView(guideContent: (@Composable () -> Unit)? = null) {
     val searching by nearbyDeviceManager.searching.collectAsState()
 
     val deviceGroups = rememberDeviceGroups()
-    val hasDevices = deviceGroups.hasDevices
 
     val unverifiedSyncRuntimeInfo by syncManager.unverifiedSyncRuntimeInfo.collectAsState()
 
@@ -93,60 +88,32 @@ fun DevicesContentView(guideContent: (@Composable () -> Unit)? = null) {
 
     InnerScaffold(
         floatingActionButton = {
-            Column(
-                horizontalAlignment = Alignment.End,
-                verticalArrangement = Arrangement.spacedBy(tiny),
+            FilledTonalButton(
+                onClick = { showAddDeviceDialog = true },
+                contentPadding = PaddingValues(horizontal = medium, vertical = tiny),
+                colors =
+                    ButtonDefaults.filledTonalButtonColors(
+                        containerColor = LocalThemeExtState.current.success.surface,
+                        contentColor = LocalThemeExtState.current.success.onContainer,
+                    ),
+                elevation =
+                    ButtonDefaults.filledTonalButtonElevation(
+                        defaultElevation = tiny3X,
+                        pressedElevation = tiny5X,
+                        hoveredElevation = tiny2X,
+                        focusedElevation = tiny3X,
+                    ),
             ) {
-                FilledTonalButton(
-                    onClick = { showCurrentDeviceDialog = true },
-                    contentPadding = PaddingValues(horizontal = medium, vertical = tiny),
-                    elevation =
-                        ButtonDefaults.filledTonalButtonElevation(
-                            defaultElevation = tiny3X,
-                            pressedElevation = tiny5X,
-                            hoveredElevation = tiny2X,
-                            focusedElevation = tiny3X,
-                        ),
-                ) {
-                    Icon(
-                        imageVector = MaterialSymbols.Rounded.Devices,
-                        contentDescription = null,
-                        modifier = Modifier.size(small),
-                    )
-                    Spacer(modifier = Modifier.width(tiny3X))
-                    Text(
-                        text = copywriter.getText("current_device"),
-                        style = MaterialTheme.typography.labelLarge,
-                    )
-                }
-
-                FilledTonalButton(
-                    onClick = { showAddDeviceDialog = true },
-                    contentPadding = PaddingValues(horizontal = medium, vertical = tiny),
-                    colors =
-                        ButtonDefaults.filledTonalButtonColors(
-                            containerColor = LocalThemeExtState.current.success.surface,
-                            contentColor = LocalThemeExtState.current.success.onContainer,
-                        ),
-                    elevation =
-                        ButtonDefaults.filledTonalButtonElevation(
-                            defaultElevation = tiny3X,
-                            pressedElevation = tiny5X,
-                            hoveredElevation = tiny2X,
-                            focusedElevation = tiny3X,
-                        ),
-                ) {
-                    Icon(
-                        imageVector = MaterialSymbols.Rounded.Add,
-                        contentDescription = null,
-                        modifier = Modifier.size(small),
-                    )
-                    Spacer(modifier = Modifier.width(tiny3X))
-                    Text(
-                        text = copywriter.getText("add_device_manually"),
-                        style = MaterialTheme.typography.labelLarge,
-                    )
-                }
+                Icon(
+                    imageVector = MaterialSymbols.Rounded.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(small),
+                )
+                Spacer(modifier = Modifier.width(tiny3X))
+                Text(
+                    text = copywriter.getText("add_device_manually"),
+                    style = MaterialTheme.typography.labelLarge,
+                )
             }
         },
     ) { innerPadding ->
@@ -177,18 +144,16 @@ fun DevicesContentView(guideContent: (@Composable () -> Unit)? = null) {
                 offlineExpanded = offlineExpanded,
                 onOfflineExpandedChange = { offlineExpanded = it },
                 deviceScopeFactory = deviceScopeFactory,
+                leadingItem = {
+                    LocalDeviceRow { showCurrentDeviceDialog = true }
+                },
             )
 
             stickyHeader {
                 SectionHeader(
                     text = "nearby_devices",
                     backgroundColor = MaterialTheme.colorScheme.surface,
-                    topPadding =
-                        if (hasDevices) {
-                            medium
-                        } else {
-                            zero
-                        },
+                    topPadding = medium,
                     trailingContent = {
                         NearbyRefreshButton(searching) {
                             pasteBonjourService.refreshAll()

--- a/app/src/commonMain/kotlin/com/crosspaste/ui/devices/LocalDeviceRow.kt
+++ b/app/src/commonMain/kotlin/com/crosspaste/ui/devices/LocalDeviceRow.kt
@@ -1,0 +1,53 @@
+package com.crosspaste.ui.devices
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.remember
+import com.composables.icons.materialsymbols.MaterialSymbols
+import com.composables.icons.materialsymbols.rounded.Devices
+import com.crosspaste.platform.Platform
+import com.crosspaste.ui.base.StateTagStyle
+import com.crosspaste.ui.base.StateTagView
+import com.crosspaste.utils.DeviceUtils
+import org.koin.compose.koinInject
+
+private val currentDeviceTagStyle: StateTagStyle
+    @Composable @ReadOnlyComposable
+    get() =
+        StateTagStyle(
+            label = "current_device",
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            icon = MaterialSymbols.Rounded.Devices,
+        )
+
+private class LocalDeviceScope(
+    override val platform: Platform,
+    private val deviceName: String,
+) : PlatformScope {
+    override fun getDeviceDisplayName(): String = deviceName
+}
+
+/**
+ * The local device as the first row of "my devices": same card as a paired
+ * device, marked with a "current device" tag after the name. It has no sync
+ * state or actions; tapping it opens the device info via [onClick].
+ */
+@Composable
+fun LocalDeviceRow(onClick: () -> Unit) {
+    val platform = koinInject<Platform>()
+    val deviceUtils = koinInject<DeviceUtils>()
+
+    val scope =
+        remember(platform, deviceUtils) {
+            LocalDeviceScope(platform, deviceUtils.getDeviceName())
+        }
+
+    scope.DeviceRowContent(
+        style = myDeviceStyle,
+        onClick = onClick,
+        iconTint = MaterialTheme.colorScheme.primary,
+        nameTrailing = { StateTagView(currentDeviceTagStyle) },
+    )
+}


### PR DESCRIPTION
Closes #4956

## Summary

- Add `LocalDeviceRow` in commonMain: the local device rendered with `DeviceRowContent` in the `myDeviceStyle` card, platform icon tinted primary, a "current device" tag in the `nameTrailing` slot, no sync state or actions. Tapping opens `CurrentDeviceDialog`.
- `DevicesContentView` passes it as `leadingItem` to `myDevicesSection`, so the "my devices" header and the local row are always shown, even before any device is paired.
- Remove the "Current Device" pill button; the floating action area keeps only "Add Device Manually".
- The "nearby devices" sticky header always uses its top padding now that a section always precedes it.

## Notes

- `LocalDeviceRow` lives in commonMain and only depends on `Platform`, `DeviceUtils` and the existing row/tag components, so mobile can reuse it as-is.
- No i18n changes: the tag reuses the existing `current_device` key.